### PR TITLE
Install Go Deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ are sourced.
 This is managed through the `doc-sourcer` tool. Make sure you have a copy of it available by running:
 
 ```
+go get -u -v gopkg.in/src-d/go-git.v4
 (cd ./doc_sourcer && go build -o doc-sourcer .)
 ```
 


### PR DESCRIPTION
This PR adds an instruction to install some of the doc-sourcer's dependencies inside the `GOPATH`.