### PR TITLE
Responsive fixes for home page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -63,7 +63,7 @@ const config = {
           {
             type: "doc",
             position: "left",
-            label: "Service Catalog API",
+            label: "Service Catalog API",
             docId: "reference/services/intro",
           },
           { to: "/courses", label: "Courses", position: "left" },

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -51,7 +51,7 @@ html[data-theme="dark"] {
   --ifm-menu-color-background-active: rgba(255, 255, 255, 0.05);
   --ifm-heading-color: white;
 
-  --ifm-color-primary: #AB80FE;
+  --ifm-color-primary: #ab80fe;
 }
 
 .docusaurus-highlight-code-line {
@@ -73,28 +73,29 @@ main {
 
 .hero--primary .button--lg {
   --ifm-button-size-multiplier: 1.5;
-  --ifm-button-background-color: #5849A6;
+  --ifm-button-background-color: #5849a6;
   border: none;
   /*background-color: #5849A6 !important;*/
   color: white !important;
   font-weight: 600;
   margin-top: 2rem;
-  box-shadow: 0 0 0 rgba(0,0,0,0);
+  box-shadow: 0 0 0 rgba(0, 0, 0, 0);
   transition: all 0.2s ease-in-out;
 }
 
 .hero--primary .button--lg:hover {
   /*background-color: #5849A6 !important;*/
   --ifm-button-background-color: var(--ifm-color-primary);
-  box-shadow: 0 10px 10px rgba(0,0,0,0.25);
+  box-shadow: 0 10px 10px rgba(0, 0, 0, 0.25);
 }
 
 .hero--primary {
   background-color: #252746;
 }
 
-.hero__title, .hero__subtitle {
-  color:  white;
+.hero__title,
+.hero__subtitle {
+  color: white;
 }
 
 /* NAVBAR + LOGO */
@@ -106,6 +107,12 @@ main {
   display: grid;
   align-items: center;
   justify-items: center;
+}
+
+@media only screen and (max-width: 996px) {
+  .navbar__brand {
+    border-right: none;
+  }
 }
 
 .navbar__logo {
@@ -262,4 +269,12 @@ html[data-theme="dark"] .menu__link--sublist {
 
 .snap-top {
   scroll-margin-top: 140px;
+}
+
+/* MOBILE */
+
+@media only screen and (max-width: 480px) {
+  .hideOnMobile {
+    display: none;
+  }
 }

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -23,5 +23,5 @@
 }
 
 .features {
-  margin: 3rem 0;
+  margin: 3rem 1rem;
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,14 +12,15 @@ function HomepageHeader() {
   return (
     <header className={clsx("hero hero--primary", styles.heroBanner)}>
       <div className="container">
-        <h1 className="hero__title">{siteConfig.title}</h1>
+        <h1 className="hero__title hideOnMobile">{siteConfig.title}</h1>
         <p className="hero__subtitle">{siteConfig.tagline}</p>
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
             to="/docs/intro/overview/world-class-devops"
           >
-            Get Started With the Gruntwork Tutorial
+            Get Started{" "}
+            <span className="hideOnMobile">With the Gruntwork Tutorial</span>
           </Link>
         </div>
       </div>


### PR DESCRIPTION
This tweaks the home page layout for better mobile support, including:

- Shorten tutorial button text to fit
- Hide the "Gruntwork Docs" header, which wraps and is redundant with logo
- Add some margin to the cards section
- Prevent the nav bar items from word-wrapping