### PR TITLE
[APT-1557] Add local docs source

### DIFF
--- a/_docs-sources/docs/guides/landing-zone/stub.md
+++ b/_docs-sources/docs/guides/landing-zone/stub.md
@@ -1,0 +1,5 @@
+---
+'title': 'Stub'
+---
+
+# Stub

--- a/_docs-sources/docs/guides/patcher/stub.md
+++ b/_docs-sources/docs/guides/patcher/stub.md
@@ -1,0 +1,5 @@
+---
+'title': 'Stub'
+---
+
+# Stub

--- a/_docs-sources/docs/guides/pipelines/stub.md
+++ b/_docs-sources/docs/guides/pipelines/stub.md
@@ -1,0 +1,5 @@
+---
+'title': 'Stub'
+---
+
+# Stub

--- a/_docs-sources/docs/guides/service-catalog/stub.md
+++ b/_docs-sources/docs/guides/service-catalog/stub.md
@@ -1,0 +1,5 @@
+---
+'title': 'Stub'
+---
+
+# Stub

--- a/_docs-sources/docs/guides/support.md
+++ b/_docs-sources/docs/guides/support.md
@@ -1,0 +1,11 @@
+# Where to Get Support
+
+This is where the main content goes
+
+<b>There's also just</b> regular HTML content
+
+<table>
+<tr>
+<td>Stuff</td>
+</tr>
+</table>

--- a/_docs-sources/docs/guides/welcome.md
+++ b/_docs-sources/docs/guides/welcome.md
@@ -1,0 +1,8 @@
+---
+"sidebar_label": "Introduction"
+"sidebar_position": 1
+---
+
+# Welcome
+
+This is an introduction to the guides section

--- a/_docs-sources/docs/guides/your-architecture/stub.md
+++ b/_docs-sources/docs/guides/your-architecture/stub.md
@@ -1,0 +1,5 @@
+---
+'title': 'Stub'
+---
+
+# Stub

--- a/_docs-sources/docs/intro.md
+++ b/_docs-sources/docs/intro.md
@@ -1,0 +1,35 @@
+---
+sidebar_position: 1
+---
+
+# Tutorial Intro (Home Page)
+
+Let's discover **Docusaurus in less than 5 minutes**.
+
+## Getting Started
+
+Get started by **creating a new site**.
+
+Or **try Docusaurus immediately** with **[docusaurus.new](https://docusaurus.new)**.
+
+## Generate a new site
+
+Generate a new Docusaurus site using the **classic template**:
+
+```shell
+npm init docusaurus@latest my-website classic
+```
+
+## Start your site
+
+Run the development server:
+
+```shell
+cd my-website
+
+npx docusaurus start
+```
+
+Your site starts at `http://localhost:3000`.
+
+Open `docs/intro.md` and edit some lines: the site **reloads automatically** and display your changes.

--- a/_docs-sources/docs/intro/dev-portal/_category_.json
+++ b/_docs-sources/docs/intro/dev-portal/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Accessing the Developer Portal",
+  "position": 2
+}

--- a/_docs-sources/docs/intro/dev-portal/create-account.md
+++ b/_docs-sources/docs/intro/dev-portal/create-account.md
@@ -1,0 +1,1 @@
+# Create Your Account

--- a/_docs-sources/docs/intro/dev-portal/invite-team.md
+++ b/_docs-sources/docs/intro/dev-portal/invite-team.md
@@ -1,0 +1,1 @@
+# Invite Your Team

--- a/_docs-sources/docs/intro/dev-portal/link-github-id.md
+++ b/_docs-sources/docs/intro/dev-portal/link-github-id.md
@@ -1,0 +1,1 @@
+# Link Your GitHub ID

--- a/_docs-sources/docs/intro/environment-setup/stub.md
+++ b/_docs-sources/docs/intro/environment-setup/stub.md
@@ -1,0 +1,5 @@
+---
+'title': 'Stub'
+---
+
+# Stub

--- a/_docs-sources/docs/intro/first-deployment/stub.md
+++ b/_docs-sources/docs/intro/first-deployment/stub.md
@@ -1,0 +1,5 @@
+---
+'title': 'Stub'
+---
+
+# Stub

--- a/_docs-sources/docs/intro/next-steps.md
+++ b/_docs-sources/docs/intro/next-steps.md
@@ -1,0 +1,5 @@
+---
+"sidebar_position": 6
+---
+
+# Next Steps

--- a/_docs-sources/docs/intro/overview/account-baselines.md
+++ b/_docs-sources/docs/intro/overview/account-baselines.md
@@ -1,0 +1,5 @@
+---
+'title': 'Account Baselines'
+---
+
+# Account Baselines Header

--- a/_docs-sources/docs/intro/overview/app-catalog.md
+++ b/_docs-sources/docs/intro/overview/app-catalog.md
@@ -1,0 +1,5 @@
+---
+'title': 'App Catalog'
+---
+
+# App Catalog Header

--- a/_docs-sources/docs/intro/overview/auto-updates.md
+++ b/_docs-sources/docs/intro/overview/auto-updates.md
@@ -1,0 +1,5 @@
+---
+'title': 'Automatic Updates'
+---
+
+# Auto Updates Header

--- a/_docs-sources/docs/intro/overview/iac-pipeline.md
+++ b/_docs-sources/docs/intro/overview/iac-pipeline.md
@@ -1,0 +1,5 @@
+---
+'title': 'IaC Pipeline'
+---
+
+# IaC Pipeline Header

--- a/_docs-sources/docs/intro/overview/self-service.md
+++ b/_docs-sources/docs/intro/overview/self-service.md
@@ -1,0 +1,5 @@
+---
+'title': 'Self Service'
+---
+
+# Self Service Header

--- a/_docs-sources/docs/intro/overview/service-catalog.md
+++ b/_docs-sources/docs/intro/overview/service-catalog.md
@@ -1,0 +1,5 @@
+---
+'title': 'DevOps Service Catalog'
+---
+
+# Service Catalog Header

--- a/_docs-sources/docs/intro/overview/world-class-devops.md
+++ b/_docs-sources/docs/intro/overview/world-class-devops.md
@@ -1,0 +1,5 @@
+---
+'title': 'Components of a World Class DevOps Setup'
+---
+
+# Components of a World Class DevOps Setup

--- a/_docs-sources/docs/intro/setup-workspace/stub.md
+++ b/_docs-sources/docs/intro/setup-workspace/stub.md
@@ -1,0 +1,5 @@
+---
+'title': 'Stub'
+---
+
+# Stub

--- a/_docs-sources/docs/intro/tool-fundamentals/stub.md
+++ b/_docs-sources/docs/intro/tool-fundamentals/stub.md
@@ -1,0 +1,5 @@
+---
+'title': 'Stub'
+---
+
+# Stub

