### PR TITLE
Add more modules to tf12 compatibility chart

### DIFF
--- a/content/reference/version-compatibility/index.md
+++ b/content/reference/version-compatibility/index.md
@@ -20,9 +20,12 @@ The following lists our Terraform packages and their compatibility with Terrafor
 | [module-vpc](https://github.com/gruntwork-io/module-vpc)                                         | <=v0.5.8           | >=v0.6.0         |
 | [module-server](https://github.com/gruntwork-io/module-server)                                   | <=v0.6.2           | >=v0.7.0         |
 | [module-load-balancer](https://github.com/gruntwork-io/module-load-balancer)                     | <=v0.13.3          | >=v0.14.0        |
+| [module-data-storage](https://github.com/gruntwork-io/module-data-storage)                       | <=v0.8.9          | >=v0.9.0          |
 | [module-asg](https://github.com/gruntwork-io/module-asg)                                         | <=v0.6.26          | >=v0.7.0         |
 | [package-messaging](https://github.com/gruntwork-io/package-messaging)                           | <=v0.2.0           | >=v0.3.0         |
+| [package-lambda](https://github.com/gruntwork-io/package-lambda)                                 | <=v0.5.1           | >=v0.6.0         |
 | [terraform-kubernetes-helm](https://github.com/gruntwork-io/terraform-kubernetes-helm)           | <=v0.4.0           | >=v0.5.0         |
 | [terraform-google-network](https://github.com/gruntwork-io/terraform-google-network)             | <=v0.1.2           | >=v0.2.0         |
 | [terraform-google-load-balancer](https://github.com/gruntwork-io/terraform-google-load-balancer) | <=v0.1.2           | >=v0.2.0         |
 | [terraform-google-static-assets](https://github.com/gruntwork-io/terraform-google-static-assets) | <=v0.1.1           | >=v0.2.0         |
+| [terraform-google-gke](https://github.com/gruntwork-io/terraform-google-gke)                     | <=v0.2.0           | >=v0.3.0         |


### PR DESCRIPTION
`package-lambda`
`module-data-storage`
`terraform-google-gke`