### PR TITLE
Mention tgswitch in recommended_tools.md

### DIFF
--- a/_docs-sources/intro/environment-setup/recommended_tools.md
+++ b/_docs-sources/intro/environment-setup/recommended_tools.md
@@ -10,7 +10,7 @@
 * [Terragrunt](https://terragrunt.gruntwork.io/docs/getting-started/install/) – Terragrunt is our layer on top of Terraform to enable a highly DRY code base.
 * [Terratest](https://github.com/gruntwork-io/terratest) – If you want to test your infrastructure, Terratest enables you to write those tests for manual testing or integration with a CI/CD pipeline.
 * [tfenv](https://github.com/tfutils/tfenv#installation) – `tfenv` is a set of bash scripts that provide a workflow for managing and using multiple versions of Terraform. It was inspired by similar tools `rbenv` for Ruby versions and `pyenv` for Python.
-* [tgswitch](https://github.com/warrensbox/tgswitch) – `tgswitch` is a tool for managing and using multiple versions of Terragrunt. Written in golang, it offers similar features as `tfenv`, including managing the versions to use in a version file.
+* [tgswitch](https://github.com/warrensbox/tgswitch#installation) – `tgswitch` is a tool for managing and using multiple versions of Terragrunt. Written in golang, it offers similar features as `tfenv`, including managing the versions to use in a version file.
 
 ## Installation
 

--- a/_docs-sources/intro/environment-setup/recommended_tools.md
+++ b/_docs-sources/intro/environment-setup/recommended_tools.md
@@ -10,7 +10,7 @@
 * [Terragrunt](https://terragrunt.gruntwork.io/docs/getting-started/install/) – Terragrunt is our layer on top of Terraform to enable a highly DRY code base.
 * [Terratest](https://github.com/gruntwork-io/terratest) – If you want to test your infrastructure, Terratest enables you to write those tests for manual testing or integration with a CI/CD pipeline.
 * [tfenv](https://github.com/tfutils/tfenv#installation) – `tfenv` is a set of bash scripts that provide a workflow for managing and using multiple versions of Terraform. It was inspired by similar tools `rbenv` for Ruby versions and `pyenv` for Python.
-* [tgswitch](https://github.com/warrensbox/tgswitch) – `tgswitch` is a tool for versioning Terragrunt written in golang that offers similar features as `tfenv`, including managing the versions to use in a version file.
+* [tgswitch](https://github.com/warrensbox/tgswitch) – `tgswitch` is a tool for managing and using multiple versions of Terragrunt. Written in golang, it offers similar features as `tfenv`, including managing the versions to use in a version file.
 
 ## Installation
 

--- a/_docs-sources/intro/environment-setup/recommended_tools.md
+++ b/_docs-sources/intro/environment-setup/recommended_tools.md
@@ -9,7 +9,7 @@
 * [Terraform](https://www.terraform.io/downloads) – Terraform's declarative nature describes your infrastructure as code. If you're using Gruntwork's products, you're using Terraform.
 * [Terragrunt](https://terragrunt.gruntwork.io/docs/getting-started/install/) – Terragrunt is our layer on top of Terraform to enable a highly DRY code base.
 * [Terratest](https://github.com/gruntwork-io/terratest) – If you want to test your infrastructure, Terratest enables you to write those tests for manual testing or integration with a CI/CD pipeline.
-* [tfenv](https://github.com/tfutils/tfenv#installation) – `tfenv` was inspired by a similar tool `rbenv` for Ruby versions. The tool is a set of bash scripts that provide a workflow for managing and using multiple versions of Terraform.
+* [tfenv](https://github.com/tfutils/tfenv#installation) – `tfenv` is a set of bash scripts that provide a workflow for managing and using multiple versions of Terraform. It was inspired by similar tools `rbenv` for Ruby versions and `pyenv` for Python.
 * [tgswitch](https://github.com/warrensbox/tgswitch) – `tgswitch` is a tool for versioning Terragrunt written in golang that offers similar features as `tfenv`, including managing the versions to use in a version file.
 
 ## Installation

--- a/_docs-sources/intro/environment-setup/recommended_tools.md
+++ b/_docs-sources/intro/environment-setup/recommended_tools.md
@@ -9,8 +9,9 @@
 * [Terraform](https://www.terraform.io/downloads) – Terraform's declarative nature describes your infrastructure as code. If you're using Gruntwork's products, you're using Terraform.
 * [Terragrunt](https://terragrunt.gruntwork.io/docs/getting-started/install/) – Terragrunt is our layer on top of Terraform to enable a highly DRY code base.
 * [Terratest](https://github.com/gruntwork-io/terratest) – If you want to test your infrastructure, Terratest enables you to write those tests for manual testing or integration with a CI/CD pipeline.
-* [tfenv](https://github.com/tfutils/tfenv#installation) – `tfenv` is a version manager for Terraform, similar to `pyenv` for Python.
-* [tgenv](https://gitlab.com/claudiuskastner/tgenv) – `tgenv` is a version manager for Terragrunt
+* [tfenv](https://github.com/tfutils/tfenv#installation) – `tfenv` was inspired by a similar tool `rbenv` for Ruby versions. The tool is a set of bash scripts that provide a workflow for managing and using multiple versions of Terraform.
+* [tgswitch](https://github.com/warrensbox/tgswitch) – `tgswitch` is a tool for versioning Terragrunt written in golang that offers similar features as `tfenv`, including managing the versions to use in a version file.
+
 ## Installation
 
 If you would like to run the tools natively on your computer, the links provided above give installation instructions. If you are a user of [brew](https://brew.sh/), then in many cases, a `brew install <TOOL>` will work.

--- a/docs/intro/environment-setup/recommended_tools.md
+++ b/docs/intro/environment-setup/recommended_tools.md
@@ -10,7 +10,7 @@
 * [Terragrunt](https://terragrunt.gruntwork.io/docs/getting-started/install/) – Terragrunt is our layer on top of Terraform to enable a highly DRY code base.
 * [Terratest](https://github.com/gruntwork-io/terratest) – If you want to test your infrastructure, Terratest enables you to write those tests for manual testing or integration with a CI/CD pipeline.
 * [tfenv](https://github.com/tfutils/tfenv#installation) – `tfenv` is a set of bash scripts that provide a workflow for managing and using multiple versions of Terraform. It was inspired by similar tools `rbenv` for Ruby versions and `pyenv` for Python.
-* [tgswitch](https://github.com/warrensbox/tgswitch) – `tgswitch` is a tool for managing and using multiple versions of Terragrunt. Written in golang, it offers similar features as `tfenv`, including managing the versions to use in a version file.
+* [tgswitch](https://github.com/warrensbox/tgswitch#installation) – `tgswitch` is a tool for managing and using multiple versions of Terragrunt. Written in golang, it offers similar features as `tfenv`, including managing the versions to use in a version file.
 
 ## Installation
 

--- a/docs/intro/environment-setup/recommended_tools.md
+++ b/docs/intro/environment-setup/recommended_tools.md
@@ -10,7 +10,7 @@
 * [Terragrunt](https://terragrunt.gruntwork.io/docs/getting-started/install/) – Terragrunt is our layer on top of Terraform to enable a highly DRY code base.
 * [Terratest](https://github.com/gruntwork-io/terratest) – If you want to test your infrastructure, Terratest enables you to write those tests for manual testing or integration with a CI/CD pipeline.
 * [tfenv](https://github.com/tfutils/tfenv#installation) – `tfenv` is a set of bash scripts that provide a workflow for managing and using multiple versions of Terraform. It was inspired by similar tools `rbenv` for Ruby versions and `pyenv` for Python.
-* [tgswitch](https://github.com/warrensbox/tgswitch) – `tgswitch` is a tool for versioning Terragrunt written in golang that offers similar features as `tfenv`, including managing the versions to use in a version file.
+* [tgswitch](https://github.com/warrensbox/tgswitch) – `tgswitch` is a tool for managing and using multiple versions of Terragrunt. Written in golang, it offers similar features as `tfenv`, including managing the versions to use in a version file.
 
 ## Installation
 

--- a/docs/intro/environment-setup/recommended_tools.md
+++ b/docs/intro/environment-setup/recommended_tools.md
@@ -9,7 +9,7 @@
 * [Terraform](https://www.terraform.io/downloads) – Terraform's declarative nature describes your infrastructure as code. If you're using Gruntwork's products, you're using Terraform.
 * [Terragrunt](https://terragrunt.gruntwork.io/docs/getting-started/install/) – Terragrunt is our layer on top of Terraform to enable a highly DRY code base.
 * [Terratest](https://github.com/gruntwork-io/terratest) – If you want to test your infrastructure, Terratest enables you to write those tests for manual testing or integration with a CI/CD pipeline.
-* [tfenv](https://github.com/tfutils/tfenv#installation) – `tfenv` was inspired by a similar tool `rbenv` for Ruby versions. The tool is a set of bash scripts that provide a workflow for managing and using multiple versions of Terraform.
+* [tfenv](https://github.com/tfutils/tfenv#installation) – `tfenv` is a set of bash scripts that provide a workflow for managing and using multiple versions of Terraform. It was inspired by similar tools `rbenv` for Ruby versions and `pyenv` for Python.
 * [tgswitch](https://github.com/warrensbox/tgswitch) – `tgswitch` is a tool for versioning Terragrunt written in golang that offers similar features as `tfenv`, including managing the versions to use in a version file.
 
 ## Installation

--- a/docs/intro/environment-setup/recommended_tools.md
+++ b/docs/intro/environment-setup/recommended_tools.md
@@ -9,8 +9,9 @@
 * [Terraform](https://www.terraform.io/downloads) – Terraform's declarative nature describes your infrastructure as code. If you're using Gruntwork's products, you're using Terraform.
 * [Terragrunt](https://terragrunt.gruntwork.io/docs/getting-started/install/) – Terragrunt is our layer on top of Terraform to enable a highly DRY code base.
 * [Terratest](https://github.com/gruntwork-io/terratest) – If you want to test your infrastructure, Terratest enables you to write those tests for manual testing or integration with a CI/CD pipeline.
-* [tfenv](https://github.com/tfutils/tfenv#installation) – `tfenv` is a version manager for Terraform, similar to `pyenv` for Python.
-* [tgenv](https://gitlab.com/claudiuskastner/tgenv) – `tgenv` is a version manager for Terragrunt
+* [tfenv](https://github.com/tfutils/tfenv#installation) – `tfenv` was inspired by a similar tool `rbenv` for Ruby versions. The tool is a set of bash scripts that provide a workflow for managing and using multiple versions of Terraform.
+* [tgswitch](https://github.com/warrensbox/tgswitch) – `tgswitch` is a tool for versioning Terragrunt written in golang that offers similar features as `tfenv`, including managing the versions to use in a version file.
+
 ## Installation
 
 If you would like to run the tools natively on your computer, the links provided above give installation instructions. If you are a user of [brew](https://brew.sh/), then in many cases, a `brew install <TOOL>` will work.


### PR DESCRIPTION
- [x] Updated `tgenv` to `tgswitch` using the verbiage from https://blog.gruntwork.io/how-to-manage-multiple-versions-of-terragrunt-and-terraform-as-a-team-in-your-iac-project-da5b59209f2d. 
- [x] Updated description of `tfenv` based on this article, if that is okay. 
  - Taking a look at the sources for these tools, `pyenv` is partly written in `roff`, which is just for the manpages, I think. So maybe `tfenv` is actually inspired by both `rbenv` and `pyenv`, which are both mainly shell scripts.
- [x] Aimed to keep the em dashes. 