### PR TITLE
Add influx to tf12 compatibility list

### DIFF
--- a/content/reference/version-compatibility/index.md
+++ b/content/reference/version-compatibility/index.md
@@ -40,6 +40,7 @@ The following lists our Terraform packages and their compatibility with Terrafor
 | [package-beanstalk](https://github.com/gruntwork-io/package-beanstalk)                           | <=v0.0.4         | >=v0.1.0         |
 | [terraform-aws-eks](https://github.com/gruntwork-io/terraform-aws-eks)                           | <=v0.5.5         | >=v0.6.0         |
 | [terraform-aws-couchbase](https://github.com/gruntwork-io/terraform-aws-couchbase)               | <=v0.1.5         | >=v0.2.0         |
+| [terraform-aws-influx](https://github.com/gruntwork-io/terraform-aws-influx)                     | <=v0.0.4         | >=v0.1.0         |
 | [terraform-aws-consul](https://github.com/hashicorp/terraform-aws-consul)                        | <=v0.6.1         | >=v0.7.0         |
 | [terraform-aws-nomad](https://github.com/hashicorp/terraform-aws-nomad)                          | <=v0.4.5         | >=v0.5.0         |
 | [terraform-aws-vault](https://github.com/hashicorp/terraform-aws-vault)                          | <=v0.12.2        | >=v0.13.0        |


### PR DESCRIPTION
As the title states, this adds the `terraform-aws-influx` module to the tf12 version compatibility chart.