--- a/_docs-sources/docs/intro/zero2hero/a-web-app-using-docker.md
+++ b/_docs-sources/docs/intro/zero2hero/a-web-app-using-docker.md
@@ -1,0 +1,86 @@
+# A web app using Docker
+
+## Prerequisites
+
+In this section, we will be running commands locally on your development machine, _not_ inside the Docker container created in the previous chapter.
+
+## Build the container
+
+Let's start with the simple web front end. First, we'll build the container:
+
+```bash
+cd src/web && docker build . -t web && cd -
+```
+
+<!--include:: -->
+
+## Run the container
+
+Now, we'll run the container, directing the container's traffic on port 8081 to our local port 8081:
+
+```bash
+docker run -p 8081:8081 web
+```
+
+You'll see something that looks like this:
+
+```bash
+$ docker run -p 8081:8081 web
+time="2021-07-13T18:43:48Z" level=info msg="Starting web server on :8081 connecting to API at http://localhost:8080/"
+```
+
+Don't worry, there's no API for it to connect to. Try opening your browser to [http://localhost:8081] and you should see a message:
+
+```bash
+Unable to get counter information
+```
+
+You can also use `curl` from another terminal window to get the same results:
+
+```bash
+$ curl localhost:8081
+Unable to get counter information
+```
+
+You will see warning messages eminating from the web application. This is fine for now.
+
+```bash
+time="2021-07-13T18:44:05Z" level=warning msg="Error getting response from http://localhost:8080/: Get \"http://localhost:8080/\": dial tcp 127.0.0.1:8080: connect: connection refused"
+```
+
+When done, use `Ctrl-C` to shut down your docker container and the web application inside it.
+
+## Build and run all three containers
+
+Use `docker-compose` to build run the web app, the API, and the PostgreSQL backend.
+
+```bash
+docker-compose build
+docker-compose up
+```
+
+Give it a little time for all three containers to fully launch. Then, point your browser at [http://localhost:8081] again, or use `curl`:
+
+```bash
+$ curl localhost:8081
+Counter: 1
+```
+
+Great! We now have a minimalistic "counter" web application that uses an internal API that talks to a persistent database.
+
+When you're done, destroy `docker-compose` with `Ctrl-C`, and then clean up:
+
+```bash
+docker-compose down
+```
+
+We've provided some helper scripts in the scripts directory to facilitate the bringing up and down of the stack.
+
+Run `scripts/up.sh` to bring everything up, and `scripts/down.sh` to destroy everything. Note that the counter value will persist after bringing the stack down and then back up.
+If you want the counter to reset, you can run `scripts/up.sh clean`.
+
+---
+
+[Table of Contents](zero-to-hero)
+
+Next Section: [Create an ECR Repository with Terraform](create-an-ecr-repository-with-terraform)

--- a/_docs-sources/docs/intro/zero2hero/create-an-ecr-repository-with-terraform.md
+++ b/_docs-sources/docs/intro/zero2hero/create-an-ecr-repository-with-terraform.md
@@ -1,0 +1,284 @@
+# Create an ECR Repository with Terraform
+
+## Prerequisites
+
+- [Setup for the Course](setup-for-courses-in-gruntwork-academy)
+- [Create a Web App via Docker](a-web-app-using-docker)
+
+This is using basic [Terraform](https://terraform.io) skills, so you'll either need Terraform installed locally or use the container provided in [Setup for the Course](./setup-for-courses-in-gruntwork-academy). Make sure you are properly set up for AWS authentication.
+
+## Create the terrafom code
+
+tag::start-tag-name
+
+### main.tf
+
+This file is basic setup. We require a minimum version of terraform, pull in the Terraform [AWS Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs), and then set up a data block so that we can retrieve the AWS Account ID later on.
+
+```bash
+terraform {
+  required_version = ">= 1.0.0"
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_caller_identity" "current" {}
+```
+
+tag::end-tag-name
+
+### variables.tf
+
+We'll define just a few variables in this file, so that our code can be changed to suit our needs. We might want to launch resources in a different region or rename our application. Both variables have initial default values.
+
+```bash
+variable "aws_region" {
+  description = "The AWS region in which to deploy the resources."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "app_name" {
+  description = "The name of the application"
+  type        = string
+  default     = "zero2hero"
+}
+```
+
+### ecr.tf
+
+Here is where the AWS ECR repositories are actually created. We'll create one for each of our three applications (`web`, `api`, and `db`) from the [previous section](./a-web-app-using-docker).
+
+```bash
+# AWS ECR Repository Terraform documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository
+
+resource "aws_ecr_repository" "web" {
+  name = "${var.app_name}_web"
+}
+
+resource "aws_ecr_repository" "api" {
+  name = "${var.app_name}_api"
+}
+
+resource "aws_ecr_repository" "db" {
+  name = "${var.app_name}_db"
+}
+```
+
+### outputs.tf
+
+Finally, we specify some outputs for convenience. We'll output the AWS Account ID, and then URLs for the three repositories and URLs for ease of accessing the AWS ECR console for each of the three repositories.
+
+```bash
+output "aws_account_id" {
+  description = "AWS Account ID"
+  value       = data.aws_caller_identity.current.account_id
+}
+
+output "api_repo_url" {
+  description = "The repository URL for the api container"
+  value       = aws_ecr_repository.api.repository_url
+}
+
+output "api_aws_ecr_console_url" {
+  description = "A URL for the api AWS ECR Console"
+  value       = format("https://console.aws.amazon.com/ecr/repositories/private/%s/%s_api?region=%s", data.aws_caller_identity.current.account_id, var.app_name, var.aws_region)
+}
+
+output "db_repo_url" {
+  description = "The repository URL for the db container"
+  value       = aws_ecr_repository.db.repository_url
+}
+
+output "db_aws_ecr_console_url" {
+  description = "A URL for the db AWS ECR Console"
+  value       = format("https://console.aws.amazon.com/ecr/repositories/private/%s/%s_db?region=%s", data.aws_caller_identity.current.account_id, var.app_name, var.aws_region)
+}
+
+
+output "web_repo_url" {
+  description = "The repository URL for the web container"
+  value       = aws_ecr_repository.web.repository_url
+}
+
+output "web_aws_ecr_console_url" {
+  description = "A URL for the web AWS ECR Console"
+  value       = format("https://console.aws.amazon.com/ecr/repositories/private/%s/%s_web?region=%s", data.aws_caller_identity.current.account_id, var.app_name, var.aws_region)
+}
+```
+
+## Initialize terraform
+
+```bash
+terraform init
+```
+
+The output will look similar to this:
+
+```
+Initializing the backend...
+
+Initializing provider plugins...
+- Finding latest version of hashicorp/aws...
+- Installing hashicorp/aws v3.56.0...
+- Installed hashicorp/aws v3.56.0 (signed by HashiCorp)
+
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+```
+
+## Run the terraform plan
+
+```bash
+terraform plan -out current.plan
+```
+
+The output will look similar to this:
+
+````bash
+Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # aws_ecr_repository.api will be created
+  + resource "aws_ecr_repository" "api" {
+      + arn                  = (known after apply)
+      + id                   = (known after apply)
+      + image_tag_mutability = "MUTABLE"
+      + name                 = "zero2hero_api"
+      + registry_id          = (known after apply)
+      + repository_url       = (known after apply)
+      + tags_all             = (known after apply)
+    }
+
+  # aws_ecr_repository.db will be created
+  + resource "aws_ecr_repository" "db" {
+      + arn                  = (known after apply)
+      + id                   = (known after apply)
+      + image_tag_mutability = "MUTABLE"
+      + name                 = "zero2hero_db"
+      + registry_id          = (known after apply)
+      + repository_url       = (known after apply)
+      + tags_all             = (known after apply)
+    }
+
+  # aws_ecr_repository.web will be created
+  + resource "aws_ecr_repository" "web" {
+      + arn                  = (known after apply)
+      + id                   = (known after apply)
+      + image_tag_mutability = "MUTABLE"
+      + name                 = "zero2hero_web"
+      + registry_id          = (known after apply)
+      + repository_url       = (known after apply)
+      + tags_all             = (known after apply)
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+
+Changes to Outputs:
+  + api_aws_ecr_console_url = "https://console.aws.amazon.com/ecr/repositories/private/012345678910/zero2hero_api?region=us-west-2"
+  + api_repo_url            = (known after apply)
+  + aws_account_id          = "012345678910"
+  + db_aws_ecr_console_url  = "https://console.aws.amazon.com/ecr/repositories/private/012345678910/zero2hero_db?region=us-west-2"
+  + db_repo_url             = (known after apply)
+  + web_aws_ecr_console_url = "https://console.aws.amazon.com/ecr/repositories/private/012345678910/zero2hero_web?region=us-west-2"
+  + web_repo_url            = (known after apply)```
+````
+
+## Apply the plan
+
+```bash
+terraform apply current.plan
+```
+
+Output will look similar to this:
+
+```bash
+aws_ecr_repository.db: Creating...
+aws_ecr_repository.web: Creating...
+aws_ecr_repository.api: Creating...
+aws_ecr_repository.web: Creation complete after 1s [id=zero2hero_web]
+aws_ecr_repository.db: Creation complete after 1s [id=zero2hero_db]
+aws_ecr_repository.api: Creation complete after 1s [id=zero2hero_api]
+
+Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+api_aws_ecr_console_url = "https://console.aws.amazon.com/ecr/repositories/private/012345678910/zero2hero_api?region=us-west-2"
+api_repo_url = "012345678910.dkr.ecr.us-west-2.amazonaws.com/zero2hero_api"
+aws_account_id = "012345678910"
+db_aws_ecr_console_url = "https://console.aws.amazon.com/ecr/repositories/private/012345678910/zero2hero_db?region=us-west-2"
+db_repo_url = "012345678910.dkr.ecr.us-west-2.amazonaws.com/zero2hero_db"
+web_aws_ecr_console_url = "https://console.aws.amazon.com/ecr/repositories/private/012345678910/zero2hero_web?region=us-west-2"
+web_repo_url = "012345678910.dkr.ecr.us-west-2.amazonaws.com/zero2hero_web"
+```
+
+## Push your code to the repositories
+
+You can visit the AWS ECR Console by going to the `aws_ecr_console_url` URL as shown above (Your URL will be different). The instructions are duplicated below.
+
+Let's first export your AWS Account ID listed above (`aws_account_id`) in the outputs:
+
+```bash
+export AWS_ACCOUNT_ID=<aws_account_id from terraform output>
+```
+
+Use the AWS CLI to log in to ECR with docker:
+
+```bash
+aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com
+```
+
+Build the Docker image (note this is referencing the directory in the [previous section](a-web-app-using-docker)):
+
+```bash
+docker build -t zero2hero_web ../02_web_app_via_docker/src/web
+```
+
+After the build completes, tag your image so you can push the image to this repository:
+
+```bash
+docker tag zero2hero_web:latest ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/zero2hero_web:latest
+```
+
+Run the following command to push this image to your newly created AWS repository:
+
+```bash
+docker push ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/zero2hero_web:latest
+```
+
+Repeat the process for the API and the DB containers (you don't need to log in again):
+
+```bash
+# API
+
+docker build -t zero2hero_api ../02_web_app_via_docker/src/api
+docker tag zero2hero_api:latest ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/zero2hero_api:latest
+docker push ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/zero2hero_:latest
+
+# DB
+
+docker build -t zero2hero_db ../02_db_app_via_docker/src/db
+docker tag zero2hero_db:latest ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/zero2hero_db:latest
+docker push ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/zero2hero_db:latest
+```
+
+---
+
+[Table of Contents](zero-to-hero)

--- a/_docs-sources/docs/intro/zero2hero/html-content.mdx
+++ b/_docs-sources/docs/intro/zero2hero/html-content.mdx
@@ -1,0 +1,5 @@
+import AsciiDocContent from "/src/components/AsciiDocContent";
+
+# Rendering HTML content
+
+<AsciiDocContent content="fooo" />

--- a/_docs-sources/docs/intro/zero2hero/setup-for-courses-in-gruntwork-academy.md
+++ b/_docs-sources/docs/intro/zero2hero/setup-for-courses-in-gruntwork-academy.md
@@ -1,0 +1,93 @@
+# Setup for courses in Gruntwork Academy
+
+## AWS
+
+Most of the [Gruntwork Academy courses](https://github.com/gruntwork-io/gruntwork-academy) will build infrastructure in AWS. You'll need an [AWS account](https://aws.amazon.com/) and a user for that account with sufficient permissions to create and destroy infrastructure.
+
+Note that this infrastructure will cost you some money! We will make best efforts to minimize the cost to you by leveraging low cost infrastructure and helping you destroy it afterwards. The responsibility is yours to monitor, pay for, and destroy any lingering infrastructure.
+
+## AWS Authentication
+
+The tools used will all need to be authorized and authenticated. See [AWS's documention](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
+
+The examples in this class will assume that you are authenticated via one of the methods described.
+
+99design's [AWS Vault](https://github.com/99designs/aws-vault) makes it easy to use multiple AWS accounts. If you set up an AWS account with the name `sand`, for example, you can do the following to run the AWS cli in that account and get a list of S3 buckets:
+
+```bash
+aws-vault exec sand -- aws s3api list-buckets
+```
+
+
+## CLI Tools
+
+In order to complete these courses, you'll need some or all the following third party tools:
+
+TODO: Make sure this list is complete and doesn't list something we don't actually need
+
+* [Docker](https://www.docker.com/)
+* [Packer](https://www.packer.io/)
+* [Terraform](https://www.terraform.io/)
+* [Terragrunt](https://terragrunt.gruntwork.io/)
+* [AWS CLI](https://aws.amazon.com/cli/)
+* [AWS Vault](https://github.com/99designs/aws-vault)
+
+If you have these tools already installed, you can run them natively from your machine. Make sure the versions of each of the tools match what is inside the Dockerfile for best results:
+
+```bash
+# Show the current tool versions defined in the Dockerfile
+$ grep 'ARG [A-Z]*_VERSION' Dockerfile | awk '{print $2}'
+PACKER_VERSION=1.7.3
+TERRAFORM_VERSION=1.0.2
+TERRAGRUNT_VERSION=0.31.0
+```
+
+If you'd prefer, you can use Docker and the included Dockerfile to build a container with the tools installed.
+
+From the root directory of the course (one directory up from here):
+
+```bash
+# Build the docker container named gw_academy
+docker build . -t zero2hero -f 01_setup/Dockerfile
+```
+
+If you need to change the version of packer, terraform, or terragrunt, you can pass those variables in as `--build-arg`s:
+
+```bash
+# Build the docker container with specific tool versions
+docker build . --build-arg PACKER_VERSION=1.7.3 --build-arg TERRAFORM_VERSION=1.0.2 --build-arg TERRAGRUNT_VERSION=0.31.0 -t zero2hero -f 01_setup/Dockerfile
+```
+
+Once the container has been built, you can run the container, mounting the current directory to `/zero2hero`:
+
+```bash
+# Run the container, mounting the course at /gw_academy
+docker run -it -v $(pwd):/zero2hero zero2hero /bin/bash
+```
+
+You should see the courses mounted:
+
+```bash
+# Inside the docker container!
+
+root@cc8ae6945307:/# ls /zero2hero
+01_setup                     04_web_app_to_ecs_fargate    07_service_catalog_web_app   10_upgrade_a_module_version
+02_web_app_via_docker        05_web_app_production_ready  08_data_store                README.md
+03_ECR_repo                  06_gruntwork_modules_web_app 09_web_app_gruntwork_way
+```
+
+You will also have the AWS CLI, AWS Vault, aws-vault, Packer, Terraform, and Terragrunt installed:
+
+```bash
+# Inside the docker container!
+
+root@cc8ae6945307:/# ls /usr/local/bin
+aws  aws-vault  aws_completer  packer  terraform  terragrunt
+```
+
+You can run the Zero to Hero Gruntwork Academy course from inside this running container.
+
+---
+[Table of Contents](zero-to-hero)
+
+Next Section: [A Web App via Docker](a-web-app-using-docker)

--- a/_docs-sources/docs/intro/zero2hero/zero-to-hero.md
+++ b/_docs-sources/docs/intro/zero2hero/zero-to-hero.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 1
+title: Zero To Hero
+---
+
+# Zero To Hero
+
+## Overview
+
+This course is designed to incrementally take you from the terraforming you do today to the Gruntwork way of managing infrastructure. We'll start with a simple web application in Docker, and deploy it with Terraform. We'll then show you how to deploy it with our Gruntwork modules and our Service Catalog.
+
+We recommend you start with the first section and work your way through the course. However, if you read a section and know that you already comprehend all of the concepts explained in it, feel free to skip the section and move forward. We'll note any pre-requisites at the top of each section.
+
+## Table of Contents
+
+1. [Setup for the Course](zero-to-hero)
+
+   Make sure you're set up with the tools needed to go through the rest of the hands-on examples.
+
+1. [Create a Web App via Docker](a-web-app-using-docker)
+
+   We craft a simple web application backed by an API and a persistent database. Later on, we deploy these services in the cloud in a few different ways.
+
+1. [Create an ECR Repository with Terraform](create-an-ecr-repository-with-terraform)
+
+   We create a simple Terraform module to provision an [Elastic Container Registry](https://aws.amazon.com/ecr/) for your Docker image, and push your image to that repository.

--- a/_docs-sources/docs/reference/intro.md
+++ b/_docs-sources/docs/reference/intro.md
@@ -1,0 +1,7 @@
+---
+'title': 'Overview'
+---
+
+# Gruntwork Service Catalog API Reference
+
+This section introduces what's found in the reference area.

--- a/_docs-sources/docs/reference/modules/stub.md
+++ b/_docs-sources/docs/reference/modules/stub.md
@@ -1,0 +1,5 @@
+---
+'title': 'Module'
+---
+
+# Module

--- a/_docs-sources/docs/reference/services/stub.md
+++ b/_docs-sources/docs/reference/services/stub.md
@@ -1,0 +1,5 @@
+---
+'title': 'Service'
+---
+
+# Service

--- a/_docs-sources/docs/reference/tools/stub.md
+++ b/_docs-sources/docs/reference/tools/stub.md
@@ -1,0 +1,5 @@
+---
+'title': 'Tool'
+---
+
+# Tool

--- a/docs/guides/landing-zone/stub.md
+++ b/docs/guides/landing-zone/stub.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"85953ded58c5bca69f54a0e0002446b7"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'Stub'
 ---

--- a/docs/guides/patcher/stub.md
+++ b/docs/guides/patcher/stub.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"85953ded58c5bca69f54a0e0002446b7"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'Stub'
 ---

--- a/docs/guides/pipelines/stub.md
+++ b/docs/guides/pipelines/stub.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"85953ded58c5bca69f54a0e0002446b7"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'Stub'
 ---

--- a/docs/guides/service-catalog/stub.md
+++ b/docs/guides/service-catalog/stub.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"85953ded58c5bca69f54a0e0002446b7"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'Stub'
 ---

--- a/docs/guides/support.md
+++ b/docs/guides/support.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"4bfc0c5153a2e2b9fd80023b3159d711"}
+##DOCS-SOURCER-END -->
+
 # Where to Get Support
 
 This is where the main content goes

--- a/docs/guides/welcome.md
+++ b/docs/guides/welcome.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"b18be1468cbb969fa839d28cd90b9f97"}
+##DOCS-SOURCER-END -->
+
 ---
 "sidebar_label": "Introduction"
 "sidebar_position": 1

--- a/docs/guides/your-architecture/stub.md
+++ b/docs/guides/your-architecture/stub.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"85953ded58c5bca69f54a0e0002446b7"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'Stub'
 ---

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"9a76adceeb3958af906263551c8dc0c4"}
+##DOCS-SOURCER-END -->
+
 ---
 sidebar_position: 1
 ---

--- a/docs/intro/dev-portal/create-account.md
+++ b/docs/intro/dev-portal/create-account.md
@@ -1,1 +1,5 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"abb5b0695e71cb31858cedd66e5dd30c"}
+##DOCS-SOURCER-END -->
+
 # Create Your Account

--- a/docs/intro/dev-portal/invite-team.md
+++ b/docs/intro/dev-portal/invite-team.md
@@ -1,1 +1,5 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"1d33dde53f0682859b15ac8c3a0890e0"}
+##DOCS-SOURCER-END -->
+
 # Invite Your Team

--- a/docs/intro/dev-portal/link-github-id.md
+++ b/docs/intro/dev-portal/link-github-id.md
@@ -1,1 +1,5 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"0204fbe00bb0c375d92bb4d13aaeefef"}
+##DOCS-SOURCER-END -->
+
 # Link Your GitHub ID

--- a/docs/intro/environment-setup/stub.md
+++ b/docs/intro/environment-setup/stub.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"85953ded58c5bca69f54a0e0002446b7"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'Stub'
 ---

--- a/docs/intro/first-deployment/stub.md
+++ b/docs/intro/first-deployment/stub.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"85953ded58c5bca69f54a0e0002446b7"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'Stub'
 ---

--- a/docs/intro/next-steps.md
+++ b/docs/intro/next-steps.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"331568acc23cef5a482b1561191601e5"}
+##DOCS-SOURCER-END -->
+
 ---
 "sidebar_position": 6
 ---

--- a/docs/intro/overview/account-baselines.md
+++ b/docs/intro/overview/account-baselines.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"897c9fb806bab05d78544c56ae229d0b"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'Account Baselines'
 ---

--- a/docs/intro/overview/app-catalog.md
+++ b/docs/intro/overview/app-catalog.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"97acc9a7fd95fef794643119aaada96c"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'App Catalog'
 ---

--- a/docs/intro/overview/auto-updates.md
+++ b/docs/intro/overview/auto-updates.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"22b1520b9377b1ea0f5e40b49d490b9b"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'Automatic Updates'
 ---

--- a/docs/intro/overview/iac-pipeline.md
+++ b/docs/intro/overview/iac-pipeline.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"2443c705d04106a33d422fd9e1728350"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'IaC Pipeline'
 ---

--- a/docs/intro/overview/self-service.md
+++ b/docs/intro/overview/self-service.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"8f644c196429e81a278b19be9140d49b"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'Self Service'
 ---

--- a/docs/intro/overview/service-catalog.md
+++ b/docs/intro/overview/service-catalog.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"3804b1005a560115567fd35f937524ea"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'DevOps Service Catalog'
 ---

--- a/docs/intro/overview/world-class-devops.md
+++ b/docs/intro/overview/world-class-devops.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"016ea529b655424dd218ade45b2ffd3a"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'Components of a World Class DevOps Setup'
 ---

--- a/docs/intro/setup-workspace/stub.md
+++ b/docs/intro/setup-workspace/stub.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"85953ded58c5bca69f54a0e0002446b7"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'Stub'
 ---

--- a/docs/intro/tool-fundamentals/stub.md
+++ b/docs/intro/tool-fundamentals/stub.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"85953ded58c5bca69f54a0e0002446b7"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'Stub'
 ---

--- a/docs/intro/zero2hero/a-web-app-using-docker.md
+++ b/docs/intro/zero2hero/a-web-app-using-docker.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"032fcd9c67a72080a8c5b0d0eb30b58d"}
+##DOCS-SOURCER-END -->
+
 # A web app using Docker
 
 ## Prerequisites

--- a/docs/intro/zero2hero/create-an-ecr-repository-with-terraform.md
+++ b/docs/intro/zero2hero/create-an-ecr-repository-with-terraform.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"a1715d16a673099fac9e6d4daa28101e"}
+##DOCS-SOURCER-END -->
+
 # Create an ECR Repository with Terraform
 
 ## Prerequisites

--- a/docs/intro/zero2hero/setup-for-courses-in-gruntwork-academy.md
+++ b/docs/intro/zero2hero/setup-for-courses-in-gruntwork-academy.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"6113038c1e71fa3ff7d18b7db66e295d"}
+##DOCS-SOURCER-END -->
+
 # Setup for courses in Gruntwork Academy
 
 ## AWS

--- a/docs/intro/zero2hero/zero-to-hero.md
+++ b/docs/intro/zero2hero/zero-to-hero.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"f1fff0d34f39c232922f1e4878a860f9"}
+##DOCS-SOURCER-END -->
+
 ---
 sidebar_position: 1
 title: Zero To Hero

--- a/docs/reference/intro.md
+++ b/docs/reference/intro.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"7d8cca66029815dd0e83044962ad5bbd"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'Overview'
 ---

--- a/docs/reference/modules/stub.md
+++ b/docs/reference/modules/stub.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"c49fe59e5436e774d662dd58b36e767c"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'Module'
 ---

--- a/docs/reference/services/stub.md
+++ b/docs/reference/services/stub.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"c66ab70cf22b05eda974f105e7affab4"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'Service'
 ---

--- a/docs/reference/tools/stub.md
+++ b/docs/reference/tools/stub.md
@@ -1,3 +1,7 @@
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"Local File Copier","hash":"7b9768e8298d0d83fd9e1ccc3a2328b1"}
+##DOCS-SOURCER-END -->
+
 ---
 'title': 'Tool'
 ---

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,5 @@
+{
+  "watch": ["_docs-sources"],
+  "exec": "yarn regenerate:local",
+  "ext": "md"
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "docusaurus start & nodemon",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
@@ -12,7 +12,8 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "regenerate:local": "docs-sourcer"
   },
   "dependencies": {
     "@docusaurus/core": "^2.0.0-beta.9",
@@ -20,6 +21,7 @@
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
+    "docs-sourcer": "git+https://github.com/gruntwork-io/docs-sourcer.git#initial-skeleton",
     "file-loader": "^6.2.0",
     "plugin-image-zoom": "ataft/plugin-image-zoom",
     "prism-react-renderer": "^1.2.1",
@@ -31,6 +33,7 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^2.0.0-beta.9",
     "@tsconfig/docusaurus": "^1.0.4",
+    "nodemon": "^2.0.15",
     "typescript": "^4.3.5"
   },
   "browserslist": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,6 +1154,15 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
+"@dabh/diagnostics@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.2.tgz#290d08f7b381b8f94607dc8f471a12c675f9db31"
+  integrity sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==
+  dependencies:
+    colorspace "1.1.x"
+    enabled "2.0.x"
+    kuler "^2.0.0"
+
 "@docsearch/css@3.0.0-alpha.41":
   version "3.0.0-alpha.41"
   resolved "https://registry.yarnpkg.com/@docsearch/css/-/css-3.0.0-alpha.41.tgz#c5c8e803541bd157ad86e764c2c1e9f1b5a68592"
@@ -1614,6 +1623,182 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@octokit/auth-app@^3.6.1":
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-app/-/auth-app-3.6.1.tgz#aa5b02cc211175cbc28ce6c03c73373c1206d632"
+  integrity sha512-6oa6CFphIYI7NxxHrdVOzhG7hkcKyGyYocg7lNDSJVauVOLtylg8hNJzoUyPAYKKK0yUeoZamE/lMs2tG+S+JA==
+  dependencies:
+    "@octokit/auth-oauth-app" "^4.3.0"
+    "@octokit/auth-oauth-user" "^1.2.3"
+    "@octokit/request" "^5.6.0"
+    "@octokit/request-error" "^2.1.0"
+    "@octokit/types" "^6.0.3"
+    "@types/lru-cache" "^5.1.0"
+    deprecation "^2.3.1"
+    lru-cache "^6.0.0"
+    universal-github-app-jwt "^1.0.1"
+    universal-user-agent "^6.0.0"
+
+"@octokit/auth-oauth-app@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-app/-/auth-oauth-app-4.3.0.tgz#de02f184360ffd7cfccef861053784fc4410e7ea"
+  integrity sha512-cETmhmOQRHCz6cLP7StThlJROff3A/ln67Q961GuIr9zvyFXZ4lIJy9RE6Uw5O7D8IXWPU3jhDnG47FTSGQr8Q==
+  dependencies:
+    "@octokit/auth-oauth-device" "^3.1.1"
+    "@octokit/auth-oauth-user" "^1.2.1"
+    "@octokit/request" "^5.3.0"
+    "@octokit/types" "^6.0.3"
+    "@types/btoa-lite" "^1.0.0"
+    btoa-lite "^1.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/auth-oauth-device@^3.1.1":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-device/-/auth-oauth-device-3.1.2.tgz#d299f51f491669f37fe7af8738f5ac921e63973c"
+  integrity sha512-w7Po4Ck6N2aAn2VQyKLuojruiyKROTBv4qs6IwE5rbwF7HhBXXp4A/NKmkpoFIZkiXQtM+N8QtkSck4ApYWdGg==
+  dependencies:
+    "@octokit/oauth-methods" "^1.1.0"
+    "@octokit/request" "^5.4.14"
+    "@octokit/types" "^6.10.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/auth-oauth-user@^1.2.1", "@octokit/auth-oauth-user@^1.2.3":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-user/-/auth-oauth-user-1.3.0.tgz#da4e4529145181a6aa717ae858afb76ebd6e3360"
+  integrity sha512-3QC/TAdk7onnxfyZ24BnJRfZv8TRzQK7SEFUS9vLng4Vv6Hv6I64ujdk/CUkREec8lhrwU764SZ/d+yrjjqhaQ==
+  dependencies:
+    "@octokit/auth-oauth-device" "^3.1.1"
+    "@octokit/oauth-methods" "^1.1.0"
+    "@octokit/request" "^5.4.14"
+    "@octokit/types" "^6.12.2"
+    btoa-lite "^1.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/auth-token@^2.4.4":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.5.0.tgz#27c37ea26c205f28443402477ffd261311f21e36"
+  integrity sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+
+"@octokit/core@^3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.5.1.tgz#8601ceeb1ec0e1b1b8217b960a413ed8e947809b"
+  integrity sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==
+  dependencies:
+    "@octokit/auth-token" "^2.4.4"
+    "@octokit/graphql" "^4.5.8"
+    "@octokit/request" "^5.6.0"
+    "@octokit/request-error" "^2.0.5"
+    "@octokit/types" "^6.0.3"
+    before-after-hook "^2.2.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/endpoint@^6.0.1":
+  version "6.0.12"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.12.tgz#3b4d47a4b0e79b1027fb8d75d4221928b2d05658"
+  integrity sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    is-plain-object "^5.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/graphql@^4.5.8":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.8.0.tgz#664d9b11c0e12112cbf78e10f49a05959aa22cc3"
+  integrity sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==
+  dependencies:
+    "@octokit/request" "^5.6.0"
+    "@octokit/types" "^6.0.3"
+    universal-user-agent "^6.0.0"
+
+"@octokit/oauth-authorization-url@^4.3.1":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@octokit/oauth-authorization-url/-/oauth-authorization-url-4.3.3.tgz#6a6ef38f243086fec882b62744f39b517528dfb9"
+  integrity sha512-lhP/t0i8EwTmayHG4dqLXgU+uPVys4WD/qUNvC+HfB1S1dyqULm5Yx9uKc1x79aP66U1Cb4OZeW8QU/RA9A4XA==
+
+"@octokit/oauth-methods@^1.1.0":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@octokit/oauth-methods/-/oauth-methods-1.2.6.tgz#b9ac65e374b2cc55ee9dd8dcdd16558550438ea7"
+  integrity sha512-nImHQoOtKnSNn05uk2o76om1tJWiAo4lOu2xMAHYsNr0fwopP+Dv+2MlGvaMMlFjoqVd3fF3X5ZDTKCsqgmUaQ==
+  dependencies:
+    "@octokit/oauth-authorization-url" "^4.3.1"
+    "@octokit/request" "^5.4.14"
+    "@octokit/request-error" "^2.0.5"
+    "@octokit/types" "^6.12.2"
+    btoa-lite "^1.0.0"
+
+"@octokit/openapi-types@^11.2.0":
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-11.2.0.tgz#b38d7fc3736d52a1e96b230c1ccd4a58a2f400a6"
+  integrity sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==
+
+"@octokit/plugin-paginate-rest@^2.16.8":
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz#32e9c7cab2a374421d3d0de239102287d791bce7"
+  integrity sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==
+  dependencies:
+    "@octokit/types" "^6.34.0"
+
+"@octokit/plugin-request-log@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz#5e50ed7083a613816b1e4a28aeec5fb7f1462e85"
+  integrity sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==
+
+"@octokit/plugin-rest-endpoint-methods@^5.12.0":
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz#8c46109021a3412233f6f50d28786f8e552427ba"
+  integrity sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==
+  dependencies:
+    "@octokit/types" "^6.34.0"
+    deprecation "^2.3.1"
+
+"@octokit/plugin-retry@^3.0.9":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-retry/-/plugin-retry-3.0.9.tgz#ae625cca1e42b0253049102acd71c1d5134788fe"
+  integrity sha512-r+fArdP5+TG6l1Rv/C9hVoty6tldw6cE2pRHNGmFPdyfrc696R6JjrQ3d7HdVqGwuzfyrcaLAKD7K8TX8aehUQ==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    bottleneck "^2.15.3"
+
+"@octokit/request-error@^2.0.5", "@octokit/request-error@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
+  integrity sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
+"@octokit/request@^5.3.0", "@octokit/request@^5.4.14", "@octokit/request@^5.6.0":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.2.tgz#1aa74d5da7b9e04ac60ef232edd9a7438dcf32d8"
+  integrity sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==
+  dependencies:
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.1.0"
+    "@octokit/types" "^6.16.1"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.1"
+    universal-user-agent "^6.0.0"
+
+"@octokit/rest@^18.12.0":
+  version "18.12.0"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.12.0.tgz#f06bc4952fc87130308d810ca9d00e79f6988881"
+  integrity sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==
+  dependencies:
+    "@octokit/core" "^3.5.1"
+    "@octokit/plugin-paginate-rest" "^2.16.8"
+    "@octokit/plugin-request-log" "^1.0.4"
+    "@octokit/plugin-rest-endpoint-methods" "^5.12.0"
+
+"@octokit/types@^6.0.3", "@octokit/types@^6.10.0", "@octokit/types@^6.12.2", "@octokit/types@^6.16.1", "@octokit/types@^6.34.0":
+  version "6.34.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.34.0.tgz#c6021333334d1ecfb5d370a8798162ddf1ae8218"
+  integrity sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==
+  dependencies:
+    "@octokit/openapi-types" "^11.2.0"
+
 "@polka/url@^1.0.0-next.20":
   version "1.0.0-next.21"
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
@@ -1772,6 +1957,16 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/docusaurus/-/docusaurus-1.0.4.tgz#fc40f87a672568678d83533dd4031a09d75877ca"
   integrity sha512-I6sziQAzLrrqj9r6S26c7aOAjfGVXIE7gWdNONPwnpDcHiMRMQut1s1YCi/APem3dOy23tAb2rvHfNtGCaWuUQ==
 
+"@types/btoa-lite@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/btoa-lite/-/btoa-lite-1.0.0.tgz#e190a5a548e0b348adb0df9ac7fa5f1151c7cca4"
+  integrity sha512-wJsiX1tosQ+J5+bY5LrSahHxr2wT+uME5UDwdN1kg4frt40euqA+wzECkmq4t5QbveHiJepfdThgQrPw6KiSlg==
+
+"@types/config@^0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/config/-/config-0.0.39.tgz#aad18ceb9439329adc3d4c6b91a908a72c715612"
+  integrity sha512-EBHj9lSIyw62vwqCwkeJXjiV6C2m2o+RJZlRWLkHduGYiNBoMXcY6AhSLqjQQ+uPdrPYrOMYvVa41zjo00LbFQ==
+
 "@types/eslint-scope@^3.7.0":
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.1.tgz#8dc390a7b4f9dd9f1284629efce982e41612116e"
@@ -1827,6 +2022,18 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
+"@types/jsonwebtoken@^8.3.3":
+  version "8.5.6"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.5.6.tgz#1913e5a61e70a192c5a444623da4901a7b1a9d42"
+  integrity sha512-+P3O/xC7nzVizIi5VbF34YtqSonFsdnbXBnWUCYRiKOi1f9gA4sEFvXkrGr/QVV23IbMYvcoerI7nnhDUiWXRQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/lru-cache@^5.1.0":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.1.tgz#c48c2e27b65d2a153b19bfc1a317e30872e01eef"
+  integrity sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==
+
 "@types/mdast@^3.0.0":
   version "3.0.10"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.10.tgz#4724244a82a4598884cbbe9bcfd73dff927ee8af"
@@ -1843,6 +2050,11 @@
   version "15.14.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.14.9.tgz#bc43c990c3c9be7281868bbc7b8fdd6e2b57adfa"
   integrity sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==
+
+"@types/node@^16.11.7":
+  version "16.11.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.11.tgz#6ea7342dfb379ea1210835bada87b3c512120234"
+  integrity sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -1922,6 +2134,11 @@
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
+
+"@types/spark-md5@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/spark-md5/-/spark-md5-3.0.2.tgz#da2e8a778a20335fc4f40b6471c4b0d86b70da55"
+  integrity sha512-82E/lVRaqelV9qmRzzJ1PKTpyrpnT7mwdneKNJB9hUtypZDMggloDfFUCIqRRx3lYRxteCwXSq9c+W71Vf0QnQ==
 
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2", "@types/unist@^2.0.3":
   version "2.0.6"
@@ -2059,6 +2276,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+abbrev@1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -2096,6 +2318,11 @@ acorn@^8.0.4, acorn@^8.4.1:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
   integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
+
+add@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/add/-/add-2.0.6.tgz#248f0a9f6e5a528ef2295dbeec30532130ae2235"
+  integrity sha1-JI8Kn25aUo7yKV2+7DBTITCuIjU=
 
 address@^1.0.1, address@^1.1.2:
   version "1.1.2"
@@ -2252,6 +2479,11 @@ async@^2.6.2:
   dependencies:
     lodash "^4.17.14"
 
+async@^3.1.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.2.tgz#2eb7671034bb2194d45d30e31e24ec7e7f9670cd"
+  integrity sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==
+
 at-least-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
@@ -2359,6 +2591,11 @@ batch@0.6.1:
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
   integrity sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=
 
+before-after-hook@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.2.tgz#a6e8ca41028d90ee2c24222f201c90956091613e"
+  integrity sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -2406,6 +2643,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
+bottleneck@^2.15.3:
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
 
 boxen@^5.0.0, boxen@^5.0.1:
   version "5.1.2"
@@ -2458,6 +2700,11 @@ browserslist@^4.16.5:
     node-releases "^2.0.1"
     picocolors "^1.0.0"
 
+btoa-lite@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
+  integrity sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
+
 buble-jsx-only@^0.19.8:
   version "0.19.8"
   resolved "https://registry.yarnpkg.com/buble-jsx-only/-/buble-jsx-only-0.19.8.tgz#6e3524aa0f1c523de32496ac9aceb9cc2b493867"
@@ -2470,6 +2717,11 @@ buble-jsx-only@^0.19.8:
     magic-string "^0.25.3"
     minimist "^1.2.0"
     regexpu-core "^4.5.4"
+
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
 
 buffer-from@^1.0.0:
   version "1.1.2"
@@ -2696,7 +2948,7 @@ collapse-white-space@^1.0.2:
   resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.6.tgz#e63629c0016665792060dbbeb79c42239d2c5287"
   integrity sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -2715,10 +2967,26 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.6.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.8.1.tgz#d1aac7fab890df2b54c8012ca939c0a1129c370e"
+  integrity sha512-AGfGNQbnXlYqPStIx3QB2XA3Wy8vjbreqklmCiGVwcoHSLN5KIpDZDflYnXlBliKHI8CTBX3PsCgG+xfZgqK8A==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@^3.1.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+  dependencies:
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
 
 colord@^2.0.1, colord@^2.6:
   version "2.9.1"
@@ -2729,6 +2997,19 @@ colorette@^2.0.10:
   version "2.0.16"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
   integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
+
+colors@^1.2.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
+colorspace@1.1.x:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.4.tgz#8d442d1186152f60453bf8070cd66eb364e59243"
+  integrity sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==
+  dependencies:
+    color "^3.1.3"
+    text-hex "1.0.x"
 
 combine-promises@^1.1.0:
   version "1.1.0"
@@ -2789,6 +3070,13 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+config@^3.3.6:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/config/-/config-3.3.6.tgz#b87799db7399cc34988f55379b5f43465b1b065c"
+  integrity sha512-Hj5916C5HFawjYJat1epbyY2PlAgLpBtDUlr0MxGLgo3p5+7kylyvnRY18PqJHgnNWXcdd0eWDemT7eYWuFgwg==
+  dependencies:
+    json5 "^2.1.1"
 
 configstore@^5.0.1:
   version "5.0.1"
@@ -3124,7 +3412,7 @@ debug@2.6.9, debug@^2.6.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.1:
+debug@^3.1.1, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -3210,6 +3498,11 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+deprecation@^2.0.0, deprecation@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
+  integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
+
 destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
@@ -3269,6 +3562,29 @@ dns-txt@^2.0.2:
   integrity sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=
   dependencies:
     buffer-indexof "^1.0.0"
+
+"docs-sourcer@git+https://github.com/gruntwork-io/docs-sourcer.git#initial-skeleton":
+  version "0.0.1"
+  resolved "git+https://github.com/gruntwork-io/docs-sourcer.git#c22f2ed3c8ab16e6d98219d0605e13b3e2cfad79"
+  dependencies:
+    "@octokit/auth-app" "^3.6.1"
+    "@octokit/plugin-retry" "^3.0.9"
+    "@octokit/rest" "^18.12.0"
+    "@types/config" "^0.0.39"
+    "@types/node" "^16.11.7"
+    "@types/spark-md5" "^3.0.2"
+    add "^2.0.6"
+    config "^3.3.6"
+    dotenv "^10.0.0"
+    file-loader "^6.2.0"
+    fs "^0.0.1-security"
+    lodash "^4.17.21"
+    node-html-markdown "^1.1.3"
+    querystring "^0.2.1"
+    spark-md5 "^3.0.2"
+    unescape "^1.0.1"
+    url-loader "^4.1.1"
+    winston "^3.3.3"
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -3366,6 +3682,11 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
+  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -3375,6 +3696,13 @@ duplexer@^0.1.1, duplexer@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -3405,6 +3733,11 @@ emoticon@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/emoticon/-/emoticon-3.2.0.tgz#c008ca7d7620fac742fe1bf4af8ff8fed154ae7f"
   integrity sha512-SNujglcLTTg+lDAcApPNgEdudaqQFiAbJCqzjNxJkvN9vAwCGi0uu8IUVvx+f16h+V44KCY6Y2yboroc9pilHg==
+
+enabled@2.0.x:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
+  integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -3710,6 +4043,11 @@ fbjs@^3.0.0:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.30"
 
+fecha@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.1.tgz#0a83ad8f86ef62a091e22bb5a039cd03d23eecce"
+  integrity sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==
+
 feed@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/feed/-/feed-4.2.2.tgz#865783ef6ed12579e2c44bbef3c9113bc4956a7e"
@@ -3797,6 +4135,11 @@ flux@^4.0.1:
     fbemitter "^3.0.0"
     fbjs "^3.0.0"
 
+fn.name@1.x.x:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
+  integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
+
 follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   version "1.14.4"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
@@ -3864,6 +4207,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+
+fs@^0.0.1-security:
+  version "0.0.1-security"
+  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
+  integrity sha1-invTcYa23d84E/I4WLV+yq9eQdQ=
 
 fsevents@~2.3.2:
   version "2.3.2"
@@ -4177,7 +4525,7 @@ hastscript@^6.0.0:
     property-information "^5.0.0"
     space-separated-tokens "^1.0.0"
 
-he@^1.2.0:
+he@1.2.0, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -4356,6 +4704,11 @@ icss-utils@^5.0.0, icss-utils@^5.1.0:
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
+ignore-by-default@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
+  integrity sha1-SMptcvbGo68Aqa1K5odr44ieKwk=
+
 ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
@@ -4501,6 +4854,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-bigint@^1.0.1:
   version "1.0.4"
@@ -4665,6 +5023,11 @@ is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
+
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-regex@^1.0.4, is-regex@^1.1.4:
   version "1.1.4"
@@ -4844,7 +5207,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.2:
+json5@^2.1.1, json5@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
@@ -4859,6 +5222,39 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 keyv@^3.0.0:
   version "3.1.0"
@@ -4881,6 +5277,11 @@ klona@^2.0.4:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.5.tgz#d166574d90076395d9963aa7a928fabb8d76afbc"
   integrity sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==
+
+kuler@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
+  integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
 
 latest-version@^5.1.0:
   version "5.1.0"
@@ -4994,6 +5395,36 @@ lodash.foreach@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
   integrity sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
 lodash.map@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
@@ -5008,6 +5439,11 @@ lodash.merge@^4.4.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
 lodash.pick@^4.2.1:
   version "4.4.0"
@@ -5038,6 +5474,17 @@ lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+logform@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.3.0.tgz#a3997a05985de2ebd325ae0d166dffc9c6fe6b57"
+  integrity sha512-graeoWUH2knKbGthMtuG1EfaSPMZFZBIrhuJHhkS5ZseFBrc7DupCzihOQAzsK/qIKPQaPJ/lFQFctILUY5ARQ==
+  dependencies:
+    colors "^1.2.1"
+    fecha "^4.2.0"
+    ms "^2.1.1"
+    safe-stable-stringify "^1.1.0"
+    triple-beam "^1.3.0"
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
@@ -5357,15 +5804,60 @@ node-fetch@2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
+node-fetch@^2.6.1:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
+  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
+node-html-markdown@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/node-html-markdown/-/node-html-markdown-1.1.3.tgz#355e09b1d2624755a258404cb17219d49e6dd18d"
+  integrity sha512-iB5Nb8eQjeKHr1k9ot0FkVo5uah6IvYzSbOiNPbmtMt8OWf8os9TCsGEg1Xf51xwYLW461AvKl74HVjiMxvblg==
+  dependencies:
+    node-html-parser "^4.1.5"
+
+node-html-parser@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-4.1.5.tgz#e3ff5b39a098e70de3629c9c79c4e29a3fa5f062"
+  integrity sha512-NLgqUXtftqnBqIjlRjYSaApaqE7TTxfTiH4VqKCjdUJKFOtUzRwney83EHz2qYc0XoxXAkYdmLjENCuZHvsIFg==
+  dependencies:
+    css-select "^4.1.3"
+    he "1.2.0"
+
 node-releases@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
   integrity sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
+
+nodemon@^2.0.15:
+  version "2.0.15"
+  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-2.0.15.tgz#504516ce3b43d9dc9a955ccd9ec57550a31a8d4e"
+  integrity sha512-gdHMNx47Gw7b3kWxJV64NI+Q5nfl0y5DgDbiVtShiwa7Z0IZ07Ll4RLFo6AjrhzMtoEZn5PDE3/c2AbVsiCkpA==
+  dependencies:
+    chokidar "^3.5.2"
+    debug "^3.2.7"
+    ignore-by-default "^1.0.1"
+    minimatch "^3.0.4"
+    pstree.remy "^1.1.8"
+    semver "^5.7.1"
+    supports-color "^5.5.0"
+    touch "^3.1.0"
+    undefsafe "^2.0.5"
+    update-notifier "^5.1.0"
+
+nopt@~1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  integrity sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=
+  dependencies:
+    abbrev "1"
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
@@ -5487,6 +5979,13 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
+
+one-time@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45"
+  integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
+  dependencies:
+    fn.name "1.x.x"
 
 onetime@^5.1.2:
   version "5.1.2"
@@ -6145,6 +6644,11 @@ proxy-addr@~2.0.5:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
+pstree.remy@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.8.tgz#c242224f4a67c21f686839bbdb4ac282b8373d3a"
+  integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
+
 pump@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
@@ -6194,6 +6698,11 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+
+querystring@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.1.tgz#40d77615bb09d16902a85c3e38aa8b5ed761c2dd"
+  integrity sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -6404,7 +6913,7 @@ react@^17.0.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-readable-stream@^2.0.1:
+readable-stream@^2.0.1, readable-stream@^2.3.7:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -6417,7 +6926,7 @@ readable-stream@^2.0.1:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.6, readable-stream@^3.1.1:
+readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -6724,6 +7233,11 @@ safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
+safe-stable-stringify@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz#c8a220ab525cd94e60ebf47ddc404d610dc5d84a"
+  integrity sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw==
+
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
@@ -6801,7 +7315,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^5.4.1:
+semver@^5.4.1, semver@^5.6.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -6943,6 +7457,13 @@ signal-exit@^3.0.2, signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.5.tgz#9e3e8cc0c75a99472b44321033a7702e7738252f"
   integrity sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==
 
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
+  dependencies:
+    is-arrayish "^0.3.1"
+
 sirv@^1.0.7:
   version "1.0.18"
   resolved "https://registry.yarnpkg.com/sirv/-/sirv-1.0.18.tgz#105fab52fb656ce8a2bebbf36b11052005952899"
@@ -7029,6 +7550,11 @@ space-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
   integrity sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==
 
+spark-md5@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
+  integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==
+
 spdy-transport@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/spdy-transport/-/spdy-transport-3.0.0.tgz#00d4863a6400ad75df93361a1608605e5dcdcf31"
@@ -7061,6 +7587,11 @@ stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
+
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
 state-toggle@^1.0.0:
   version "1.0.3"
@@ -7176,7 +7707,7 @@ stylehacks@^5.0.1:
     browserslist "^4.16.0"
     postcss-selector-parser "^6.0.4"
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -7265,6 +7796,11 @@ terser@^5.7.2:
     source-map "~0.7.2"
     source-map-support "~0.5.20"
 
+text-hex@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
+  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -7317,6 +7853,18 @@ totalist@^1.0.0:
   resolved "https://registry.yarnpkg.com/totalist/-/totalist-1.1.0.tgz#a4d65a3e546517701e3e5c37a47a70ac97fe56df"
   integrity sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==
 
+touch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.0.tgz#fe365f5f75ec9ed4e56825e0bb76d24ab74af83b"
+  integrity sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==
+  dependencies:
+    nopt "~1.0.10"
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 trim-trailing-lines@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
@@ -7326,6 +7874,11 @@ trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
   integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+
+triple-beam@^1.2.0, triple-beam@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
+  integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
 trough@^1.0.0:
   version "1.0.5"
@@ -7391,6 +7944,18 @@ unbox-primitive@^1.0.1:
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
+
+undefsafe@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
+  integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
+
+unescape@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unescape/-/unescape-1.0.1.tgz#956e430f61cad8a4d57d82c518f5e6cc5d0dda96"
+  integrity sha512-O0+af1Gs50lyH1nUu3ZyYS1cRh01Q/kUKatTOkSs7jukXE6/NebucDVxyiDsA9AQ4JC1V1jUH9EO8JX2nMDgGQ==
+  dependencies:
+    extend-shallow "^2.0.1"
 
 unherit@^1.0.4:
   version "1.1.3"
@@ -7522,6 +8087,19 @@ unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.1, unist-
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
+
+universal-github-app-jwt@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/universal-github-app-jwt/-/universal-github-app-jwt-1.1.0.tgz#0abaa876101cdf1d3e4c546be2768841c0c1b514"
+  integrity sha512-3b+ocAjjz4JTyqaOT+NNBd5BtTuvJTxWElIoeHSVelUV9J3Jp7avmQTdLKCaoqi/5Ox2o/q+VK19TJ233rVXVQ==
+  dependencies:
+    "@types/jsonwebtoken" "^8.3.3"
+    jsonwebtoken "^8.5.1"
+
+universal-user-agent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
+  integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
 
 universalify@^2.0.0:
   version "2.0.0"
@@ -7712,6 +8290,11 @@ web-namespaces@^1.0.0, web-namespaces@^1.1.2:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webpack-bundle-analyzer@^4.4.2:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.5.0.tgz#1b0eea2947e73528754a6f9af3e91b2b6e0f79d5"
@@ -7848,6 +8431,14 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
+
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
@@ -7884,6 +8475,29 @@ wildcard@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
   integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
+
+winston-transport@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.4.0.tgz#17af518daa690d5b2ecccaa7acf7b20ca7925e59"
+  integrity sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==
+  dependencies:
+    readable-stream "^2.3.7"
+    triple-beam "^1.2.0"
+
+winston@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.3.3.tgz#ae6172042cafb29786afa3d09c8ff833ab7c9170"
+  integrity sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==
+  dependencies:
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.1.0"
+    is-stream "^2.0.0"
+    logform "^2.2.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.4.0"
 
 wrap-ansi@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
This PR adds a new `_docs-sources/` folder that contains the _true_ markdown source files which comprise the manually written content of the docs site.

Content creators can now add content into the `_docs-sources/` folder. Internally this folder has the same structure as will be outputted into the top level `docs/` folder. All source files will be subject to pre-processing by being put through the `docs-sourcer`. 