### PR TITLE
[APT-1593] Add syntax highlighting for hcl

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,7 +14,9 @@ const config = {
   organizationName: "gruntwork-io", // Usually your GitHub org/user name.
   projectName: "docs", // Usually your repo name.,
 
-  stylesheets: ["https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600;1,700&display=swap"],
+  stylesheets: [
+    "https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600;1,700&display=swap",
+  ],
 
   presets: [
     [
@@ -177,6 +179,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ["hcl"],
       },
       zoomSelector: ".markdown img",
     }),


### PR DESCRIPTION
[APT-1593]

#### Before
<img width="987" alt="Screen Shot 2021-12-06 at 12 31 37 PM" src="https://user-images.githubusercontent.com/21035422/144911844-6df932b5-ce5c-4eee-a67c-f874b7d841e1.png">


#### After
<img width="992" alt="Screen Shot 2021-12-06 at 12 31 08 PM" src="https://user-images.githubusercontent.com/21035422/144911878-4470d1d9-9808-4ee3-8eee-cb32eceee1e7.png">


[APT-1593]: https://gruntwork.atlassian.net/browse/APT-1593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