### PR TITLE
Use cards in the home page layout

### DIFF
--- a/src/components/Grid.module.css
+++ b/src/components/Grid.module.css
@@ -3,6 +3,41 @@
   grid-template-columns: repeat(3, 1fr);
   grid-column-gap: 1rem;
   grid-row-gap: 1rem;
-  /*grid-auto-rows: 1fr*/
-  /*grid-template-rows: auto;*/
+  margin: 3rem 0;
+}
+
+.grid + .grid {
+  margin-top: 0 !important;
+}
+
+.col1 {
+  grid-template-columns: repeat(1, 1fr);
+}
+
+.col2 {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.col3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.col4 {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.col5 {
+  grid-template-columns: repeat(5, 1fr);
+}
+
+@media only screen and (max-width: 1280px) {
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media only screen and (max-width: 640px) {
+  .grid {
+    grid-template-columns: repeat(1, 1fr);
+  }
 }

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -1,28 +1,52 @@
-import React from 'react';
-import styles from './Grid.module.css';
+import React from "react"
+import clsx from "clsx"
+import styles from "./Grid.module.css"
 
 type GridProps = {
-  cols?: number;
-  colGap?: number | string;
-  rowGap?: number | string;
-  equalHeight?: boolean;
-  children?: JSX.Element;
-};
+  cols?: number
+  gap?: number | string
+  colGap?: number | string
+  rowGap?: number | string
+  equalHeightRows?: boolean
+  stacked?: boolean
+  children?: JSX.Element | JSX.Element[]
+}
 
 export default function Grid({
-  cols=3,
-  colGap="1rem",
-  rowGap="1rem",
-  equalHeight=true,
-  children
+  cols = 3,
+  gap = "1rem",
+  colGap,
+  rowGap,
+  equalHeightRows = true,
+  stacked = false,
+  children,
 }: GridProps): JSX.Element {
+  const classes = clsx(
+    styles.grid,
+    cols == 1 && styles.col1,
+    cols == 2 && styles.col2,
+    cols == 3 && styles.col3,
+    cols == 4 && styles.col4,
+    cols == 5 && styles.col5
+  )
+
+  colGap = colGap || gap
+  rowGap = rowGap || gap
+
   return (
-    <section className={styles.grid} style={{
-      gridTemplateColumns: `repeat(${cols}, 1fr)`,
-      gridColumnGap: Number.isInteger(colGap) ? `${colGap}px` : colGap,
-      gridRowGap: Number.isInteger(rowGap) ? `${rowGap}px` : rowGap,
-      gridAutoRows: equalHeight ? "1fr" : "inherit"
-    }}>
+    <section
+      className={classes}
+      style={{
+        gridColumnGap: Number.isInteger(colGap) ? `${colGap}px` : colGap,
+        gridRowGap: Number.isInteger(rowGap) ? `${rowGap}px` : rowGap,
+        gridAutoRows: equalHeightRows ? "1fr" : "inherit",
+        margin: stacked
+          ? Number.isInteger(rowGap)
+            ? `${rowGap}px 0`
+            : `${rowGap} 0`
+          : "3rem 0",
+      }}
+    >
       {children}
     </section>
   )

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -21,3 +21,7 @@
   align-items: center;
   justify-content: center;
 }
+
+.features {
+  margin: 3rem 0;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,7 +31,7 @@ export default function Home(): JSX.Element {
   const { siteConfig } = useDocusaurusContext()
   return (
     <Layout
-      title={`Hello from ${siteConfig.title}`}
+      title={`Gruntwork Docs`}
       description="Documentation and guides for Gruntwork's tools and services"
     >
       <HomepageHeader />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,40 +1,90 @@
-import React from 'react';
-import clsx from 'clsx';
-import Layout from '@theme/Layout';
-import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import styles from './index.module.css';
-import HomepageFeatures from '../components/HomepageFeatures';
+import React from "react"
+import clsx from "clsx"
+import Layout from "@theme/Layout"
+import Link from "@docusaurus/Link"
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext"
+import styles from "./index.module.css"
+import Card from "../components/Card"
+import Grid from "../components/Grid"
 
 function HomepageHeader() {
-  const {siteConfig} = useDocusaurusContext();
+  const { siteConfig } = useDocusaurusContext()
   return (
-    <header className={clsx('hero hero--primary', styles.heroBanner)}>
+    <header className={clsx("hero hero--primary", styles.heroBanner)}>
       <div className="container">
         <h1 className="hero__title">{siteConfig.title}</h1>
         <p className="hero__subtitle">{siteConfig.tagline}</p>
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/intro/overview/world-class-devops">
+            to="/docs/intro/overview/world-class-devops"
+          >
             Get Started With the Gruntwork Tutorial
           </Link>
         </div>
       </div>
     </header>
-  );
+  )
 }
 
 export default function Home(): JSX.Element {
-  const {siteConfig} = useDocusaurusContext();
+  const { siteConfig } = useDocusaurusContext()
   return (
     <Layout
       title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />">
+      description="Description will go into a meta tag in <head />"
+    >
       <HomepageHeader />
       <main>
-        <HomepageFeatures />
+        <section className={styles.features}>
+          <div className="container">
+            <div className="row">
+              <Grid cols={3} gap="2rem">
+                <Card
+                  title="Set Up Your Accounts"
+                  href="/docs/guides/build-it-yourself/landing-zone"
+                >
+                  Streamline how you create, configure, and secure AWS accounts
+                  and multi-account structures.
+                </Card>
+                <Card
+                  title="Configure a CI/CD Pipeline"
+                  href="/docs/guides/build-it-yourself/pipelines"
+                >
+                  Use your preferred CI tool to set up an end‑to‑end pipeline
+                  for your infrastructure code.
+                </Card>
+                <Card
+                  title="Achieve Compliance"
+                  href="/docs/guides/build-it-yourself/compliance"
+                >
+                  Implement the CIS AWS Foundations Benchmark using our curated
+                  collection of modules and services.
+                </Card>
+                <Card
+                  title="The Reference Architecture"
+                  href="/docs/guides/reference-architecture/overview/overview"
+                >
+                  Bootstrap your infrastructure in about a day by letting
+                  Gruntwork deploy a Reference Architecture customized just for
+                  you.
+                </Card>
+                <Card
+                  title="Deploy a Service"
+                  href="/docs/guides/build-it-yourself/overview"
+                >
+                  Learn how to deploy Gruntwork services to construct your own
+                  bespoke architecture.
+                </Card>
+                <Card title="Courses" href="/courses">
+                  Learn DevOps fundamentals with our series of introductory
+                  video tutorials.
+                </Card>
+              </Grid>
+            </div>
+          </div>
+        </section>
       </main>
     </Layout>
-  );
+  )
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -32,7 +32,7 @@ export default function Home(): JSX.Element {
   return (
     <Layout
       title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />"
+      description="Documentation and guides for Gruntwork's tools and services"
     >
       <HomepageHeader />
       <main>


### PR DESCRIPTION
In addition to adding cards to the home page, this adds some addition features to our `Grid` component:
- Responsive
- Option to stack multiple grids together (with different column widths)
- Better support for equal height rows
- Shorthand `gap` property for equal row and column gaps