### PR TITLE
[APT-1692] Strip /docs/ prefix from all site URLs

### DIFF
--- a/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-root-to-root-account.md
+++ b/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-root-to-root-account.md
@@ -58,9 +58,9 @@ We’ll be using the `landingzone/account-baseline-root` module from [terraform-
 :::info
 
 This guide will use [Terragrunt](https://github.com/gruntwork-io/terragrunt) and its associated file and folder
-structure to deploy Terraform modules. Please note that **Terragrunt is NOT required for using Terraform modules from the Gruntwork Infrastructure as Code Library.** Check out our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork) section
+structure to deploy Terraform modules. Please note that **Terragrunt is NOT required for using Terraform modules from the Gruntwork Infrastructure as Code Library.** Check out our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork) section
 for instructions on alternative options, such as how to
-[deploying how to use plain terraform](/docs/intro/first-deployment/deploy#deploy-using-plain-terraform).
+[deploying how to use plain terraform](/intro/first-deployment/deploy#deploy-using-plain-terraform).
 
 :::
 

--- a/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/pre-requisites.md
+++ b/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/pre-requisites.md
@@ -13,7 +13,7 @@ This walkthrough has the following pre-requisites:
 
 This guide uses code from the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/), as it
 implements most of the production-grade design for you out of the box. Make sure to read
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork).
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork).
 
 ## Gruntwork Compliance for CIS AWS Foundations Benchmark
 
@@ -37,7 +37,7 @@ This guide uses [Terraform](https://www.terraform.io/) to define and manage all 
 you’re not familiar with Terraform, check out
 [A Comprehensive Guide to Terraform](https://blog.gruntwork.io/a-comprehensive-guide-to-terraform-b3d32832baca),
 [A Crash Course on Terraform](https://training.gruntwork.io/p/terraform), and
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork).
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork).
 
 ## Terragrunt
 

--- a/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/the-gruntwork-solution.md
+++ b/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/the-gruntwork-solution.md
@@ -55,4 +55,4 @@ You can use this approach on each AWS account. In many cases, you’ll only need
 same methodology can be applied to pre-production accounts as well.
 
 If you need to brush up on how the IaC Library works, read the
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork) section.
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork) section.

--- a/_docs-sources/guides/build-it-yourself/achieve-compliance/index.md
+++ b/_docs-sources/guides/build-it-yourself/achieve-compliance/index.md
@@ -11,7 +11,7 @@ import { CardList } from "/src/components/CardGroup"
 
 This guide was last updated on 6th September 2021, and it covers CIS 1.4.0 Benchmark recommendations. We aim to keep
 it up to date with our infrastructure-as-code modules with the latest CIS Benchmark that has been released.
-If you need to access older versions, please [get in touch](/docs/guides/support) with us.
+If you need to access older versions, please [get in touch](/guides/support) with us.
 
 :::
 
@@ -24,8 +24,8 @@ compliant state over time because all of the infrastructure is defined as code. 
 
 Previously, we supported versions 1.3.0 and 1.2.0 of the Benchmark. If you are looking to upgrade from an older version please follow these in order:
 
-- To upgrade from v1.2.0 to v1.3.0, please follow [this upgrade guide](/docs/guides/stay-up-to-date/cis/cis-1.3.0).
-- To upgrade from v1.3.0 to v1.4.0, please follow [this upgrade guide](/docs/guides/stay-up-to-date/cis/cis-1.4.0).
+- To upgrade from v1.2.0 to v1.3.0, please follow [this upgrade guide](/guides/stay-up-to-date/cis/cis-1.3.0).
+- To upgrade from v1.3.0 to v1.4.0, please follow [this upgrade guide](/guides/stay-up-to-date/cis/cis-1.4.0).
 
 ![CIS Benchmark Architecture](/img/guides/build-it-yourself/achieve-compliance/cis-account-architecture.png)
 
@@ -36,31 +36,31 @@ Feel free to read this guide from start to finish or skip around to whatever sec
 <CardList>
   <Card
     title="Core Concepts"
-    href="/docs/guides/build-it-yourself/achieve-compliance/core-concepts/intro"
+    href="/guides/build-it-yourself/achieve-compliance/core-concepts/intro"
   >
     An overview of the AWS Foundations Benchmark, including its control sections and structure.
   </Card>
   <Card
     title="Production-grade Design"
-    href="/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/intro"
+    href="/guides/build-it-yourself/achieve-compliance/production-grade-design/intro"
   >
     How to use infrastructure as code to achieve compliance with minimal redundancy and maximum flexibility.
   </Card>
   <Card
     title="Deployment Walkthrough"
-    href="/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/pre-requisites"
+    href="/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/pre-requisites"
   >
     A step-by-step guide to achieving compliance using the Gruntwork Infrastructure as Code Library and the Gruntwork CIS AWS Foundations Benchmark wrapper modules.
   </Card>
   <Card
     title="Next Steps"
-    href="/docs/guides/build-it-yourself/achieve-compliance/next-steps"
+    href="/guides/build-it-yourself/achieve-compliance/next-steps"
   >
     How to measure and maintain compliance.
   </Card>
   <Card
     title="Traceability Matrix"
-    href="/docs/guides/build-it-yourself/achieve-compliance/traceability-matrix"
+    href="/guides/build-it-yourself/achieve-compliance/traceability-matrix"
   >
     A reference table that maps each Benchmark recommendation to the corresponding section in the deployment
 walkthrough.

--- a/_docs-sources/guides/build-it-yourself/achieve-compliance/production-grade-design/intro.md
+++ b/_docs-sources/guides/build-it-yourself/achieve-compliance/production-grade-design/intro.md
@@ -6,7 +6,7 @@ pagination_label: Production-grade Design
 
 In [core concepts](../core-concepts/intro.md) we discussed the basics of the AWS Foundations Benchmark. Although it's possible to achieve
 compliance with the Benchmark by manually configuring each setting in the web console or entering the CLI commands, we
-strongly discourage this approach. It precludes [the myriad benefits of using code to manage infrastructure](/docs/intro/core-concepts/infrastructure-as-code).
+strongly discourage this approach. It precludes [the myriad benefits of using code to manage infrastructure](/intro/core-concepts/infrastructure-as-code).
 
 Instead, we advise using [Terraform](https://www.terraform.io) (or similar tools, such as
 [CloudFormation](https://aws.amazon.com/cloudformation/) or [Pulumi](https://www.pulumi.com/) to configure cloud

--- a/_docs-sources/guides/build-it-yourself/achieve-compliance/production-grade-design/storage.md
+++ b/_docs-sources/guides/build-it-yourself/achieve-compliance/production-grade-design/storage.md
@@ -65,7 +65,7 @@ The CIS 1.4.0 Benchmark recommends a few additional steps to ensure your data is
 
 :::info
 
-The steps below are not the full list of actions needed to configure MFA Delete or Amazon Macie for your account. To follow the steps necessary to configure it according to the CIS 1.4.0 Benchmark, please follow the MFA Delete and Macie section in the [the migration guide to CIS 1.4.0](/docs/guides/stay-up-to-date/cis/cis-1.4.0), or the deployment guide section in this guide.
+The steps below are not the full list of actions needed to configure MFA Delete or Amazon Macie for your account. To follow the steps necessary to configure it according to the CIS 1.4.0 Benchmark, please follow the MFA Delete and Macie section in the [the migration guide to CIS 1.4.0](/guides/stay-up-to-date/cis/cis-1.4.0), or the deployment guide section in this guide.
 :::
 
 ### Enable MFA Delete (recommendation 2.1.3)

--- a/_docs-sources/guides/build-it-yourself/index.md
+++ b/_docs-sources/guides/build-it-yourself/index.md
@@ -3,39 +3,39 @@ import Grid from "/src/components/Grid"
 
 # Build Your Own Architecture
 
-The Gruntwork IaC library empowers you to construct your own bespoke architecture in record time. By mix-and-matching our modules and services you can quickly define a custom architecture to suit your needs, all with the confidence of having world-class, battle-tested code running under the hood. This series of guides aims to teach you how to configure and deploy some of our most popular services. Additional guides will be added over time, but the principles covered extend to the rest of the IaC library. If you have trouble, don’t hesitate to ask questions via our [support channels](/docs/guides/support).
+The Gruntwork IaC library empowers you to construct your own bespoke architecture in record time. By mix-and-matching our modules and services you can quickly define a custom architecture to suit your needs, all with the confidence of having world-class, battle-tested code running under the hood. This series of guides aims to teach you how to configure and deploy some of our most popular services. Additional guides will be added over time, but the principles covered extend to the rest of the IaC library. If you have trouble, don’t hesitate to ask questions via our [support channels](/guides/support).
 
 ## Follow Our Deployment Guides
 
 <Grid cols={2}>
   <Card
     title="Set Up Your AWS Accounts"
-    href="/docs/guides/build-it-yourself/landing-zone"
+    href="/guides/build-it-yourself/landing-zone"
   >
     Set up a multi-account structure using Gruntwork Landing Zone.
   </Card>
   <Card
     title="Configure a CI/CD Pipeline"
-    href="/docs/guides/build-it-yourself/pipelines"
+    href="/guides/build-it-yourself/pipelines"
   >
     Implement continuous deployment for your infrastructure code with Gruntwork
     Pipelines.
   </Card>
   <Card
     title="Deploy a VPC"
-    href="/docs/guides/build-it-yourself/vpc"
+    href="/guides/build-it-yourself/vpc"
   >
     Set up your network according to industry best practices using our VPC service.
   </Card>
   <Card
     title="Deploy a Kubernetes Cluster"
-    href="/docs/guides/build-it-yourself/kubernetes-cluster"
+    href="/guides/build-it-yourself/kubernetes-cluster"
   >
     Deploy a Kubernetes Cluster to host all of your apps and services.
   </Card>
   <Card
     title="Acheive Compliance"
-    href="/docs/guides/build-it-yourself/achieve-compliance"
+    href="/guides/build-it-yourself/achieve-compliance"
   >
     Make your infrastructure compliant with the CIS AWS Foundations Benchmark.
   </Card>
@@ -44,7 +44,7 @@ The Gruntwork IaC library empowers you to construct your own bespoke architectur
 ## Dig Into the Code
 
 <Grid cols={2}>
-  <Card title="Browse Services" href="/docs/reference/services/intro">
+  <Card title="Browse Services" href="/reference/services/intro">
     View the API reference for our entire service catalog to learn what’s
     available.
   </Card>

--- a/_docs-sources/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/deploy-the-vpc.md
+++ b/_docs-sources/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/deploy-the-vpc.md
@@ -1,7 +1,7 @@
 # Deploy the VPC
 
 The first step is to deploy a VPC. Follow the instructions in
-[How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/) to use
+[How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/) to use
 `module-vpc` to create a VPC setup that looks like this:
 
 ![A production-grade VPC setup deployed using module-vpc from the Gruntwork Infrastructure as Code Library](/img/guides/build-it-yourself/vpc/vpc-diagram.png)
@@ -107,9 +107,9 @@ module "dns_mgmt_to_app" {
 ```
 
 At this point, you’ll want to test your code. See
-[Manual tests for Terraform code](/docs/intro/first-deployment/testing#manual-tests-for-terraform-code)
+[Manual tests for Terraform code](/intro/first-deployment/testing#manual-tests-for-terraform-code)
 and
-[Automated tests for Terraform code](/docs/intro/first-deployment/testing#automated-tests-for-terraform-code)
+[Automated tests for Terraform code](/intro/first-deployment/testing#automated-tests-for-terraform-code)
 for instructions.
 
 Once your updated `vpc-app` wrapper module is working the way you want, submit a pull request, get your changes merged
@@ -126,9 +126,9 @@ git push --follow-tags
 This guide will use [Terragrunt](https://github.com/gruntwork-io/terragrunt) and its associated file and folder
 structure to deploy Terraform modules. Please note that **Terragrunt is NOT required for using Terraform modules from
 the Gruntwork Infrastructure as Code Library.** Check out
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork) for instructions
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork) for instructions
 on alternative options, such as how to
-[Deploy using plain Terraform](/docs/intro/first-deployment/deploy#deploy-using-plain-terraform).
+[Deploy using plain Terraform](/intro/first-deployment/deploy#deploy-using-plain-terraform).
 
 :::
 

--- a/_docs-sources/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/pre-requisites.md
+++ b/_docs-sources/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/pre-requisites.md
@@ -14,7 +14,7 @@ This walkthrough has the following pre-requisites:
 
 This guide uses code from the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/), as it
 implements most of the production-grade design for you out of the box. Make sure to read
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork).
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork).
 
 </div>
 
@@ -31,7 +31,7 @@ You must be a <span className="js-subscribe-cta">Gruntwork subscriber</span> to 
 This guide uses [Terraform](https://www.terraform.io/) to define and manage all the infrastructure as code. If you’re
 not familiar with Terraform, check out [A
 Comprehensive Guide to Terraform](https://blog.gruntwork.io/a-comprehensive-guide-to-terraform-b3d32832baca), [A Crash Course on Terraform](https://training.gruntwork.io/p/terraform), and
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork).
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork).
 
 #### Python and Kubergrunt
 
@@ -44,12 +44,12 @@ Python and `kubergrunt` installed on any computer where you will be running Terr
 This guide assumes you are deploying a Kubernetes cluster for use with [Docker](https://www.docker.com). The guide also
 uses [Packer](https://www.packer.io) to build VM images. If you’re not familiar with Docker or Packer, check out
 [A Crash Course on Docker and Packer](https://training.gruntwork.io/p/a-crash-course-on-docker-packer) and
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork).
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork).
 
 #### AWS accounts
 
 This guide deploys infrastructure into one or more AWS accounts. Check out the
-[How to configure a production-grade AWS account structure](/docs/guides/build-it-yourself/landing-zone/)
+[How to configure a production-grade AWS account structure](/guides/build-it-yourself/landing-zone/)
 guide for instructions. You will also need to be able to authenticate to these accounts on the CLI: check out
 [A Comprehensive Guide to Authenticating to AWS on the Command Line](https://blog.gruntwork.io/a-comprehensive-guide-to-authenticating-to-aws-on-the-command-line-63656a686799)
 for instructions.

--- a/_docs-sources/guides/build-it-yourself/kubernetes-cluster/index.md
+++ b/_docs-sources/guides/build-it-yourself/kubernetes-cluster/index.md
@@ -20,7 +20,7 @@ This guide will walk you through the process of configuring a production-grade K
 <CardList>
   <Card
     title="Core Concepts"
-    href="/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/why-kubernetes"
+    href="/guides/build-it-yourself/kubernetes-cluster/core-concepts/why-kubernetes"
   >
     An overview of the core concepts you need to understand to use Kubernetes, including why you may want to use
     ubernetes, Kubernetes architecture, the control plane, worker nodes, different ways to run Kubernetes, services,
@@ -28,21 +28,21 @@ This guide will walk you through the process of configuring a production-grade K
   </Card>
   <Card
     title="Production-grade Design"
-    href="/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/intro"
+    href="/guides/build-it-yourself/kubernetes-cluster/production-grade-design/intro"
   >
     An overview of how to configure a secure, scalable, highly available Kubernetes cluster that you can rely on in
     production.
   </Card>
   <Card
     title="Deployment Walkthrough"
-    href="/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/pre-requisites"
+    href="/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/pre-requisites"
   >
     A step-by-step guide to deploying a production-grade Kubernetes cluster in AWS using code from the Gruntwork
     Infrastructure as Code Library.
   </Card>
   <Card
     title="Next Steps"
-    href="/docs/guides/build-it-yourself/kubernetes-cluster/next-steps"
+    href="/guides/build-it-yourself/kubernetes-cluster/next-steps"
   >
     What to do once you’ve got your Kubernetes cluster deployed.
   </Card>

--- a/_docs-sources/guides/build-it-yourself/kubernetes-cluster/production-grade-design/control-plane.md
+++ b/_docs-sources/guides/build-it-yourself/kubernetes-cluster/production-grade-design/control-plane.md
@@ -19,7 +19,7 @@ minor version.
 
 Your EKS cluster will run in the subnets you specify. We strongly recommend running solely in private subnets that
 are NOT directly accessible from the public Internet. See
-[How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/) for more
+[How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/) for more
 info.
 
 #### Endpoint access
@@ -28,7 +28,7 @@ You can configure whether the [API endpoint for your EKS cluster](https://docs.a
 is accessible from (a) within the same VPC and/or (b) from the public Internet. We recommend allowing access from
 within the VPC, but not from the public Internet. If you need to talk to your Kubernetes cluster from your own
 computer (e.g., to issue commands via `kubectl`), use a bastion host or VPN server. See
-[How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/) for more
+[How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/) for more
 info.
 
 #### Cluster IAM Role

--- a/_docs-sources/guides/build-it-yourself/kubernetes-cluster/production-grade-design/vpc-configuration.md
+++ b/_docs-sources/guides/build-it-yourself/kubernetes-cluster/production-grade-design/vpc-configuration.md
@@ -2,7 +2,7 @@
 
 EKS relies on a _[Virtual Private Cloud (VPC)](https://aws.amazon.com/vpc/)_ to provide the basic network topology and
 to manage communication across the nodes (see
-[How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/) for more
+[How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/) for more
 information on VPCs). Here are the key VPC considerations for your EKS cluster:
 
 <div className="dlist">

--- a/_docs-sources/guides/build-it-yourself/kubernetes-cluster/production-grade-design/worker-nodes.md
+++ b/_docs-sources/guides/build-it-yourself/kubernetes-cluster/production-grade-design/worker-nodes.md
@@ -20,7 +20,7 @@ value `owned`.
 
 We strongly recommend running the Auto Scaling Group for your worker nodes in private subnets that are NOT directly
 accessible from the public Internet. See
-[How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/) for more
+[How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/) for more
 info.
 
 #### AMI

--- a/_docs-sources/guides/build-it-yourself/landing-zone/deployment-walkthrough/pre-requisites.md
+++ b/_docs-sources/guides/build-it-yourself/landing-zone/deployment-walkthrough/pre-requisites.md
@@ -14,7 +14,7 @@ This walkthrough has the following pre-requisites:
 
 This guide uses code from the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/), as it
 implements most of the production-grade design for you out of the box. Make sure to read
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork).
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork).
 
 </div>
 
@@ -31,7 +31,7 @@ You must be a <span className="js-subscribe-cta">Gruntwork subscriber</span> to 
 This guide uses [Terraform](https://www.terraform.io/) to define and manage all the infrastructure as code. If you’re
 not familiar with Terraform, check out [A
 Comprehensive Guide to Terraform](https://blog.gruntwork.io/a-comprehensive-guide-to-terraform-b3d32832baca), [A Crash Course on Terraform](https://training.gruntwork.io/p/terraform), and
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork).
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork).
 
 #### Terragrunt
 

--- a/_docs-sources/guides/build-it-yourself/landing-zone/deployment-walkthrough/prepare-your-infrastructure-live-repository.md
+++ b/_docs-sources/guides/build-it-yourself/landing-zone/deployment-walkthrough/prepare-your-infrastructure-live-repository.md
@@ -4,9 +4,9 @@
 
 This guide uses [Terragrunt](https://github.com/gruntwork-io/terragrunt) and its associated file and folder
 structure to deploy Terraform modules. Please note that **Terragrunt is NOT required for using Terraform modules from
-the Gruntwork Infrastructure as Code Library.** Check out our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork)
+the Gruntwork Infrastructure as Code Library.** Check out our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork)
 for instructions on alternative options, such as
-[deploying with plain Terraform](/docs/intro/first-deployment/deploy#deploy-using-plain-terraform).
+[deploying with plain Terraform](/intro/first-deployment/deploy#deploy-using-plain-terraform).
 
 :::
 

--- a/_docs-sources/guides/build-it-yourself/landing-zone/index.md
+++ b/_docs-sources/guides/build-it-yourself/landing-zone/index.md
@@ -71,25 +71,25 @@ Feel free to read this guide from start to finish or skip around to whatever sec
 <CardList>
   <Card
     title="Core Concepts"
-    href="/docs/guides/build-it-yourself/landing-zone/core-concepts/aws-account"
+    href="/guides/build-it-yourself/landing-zone/core-concepts/aws-account"
   >
     An overview of the core concepts you need to understand to set up an AWS account structure, including AWS Organizations, IAM Users, IAM Roles, IAM Groups, CloudTrail, and more.
   </Card>
   <Card
     title="Production-grade Design"
-    href="/docs/guides/build-it-yourself/landing-zone/production-grade-design/intro"
+    href="/guides/build-it-yourself/landing-zone/production-grade-design/intro"
   >
     An overview of how to configure a secure, scalable, highly available AWS account structure that you can rely on in production.
   </Card>
   <Card
     title="Deployment Walkthrough"
-    href="/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/pre-requisites"
+    href="/guides/build-it-yourself/landing-zone/deployment-walkthrough/pre-requisites"
   >
     A step-by-step guide to configuring a production-grade AWS account structure using the Gruntwork AWS Landing Zone solution, including how to manage it all with customizable security baselines defined in Terraform.
   </Card>
   <Card
     title="Next Steps"
-    href="/docs/guides/build-it-yourself/landing-zone/next-steps"
+    href="/guides/build-it-yourself/landing-zone/next-steps"
   >
     What to do once you’ve got your AWS account structure configured.
   </Card>

--- a/_docs-sources/guides/build-it-yourself/landing-zone/next-steps.md
+++ b/_docs-sources/guides/build-it-yourself/landing-zone/next-steps.md
@@ -2,4 +2,4 @@
 
 Now that you have your basic AWS account structure set up, the next step is to start deploying infrastructure in those
 accounts! Usually, the best starting point is to configure your network topology, as described in
-[How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/).
+[How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/).

--- a/_docs-sources/guides/build-it-yourself/landing-zone/production-grade-design/iam-roles-for-services.md
+++ b/_docs-sources/guides/build-it-yourself/landing-zone/production-grade-design/iam-roles-for-services.md
@@ -54,7 +54,7 @@ need to take extra care in terms of who can assume this IAM role, what permissio
 services. For example, if you have Jenkins running on an EC2 instance, and you give that EC2 instance access to an
 IAM role so it can deploy your apps, you should do your best to minimize the permissions that IAM role has (e.g.,
 to just `ecs` permissions if deploying to ECS) and you should ensure that your Jenkins instance runs in private
-subnets so that it is NOT accessible from the public Internet (see [How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/)).
+subnets so that it is NOT accessible from the public Internet (see [How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/)).
 
 #### Use the right Principal
 

--- a/_docs-sources/guides/build-it-yourself/pipelines/deployment-walkthrough/deploy-a-vpc.md
+++ b/_docs-sources/guides/build-it-yourself/pipelines/deployment-walkthrough/deploy-a-vpc.md
@@ -1,7 +1,7 @@
 # Deploy a VPC
 
 The first step is to deploy a VPC. Follow the instructions in
-[How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/) to use
+[How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/) to use
 `module-vpc` to create a VPC setup that looks like this:
 
 ![A production-grade VPC setup deployed using module-vpc from the Gruntwork Infrastructure as Code Library](/img/guides/build-it-yourself/pipelines/vpc-diagram.png)

--- a/_docs-sources/guides/build-it-yourself/pipelines/deployment-walkthrough/deploy-the-ecs-deploy-runner.md
+++ b/_docs-sources/guides/build-it-yourself/pipelines/deployment-walkthrough/deploy-the-ecs-deploy-runner.md
@@ -125,9 +125,9 @@ output "url" {
 ```
 
 At this point, you’ll want to test your code. See
-[Manual tests for Terraform code](/docs/intro/first-deployment/testing#manual-tests-for-terraform-code)
+[Manual tests for Terraform code](/intro/first-deployment/testing#manual-tests-for-terraform-code)
 and
-[Automated tests for Terraform code](/docs/intro/first-deployment/testing#automated-tests-for-terraform-code)
+[Automated tests for Terraform code](/intro/first-deployment/testing#automated-tests-for-terraform-code)
 for instructions.
 
 Once your `ecr-repo` module is working the way you want, submit a pull request, get your changes merged into the

--- a/_docs-sources/guides/build-it-yourself/pipelines/deployment-walkthrough/pre-requisites.md
+++ b/_docs-sources/guides/build-it-yourself/pipelines/deployment-walkthrough/pre-requisites.md
@@ -8,7 +8,7 @@ This walkthrough has the following pre-requisites:
 
 This guide uses code from the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/), as it
 implements most of the production-grade design for you out of the box. Make sure to read
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork).
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork).
 
 </div>
 
@@ -25,7 +25,7 @@ You must be a <span className="js-subscribe-cta">Gruntwork subscriber</span> to 
 This guide uses [Terraform](https://www.terraform.io/) to define and manage all the infrastructure as code. If you’re
 not familiar with Terraform, check out [A
 Comprehensive Guide to Terraform](https://blog.gruntwork.io/a-comprehensive-guide-to-terraform-b3d32832baca), [A Crash Course on Terraform](https://training.gruntwork.io/p/terraform), and
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork)
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork)
 
 #### CircleCI
 
@@ -46,7 +46,7 @@ instructions.
 #### Repository structure
 
 This guide assumes your infrastructure code is organized in a manner similar to that covered in the [Prepare Your
-Module](/docs/intro/first-deployment/using-terraform-modules) introduction section. This means that you should have two
+Module](/intro/first-deployment/using-terraform-modules) introduction section. This means that you should have two
 repositories for your≤ infrastructure code, `infrastructure-modules` and `infrastructure-live`. Make sure that the
 `infrastructure-live` repository is locked down as recommended in [Lock down VCS
 systems](../production-grade-design/lock-down-vcs-systems.md). This guide will assume that `master` is the protected
@@ -59,8 +59,8 @@ branch where infrastructure is deployed from.
 This guide will use [Terragrunt](https://github.com/gruntwork-io/terragrunt) and its associated file and folder
 structure to deploy Terraform modules. Please note that **Terragrunt is NOT required for using Terraform modules from
 the Gruntwork Infrastructure as Code Library.** Check out
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork) for instructions
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork) for instructions
 on alternative options, such as how to
-[Deploy using plain Terraform](/docs/intro/first-deployment/deploy#deploy-using-plain-terraform).
+[Deploy using plain Terraform](/intro/first-deployment/deploy#deploy-using-plain-terraform).
 
 :::

--- a/_docs-sources/guides/build-it-yourself/pipelines/index.md
+++ b/_docs-sources/guides/build-it-yourself/pipelines/index.md
@@ -60,7 +60,7 @@ Feel free to read this guide from start to finish or skip around to whatever sec
 <CardList>
   <Card
     title="Core Concepts"
-    href="/docs/guides/build-it-yourself/pipelines/core-concepts/why-is-it-important-to-have-ci-cd"
+    href="/guides/build-it-yourself/pipelines/core-concepts/why-is-it-important-to-have-ci-cd"
   >
     An overview of the core concepts you need to understand what a typical CI/CD pipeline entails for infrastructure code,
     including a comparison with CI/CD for application code, a sample workflow, infrastructure to support CI/CD, and threat
@@ -68,21 +68,21 @@ Feel free to read this guide from start to finish or skip around to whatever sec
   </Card>
   <Card
     title="Production-grade Design"
-    href="/docs/guides/build-it-yourself/pipelines/production-grade-design/intro"
+    href="/guides/build-it-yourself/pipelines/production-grade-design/intro"
   >
     An overview of how to configure a secure, scalable, and robust CI/CD workflow that you can rely on for your
     production application and infrastructure code.
   </Card>
   <Card
     title="Deployment Walkthrough"
-    href="/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/pre-requisites"
+    href="/guides/build-it-yourself/pipelines/deployment-walkthrough/pre-requisites"
   >
     A step-by-step guide to deploying a production-grade CI/CD pipeline in AWS using code from the Gruntwork
     Infrastructure as Code Library.
   </Card>
   <Card
     title="Next Steps"
-    href="/docs/guides/build-it-yourself/pipelines/next-steps"
+    href="/guides/build-it-yourself/pipelines/next-steps"
   >
     What to do once you’ve got your CI/CD pipeline set up.
   </Card>

--- a/_docs-sources/guides/build-it-yourself/pipelines/production-grade-design/use-a-vpc-to-lock-down-deploy-server.md
+++ b/_docs-sources/guides/build-it-yourself/pipelines/production-grade-design/use-a-vpc-to-lock-down-deploy-server.md
@@ -1,6 +1,6 @@
 # Use a VPC to lock down deploy server
 
 Run your infrastructure deployment workloads in a [Virtual Private Cloud (VPC)](https://aws.amazon.com/vpc/) to isolate
-the workloads in a restricted network topology (see [How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/) for more information on VPCs). Configure it to run all workloads in private
+the workloads in a restricted network topology (see [How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/) for more information on VPCs). Configure it to run all workloads in private
 subnets that are not publicly accessible. Make sure to block all inbound internet access and consider blocking all
 outbound access except for the minimum required (e.g, allow access to AWS APIs).

--- a/_docs-sources/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-a-management-vpc.md
+++ b/_docs-sources/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-a-management-vpc.md
@@ -103,8 +103,8 @@ file for reference.
 
 ## Test your wrapper module
 
-At this point, you’ll want to test your code. See [Manual tests for Terraform code](/docs/intro/first-deployment/testing#manual-tests-for-terraform-code)
-and [Automated tests for Terraform code](/docs/intro/first-deployment/testing#automated-tests-for-terraform-code)
+At this point, you’ll want to test your code. See [Manual tests for Terraform code](/intro/first-deployment/testing#manual-tests-for-terraform-code)
+and [Automated tests for Terraform code](/intro/first-deployment/testing#automated-tests-for-terraform-code)
 for instructions.
 
 ## Merge and release your wrapper module
@@ -149,9 +149,9 @@ route table entries, more bastion hosts, and more credentials.
 
 This guide will use [Terragrunt](https://github.com/gruntwork-io/terragrunt) and its associated file and folder
 structure to deploy Terraform modules. Please note that **Terragrunt is NOT required for using Terraform modules from
-the Gruntwork Infrastructure as Code Library.** Check out our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork)
+the Gruntwork Infrastructure as Code Library.** Check out our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork)
 for instructions on alternative options, such as how to
-[deploy using plain terraform](/docs/intro/first-deployment/deploy#deploy-using-plain-terraform).
+[deploy using plain terraform](/intro/first-deployment/deploy#deploy-using-plain-terraform).
 
 :::
 

--- a/_docs-sources/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-application-vp-cs.md
+++ b/_docs-sources/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-application-vp-cs.md
@@ -171,8 +171,8 @@ file for reference.
 
 ## Test your wrapper module
 
-At this point, you’ll want to test your code. See [Manual tests for Terraform code](/docs/intro/first-deployment/testing#manual-tests-for-terraform-code)
-and [Automated tests for Terraform code](/docs/intro/first-deployment/testing#automated-tests-for-terraform-code)
+At this point, you’ll want to test your code. See [Manual tests for Terraform code](/intro/first-deployment/testing#manual-tests-for-terraform-code)
+and [Automated tests for Terraform code](/intro/first-deployment/testing#automated-tests-for-terraform-code)
 for instructions.
 
 ## Merge and release your wrapper module

--- a/_docs-sources/guides/build-it-yourself/vpc/deployment-walkthrough/pre-requisites.md
+++ b/_docs-sources/guides/build-it-yourself/vpc/deployment-walkthrough/pre-requisites.md
@@ -12,7 +12,7 @@ This walkthrough has the following pre-requisites:
 
 This guide uses code from the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/), as it
 implements most of the production-grade design for you out of the box. Make sure to read
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork).
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork).
 
 </div>
 
@@ -29,12 +29,12 @@ You must be a <span className="js-subscribe-cta">Gruntwork subscriber</span> to 
 This guide uses [Terraform](https://www.terraform.io/) to define and manage all the infrastructure as code. If you’re
 not familiar with Terraform, check out [A
 Comprehensive Guide to Terraform](https://blog.gruntwork.io/a-comprehensive-guide-to-terraform-b3d32832baca), [A Crash Course on Terraform](https://training.gruntwork.io/p/terraform), and
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork)
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork)
 
 #### AWS accounts
 
 This guide deploys infrastructure into one or more AWS accounts. Check out the
-[Production Grade AWS Account Structure](/docs/guides/build-it-yourself/landing-zone/) guide for instructions.
+[Production Grade AWS Account Structure](/guides/build-it-yourself/landing-zone/) guide for instructions.
 You will also need to be able to authenticate to these accounts on the CLI: check out
 [A Comprehensive Guide to Authenticating to AWS on the Command Line](https://blog.gruntwork.io/a-comprehensive-guide-to-authenticating-to-aws-on-the-command-line-63656a686799)
 for instructions.

--- a/_docs-sources/guides/build-it-yourself/vpc/index.md
+++ b/_docs-sources/guides/build-it-yourself/vpc/index.md
@@ -20,26 +20,26 @@ Feel free to read this guide from start to finish or skip around to whatever sec
 <CardList>
   <Card
     title="Core Concepts"
-    href="/docs/guides/build-it-yourself/vpc/core-concepts/default-vp-cs-and-custom-vp-cs"
+    href="/guides/build-it-yourself/vpc/core-concepts/default-vp-cs-and-custom-vp-cs"
   >
     An overview of the core concepts you need to understand to use VPCs, including subnets, route tables, security
     groups, NACLs, peering connections, and endpoints.
   </Card>
   <Card
     title="Production-grade Design"
-    href="/docs/guides/build-it-yourself/vpc/production-grade-design/intro"
+    href="/guides/build-it-yourself/vpc/production-grade-design/intro"
   >
     An overview of how to configure a secure, scalable, highly available VPC that you can rely on in production.
   </Card>
   <Card
     title="Deployment Walkthrough"
-    href="/docs/guides/build-it-yourself/vpc/deployment-walkthrough/pre-requisites"
+    href="/guides/build-it-yourself/vpc/deployment-walkthrough/pre-requisites"
   >
     A step-by-step guide to deploying a production-grade VPC in AWS using code from the Gruntwork Infrastructure as Code Library.
   </Card>
   <Card
     title="Next Steps"
-    href="/docs/guides/build-it-yourself/vpc/next-steps"
+    href="/guides/build-it-yourself/vpc/next-steps"
   >
     What to do once you’ve got your VPC(s) deployed.
   </Card>

--- a/_docs-sources/guides/build-it-yourself/vpc/next-steps.md
+++ b/_docs-sources/guides/build-it-yourself/vpc/next-steps.md
@@ -4,7 +4,7 @@ Now that you have your management and application VPCs deployed, you can start b
 on top of them! Typically, the best next step is to deploy a cluster of servers for running your applications by using
 one of the following guides:
 
-- [How to deploy a production-grade Kubernetes cluster on AWS](/docs/guides/build-it-yourself/kubernetes-cluster/)
+- [How to deploy a production-grade Kubernetes cluster on AWS](/guides/build-it-yourself/kubernetes-cluster/)
 - `How to deploy a production grade ECS cluster on AWS` _(coming soon!)_
 - `How to deploy a production grade Nomad cluster on AWS` _(coming soon!)_
 - `How to deploy a production grade Auto Scaling Group on AWS` _(coming soon!)_

--- a/_docs-sources/guides/build-it-yourself/vpc/production-grade-design/multiple-aws-accounts.md
+++ b/_docs-sources/guides/build-it-yourself/vpc/production-grade-design/multiple-aws-accounts.md
@@ -11,5 +11,5 @@ change something in prod rather than pre-prod).
 
 Therefore, your best bet is to put pre-production environments and production environments in completely separate AWS
 accounts. This makes it easy to, for example, grant relatively lax permissions in pre-prod environments, but very
-strict permissions in production. Check out the [Production Grade AWS Account Structure](/docs/guides/build-it-yourself/landing-zone/)
+strict permissions in production. Check out the [Production Grade AWS Account Structure](/guides/build-it-yourself/landing-zone/)
 guide for instructions.

--- a/_docs-sources/guides/index.md
+++ b/_docs-sources/guides/index.md
@@ -9,12 +9,12 @@ Before you get too deep into the code, it's important to understand Gruntwork's 
 
 <Card
   title="Introduction to Gruntwork"
-  href="/docs/intro/overview/intro-to-gruntwork">
+  href="/intro/overview/intro-to-gruntwork">
 Before anything else, check out our introductory guide to set up your account, prepare your tools, and understand what to expect.
 </Card>
 <Card
   title="The Gruntwork Production Framework"
-  href="/docs/guides/production-framework">
+  href="/guides/production-framework">
 We present a comprehensive model to help you establish a robust infrastructure platform, and explain how Gruntwork can accelarate its adoption in your org.
 </Card>
 

--- a/_docs-sources/guides/production-framework/index.md
+++ b/_docs-sources/guides/production-framework/index.md
@@ -1,3 +1,6 @@
+import Card from "/src/components/Card"
+import { CardList } from "/src/components/CardGroup"
+
 # The Gruntwork Production Framework
 
 In this guide, we are going to share our opinionated, step-by-step framework for successfully going to production on
@@ -5,7 +8,46 @@ the public cloud. At Gruntwork, we've had the privilege to work with everything 
 50 companies to some of the world's largest government agencies, and this document captures the common patterns we've
 seen that actually worked.
 
-![Gruntwork Production Framework](/img/guides/production-framework/gruntwork-production-framework-small.png)
+<div style={{maxWidth: "640px", margin: "auto", marginTop: "3rem"}}>
+
+## The Elements of the Gruntwork Production Framework
+
+<CardList style={{marginTop: 0}}>
+
+<Card
+  title="Service Catalog"
+  href="./ingredients/service-catalog"
+  icon="/img/icons/service-catalog.svg">
+Your company's vetted, tested, reusable, off-the-shelf solutions for infrastructure and appliactions.
+</Card>
+<Card
+  title="Landing Zone"
+  href="./ingredients/landing-zone"
+  icon="/img/icons/landing-zone.svg">
+The basic structure for your cloud accounts, including auth, guard rails, and other scaffolding.
+</Card>
+<Card
+  title="CI / CD"
+  href="./ingredients/ci-cd-pipeline"
+  icon="/img/icons/ci-cd.svg">
+A Continuous Integration / Continuous Delivery pipeline to automate builds, tests, and deployments.
+</Card>
+<Card
+  title="Self-service"
+  href="./ingredients/self-service"
+  icon="/img/icons/self-service.svg">
+Allow developers to deploy and manage their own apps and infrastructure.
+</Card>
+<Card
+  title="Automatic Updates"
+  href="./ingredients/automatic-updates"
+  icon="/img/icons/auto-update.svg">
+Kepp all your application and infrastructure dependencies up to date, automatically.
+</Card>
+
+</CardList>
+
+</div>
 
 This is not another high-level, vague "cloud operating model" document that is heavy on buzzwords but light on
 actionable content. Instead, you'll find a clear mental model of how to think about cloud usage, plus a set of
@@ -27,30 +69,30 @@ its time working with software tools such as Terraform, Packer, Docker, and Kube
 writing code and "tossing it over the wall" to Ops, Devs want to be self-sufficient, deploying and managing everything
 they need themselves without being bottlenecked by Ops team.
 
-In other words, the distinction between Dev and Ops teams is blurring: this is where the term *DevOps* comes from.
+In other words, the distinction between Dev and Ops teams is blurring: this is where the term _DevOps_ comes from.
 There's no widely agreed-upon definition for DevOps, but for the purposes of this article, we'll think of it as a
-movement which has the goal of *making software delivery vastly more efficient*. And the one thing you can be certain
-of is that trying to port the "old way" of doing things to the cloud will *not* be efficient. The shift to the cloud
+movement which has the goal of _making software delivery vastly more efficient_. And the one thing you can be certain
+of is that trying to port the "old way" of doing things to the cloud will _not_ be efficient. The shift to the cloud
 and DevOps brings a huge number of changes:
 
-|                                 | Before                                               | After                                                  |
-|---------------------------------|------------------------------------------------------|--------------------------------------------------------|
-| **Teams**                       | Devs write code, "toss it over the wall" to Ops      | Devs &amp; Ops work together on cross-functional teams |
-| **Servers**                     | Dedicated physical servers                           | Elastic virtual servers                                |
-| **Connectivity**                | Static IPs                                           | Dynamic IPs, service discovery                         |
-| **Security**                    | Physical, strong perimeter, high trust interior      | Virtual, end-to-end, zero trust                        |
-| **Infrastructure provisioning** | Manual                                               | Infrastructure as Code (IaC) tools                     |
-| **Server configuration**        | Manual                                               | Configuration management tools                         |
-| **Testing**                     | Manual                                               | Automated testing                                      |
-| **Deployments**                 | Manual                                               | Automated                                              |
-| **Deployment cadence**          | Weeks or months                                      | Many times per day                                     |
-| **Change process**              | Change request tickets                               | Self-service                                           |
-| **Change cadence**              | Weeks or months                                      | Minutes                                                |
+|                                 | Before                                          | After                                                  |
+| ------------------------------- | ----------------------------------------------- | ------------------------------------------------------ |
+| **Teams**                       | Devs write code, "toss it over the wall" to Ops | Devs &amp; Ops work together on cross-functional teams |
+| **Servers**                     | Dedicated physical servers                      | Elastic virtual servers                                |
+| **Connectivity**                | Static IPs                                      | Dynamic IPs, service discovery                         |
+| **Security**                    | Physical, strong perimeter, high trust interior | Virtual, end-to-end, zero trust                        |
+| **Infrastructure provisioning** | Manual                                          | Infrastructure as Code (IaC) tools                     |
+| **Server configuration**        | Manual                                          | Configuration management tools                         |
+| **Testing**                     | Manual                                          | Automated testing                                      |
+| **Deployments**                 | Manual                                          | Automated                                              |
+| **Deployment cadence**          | Weeks or months                                 | Many times per day                                     |
+| **Change process**              | Change request tickets                          | Self-service                                           |
+| **Change cadence**              | Weeks or months                                 | Minutes                                                |
 
 ## Who the framework is for
 
 This framework is for companies who wish to adopt the public cloud (e.g., Amazon Web Services, Microsoft Azure, Google
-Cloud Platform) for *production and mission-critical use cases.* We're talking about use cases where you're betting
+Cloud Platform) for _production and mission-critical use cases._ We're talking about use cases where you're betting
 your company on the reliability and security of the cloud: you're betting that your infrastructure won't fall over if
 there's a traffic spike; you're betting that you won't lose data if there's an outage; you're betting that hackers
 won't be able to break in and compromise your data; and if these bets don’t work out, your company may go out of
@@ -72,14 +114,14 @@ another team will focus on what compliance and regulatory requirements you must 
 the details of your scalability and high availability requirements.
 
 As Yogi Berra said, if you don't know where you are going, you'll end up someplace else. Something similar is true of
-the cloud: if you don't know *exactly* what your cloud requirements are, you won't meet them. Trying to backfill
-security, compliance, monitoring, availability, and other requirements *after* your team has been running wild in the
+the cloud: if you don't know _exactly_ what your cloud requirements are, you won't meet them. Trying to backfill
+security, compliance, monitoring, availability, and other requirements _after_ your team has been running wild in the
 cloud for months is much harder.
 
 Therefore, it's essential to get your requirements down in writing, ideally in the form of a checklist (see also:
-*The Checklist Manifesto*). This will give you a real sense of the work involved: seeing a long list of requirements,
+_The Checklist Manifesto_). This will give you a real sense of the work involved: seeing a long list of requirements,
 in front of you, on (digital) paper, makes the scope of the work much more visible, which is particularly useful in the
-face of bosses who blindly demand "we must be 100% in the cloud by *&lt;unrealistic timeline&gt;*!!!" with zero context
+face of bosses who blindly demand "we must be 100% in the cloud by _&lt;unrealistic timeline&gt;_!!!" with zero context
 on just how much work is involved. You can use the list of requirements to coordinate the work and track progress
 towards. You can use this list not only for an initial launch, but for all new deployments in the future too. You can
 of course include diagrams and images too. And when you put it all together, you'll finally have a single, canonical,
@@ -88,7 +130,7 @@ written answer to "what do I have to do to put a new app in prod?"
 There are many types of requirements to take into consideration:
 
 | Requirement                   | Examples                                       |
-|-------------------------------|------------------------------------------------|
+| ----------------------------- | ---------------------------------------------- |
 | Infrastructure                | Servers, databases, load balancers, etc.       |
 | Compliance                    | SOC 2, ISO 27001, HIPAA, PCI, CIS, etc.        |
 | Observability                 | Metrics, logging, alerting, audit trails, etc. |
@@ -108,13 +150,13 @@ In the past, doing this requirements analysis, capturing it in writing in checkl
 your org to enforce these requirements might have been enough. But in the era of elastic, self-service,
 instantly-available cloud environments, it's not enough to have a bunch of written documents and manual processes. You
 can no longer rely on manual deployments, manual security checks, or manual responses to outages. You must go one step
-further and capture and enforce requirements *as code*.
+further and capture and enforce requirements _as code_.
 
 Let's extend the table of requirements from the previous section with examples of how you can implement each one using
 different types of code:
 
 | Requirement                   | Examples                                       | Code examples                                                  |
-|-------------------------------|------------------------------------------------|----------------------------------------------------------------|
+| ----------------------------- | ---------------------------------------------- | -------------------------------------------------------------- |
 | Infrastructure                | Servers, databases, load balancers, etc.       | Infrastructure as Code (IaC) tools: Terraform, CloudFormation. |
 | Compliance                    | SOC 2, ISO 27001, HIPAA, PCI, CIS, etc.        | Continuous testing tools: Terratest, Open Policy Agent (OPA).  |
 | Observability                 | Metrics, logging, alerting, audit trails, etc. | Monitoring tools: CloudWatch, DataDog, Prometheus.             |
@@ -128,7 +170,7 @@ The list above is just an example of some of the tools you use. There are plenty
 less important which tool you pick, so long as that tool lets you manage everything as code.
 
 Why code? We've found that companies that successfully use the cloud almost always capture and enforce their
-requirements not only in software (rather than manual processes), but specifically as *software managed with code*.
+requirements not only in software (rather than manual processes), but specifically as _software managed with code_.
 Software managed manually with a web UI—e.g., setting up infrastructure by manually clicking around the AWS Web Console
 ("ClickOps"*)—*is not enough, as there are a number of benefits that you only get when you manage your requirements with
 code:
@@ -149,7 +191,6 @@ code:
 So, as you go through this framework, keep in mind that the goal is to define and manage each part of the framework
 in code.
 
-
 ## Let's get started
 
 So how do you accomplish all of this? How do you allow your Dev teams to be highly productive and self-sufficient,
@@ -157,21 +198,21 @@ while still allowing your Ops team to control what's happening under the hood an
 and legal requirements are met?
 
 The goal of the Gruntwork Production Framework is to help you answer these questions. First, we'll define the basic
-*ingredients*: the raw primitives your company will need to put in place to use the cloud successfully. Then, we'll
-take a look at some *recipes*: a walkthrough of one way you could put all those ingredients together into an end-to-end
-experience for your Dev and Ops teams. Finally, we'll talk about the off-the-shelf *solutions* we have available at
+_ingredients_: the raw primitives your company will need to put in place to use the cloud successfully. Then, we'll
+take a look at some _recipes_: a walkthrough of one way you could put all those ingredients together into an end-to-end
+experience for your Dev and Ops teams. Finally, we'll talk about the off-the-shelf _solutions_ we have available at
 Gruntwork to help you implement this framework.
 
 1. **Ingredients**
-    1. [Service Catalog](ingredients/service-catalog/index.md)
-    1. [Landing Zone](ingredients/landing-zone/index.md)
-    1. [CI / CD Pipeline](ingredients/ci-cd-pipeline/index.md)
-    1. [Self-Service](ingredients/self-service/index.md)
-    1. [Automatic Updates](ingredients/automatic-updates/index.md)
-    1. [Other Ingredients](ingredients/other-ingredients/index.md)
+   1. [Service Catalog](ingredients/service-catalog/index.md)
+   1. [Landing Zone](ingredients/landing-zone/index.md)
+   1. [CI / CD Pipeline](ingredients/ci-cd-pipeline/index.md)
+   1. [Self-Service](ingredients/self-service/index.md)
+   1. [Automatic Updates](ingredients/automatic-updates/index.md)
+   1. [Other Ingredients](ingredients/other-ingredients/index.md)
 2. **Recipes**
-    1. [Intro](recipes/index.md)
-    1. [The Dev team experience](recipes/dev-team-experience.md)
-    1. [The Ops team experience](recipes/ops-team-experience.md)
+   1. [Intro](recipes/index.md)
+   1. [The Dev team experience](recipes/dev-team-experience.md)
+   1. [The Ops team experience](recipes/ops-team-experience.md)
 3. **Solutions**
-    1. [How Gruntwork can help](gruntwork-solutions/index.md)
+   1. [How Gruntwork can help](gruntwork-solutions/index.md)

--- a/_docs-sources/guides/reference-architecture/example-usage-guide/index.md
+++ b/_docs-sources/guides/reference-architecture/example-usage-guide/index.md
@@ -39,7 +39,7 @@ All of the infrastructure in this repo is managed as **code** using [Terragrunt]
   [Gruntwork Service Catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog/).
 
 For more info on Infrastructure as Code and Terraform, check out [A Comprehensive Guide to
-Terraform](https://blog.gruntwork.io/a-comprehensive-guide-to-terraform-b3d32832baca) and our our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork) section.
+Terraform](https://blog.gruntwork.io/a-comprehensive-guide-to-terraform-b3d32832baca) and our our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork) section.
 
 ## AWS accounts
 

--- a/_docs-sources/guides/reference-architecture/index.md
+++ b/_docs-sources/guides/reference-architecture/index.md
@@ -11,12 +11,12 @@ If you've purchased a Reference Architecture, these guides will help guide you t
 
 <Card
   title="Configure Your Reference Architecture"
-  href="/docs/guides/reference-architecture/configuration-guide">
+  href="/guides/reference-architecture/configuration-guide">
 Learn how to configure your Reference Architecture so Gruntwork can deliver it directly into your repo.
 </Card>
 <Card
   title="Example Usage Guide"
-  href="/docs/guides/reference-architecture/example-usage-guide">
+  href="/guides/reference-architecture/example-usage-guide">
 See a preview of how to use your customized Reference Architecture once we've delivered it in your repo.
 </Card>
 

--- a/_docs-sources/guides/stay-up-to-date/cis/cis-1.3.0/deployment-walkthrough/step-1-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/_docs-sources/guides/stay-up-to-date/cis/cis-1.3.0/deployment-walkthrough/step-1-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -18,7 +18,7 @@ To update to the CIS AWS Foundations Benchmark v1.3.0, you need to update your r
 Infrastructure as Code Library to use compatible versions. We (Gruntwork) have reviewed and updated all the library modules for compatibility with the new version of the Benchmark. As a customer, you need to update to
 the proper versions of the Gruntwork library to pick up the fixes/changes made to be compatible. Refer to
 [the
-"Updating to new versions" section of "Stay Up to Date"](/docs/guides/working-with-code/versioning#updating-to-new-versions) for instructions on how to update the
+"Updating to new versions" section of "Stay Up to Date"](/guides/working-with-code/versioning#updating-to-new-versions) for instructions on how to update the
 versions in your code.
 
 For the vast majority of the repos, the only change that will be necessary is a version number bump, but several repos
@@ -30,7 +30,7 @@ version.**
 
 Gruntwork follows
 [semantic
-versioning](/docs/guides/working-with-code/versioning#semantic-versioning). For any pre-1.0 modules, this means that version updates to the minor version are considered backward
+versioning](/guides/working-with-code/versioning#semantic-versioning). For any pre-1.0 modules, this means that version updates to the minor version are considered backward
 incompatible releases for any version updates before the 1.0.0 release. Make sure to read the release notes for the
 relevant modules any time you are updating minor versions! Note that you will want to read the release notes for each
 minor version that is updated (e.g., if you are going from v0.5.x to v0.9.x, you will want to read the notes for v0.6.0,

--- a/_docs-sources/guides/stay-up-to-date/cis/cis-1.3.0/index.md
+++ b/_docs-sources/guides/stay-up-to-date/cis/cis-1.3.0/index.md
@@ -7,7 +7,7 @@ pagination_label: Update to CIS AWS Foundations Benchmark 1.3.0
 This guide will walk you through how to update from version 1.2.0 to version 1.3.0 of the CIS AWS Foundations Benchmark.
 If your infrastructure is already compliant with the Benchmark's version 1.2.0, and you are looking to upgrade to v1.3.0,
 this guide is for you. If you are starting to work on compliance with this benchmark from scratch, check out our
-[How to achieve compliance with the CIS AWS Foundations Benchmark](/docs/guides/build-it-yourself/achieve-compliance/) guide instead.
+[How to achieve compliance with the CIS AWS Foundations Benchmark](/guides/build-it-yourself/achieve-compliance/) guide instead.
 
 This guide consists of two main sections:
 

--- a/_docs-sources/guides/stay-up-to-date/cis/cis-1.4.0/deployment-walkthrough/step-1-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/_docs-sources/guides/stay-up-to-date/cis/cis-1.4.0/deployment-walkthrough/step-1-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -7,12 +7,12 @@ sidebar_label: Update references to the Gruntwork Infrastructure as Code Library
 To update to the CIS AWS Foundations Benchmark v1.4.0, you need to update your references to the Gruntwork
 Infrastructure as Code Library to use compatible versions. We (Gruntwork) have reviewed and updated all the library
 modules for compatibility with the new version of the benchmark. As a customer, you need to update to
-the proper versions of the Gruntwork library to pick up the fixes/changes made to be compatible. Refer to our ["Updating to new versions"](/docs/guides/working-with-code/versioning#updating-to-new-versions) guide for instructions on how to update the
+the proper versions of the Gruntwork library to pick up the fixes/changes made to be compatible. Refer to our ["Updating to new versions"](/guides/working-with-code/versioning#updating-to-new-versions) guide for instructions on how to update the
 versions in your code.
 
 Gruntwork follows
 [semantic
-versioning](/docs/guides/working-with-code/versioning#semantic-versioning). For any pre-1.0 modules, this means that version updates to the minor version are considered backward
+versioning](/guides/working-with-code/versioning#semantic-versioning). For any pre-1.0 modules, this means that version updates to the minor version are considered backward
 incompatible releases for any version updates before the 1.0.0 release. Make sure to read the release notes for the
 relevant modules any time you are updating minor versions! Note that you will want to read the release notes for each
 minor version that is updated (e.g., if you are going from v0.5.x to v0.9.x, you will want to read the notes for v0.6.0,

--- a/_docs-sources/guides/stay-up-to-date/cis/cis-1.4.0/index.md
+++ b/_docs-sources/guides/stay-up-to-date/cis/cis-1.4.0/index.md
@@ -23,4 +23,4 @@ CIS AWS Foundations Benchmark.
 
 ## Previous versions of this guide
 
-- [How to update to CIS AWS Foundations Benchmark v1.3.0](/docs/guides/stay-up-to-date/cis/cis-1.3.0)
+- [How to update to CIS AWS Foundations Benchmark v1.3.0](/guides/stay-up-to-date/cis/cis-1.3.0)

--- a/_docs-sources/guides/stay-up-to-date/index.md
+++ b/_docs-sources/guides/stay-up-to-date/index.md
@@ -18,31 +18,31 @@ import CardGroup from "/src/components/CardGroup"
 
 <Card
   title="Update to version 1.X"
-  href="/docs/guides/stay-up-to-date/terraform/terraform-1.x"
+  href="/guides/stay-up-to-date/terraform/terraform-1.x"
   />
 <Card
   title="Update to Terraform 15"
-  href="/docs/guides/stay-up-to-date/terraform/terraform-15"
+  href="/guides/stay-up-to-date/terraform/terraform-15"
   />
 <Card
   title="Update to Terraform 14"
-  href="/docs/guides/stay-up-to-date/terraform/terraform-14"
+  href="/guides/stay-up-to-date/terraform/terraform-14"
   />
 <Card
   title="Update to Terraform 13"
-  href="/docs/guides/stay-up-to-date/terraform/terraform-13"
+  href="/guides/stay-up-to-date/terraform/terraform-13"
   />
 <Card
   title="Update to Terraform 12"
-  href="/docs/guides/stay-up-to-date/terraform/terraform-12"
+  href="/guides/stay-up-to-date/terraform/terraform-12"
   />
 <Card
   title="Update to Version 3 of the Terraform provider"
-  href="/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3"
+  href="/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3"
   />
 <Card
   title="DRY your Reference Architecture"
-  href="/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture"
+  href="/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture"
   />
 
 </CardGroup>
@@ -57,11 +57,11 @@ import CardGroup from "/src/components/CardGroup"
 
 <Card
   title="Update to version 1.4.0"
-  href="/docs/guides/stay-up-to-date/cis/cis-1.4.0"
+  href="/guides/stay-up-to-date/cis/cis-1.4.0"
   />
 <Card
   title="Update to version 1.3.0"
-  href="/docs/guides/stay-up-to-date/cis/cis-1.3.0"
+  href="/guides/stay-up-to-date/cis/cis-1.3.0"
   />
 
 </CardGroup>

--- a/_docs-sources/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3/deployment-walkthrough.md
+++ b/_docs-sources/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3/deployment-walkthrough.md
@@ -8,7 +8,7 @@ library to test and update the code to be compatible with AWS provider version 3
 the proper versions of the Gruntwork library to pick up the fixes/changes that were made to be compatible. Be sure to
 read the release notes to know what changes need to be made to update to that version.
 
-Refer to our ["Updating to new versions"](/docs/guides/working-with-code/versioning#updating-to-new-versions) guide
+Refer to our ["Updating to new versions"](/guides/working-with-code/versioning#updating-to-new-versions) guide
 for instructions on how to update the versions in your code.
 
 The following table provides a summary of all the relevant Gruntwork AWS modules and the respective versions that are
@@ -17,7 +17,7 @@ compatible with AWS provider version 3.
 :::caution
 
 Gruntwork follows [semantic
-versioning](/docs/guides/working-with-code/versioning#semantic-versioning).
+versioning](/guides/working-with-code/versioning#semantic-versioning).
 For any pre-1.0 modules, this means that version updates to the minor version
 are considered backwards incompatible releases for any version updates prior to
 1.0.0 release. Make sure to read the release notes for the relevant modules any

--- a/_docs-sources/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-15.md
+++ b/_docs-sources/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-15.md
@@ -22,5 +22,5 @@ If you haven’t already, you need to:
         [Terraform 0.15 upgrade guide](../../terraform-15).
 
 2.  Update all your Gruntwork modules to the latest versions just _before_ the TF 1.x versions in the [compatibility
-    table](/docs/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library#version-compatibility-table). The upgrade will be much easier and less error prone if you keep the number of version jumps as small
+    table](/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library#version-compatibility-table). The upgrade will be much easier and less error prone if you keep the number of version jumps as small
     as possible.

--- a/_docs-sources/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/_docs-sources/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -10,7 +10,7 @@ version. We (Gruntwork) have gone through all our modules in the library to test
 and update the code to be compatible with Terraform 1.x. As a customer, you need
 to update to the proper versions of the Gruntwork library to pick up the
 fixes/changes that we made to be compatible. Refer to [the "Updating to new versions" section of
-"Stay Up to Date"](/docs/guides/working-with-code/versioning#updating-to-new-versions#updating)
+"Stay Up to Date"](/guides/working-with-code/versioning#updating-to-new-versions#updating)
 for instructions on how to update the versions in your code.
 
 For the vast majority of the repos, the only change that will be necessary is a
@@ -22,7 +22,7 @@ changes need to be made to update to the new version.**
 :::caution
 
 Gruntwork follows [semantic
-versioning](/docs/guides/working-with-code/versioning#semantic-versioning).
+versioning](/guides/working-with-code/versioning#semantic-versioning).
 For any pre-1.0 modules, this means that version updates to the minor version
 are considered backwards incompatible releases for any version updates prior to
 1.0.0 release. Make sure to read the release notes for the relevant modules any

--- a/_docs-sources/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/_docs-sources/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -7,7 +7,7 @@ sidebar_label: Update Gruntwork IaC module references
 In order to take advantage of the Terraform 0.13, you need to update your references to the Gruntwork
 Infrastructure as Code Library to use a compatible version. We (Gruntwork) have gone through all our modules in the
 library to test and update the code to be compatible with Terraform 0.13. As a customer, you need to update to
-the proper versions of the Gruntwork library to pick up the fixes/changes that were made to be compatible. Refer to our ["Updating to new versions"](/docs/guides/working-with-code/versioning#updating-to-new-versions) guide for instructions on how to update the
+the proper versions of the Gruntwork library to pick up the fixes/changes that were made to be compatible. Refer to our ["Updating to new versions"](/guides/working-with-code/versioning#updating-to-new-versions) guide for instructions on how to update the
 versions in your code.
 
 For the vast majority of the repos, the only change that will be necessary is a version number bump, but several repos
@@ -19,7 +19,7 @@ user, pay special attention to the release notes!
 :::caution
 
 Gruntwork follows [semantic
-versioning](/docs/guides/working-with-code/versioning#semantic-versioning).
+versioning](/guides/working-with-code/versioning#semantic-versioning).
 For any pre-1.0 modules, this means that version updates to the minor version
 are considered backwards incompatible releases for any version updates prior to
 1.0.0 release. Make sure to read the release notes for the relevant modules any

--- a/_docs-sources/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/_docs-sources/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -7,7 +7,7 @@ sidebar_label: Update Gruntwork IaC module references
 In order to take advantage of the Terraform 0.14, you need to update your references to the Gruntwork
 Infrastructure as Code Library to use a compatible version. We (Gruntwork) have gone through all our modules in the
 library to test and update the code to be compatible with Terraform 0.14. As a customer, you need to update to
-the proper versions of the Gruntwork library to pick up the fixes/changes that we made to be compatible. Refer to our ["Updating to new versions"](/docs/guides/working-with-code/versioning#updating-to-new-versions) guide for instructions on how to update the
+the proper versions of the Gruntwork library to pick up the fixes/changes that we made to be compatible. Refer to our ["Updating to new versions"](/guides/working-with-code/versioning#updating-to-new-versions) guide for instructions on how to update the
 versions in your code.
 
 For the vast majority of the repos, the only change that will be necessary is a version number bump, but several repos
@@ -18,7 +18,7 @@ version.**
 :::caution
 
 Gruntwork follows [semantic
-versioning](/docs/guides/working-with-code/versioning#semantic-versioning).
+versioning](/guides/working-with-code/versioning#semantic-versioning).
 For any pre-1.0 modules, this means that version updates to the minor version
 are considered backwards incompatible releases for any version updates prior to
 1.0.0 release. Make sure to read the release notes for the relevant modules any

--- a/_docs-sources/guides/stay-up-to-date/terraform/terraform-15/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/_docs-sources/guides/stay-up-to-date/terraform/terraform-15/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -7,7 +7,7 @@ sidebar_label: Update Gruntwork IaC module references
 In order to take advantage of the Terraform 0.15, you need to update your references to the Gruntwork
 Infrastructure as Code Library to use a compatible version. We (Gruntwork) have gone through all our modules in the
 library to test and update the code to be compatible with Terraform 0.15. As a customer, you need to update to
-the proper versions of the Gruntwork library to pick up the fixes/changes that we made to be compatible. Refer to our ["Updating to new versions"](/docs/guides/working-with-code/versioning#updating-to-new-versions) guide for instructions on how to update the
+the proper versions of the Gruntwork library to pick up the fixes/changes that we made to be compatible. Refer to our ["Updating to new versions"](/guides/working-with-code/versioning#updating-to-new-versions) guide for instructions on how to update the
 versions in your code.
 
 For the vast majority of the repos, the only change that will be necessary is a version number bump, but several repos
@@ -18,7 +18,7 @@ version.**
 :::caution
 
 Gruntwork follows [semantic
-versioning](/docs/guides/working-with-code/versioning#semantic-versioning).
+versioning](/guides/working-with-code/versioning#semantic-versioning).
 For any pre-1.0 modules, this means that version updates to the minor version
 are considered backwards incompatible releases for any version updates prior to
 1.0.0 release. Make sure to read the release notes for the relevant modules any

--- a/_docs-sources/guides/style/index.md
+++ b/_docs-sources/guides/style/index.md
@@ -7,12 +7,12 @@ import CardGroup from "/src/components/CardGroup"
 
 <Card
   title="Terraform Style Guide"
-  href="/docs/guides/style/terraform-style-guide">
+  href="/guides/style/terraform-style-guide">
 Learn Gruntwork's Terraform coding style.
 </Card>
 <Card
   title="Go Style Guide"
-  href="/docs/guides/style/golang-style-guide">
+  href="/guides/style/golang-style-guide">
 Learn Gruntwork's Go coding style.
 </Card>
 

--- a/_docs-sources/guides/support.mdx
+++ b/_docs-sources/guides/support.mdx
@@ -114,7 +114,7 @@ We’re here to help you with:
 
 - **Bug fixes** — Raise concerns regarding any bugs you find, and help us understand how they impact you.
 
-- **DevOps guidance** — While we don’t provide DevOps training beyond our [video training courses](/docs/courses), we can help you understand how to apply general DevOps principles to devise the right infrastructure for your needs.
+- **DevOps guidance** — While we don’t provide DevOps training beyond our [video training courses](/courses), we can help you understand how to apply general DevOps principles to devise the right infrastructure for your needs.
 
 ### How to reach us
 
@@ -151,7 +151,7 @@ We’re here to help you with:
 
 - **Code reviews** — Get another pair of eyes on any changes you make to your infrastructure so you can have confidence taking them live.
 
-- **DevOps guidance** — While we don’t provide DevOps training beyond our [video training courses](/docs/courses), we can help you understand how to apply general DevOps principles to devise the right infrastructure for your needs.
+- **DevOps guidance** — While we don’t provide DevOps training beyond our [video training courses](/courses), we can help you understand how to apply general DevOps principles to devise the right infrastructure for your needs.
 
 ### How to reach us
 

--- a/_docs-sources/guides/working-with-code/forking.md
+++ b/_docs-sources/guides/working-with-code/forking.md
@@ -34,7 +34,7 @@ so you’ll want to pull in these updates as quickly as you can.
 
 ## How to use your forked code
 
-Once you’ve forked the code, using it is very similar to what is outlined in [Using Terraform Modules](/docs/intro/first-deployment/using-terraform-modules), except for the following differences:
+Once you’ve forked the code, using it is very similar to what is outlined in [Using Terraform Modules](/intro/first-deployment/using-terraform-modules), except for the following differences:
 
 1.  Point the `source` URLs of your Terraform modules to your own Git repos, rather than the `gruntwork-io` GitHub org.
 2.  Point the `--repo` parameter of `gruntwork-install` to your own Git repos, rather than the `gruntwork-io` GitHub org.
@@ -50,6 +50,6 @@ While forking is allowed under the Gruntwork Terms of Services, it has some down
   participate in issues and pull requests, and you won’t be benefiting as much from the Gruntwork community.
 
 So, whenever possible, use the code directly from the `gruntwork-io` GitHub org, as documented in
-[Using Terraform Modules](/docs/intro/first-deployment/using-terraform-modules). If your team relies on NPM, Docker Hub, Maven Central,
+[Using Terraform Modules](/intro/first-deployment/using-terraform-modules). If your team relies on NPM, Docker Hub, Maven Central,
 GitHub, or the Terraform Registry, using Gruntwork repos directly is no different. However, if your company completely
 bans all outside sources, then follow the instructions above to fork the code, and good luck!

--- a/_docs-sources/guides/working-with-code/versioning.md
+++ b/_docs-sources/guides/working-with-code/versioning.md
@@ -61,7 +61,7 @@ Follow the steps below to keep your code up to date:
     was increased (e.g., `v0.18.0` → `v0.19.0`), that implies a backwards incompatible change, and the release notes will
     explain what you need to do (e.g., you might have to add, remove, or change arguments you pass to the module).
 
-4.  Test your changes locally. You do this using the same process outlined in [Manual tests for Terraform code](/docs/intro/first-deployment/testing#manual-tests-for-terraform-code) and
-    [Automated tests for Terraform code](/docs/intro/first-deployment/testing#automated-tests-for-terraform-code).
+4.  Test your changes locally. You do this using the same process outlined in [Manual tests for Terraform code](/intro/first-deployment/testing#manual-tests-for-terraform-code) and
+    [Automated tests for Terraform code](/intro/first-deployment/testing#automated-tests-for-terraform-code).
 
 5.  Deploy your changes to each environment. You do this using the same process outlined in [Deploying Terraform code](#deploy_terraform).

--- a/_docs-sources/intro/core-concepts/production-framework.md
+++ b/_docs-sources/intro/core-concepts/production-framework.md
@@ -12,4 +12,4 @@ cloud:
 
 If you'd like to build your mental model on how to think about cloud usage, and you're looking for a set of steps you
 can follow to make better use of the cloud at your company, read the [Gruntwork Production Framework
-Guide](/docs/guides/production-framework) for the full details.
+Guide](/guides/production-framework) for the full details.

--- a/_docs-sources/intro/first-deployment/deploy.md
+++ b/_docs-sources/intro/first-deployment/deploy.md
@@ -144,7 +144,7 @@ balancers, and so on. Each module is configured via a `terragrunt.hcl` file.
 </div>
 
 For example, if you were using AWS, with separate accounts for staging and production (see
-[How to Configure a Production Grade AWS Account Structure](/docs/guides/build-it-yourself/landing-zone/)),
+[How to Configure a Production Grade AWS Account Structure](/guides/build-it-yourself/landing-zone/)),
 and you wanted to deploy the `vpc-app` module in the `us-east-2` region in
 each of these accounts, the folder structure would look like this:
 

--- a/_docs-sources/intro/first-deployment/using-terraform-modules.md
+++ b/_docs-sources/intro/first-deployment/using-terraform-modules.md
@@ -10,7 +10,7 @@ You must be a <span class="js-subscribe-cta">Gruntwork subscriber</span> to acce
 :::
 
 You can use this module to deploy a production-grade VPC on AWS. For full background information on VPCs, check
-out [How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/).
+out [How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/).
 
 ## Create a wrapper module
 
@@ -66,7 +66,7 @@ The code above will only allow you to run it against the AWS account with ID pas
 variable (you’ll declare this shortly). This is an extra safety measure to ensure you don’t accidentally authenticate
 to the wrong AWS account while deploying this code—e.g., so you don’t accidentally deploy changes intended for
 staging to production (for more info on working with multiple AWS accounts, see
-[How to Configure a Production Grade AWS Account Structure](/docs/guides/build-it-yourself/landing-zone/)).
+[How to Configure a Production Grade AWS Account Structure](/guides/build-it-yourself/landing-zone/)).
 
 </div>
 
@@ -158,7 +158,7 @@ This code pulls in a module using Terraform’s native `module` functionality. F
 
 The `source` URL in the code above uses a Git URL with SSH authentication (see
 [module sources](https://www.terraform.io/docs/modules/sources.html) for all the types of `source` URLs you can use).
-If you have established your account and linked your GitHub ID according to the instruction in [Accessing the Dev Portal](/docs/intro/dev-portal/create-account), this will allow you to access private repos in the Gruntwork
+If you have established your account and linked your GitHub ID according to the instruction in [Accessing the Dev Portal](/intro/dev-portal/create-account), this will allow you to access private repos in the Gruntwork
 Infrastructure as Code Library without having to hard-code a password in your Terraform code.
 
 #### Versioned URL

--- a/_docs-sources/intro/next-steps.mdx
+++ b/_docs-sources/intro/next-steps.mdx
@@ -7,19 +7,19 @@ import Grid from "/src/components/Grid"
 
 # Next Steps
 
-Now that your foundational knowledge is in place and your workspace is configured, you’re ready to dive in and learn how to deploy production-grade infrastructure. If you’ve purchased a Gruntwork Reference Architecture, use [this guide](/docs/guides/reference-architecture) to get started. Otherwise, view our [courses](/docs/courses) and [guides](/docs/guides), or check out the [Service Catalog API reference](/docs/reference/services/intro/overview) to learn what’s available.
+Now that your foundational knowledge is in place and your workspace is configured, you’re ready to dive in and learn how to deploy production-grade infrastructure. If you’ve purchased a Gruntwork Reference Architecture, use [this guide](/guides/reference-architecture) to get started. Otherwise, view our [courses](/courses) and [guides](/guides), or check out the [Service Catalog API reference](/reference/services/intro/overview) to learn what’s available.
 
 <Grid cols={2}>
   <Card
     title="Set Up Your Reference Architecture"
-    href="/docs/guides/reference-architecture"
+    href="/guides/reference-architecture"
   >
     Learn how to use and administer a Reference Architecture which Gruntwork has
     deployed for you.
   </Card>
   <Card
     title="Build Your Own Architecture"
-    href="/docs/guides#build-your-own-architecture"
+    href="/guides#build-your-own-architecture"
   >
     Learn how to utilize our service modules to construct a world-class
     architecture on your own.

--- a/_docs-sources/intro/overview/getting-started.mdx
+++ b/_docs-sources/intro/overview/getting-started.mdx
@@ -2,26 +2,26 @@ import { CardList } from "/src/components/CardGroup"
 
 # Getting started
 
-In this introductory guide we’ll cover the fundamentals you'll need in order to be successful with Gruntwork. After setting up your account to gain access to Gruntwork products, we’ll help you install necessary tools and understand how they fit into the Gruntwork development workflow. Once finished, you’ll have the knowledge required to dive into our [guides](/docs/guides) and make full use of the IaC Library.
+In this introductory guide we’ll cover the fundamentals you'll need in order to be successful with Gruntwork. After setting up your account to gain access to Gruntwork products, we’ll help you install necessary tools and understand how they fit into the Gruntwork development workflow. Once finished, you’ll have the knowledge required to dive into our [guides](/guides) and make full use of the IaC Library.
 
 <CardList>
   <Card
     title="Gain access to Gruntwork’s products"
-    href="/docs/intro/dev-portal/create-account"
+    href="/intro/dev-portal/create-account"
   >
     Create an account with our Developer Portal to access the IaC Library and
     training courses.
   </Card>
   <Card
     title="Set up your environment"
-    href="/docs/intro/environment-setup/recommended_tools"
+    href="/intro/environment-setup/recommended_tools"
   >
     Prepare your local development environment for efficiently working with the
     industry standard DevOps tools.
   </Card>
   <Card
     title="Learn the tools of the trade"
-    href="/docs/intro/tool-fundamentals/docker"
+    href="/intro/tool-fundamentals/docker"
   >
     Learn how to leverage these tools with Gruntwork products to realize your
     infrastructure needs.

--- a/_docs-sources/intro/overview/how-it-works.md
+++ b/_docs-sources/intro/overview/how-it-works.md
@@ -5,7 +5,7 @@
 There are two fundamental ways to engage Gruntwork:
 
 1. **Gruntwork builds your architecture.** We generate the [Reference Architecture](https://gruntwork.io/reference-architecture/) based on your needs, deploy into your AWS accounts, and give you 100% of the code. Since you have all the code, you can extend, enhance, and customize the environment exactly according to your needs. The deploy process takes about one day.
-2. **Build it yourself.** The Gruntwork IaC library empowers you to [construct your own bespoke architecture](/docs/guides#build-your-own-architecture) in record time. By mix-and-matching our modules and services you can quickly define a custom architecture to suit your needs, all with the confidence of having world-class, battle-tested code running under the hood.
+2. **Build it yourself.** The Gruntwork IaC library empowers you to [construct your own bespoke architecture](/guides#build-your-own-architecture) in record time. By mix-and-matching our modules and services you can quickly define a custom architecture to suit your needs, all with the confidence of having world-class, battle-tested code running under the hood.
 
 ## What we provide
 
@@ -38,8 +38,8 @@ A team of experienced Gruntwork engineers who help you achieve success using Gru
 
 Gruntwork offers basic and paid support options:
 
-- **[Community support](/docs/guides/support#get-support).** Get help via a [Gruntwork Community Slack](https://gruntwork-community.slack.com/archives/CHH9Y3Z62) and our [Knowledge Base](https://github.com/gruntwork-io/knowledge-base/discussions).
-- **[Paid support](/docs/guides/support#paid-support-tiers).** Get help via email, a private Slack channel, or scheduled Zoom calls, with response times backed by SLAs.
+- **[Community support](/guides/support#get-support).** Get help via a [Gruntwork Community Slack](https://gruntwork-community.slack.com/archives/CHH9Y3Z62) and our [Knowledge Base](https://github.com/gruntwork-io/knowledge-base/discussions).
+- **[Paid support](/guides/support#paid-support-tiers).** Get help via email, a private Slack channel, or scheduled Zoom calls, with response times backed by SLAs.
 
 ## What you provide
 

--- a/_docs-sources/intro/tool-fundamentals/packer.md
+++ b/_docs-sources/intro/tool-fundamentals/packer.md
@@ -39,7 +39,7 @@ includes an `ssh-grunt` binary you can run on each server to manage SSH access t
 IAM users in specific IAM groups will be able to SSH to specific servers using their own usernames and SSH keys).
 
 To get these scripts and binaries onto your virtual servers (e.g., onto EC2 instances in AWS), we recommend using Packer to build VM images that have these scripts and binaries installed. You'll see an
-example of how to do this in our [Deploy Your First Module](/docs/intro/first-deployment/using-terraform-modules) section.
+example of how to do this in our [Deploy Your First Module](/intro/first-deployment/using-terraform-modules) section.
 
 :::note
 

--- a/_docs-sources/reference/services/intro/create-your-own-service-catalog.md
+++ b/_docs-sources/reference/services/intro/create-your-own-service-catalog.md
@@ -25,7 +25,7 @@ the Gruntwork Service Catalog? There are two things to check:
    common and likely affects many companies, we should support it! If that's the case, please [file a GitHub issue in
    this repo](https://github.com/gruntwork-io/terraform-aws-service-catalog/issues/new), and the Gruntwork team may be able to implement it for you. Also, pull requests are VERY welcome! See
    [Contributing to the Gruntwork Service
-   Catalog](/docs/guides/working-with-code/contributing)
+   Catalog](/guides/working-with-code/contributing)
    for instructions.
 
 If your use case isn't handled by the Gruntwork Service Catalog, and it's something fairly specific to your company,
@@ -99,13 +99,13 @@ One way to populate your Service Catalog is to extend Gruntwork Services. There 
 1. **(NOT RECOMMENDED) Copy a Gruntwork Service**. Another way to extend a Gruntwork Service is to copy all of the code
    for that one service into your own Git repo and modify the code directly. This is not recommended, as then you'll
    have to maintain all of the code for that service yourself, and won't benefit from all the [maintenance
-   work](/docs/reference/services/intro/overview#maintenance-and-versioning) done by the Gruntwork team. The only reason to copy the code this way is if you
+   work](/reference/services/intro/overview#maintenance-and-versioning) done by the Gruntwork team. The only reason to copy the code this way is if you
    need a significant change that cannot be done from outside the service.
 
 1. **(NOT RECOMMENDED) Fork the Gruntwork Service Catalog**. Yet another option is to
    [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the entire Gruntwork Service
    Catalog into a repo of your own. This is not recommended, as then you'll have to maintain all of that code yourself,
-   and won't benefit from all the [maintenance work](/docs/reference/services/intro/overview/#maintenance-and-versioning) done by the Gruntwork team. The only
+   and won't benefit from all the [maintenance work](/reference/services/intro/overview/#maintenance-and-versioning) done by the Gruntwork team. The only
    reason to fork the entire repo is if you have a company policy that only allows you consume code from your own
    repositories. Note that if you do end up forking the entire Service Catalog, you can use `git fetch` and `git merge`
    to [automatically pull in changes from

--- a/_docs-sources/reference/services/intro/deploy-new-infrastructure.md
+++ b/_docs-sources/reference/services/intro/deploy-new-infrastructure.md
@@ -118,7 +118,7 @@ deploy Terraform code from the Service Catalog. See
 
    1. **GitHub Authentication**: All of Gruntwork's code lives in GitHub, and as most of the repos are private, you must
       authenticate to GitHub to be able to access the code. For Terraform, we recommend using Git / SSH URLs and using
-      SSH keys for authentication. See [Link Your GitHub ID](/docs/intro/dev-portal/link-github-id)
+      SSH keys for authentication. See [Link Your GitHub ID](/intro/dev-portal/link-github-id)
       for instructions on linking your GitHub ID and gaining access.
 
 1. **Deploy**. You can now deploy the service as follows:
@@ -258,7 +258,7 @@ Now you can create child `terragrunt.hcl` files to deploy services as follows:
    1. **GitHub Authentication**: All of Gruntwork's code lives in GitHub, and as most of the repos are private, you must
       authenticate to GitHub to be able to access the code. For Terraform, we recommend using Git / SSH URLs and using
       SSH keys for authentication. See [How to get access to the Gruntwork Infrastructure as Code
-      Library](/docs/intro/dev-portal/create-account)
+      Library](/intro/dev-portal/create-account)
       for instructions on setting up your SSH key.
 
 1. **Deploy**. You can now deploy the service as follows:
@@ -315,7 +315,7 @@ Below are instructions on how to build an AMI using these Packer templates. We'l
       ```
 
       See [How to get access to the Gruntwork Infrastructure as Code
-      Library](/docs/intro/dev-portal/create-account)
+      Library](/intro/dev-portal/create-account)
       for instructions on setting up GitHub personal access token.
 
 1. **Set variables**. Each Packer template defines variables you can set in a `variables` block at the top, such as

--- a/_docs-sources/reference/services/intro/make-changes-to-your-infrastructure.md
+++ b/_docs-sources/reference/services/intro/make-changes-to-your-infrastructure.md
@@ -60,7 +60,7 @@ Now that your infrastructure is deployed, let's discuss how to make changes to i
 Whenever changing version numbers, make sure to read the [release
 notes](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases), especially if it's a backwards
 incompatible release (e.g., `v0.0.1` -> `v0.1.0`), to avoid errors and outages (see [maintenance and
-versioning](/docs/reference/services/intro/overview/#maintenance-and-versioning) for details)!
+versioning](/reference/services/intro/overview/#maintenance-and-versioning) for details)!
 
 :::
 
@@ -128,7 +128,7 @@ versioning](/docs/reference/services/intro/overview/#maintenance-and-versioning)
 Whenever changing version numbers, make sure to read the [release
 notes](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases), especially if it's a backwards
 incompatible release (e.g., `v0.0.1` -> `v0.1.0`), to avoid errors and outages (see [maintenance and
-versioning](/docs/reference/services/intro/overview/#maintenance-and-versioning) for details)!
+versioning](/reference/services/intro/overview/#maintenance-and-versioning) for details)!
 
 :::
 
@@ -173,7 +173,7 @@ _(Documentation coming soon. If you need help with this ASAP, please contact [su
    Whenever changing version numbers, make sure to read the [release
    notes](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases), especially if it's a backwards incompatible
    release (e.g., `v0.0.1` -> `v0.1.0`), to avoid errors and outages (see [maintenance and
-   versioning](/docs/reference/services/intro/overview/#maintenance-and-versioning) for details)!
+   versioning](/reference/services/intro/overview/#maintenance-and-versioning) for details)!
 
    :::
 

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-root-to-root-account.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-root-to-root-account.md
@@ -58,9 +58,9 @@ We’ll be using the `landingzone/account-baseline-root` module from [terraform-
 :::info
 
 This guide will use [Terragrunt](https://github.com/gruntwork-io/terragrunt) and its associated file and folder
-structure to deploy Terraform modules. Please note that **Terragrunt is NOT required for using Terraform modules from the Gruntwork Infrastructure as Code Library.** Check out our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork) section
+structure to deploy Terraform modules. Please note that **Terragrunt is NOT required for using Terraform modules from the Gruntwork Infrastructure as Code Library.** Check out our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork) section
 for instructions on alternative options, such as how to
-[deploying how to use plain terraform](/docs/intro/first-deployment/deploy#deploy-using-plain-terraform).
+[deploying how to use plain terraform](/intro/first-deployment/deploy#deploy-using-plain-terraform).
 
 :::
 
@@ -587,5 +587,5 @@ those root users again.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"4d2c256eab29805b37863d1cb894df64"}
+{"sourcePlugin":"local-copier","hash":"16a777737a8d6c48de0fe2f6ca292c5a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/pre-requisites.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/pre-requisites.md
@@ -13,7 +13,7 @@ This walkthrough has the following pre-requisites:
 
 This guide uses code from the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/), as it
 implements most of the production-grade design for you out of the box. Make sure to read
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork).
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork).
 
 ## Gruntwork Compliance for CIS AWS Foundations Benchmark
 
@@ -37,7 +37,7 @@ This guide uses [Terraform](https://www.terraform.io/) to define and manage all 
 you’re not familiar with Terraform, check out
 [A Comprehensive Guide to Terraform](https://blog.gruntwork.io/a-comprehensive-guide-to-terraform-b3d32832baca),
 [A Crash Course on Terraform](https://training.gruntwork.io/p/terraform), and
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork).
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork).
 
 ## Terragrunt
 
@@ -55,5 +55,5 @@ automatically.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"2dfc3e78de3b128b6214b1e348ad8720"}
+{"sourcePlugin":"local-copier","hash":"cfc6e23713c964098ba9f49dbe2a448f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/the-gruntwork-solution.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/the-gruntwork-solution.md
@@ -55,9 +55,9 @@ You can use this approach on each AWS account. In many cases, you’ll only need
 same methodology can be applied to pre-production accounts as well.
 
 If you need to brush up on how the IaC Library works, read the
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork) section.
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork) section.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"7a0b46868c3bef4b60bcd8b808688a14"}
+{"sourcePlugin":"local-copier","hash":"81acd02dda18bf32fb8caa79c4628c3c"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/index.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/index.md
@@ -11,7 +11,7 @@ import { CardList } from "/src/components/CardGroup"
 
 This guide was last updated on 6th September 2021, and it covers CIS 1.4.0 Benchmark recommendations. We aim to keep
 it up to date with our infrastructure-as-code modules with the latest CIS Benchmark that has been released.
-If you need to access older versions, please [get in touch](/docs/guides/support) with us.
+If you need to access older versions, please [get in touch](/guides/support) with us.
 
 :::
 
@@ -24,8 +24,8 @@ compliant state over time because all of the infrastructure is defined as code. 
 
 Previously, we supported versions 1.3.0 and 1.2.0 of the Benchmark. If you are looking to upgrade from an older version please follow these in order:
 
-- To upgrade from v1.2.0 to v1.3.0, please follow [this upgrade guide](/docs/guides/stay-up-to-date/cis/cis-1.3.0).
-- To upgrade from v1.3.0 to v1.4.0, please follow [this upgrade guide](/docs/guides/stay-up-to-date/cis/cis-1.4.0).
+- To upgrade from v1.2.0 to v1.3.0, please follow [this upgrade guide](/guides/stay-up-to-date/cis/cis-1.3.0).
+- To upgrade from v1.3.0 to v1.4.0, please follow [this upgrade guide](/guides/stay-up-to-date/cis/cis-1.4.0).
 
 ![CIS Benchmark Architecture](/img/guides/build-it-yourself/achieve-compliance/cis-account-architecture.png)
 
@@ -36,31 +36,31 @@ Feel free to read this guide from start to finish or skip around to whatever sec
 <CardList>
   <Card
     title="Core Concepts"
-    href="/docs/guides/build-it-yourself/achieve-compliance/core-concepts/intro"
+    href="/guides/build-it-yourself/achieve-compliance/core-concepts/intro"
   >
     An overview of the AWS Foundations Benchmark, including its control sections and structure.
   </Card>
   <Card
     title="Production-grade Design"
-    href="/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/intro"
+    href="/guides/build-it-yourself/achieve-compliance/production-grade-design/intro"
   >
     How to use infrastructure as code to achieve compliance with minimal redundancy and maximum flexibility.
   </Card>
   <Card
     title="Deployment Walkthrough"
-    href="/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/pre-requisites"
+    href="/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/pre-requisites"
   >
     A step-by-step guide to achieving compliance using the Gruntwork Infrastructure as Code Library and the Gruntwork CIS AWS Foundations Benchmark wrapper modules.
   </Card>
   <Card
     title="Next Steps"
-    href="/docs/guides/build-it-yourself/achieve-compliance/next-steps"
+    href="/guides/build-it-yourself/achieve-compliance/next-steps"
   >
     How to measure and maintain compliance.
   </Card>
   <Card
     title="Traceability Matrix"
-    href="/docs/guides/build-it-yourself/achieve-compliance/traceability-matrix"
+    href="/guides/build-it-yourself/achieve-compliance/traceability-matrix"
   >
     A reference table that maps each Benchmark recommendation to the corresponding section in the deployment
 walkthrough.
@@ -69,5 +69,5 @@ walkthrough.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a331244072d0a4be58b885b03c5586bb"}
+{"sourcePlugin":"local-copier","hash":"f735722cc21c3e250996429eb3b3e404"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/intro.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/intro.md
@@ -6,7 +6,7 @@ pagination_label: Production-grade Design
 
 In [core concepts](../core-concepts/intro.md) we discussed the basics of the AWS Foundations Benchmark. Although it's possible to achieve
 compliance with the Benchmark by manually configuring each setting in the web console or entering the CLI commands, we
-strongly discourage this approach. It precludes [the myriad benefits of using code to manage infrastructure](/docs/intro/core-concepts/infrastructure-as-code).
+strongly discourage this approach. It precludes [the myriad benefits of using code to manage infrastructure](/intro/core-concepts/infrastructure-as-code).
 
 Instead, we advise using [Terraform](https://www.terraform.io) (or similar tools, such as
 [CloudFormation](https://aws.amazon.com/cloudformation/) or [Pulumi](https://www.pulumi.com/) to configure cloud
@@ -18,5 +18,5 @@ edition of Terraform Up & Running](https://blog.gruntwork.io/terraform-up-runnin
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"152925cd246282831b58cf2c50820506"}
+{"sourcePlugin":"local-copier","hash":"ab4dea7e2ecd7ee7d27a518c86385d5b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/storage.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/storage.md
@@ -65,7 +65,7 @@ The CIS 1.4.0 Benchmark recommends a few additional steps to ensure your data is
 
 :::info
 
-The steps below are not the full list of actions needed to configure MFA Delete or Amazon Macie for your account. To follow the steps necessary to configure it according to the CIS 1.4.0 Benchmark, please follow the MFA Delete and Macie section in the [the migration guide to CIS 1.4.0](/docs/guides/stay-up-to-date/cis/cis-1.4.0), or the deployment guide section in this guide.
+The steps below are not the full list of actions needed to configure MFA Delete or Amazon Macie for your account. To follow the steps necessary to configure it according to the CIS 1.4.0 Benchmark, please follow the MFA Delete and Macie section in the [the migration guide to CIS 1.4.0](/guides/stay-up-to-date/cis/cis-1.4.0), or the deployment guide section in this guide.
 :::
 
 ### Enable MFA Delete (recommendation 2.1.3)
@@ -138,5 +138,5 @@ explicit list of buckets per region, namely in the variable `buckets_to_analyze`
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"24bb2e4b78e4d2e26adcc516f73a3932"}
+{"sourcePlugin":"local-copier","hash":"a42545420e9759182b9a7727a91aab4a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/index.md
+++ b/docs/guides/build-it-yourself/index.md
@@ -3,39 +3,39 @@ import Grid from "/src/components/Grid"
 
 # Build Your Own Architecture
 
-The Gruntwork IaC library empowers you to construct your own bespoke architecture in record time. By mix-and-matching our modules and services you can quickly define a custom architecture to suit your needs, all with the confidence of having world-class, battle-tested code running under the hood. This series of guides aims to teach you how to configure and deploy some of our most popular services. Additional guides will be added over time, but the principles covered extend to the rest of the IaC library. If you have trouble, don’t hesitate to ask questions via our [support channels](/docs/guides/support).
+The Gruntwork IaC library empowers you to construct your own bespoke architecture in record time. By mix-and-matching our modules and services you can quickly define a custom architecture to suit your needs, all with the confidence of having world-class, battle-tested code running under the hood. This series of guides aims to teach you how to configure and deploy some of our most popular services. Additional guides will be added over time, but the principles covered extend to the rest of the IaC library. If you have trouble, don’t hesitate to ask questions via our [support channels](/guides/support).
 
 ## Follow Our Deployment Guides
 
 <Grid cols={2}>
   <Card
     title="Set Up Your AWS Accounts"
-    href="/docs/guides/build-it-yourself/landing-zone"
+    href="/guides/build-it-yourself/landing-zone"
   >
     Set up a multi-account structure using Gruntwork Landing Zone.
   </Card>
   <Card
     title="Configure a CI/CD Pipeline"
-    href="/docs/guides/build-it-yourself/pipelines"
+    href="/guides/build-it-yourself/pipelines"
   >
     Implement continuous deployment for your infrastructure code with Gruntwork
     Pipelines.
   </Card>
   <Card
     title="Deploy a VPC"
-    href="/docs/guides/build-it-yourself/vpc"
+    href="/guides/build-it-yourself/vpc"
   >
     Set up your network according to industry best practices using our VPC service.
   </Card>
   <Card
     title="Deploy a Kubernetes Cluster"
-    href="/docs/guides/build-it-yourself/kubernetes-cluster"
+    href="/guides/build-it-yourself/kubernetes-cluster"
   >
     Deploy a Kubernetes Cluster to host all of your apps and services.
   </Card>
   <Card
     title="Acheive Compliance"
-    href="/docs/guides/build-it-yourself/achieve-compliance"
+    href="/guides/build-it-yourself/achieve-compliance"
   >
     Make your infrastructure compliant with the CIS AWS Foundations Benchmark.
   </Card>
@@ -44,7 +44,7 @@ The Gruntwork IaC library empowers you to construct your own bespoke architectur
 ## Dig Into the Code
 
 <Grid cols={2}>
-  <Card title="Browse Services" href="/docs/reference/services/intro">
+  <Card title="Browse Services" href="/reference/services/intro">
     View the API reference for our entire service catalog to learn what’s
     available.
   </Card>
@@ -59,5 +59,5 @@ The Gruntwork IaC library empowers you to construct your own bespoke architectur
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"7e84b0d672730f8915d03ca24db2536b"}
+{"sourcePlugin":"local-copier","hash":"8d722de87a83f4c7d1d73aef0a93e425"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/deploy-the-vpc.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/deploy-the-vpc.md
@@ -1,7 +1,7 @@
 # Deploy the VPC
 
 The first step is to deploy a VPC. Follow the instructions in
-[How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/) to use
+[How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/) to use
 `module-vpc` to create a VPC setup that looks like this:
 
 ![A production-grade VPC setup deployed using module-vpc from the Gruntwork Infrastructure as Code Library](/img/guides/build-it-yourself/vpc/vpc-diagram.png)
@@ -107,9 +107,9 @@ module "dns_mgmt_to_app" {
 ```
 
 At this point, you’ll want to test your code. See
-[Manual tests for Terraform code](/docs/intro/first-deployment/testing#manual-tests-for-terraform-code)
+[Manual tests for Terraform code](/intro/first-deployment/testing#manual-tests-for-terraform-code)
 and
-[Automated tests for Terraform code](/docs/intro/first-deployment/testing#automated-tests-for-terraform-code)
+[Automated tests for Terraform code](/intro/first-deployment/testing#automated-tests-for-terraform-code)
 for instructions.
 
 Once your updated `vpc-app` wrapper module is working the way you want, submit a pull request, get your changes merged
@@ -126,9 +126,9 @@ git push --follow-tags
 This guide will use [Terragrunt](https://github.com/gruntwork-io/terragrunt) and its associated file and folder
 structure to deploy Terraform modules. Please note that **Terragrunt is NOT required for using Terraform modules from
 the Gruntwork Infrastructure as Code Library.** Check out
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork) for instructions
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork) for instructions
 on alternative options, such as how to
-[Deploy using plain Terraform](/docs/intro/first-deployment/deploy#deploy-using-plain-terraform).
+[Deploy using plain Terraform](/intro/first-deployment/deploy#deploy-using-plain-terraform).
 
 :::
 
@@ -149,5 +149,5 @@ terragrunt apply
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"25998d0f52b570803234fa1b86512c30"}
+{"sourcePlugin":"local-copier","hash":"58b8f9e6fdf484fe77a7af365a0b1d52"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/pre-requisites.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/pre-requisites.md
@@ -14,7 +14,7 @@ This walkthrough has the following pre-requisites:
 
 This guide uses code from the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/), as it
 implements most of the production-grade design for you out of the box. Make sure to read
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork).
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork).
 
 </div>
 
@@ -31,7 +31,7 @@ You must be a <span className="js-subscribe-cta">Gruntwork subscriber</span> to 
 This guide uses [Terraform](https://www.terraform.io/) to define and manage all the infrastructure as code. If you’re
 not familiar with Terraform, check out [A
 Comprehensive Guide to Terraform](https://blog.gruntwork.io/a-comprehensive-guide-to-terraform-b3d32832baca), [A Crash Course on Terraform](https://training.gruntwork.io/p/terraform), and
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork).
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork).
 
 #### Python and Kubergrunt
 
@@ -44,12 +44,12 @@ Python and `kubergrunt` installed on any computer where you will be running Terr
 This guide assumes you are deploying a Kubernetes cluster for use with [Docker](https://www.docker.com). The guide also
 uses [Packer](https://www.packer.io) to build VM images. If you’re not familiar with Docker or Packer, check out
 [A Crash Course on Docker and Packer](https://training.gruntwork.io/p/a-crash-course-on-docker-packer) and
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork).
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork).
 
 #### AWS accounts
 
 This guide deploys infrastructure into one or more AWS accounts. Check out the
-[How to configure a production-grade AWS account structure](/docs/guides/build-it-yourself/landing-zone/)
+[How to configure a production-grade AWS account structure](/guides/build-it-yourself/landing-zone/)
 guide for instructions. You will also need to be able to authenticate to these accounts on the CLI: check out
 [A Comprehensive Guide to Authenticating to AWS on the Command Line](https://blog.gruntwork.io/a-comprehensive-guide-to-authenticating-to-aws-on-the-command-line-63656a686799)
 for instructions.
@@ -58,5 +58,5 @@ for instructions.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"84c48c3858a2c9855ecdf8078f675566"}
+{"sourcePlugin":"local-copier","hash":"bb604626b168b80f098c1e9b7153e517"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/index.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/index.md
@@ -20,7 +20,7 @@ This guide will walk you through the process of configuring a production-grade K
 <CardList>
   <Card
     title="Core Concepts"
-    href="/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/why-kubernetes"
+    href="/guides/build-it-yourself/kubernetes-cluster/core-concepts/why-kubernetes"
   >
     An overview of the core concepts you need to understand to use Kubernetes, including why you may want to use
     ubernetes, Kubernetes architecture, the control plane, worker nodes, different ways to run Kubernetes, services,
@@ -28,21 +28,21 @@ This guide will walk you through the process of configuring a production-grade K
   </Card>
   <Card
     title="Production-grade Design"
-    href="/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/intro"
+    href="/guides/build-it-yourself/kubernetes-cluster/production-grade-design/intro"
   >
     An overview of how to configure a secure, scalable, highly available Kubernetes cluster that you can rely on in
     production.
   </Card>
   <Card
     title="Deployment Walkthrough"
-    href="/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/pre-requisites"
+    href="/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/pre-requisites"
   >
     A step-by-step guide to deploying a production-grade Kubernetes cluster in AWS using code from the Gruntwork
     Infrastructure as Code Library.
   </Card>
   <Card
     title="Next Steps"
-    href="/docs/guides/build-it-yourself/kubernetes-cluster/next-steps"
+    href="/guides/build-it-yourself/kubernetes-cluster/next-steps"
   >
     What to do once you’ve got your Kubernetes cluster deployed.
   </Card>
@@ -50,5 +50,5 @@ This guide will walk you through the process of configuring a production-grade K
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"62cfb3027052dad19dfb4ab9cf4f35fa"}
+{"sourcePlugin":"local-copier","hash":"2bc76558e0896d476267b38e9d6182a1"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/control-plane.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/control-plane.md
@@ -19,7 +19,7 @@ minor version.
 
 Your EKS cluster will run in the subnets you specify. We strongly recommend running solely in private subnets that
 are NOT directly accessible from the public Internet. See
-[How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/) for more
+[How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/) for more
 info.
 
 #### Endpoint access
@@ -28,7 +28,7 @@ You can configure whether the [API endpoint for your EKS cluster](https://docs.a
 is accessible from (a) within the same VPC and/or (b) from the public Internet. We recommend allowing access from
 within the VPC, but not from the public Internet. If you need to talk to your Kubernetes cluster from your own
 computer (e.g., to issue commands via `kubectl`), use a bastion host or VPN server. See
-[How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/) for more
+[How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/) for more
 info.
 
 #### Cluster IAM Role
@@ -54,5 +54,5 @@ CloudWatch.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"c12632ebc1aea13de480176e30ee40e1"}
+{"sourcePlugin":"local-copier","hash":"33906f19517c426da30c4b4055e951d5"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/vpc-configuration.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/vpc-configuration.md
@@ -2,7 +2,7 @@
 
 EKS relies on a _[Virtual Private Cloud (VPC)](https://aws.amazon.com/vpc/)_ to provide the basic network topology and
 to manage communication across the nodes (see
-[How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/) for more
+[How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/) for more
 information on VPCs). Here are the key VPC considerations for your EKS cluster:
 
 <div className="dlist">
@@ -30,5 +30,5 @@ sure that remote VPC DNS resolution is enabled on both accepter and requester si
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"031957b78e9ca3c0aed6778890b0d322"}
+{"sourcePlugin":"local-copier","hash":"13fa4dbe8f473c8e7d1a69075e8b8332"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/worker-nodes.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/worker-nodes.md
@@ -20,7 +20,7 @@ value `owned`.
 
 We strongly recommend running the Auto Scaling Group for your worker nodes in private subnets that are NOT directly
 accessible from the public Internet. See
-[How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/) for more
+[How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/) for more
 info.
 
 #### AMI
@@ -66,5 +66,5 @@ a secure base image (e.g., CIS hardened images), intrusion prevention (e.g., `fa
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a17897f8b4b3730ce0c9206f71d36a3f"}
+{"sourcePlugin":"local-copier","hash":"a43f6ca97de73dd352c53ef2b9c67447"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/pre-requisites.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/pre-requisites.md
@@ -14,7 +14,7 @@ This walkthrough has the following pre-requisites:
 
 This guide uses code from the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/), as it
 implements most of the production-grade design for you out of the box. Make sure to read
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork).
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork).
 
 </div>
 
@@ -31,7 +31,7 @@ You must be a <span className="js-subscribe-cta">Gruntwork subscriber</span> to 
 This guide uses [Terraform](https://www.terraform.io/) to define and manage all the infrastructure as code. If you’re
 not familiar with Terraform, check out [A
 Comprehensive Guide to Terraform](https://blog.gruntwork.io/a-comprehensive-guide-to-terraform-b3d32832baca), [A Crash Course on Terraform](https://training.gruntwork.io/p/terraform), and
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork).
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork).
 
 #### Terragrunt
 
@@ -56,5 +56,5 @@ automatically.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"29b8c6bff7024eeabc149de8c5748f18"}
+{"sourcePlugin":"local-copier","hash":"236b0439a1fea830fcd050c5a4b2bbbf"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/prepare-your-infrastructure-live-repository.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/prepare-your-infrastructure-live-repository.md
@@ -4,9 +4,9 @@
 
 This guide uses [Terragrunt](https://github.com/gruntwork-io/terragrunt) and its associated file and folder
 structure to deploy Terraform modules. Please note that **Terragrunt is NOT required for using Terraform modules from
-the Gruntwork Infrastructure as Code Library.** Check out our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork)
+the Gruntwork Infrastructure as Code Library.** Check out our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork)
 for instructions on alternative options, such as
-[deploying with plain Terraform](/docs/intro/first-deployment/deploy#deploy-using-plain-terraform).
+[deploying with plain Terraform](/intro/first-deployment/deploy#deploy-using-plain-terraform).
 
 :::
 
@@ -176,5 +176,5 @@ locals {
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"365b0a475cb75114d49ad04e44db01f7"}
+{"sourcePlugin":"local-copier","hash":"35887123ab1bc3a011216db14a532073"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/index.md
+++ b/docs/guides/build-it-yourself/landing-zone/index.md
@@ -71,25 +71,25 @@ Feel free to read this guide from start to finish or skip around to whatever sec
 <CardList>
   <Card
     title="Core Concepts"
-    href="/docs/guides/build-it-yourself/landing-zone/core-concepts/aws-account"
+    href="/guides/build-it-yourself/landing-zone/core-concepts/aws-account"
   >
     An overview of the core concepts you need to understand to set up an AWS account structure, including AWS Organizations, IAM Users, IAM Roles, IAM Groups, CloudTrail, and more.
   </Card>
   <Card
     title="Production-grade Design"
-    href="/docs/guides/build-it-yourself/landing-zone/production-grade-design/intro"
+    href="/guides/build-it-yourself/landing-zone/production-grade-design/intro"
   >
     An overview of how to configure a secure, scalable, highly available AWS account structure that you can rely on in production.
   </Card>
   <Card
     title="Deployment Walkthrough"
-    href="/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/pre-requisites"
+    href="/guides/build-it-yourself/landing-zone/deployment-walkthrough/pre-requisites"
   >
     A step-by-step guide to configuring a production-grade AWS account structure using the Gruntwork AWS Landing Zone solution, including how to manage it all with customizable security baselines defined in Terraform.
   </Card>
   <Card
     title="Next Steps"
-    href="/docs/guides/build-it-yourself/landing-zone/next-steps"
+    href="/guides/build-it-yourself/landing-zone/next-steps"
   >
     What to do once you’ve got your AWS account structure configured.
   </Card>
@@ -97,5 +97,5 @@ Feel free to read this guide from start to finish or skip around to whatever sec
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"89a23389c258df7506ec7339fc8476fc"}
+{"sourcePlugin":"local-copier","hash":"958ca6a907fe9689d532102b723241d7"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/next-steps.md
+++ b/docs/guides/build-it-yourself/landing-zone/next-steps.md
@@ -2,9 +2,9 @@
 
 Now that you have your basic AWS account structure set up, the next step is to start deploying infrastructure in those
 accounts! Usually, the best starting point is to configure your network topology, as described in
-[How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/).
+[How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/).
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"f499b445b0574d0556670e832233def8"}
+{"sourcePlugin":"local-copier","hash":"5b9f8101edad02a62a1b7fb5f75275e6"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/iam-roles-for-services.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/iam-roles-for-services.md
@@ -54,7 +54,7 @@ need to take extra care in terms of who can assume this IAM role, what permissio
 services. For example, if you have Jenkins running on an EC2 instance, and you give that EC2 instance access to an
 IAM role so it can deploy your apps, you should do your best to minimize the permissions that IAM role has (e.g.,
 to just `ecs` permissions if deploying to ECS) and you should ensure that your Jenkins instance runs in private
-subnets so that it is NOT accessible from the public Internet (see [How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/)).
+subnets so that it is NOT accessible from the public Internet (see [How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/)).
 
 #### Use the right Principal
 
@@ -136,5 +136,5 @@ sensitive machine user access keys.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"5f42e5b6fc72aaaf319e757d874f4f2c"}
+{"sourcePlugin":"local-copier","hash":"6a6f172c3ecdc65911aeb1e7770e05e6"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/deploy-a-vpc.md
+++ b/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/deploy-a-vpc.md
@@ -1,7 +1,7 @@
 # Deploy a VPC
 
 The first step is to deploy a VPC. Follow the instructions in
-[How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/) to use
+[How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/) to use
 `module-vpc` to create a VPC setup that looks like this:
 
 ![A production-grade VPC setup deployed using module-vpc from the Gruntwork Infrastructure as Code Library](/img/guides/build-it-yourself/pipelines/vpc-diagram.png)
@@ -37,5 +37,5 @@ infrastructure-live
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"770e70a7fd8e1ad9c63a7d2d49da5076"}
+{"sourcePlugin":"local-copier","hash":"717d3f161c59cb4de6dce9c9af8d5f46"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/deploy-the-ecs-deploy-runner.md
+++ b/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/deploy-the-ecs-deploy-runner.md
@@ -125,9 +125,9 @@ output "url" {
 ```
 
 At this point, you’ll want to test your code. See
-[Manual tests for Terraform code](/docs/intro/first-deployment/testing#manual-tests-for-terraform-code)
+[Manual tests for Terraform code](/intro/first-deployment/testing#manual-tests-for-terraform-code)
 and
-[Automated tests for Terraform code](/docs/intro/first-deployment/testing#automated-tests-for-terraform-code)
+[Automated tests for Terraform code](/intro/first-deployment/testing#automated-tests-for-terraform-code)
 for instructions.
 
 Once your `ecr-repo` module is working the way you want, submit a pull request, get your changes merged into the
@@ -751,5 +751,5 @@ Repeat for each environment that you want to support the ECS Deploy Runner stack
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"7d011d8a358b5022a2a89a159c5b7136"}
+{"sourcePlugin":"local-copier","hash":"8029084fb854ab63c9abd3a29140edc0"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/pre-requisites.md
+++ b/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/pre-requisites.md
@@ -8,7 +8,7 @@ This walkthrough has the following pre-requisites:
 
 This guide uses code from the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/), as it
 implements most of the production-grade design for you out of the box. Make sure to read
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork).
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork).
 
 </div>
 
@@ -25,7 +25,7 @@ You must be a <span className="js-subscribe-cta">Gruntwork subscriber</span> to 
 This guide uses [Terraform](https://www.terraform.io/) to define and manage all the infrastructure as code. If you’re
 not familiar with Terraform, check out [A
 Comprehensive Guide to Terraform](https://blog.gruntwork.io/a-comprehensive-guide-to-terraform-b3d32832baca), [A Crash Course on Terraform](https://training.gruntwork.io/p/terraform), and
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork)
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork)
 
 #### CircleCI
 
@@ -46,7 +46,7 @@ instructions.
 #### Repository structure
 
 This guide assumes your infrastructure code is organized in a manner similar to that covered in the [Prepare Your
-Module](/docs/intro/first-deployment/using-terraform-modules) introduction section. This means that you should have two
+Module](/intro/first-deployment/using-terraform-modules) introduction section. This means that you should have two
 repositories for your≤ infrastructure code, `infrastructure-modules` and `infrastructure-live`. Make sure that the
 `infrastructure-live` repository is locked down as recommended in [Lock down VCS
 systems](../production-grade-design/lock-down-vcs-systems.md). This guide will assume that `master` is the protected
@@ -59,13 +59,13 @@ branch where infrastructure is deployed from.
 This guide will use [Terragrunt](https://github.com/gruntwork-io/terragrunt) and its associated file and folder
 structure to deploy Terraform modules. Please note that **Terragrunt is NOT required for using Terraform modules from
 the Gruntwork Infrastructure as Code Library.** Check out
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork) for instructions
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork) for instructions
 on alternative options, such as how to
-[Deploy using plain Terraform](/docs/intro/first-deployment/deploy#deploy-using-plain-terraform).
+[Deploy using plain Terraform](/intro/first-deployment/deploy#deploy-using-plain-terraform).
 
 :::
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"9197822517cdbdfa4b21dcca6bdbfaf8"}
+{"sourcePlugin":"local-copier","hash":"791cc3285e6008466de5d18f80dec125"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/index.md
+++ b/docs/guides/build-it-yourself/pipelines/index.md
@@ -60,7 +60,7 @@ Feel free to read this guide from start to finish or skip around to whatever sec
 <CardList>
   <Card
     title="Core Concepts"
-    href="/docs/guides/build-it-yourself/pipelines/core-concepts/why-is-it-important-to-have-ci-cd"
+    href="/guides/build-it-yourself/pipelines/core-concepts/why-is-it-important-to-have-ci-cd"
   >
     An overview of the core concepts you need to understand what a typical CI/CD pipeline entails for infrastructure code,
     including a comparison with CI/CD for application code, a sample workflow, infrastructure to support CI/CD, and threat
@@ -68,21 +68,21 @@ Feel free to read this guide from start to finish or skip around to whatever sec
   </Card>
   <Card
     title="Production-grade Design"
-    href="/docs/guides/build-it-yourself/pipelines/production-grade-design/intro"
+    href="/guides/build-it-yourself/pipelines/production-grade-design/intro"
   >
     An overview of how to configure a secure, scalable, and robust CI/CD workflow that you can rely on for your
     production application and infrastructure code.
   </Card>
   <Card
     title="Deployment Walkthrough"
-    href="/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/pre-requisites"
+    href="/guides/build-it-yourself/pipelines/deployment-walkthrough/pre-requisites"
   >
     A step-by-step guide to deploying a production-grade CI/CD pipeline in AWS using code from the Gruntwork
     Infrastructure as Code Library.
   </Card>
   <Card
     title="Next Steps"
-    href="/docs/guides/build-it-yourself/pipelines/next-steps"
+    href="/guides/build-it-yourself/pipelines/next-steps"
   >
     What to do once you’ve got your CI/CD pipeline set up.
   </Card>
@@ -90,5 +90,5 @@ Feel free to read this guide from start to finish or skip around to whatever sec
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"7bc81688253ed25fe174fa43506dcda0"}
+{"sourcePlugin":"local-copier","hash":"3130cb825c605b438694546804a4f87c"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/use-a-vpc-to-lock-down-deploy-server.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/use-a-vpc-to-lock-down-deploy-server.md
@@ -1,11 +1,11 @@
 # Use a VPC to lock down deploy server
 
 Run your infrastructure deployment workloads in a [Virtual Private Cloud (VPC)](https://aws.amazon.com/vpc/) to isolate
-the workloads in a restricted network topology (see [How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/) for more information on VPCs). Configure it to run all workloads in private
+the workloads in a restricted network topology (see [How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/) for more information on VPCs). Configure it to run all workloads in private
 subnets that are not publicly accessible. Make sure to block all inbound internet access and consider blocking all
 outbound access except for the minimum required (e.g, allow access to AWS APIs).
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"6bd1ba5a7eba360ea55661641c01719c"}
+{"sourcePlugin":"local-copier","hash":"31fee0a9bffad6966be2e1ab2870904e"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-a-management-vpc.md
+++ b/docs/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-a-management-vpc.md
@@ -103,8 +103,8 @@ file for reference.
 
 ## Test your wrapper module
 
-At this point, you’ll want to test your code. See [Manual tests for Terraform code](/docs/intro/first-deployment/testing#manual-tests-for-terraform-code)
-and [Automated tests for Terraform code](/docs/intro/first-deployment/testing#automated-tests-for-terraform-code)
+At this point, you’ll want to test your code. See [Manual tests for Terraform code](/intro/first-deployment/testing#manual-tests-for-terraform-code)
+and [Automated tests for Terraform code](/intro/first-deployment/testing#automated-tests-for-terraform-code)
 for instructions.
 
 ## Merge and release your wrapper module
@@ -149,9 +149,9 @@ route table entries, more bastion hosts, and more credentials.
 
 This guide will use [Terragrunt](https://github.com/gruntwork-io/terragrunt) and its associated file and folder
 structure to deploy Terraform modules. Please note that **Terragrunt is NOT required for using Terraform modules from
-the Gruntwork Infrastructure as Code Library.** Check out our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork)
+the Gruntwork Infrastructure as Code Library.** Check out our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork)
 for instructions on alternative options, such as how to
-[deploy using plain terraform](/docs/intro/first-deployment/deploy#deploy-using-plain-terraform).
+[deploy using plain terraform](/intro/first-deployment/deploy#deploy-using-plain-terraform).
 
 :::
 
@@ -214,5 +214,5 @@ terragrunt apply
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"7f08e438f61898654f9a4b98cdc19bd0"}
+{"sourcePlugin":"local-copier","hash":"8a19045805626f1cc39de968f2bb0727"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-application-vp-cs.md
+++ b/docs/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-application-vp-cs.md
@@ -171,8 +171,8 @@ file for reference.
 
 ## Test your wrapper module
 
-At this point, you’ll want to test your code. See [Manual tests for Terraform code](/docs/intro/first-deployment/testing#manual-tests-for-terraform-code)
-and [Automated tests for Terraform code](/docs/intro/first-deployment/testing#automated-tests-for-terraform-code)
+At this point, you’ll want to test your code. See [Manual tests for Terraform code](/intro/first-deployment/testing#manual-tests-for-terraform-code)
+and [Automated tests for Terraform code](/intro/first-deployment/testing#automated-tests-for-terraform-code)
 for instructions.
 
 ## Merge and release your wrapper module
@@ -245,5 +245,5 @@ terragrunt apply
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"32559a2d6f092f4ce1ca6ca73cd3086b"}
+{"sourcePlugin":"local-copier","hash":"a324250d5ea77e813734245029fd8ea3"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/deployment-walkthrough/pre-requisites.md
+++ b/docs/guides/build-it-yourself/vpc/deployment-walkthrough/pre-requisites.md
@@ -12,7 +12,7 @@ This walkthrough has the following pre-requisites:
 
 This guide uses code from the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/), as it
 implements most of the production-grade design for you out of the box. Make sure to read
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork).
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork).
 
 </div>
 
@@ -29,12 +29,12 @@ You must be a <span className="js-subscribe-cta">Gruntwork subscriber</span> to 
 This guide uses [Terraform](https://www.terraform.io/) to define and manage all the infrastructure as code. If you’re
 not familiar with Terraform, check out [A
 Comprehensive Guide to Terraform](https://blog.gruntwork.io/a-comprehensive-guide-to-terraform-b3d32832baca), [A Crash Course on Terraform](https://training.gruntwork.io/p/terraform), and
-our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork)
+our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork)
 
 #### AWS accounts
 
 This guide deploys infrastructure into one or more AWS accounts. Check out the
-[Production Grade AWS Account Structure](/docs/guides/build-it-yourself/landing-zone/) guide for instructions.
+[Production Grade AWS Account Structure](/guides/build-it-yourself/landing-zone/) guide for instructions.
 You will also need to be able to authenticate to these accounts on the CLI: check out
 [A Comprehensive Guide to Authenticating to AWS on the Command Line](https://blog.gruntwork.io/a-comprehensive-guide-to-authenticating-to-aws-on-the-command-line-63656a686799)
 for instructions.
@@ -43,5 +43,5 @@ for instructions.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a2ede7e054a17736ddfbd917000a0111"}
+{"sourcePlugin":"local-copier","hash":"897a81f742761a069a69b560cd27a435"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/index.md
+++ b/docs/guides/build-it-yourself/vpc/index.md
@@ -20,26 +20,26 @@ Feel free to read this guide from start to finish or skip around to whatever sec
 <CardList>
   <Card
     title="Core Concepts"
-    href="/docs/guides/build-it-yourself/vpc/core-concepts/default-vp-cs-and-custom-vp-cs"
+    href="/guides/build-it-yourself/vpc/core-concepts/default-vp-cs-and-custom-vp-cs"
   >
     An overview of the core concepts you need to understand to use VPCs, including subnets, route tables, security
     groups, NACLs, peering connections, and endpoints.
   </Card>
   <Card
     title="Production-grade Design"
-    href="/docs/guides/build-it-yourself/vpc/production-grade-design/intro"
+    href="/guides/build-it-yourself/vpc/production-grade-design/intro"
   >
     An overview of how to configure a secure, scalable, highly available VPC that you can rely on in production.
   </Card>
   <Card
     title="Deployment Walkthrough"
-    href="/docs/guides/build-it-yourself/vpc/deployment-walkthrough/pre-requisites"
+    href="/guides/build-it-yourself/vpc/deployment-walkthrough/pre-requisites"
   >
     A step-by-step guide to deploying a production-grade VPC in AWS using code from the Gruntwork Infrastructure as Code Library.
   </Card>
   <Card
     title="Next Steps"
-    href="/docs/guides/build-it-yourself/vpc/next-steps"
+    href="/guides/build-it-yourself/vpc/next-steps"
   >
     What to do once you’ve got your VPC(s) deployed.
   </Card>
@@ -47,5 +47,5 @@ Feel free to read this guide from start to finish or skip around to whatever sec
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"76bd75277bb1a3ebced828e532950f87"}
+{"sourcePlugin":"local-copier","hash":"b18c2f59aca7f95a28b40f641a9824bc"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/next-steps.md
+++ b/docs/guides/build-it-yourself/vpc/next-steps.md
@@ -4,7 +4,7 @@ Now that you have your management and application VPCs deployed, you can start b
 on top of them! Typically, the best next step is to deploy a cluster of servers for running your applications by using
 one of the following guides:
 
-- [How to deploy a production-grade Kubernetes cluster on AWS](/docs/guides/build-it-yourself/kubernetes-cluster/)
+- [How to deploy a production-grade Kubernetes cluster on AWS](/guides/build-it-yourself/kubernetes-cluster/)
 - `How to deploy a production grade ECS cluster on AWS` _(coming soon!)_
 - `How to deploy a production grade Nomad cluster on AWS` _(coming soon!)_
 - `How to deploy a production grade Auto Scaling Group on AWS` _(coming soon!)_
@@ -13,5 +13,5 @@ If you’re not sure which of these options to use, check out the `Server Cluste
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"2d41777d239607561dfef17b39e6e4ba"}
+{"sourcePlugin":"local-copier","hash":"77586324e67a96b2d83aa7d115ab4a1a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/production-grade-design/multiple-aws-accounts.md
+++ b/docs/guides/build-it-yourself/vpc/production-grade-design/multiple-aws-accounts.md
@@ -11,10 +11,10 @@ change something in prod rather than pre-prod).
 
 Therefore, your best bet is to put pre-production environments and production environments in completely separate AWS
 accounts. This makes it easy to, for example, grant relatively lax permissions in pre-prod environments, but very
-strict permissions in production. Check out the [Production Grade AWS Account Structure](/docs/guides/build-it-yourself/landing-zone/)
+strict permissions in production. Check out the [Production Grade AWS Account Structure](/guides/build-it-yourself/landing-zone/)
 guide for instructions.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a0d25ddca282e5554b0fc948d61b3e9a"}
+{"sourcePlugin":"local-copier","hash":"c17c05c07c1d9b5d5a89d0d4b54bee60"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -9,12 +9,12 @@ Before you get too deep into the code, it's important to understand Gruntwork's 
 
 <Card
   title="Introduction to Gruntwork"
-  href="/docs/intro/overview/intro-to-gruntwork">
+  href="/intro/overview/intro-to-gruntwork">
 Before anything else, check out our introductory guide to set up your account, prepare your tools, and understand what to expect.
 </Card>
 <Card
   title="The Gruntwork Production Framework"
-  href="/docs/guides/production-framework">
+  href="/guides/production-framework">
 We present a comprehensive model to help you establish a robust infrastructure platform, and explain how Gruntwork can accelarate its adoption in your org.
 </Card>
 
@@ -22,5 +22,5 @@ We present a comprehensive model to help you establish a robust infrastructure p
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"e926883dfcf7a34120f8dd71974374f6"}
+{"sourcePlugin":"local-copier","hash":"e4a74979df7a616ab9e0822a3da5e42f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/index.md
+++ b/docs/guides/production-framework/index.md
@@ -1,3 +1,6 @@
+import Card from "/src/components/Card"
+import { CardList } from "/src/components/CardGroup"
+
 # The Gruntwork Production Framework
 
 In this guide, we are going to share our opinionated, step-by-step framework for successfully going to production on
@@ -5,7 +8,46 @@ the public cloud. At Gruntwork, we've had the privilege to work with everything 
 50 companies to some of the world's largest government agencies, and this document captures the common patterns we've
 seen that actually worked.
 
-![Gruntwork Production Framework](/img/guides/production-framework/gruntwork-production-framework-small.png)
+<div style={{maxWidth: "640px", margin: "auto", marginTop: "3rem"}}>
+
+## The Elements of the Gruntwork Production Framework
+
+<CardList style={{marginTop: 0}}>
+
+<Card
+  title="Service Catalog"
+  href="./ingredients/service-catalog"
+  icon="/img/icons/service-catalog.svg">
+Your company's vetted, tested, reusable, off-the-shelf solutions for infrastructure and appliactions.
+</Card>
+<Card
+  title="Landing Zone"
+  href="./ingredients/landing-zone"
+  icon="/img/icons/landing-zone.svg">
+The basic structure for your cloud accounts, including auth, guard rails, and other scaffolding.
+</Card>
+<Card
+  title="CI / CD"
+  href="./ingredients/ci-cd-pipeline"
+  icon="/img/icons/ci-cd.svg">
+A Continuous Integration / Continuous Delivery pipeline to automate builds, tests, and deployments.
+</Card>
+<Card
+  title="Self-service"
+  href="./ingredients/self-service"
+  icon="/img/icons/self-service.svg">
+Allow developers to deploy and manage their own apps and infrastructure.
+</Card>
+<Card
+  title="Automatic Updates"
+  href="./ingredients/automatic-updates"
+  icon="/img/icons/auto-update.svg">
+Kepp all your application and infrastructure dependencies up to date, automatically.
+</Card>
+
+</CardList>
+
+</div>
 
 This is not another high-level, vague "cloud operating model" document that is heavy on buzzwords but light on
 actionable content. Instead, you'll find a clear mental model of how to think about cloud usage, plus a set of
@@ -27,30 +69,30 @@ its time working with software tools such as Terraform, Packer, Docker, and Kube
 writing code and "tossing it over the wall" to Ops, Devs want to be self-sufficient, deploying and managing everything
 they need themselves without being bottlenecked by Ops team.
 
-In other words, the distinction between Dev and Ops teams is blurring: this is where the term *DevOps* comes from.
+In other words, the distinction between Dev and Ops teams is blurring: this is where the term _DevOps_ comes from.
 There's no widely agreed-upon definition for DevOps, but for the purposes of this article, we'll think of it as a
-movement which has the goal of *making software delivery vastly more efficient*. And the one thing you can be certain
-of is that trying to port the "old way" of doing things to the cloud will *not* be efficient. The shift to the cloud
+movement which has the goal of _making software delivery vastly more efficient_. And the one thing you can be certain
+of is that trying to port the "old way" of doing things to the cloud will _not_ be efficient. The shift to the cloud
 and DevOps brings a huge number of changes:
 
-|                                 | Before                                               | After                                                  |
-|---------------------------------|------------------------------------------------------|--------------------------------------------------------|
-| **Teams**                       | Devs write code, "toss it over the wall" to Ops      | Devs &amp; Ops work together on cross-functional teams |
-| **Servers**                     | Dedicated physical servers                           | Elastic virtual servers                                |
-| **Connectivity**                | Static IPs                                           | Dynamic IPs, service discovery                         |
-| **Security**                    | Physical, strong perimeter, high trust interior      | Virtual, end-to-end, zero trust                        |
-| **Infrastructure provisioning** | Manual                                               | Infrastructure as Code (IaC) tools                     |
-| **Server configuration**        | Manual                                               | Configuration management tools                         |
-| **Testing**                     | Manual                                               | Automated testing                                      |
-| **Deployments**                 | Manual                                               | Automated                                              |
-| **Deployment cadence**          | Weeks or months                                      | Many times per day                                     |
-| **Change process**              | Change request tickets                               | Self-service                                           |
-| **Change cadence**              | Weeks or months                                      | Minutes                                                |
+|                                 | Before                                          | After                                                  |
+| ------------------------------- | ----------------------------------------------- | ------------------------------------------------------ |
+| **Teams**                       | Devs write code, "toss it over the wall" to Ops | Devs &amp; Ops work together on cross-functional teams |
+| **Servers**                     | Dedicated physical servers                      | Elastic virtual servers                                |
+| **Connectivity**                | Static IPs                                      | Dynamic IPs, service discovery                         |
+| **Security**                    | Physical, strong perimeter, high trust interior | Virtual, end-to-end, zero trust                        |
+| **Infrastructure provisioning** | Manual                                          | Infrastructure as Code (IaC) tools                     |
+| **Server configuration**        | Manual                                          | Configuration management tools                         |
+| **Testing**                     | Manual                                          | Automated testing                                      |
+| **Deployments**                 | Manual                                          | Automated                                              |
+| **Deployment cadence**          | Weeks or months                                 | Many times per day                                     |
+| **Change process**              | Change request tickets                          | Self-service                                           |
+| **Change cadence**              | Weeks or months                                 | Minutes                                                |
 
 ## Who the framework is for
 
 This framework is for companies who wish to adopt the public cloud (e.g., Amazon Web Services, Microsoft Azure, Google
-Cloud Platform) for *production and mission-critical use cases.* We're talking about use cases where you're betting
+Cloud Platform) for _production and mission-critical use cases._ We're talking about use cases where you're betting
 your company on the reliability and security of the cloud: you're betting that your infrastructure won't fall over if
 there's a traffic spike; you're betting that you won't lose data if there's an outage; you're betting that hackers
 won't be able to break in and compromise your data; and if these bets don’t work out, your company may go out of
@@ -72,14 +114,14 @@ another team will focus on what compliance and regulatory requirements you must 
 the details of your scalability and high availability requirements.
 
 As Yogi Berra said, if you don't know where you are going, you'll end up someplace else. Something similar is true of
-the cloud: if you don't know *exactly* what your cloud requirements are, you won't meet them. Trying to backfill
-security, compliance, monitoring, availability, and other requirements *after* your team has been running wild in the
+the cloud: if you don't know _exactly_ what your cloud requirements are, you won't meet them. Trying to backfill
+security, compliance, monitoring, availability, and other requirements _after_ your team has been running wild in the
 cloud for months is much harder.
 
 Therefore, it's essential to get your requirements down in writing, ideally in the form of a checklist (see also:
-*The Checklist Manifesto*). This will give you a real sense of the work involved: seeing a long list of requirements,
+_The Checklist Manifesto_). This will give you a real sense of the work involved: seeing a long list of requirements,
 in front of you, on (digital) paper, makes the scope of the work much more visible, which is particularly useful in the
-face of bosses who blindly demand "we must be 100% in the cloud by *&lt;unrealistic timeline&gt;*!!!" with zero context
+face of bosses who blindly demand "we must be 100% in the cloud by _&lt;unrealistic timeline&gt;_!!!" with zero context
 on just how much work is involved. You can use the list of requirements to coordinate the work and track progress
 towards. You can use this list not only for an initial launch, but for all new deployments in the future too. You can
 of course include diagrams and images too. And when you put it all together, you'll finally have a single, canonical,
@@ -88,7 +130,7 @@ written answer to "what do I have to do to put a new app in prod?"
 There are many types of requirements to take into consideration:
 
 | Requirement                   | Examples                                       |
-|-------------------------------|------------------------------------------------|
+| ----------------------------- | ---------------------------------------------- |
 | Infrastructure                | Servers, databases, load balancers, etc.       |
 | Compliance                    | SOC 2, ISO 27001, HIPAA, PCI, CIS, etc.        |
 | Observability                 | Metrics, logging, alerting, audit trails, etc. |
@@ -108,13 +150,13 @@ In the past, doing this requirements analysis, capturing it in writing in checkl
 your org to enforce these requirements might have been enough. But in the era of elastic, self-service,
 instantly-available cloud environments, it's not enough to have a bunch of written documents and manual processes. You
 can no longer rely on manual deployments, manual security checks, or manual responses to outages. You must go one step
-further and capture and enforce requirements *as code*.
+further and capture and enforce requirements _as code_.
 
 Let's extend the table of requirements from the previous section with examples of how you can implement each one using
 different types of code:
 
 | Requirement                   | Examples                                       | Code examples                                                  |
-|-------------------------------|------------------------------------------------|----------------------------------------------------------------|
+| ----------------------------- | ---------------------------------------------- | -------------------------------------------------------------- |
 | Infrastructure                | Servers, databases, load balancers, etc.       | Infrastructure as Code (IaC) tools: Terraform, CloudFormation. |
 | Compliance                    | SOC 2, ISO 27001, HIPAA, PCI, CIS, etc.        | Continuous testing tools: Terratest, Open Policy Agent (OPA).  |
 | Observability                 | Metrics, logging, alerting, audit trails, etc. | Monitoring tools: CloudWatch, DataDog, Prometheus.             |
@@ -128,7 +170,7 @@ The list above is just an example of some of the tools you use. There are plenty
 less important which tool you pick, so long as that tool lets you manage everything as code.
 
 Why code? We've found that companies that successfully use the cloud almost always capture and enforce their
-requirements not only in software (rather than manual processes), but specifically as *software managed with code*.
+requirements not only in software (rather than manual processes), but specifically as _software managed with code_.
 Software managed manually with a web UI—e.g., setting up infrastructure by manually clicking around the AWS Web Console
 ("ClickOps"*)—*is not enough, as there are a number of benefits that you only get when you manage your requirements with
 code:
@@ -149,7 +191,6 @@ code:
 So, as you go through this framework, keep in mind that the goal is to define and manage each part of the framework
 in code.
 
-
 ## Let's get started
 
 So how do you accomplish all of this? How do you allow your Dev teams to be highly productive and self-sufficient,
@@ -157,26 +198,26 @@ while still allowing your Ops team to control what's happening under the hood an
 and legal requirements are met?
 
 The goal of the Gruntwork Production Framework is to help you answer these questions. First, we'll define the basic
-*ingredients*: the raw primitives your company will need to put in place to use the cloud successfully. Then, we'll
-take a look at some *recipes*: a walkthrough of one way you could put all those ingredients together into an end-to-end
-experience for your Dev and Ops teams. Finally, we'll talk about the off-the-shelf *solutions* we have available at
+_ingredients_: the raw primitives your company will need to put in place to use the cloud successfully. Then, we'll
+take a look at some _recipes_: a walkthrough of one way you could put all those ingredients together into an end-to-end
+experience for your Dev and Ops teams. Finally, we'll talk about the off-the-shelf _solutions_ we have available at
 Gruntwork to help you implement this framework.
 
 1. **Ingredients**
-    1. [Service Catalog](ingredients/service-catalog/index.md)
-    1. [Landing Zone](ingredients/landing-zone/index.md)
-    1. [CI / CD Pipeline](ingredients/ci-cd-pipeline/index.md)
-    1. [Self-Service](ingredients/self-service/index.md)
-    1. [Automatic Updates](ingredients/automatic-updates/index.md)
-    1. [Other Ingredients](ingredients/other-ingredients/index.md)
+   1. [Service Catalog](ingredients/service-catalog/index.md)
+   1. [Landing Zone](ingredients/landing-zone/index.md)
+   1. [CI / CD Pipeline](ingredients/ci-cd-pipeline/index.md)
+   1. [Self-Service](ingredients/self-service/index.md)
+   1. [Automatic Updates](ingredients/automatic-updates/index.md)
+   1. [Other Ingredients](ingredients/other-ingredients/index.md)
 2. **Recipes**
-    1. [Intro](recipes/index.md)
-    1. [The Dev team experience](recipes/dev-team-experience.md)
-    1. [The Ops team experience](recipes/ops-team-experience.md)
+   1. [Intro](recipes/index.md)
+   1. [The Dev team experience](recipes/dev-team-experience.md)
+   1. [The Ops team experience](recipes/ops-team-experience.md)
 3. **Solutions**
-    1. [How Gruntwork can help](gruntwork-solutions/index.md)
+   1. [How Gruntwork can help](gruntwork-solutions/index.md)
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"305b27cb9a678cfe79447e061a71da69"}
+{"sourcePlugin":"local-copier","hash":"8e70078144f75a63e78b504b6c04e253"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/index.md
+++ b/docs/guides/reference-architecture/example-usage-guide/index.md
@@ -39,7 +39,7 @@ All of the infrastructure in this repo is managed as **code** using [Terragrunt]
   [Gruntwork Service Catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog/).
 
 For more info on Infrastructure as Code and Terraform, check out [A Comprehensive Guide to
-Terraform](https://blog.gruntwork.io/a-comprehensive-guide-to-terraform-b3d32832baca) and our our [Introduction to Gruntwork](/docs/intro/overview/intro-to-gruntwork) section.
+Terraform](https://blog.gruntwork.io/a-comprehensive-guide-to-terraform-b3d32832baca) and our our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork) section.
 
 ## AWS accounts
 
@@ -161,5 +161,5 @@ Next up, let's have a look at [how to authenticate](02-authenticate/01-intro.md)
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"0005c89bf8d9356bc7a93ace98e33976"}
+{"sourcePlugin":"local-copier","hash":"16a73da5e040233872dddede948a3e66"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/index.md
+++ b/docs/guides/reference-architecture/index.md
@@ -11,12 +11,12 @@ If you've purchased a Reference Architecture, these guides will help guide you t
 
 <Card
   title="Configure Your Reference Architecture"
-  href="/docs/guides/reference-architecture/configuration-guide">
+  href="/guides/reference-architecture/configuration-guide">
 Learn how to configure your Reference Architecture so Gruntwork can deliver it directly into your repo.
 </Card>
 <Card
   title="Example Usage Guide"
-  href="/docs/guides/reference-architecture/example-usage-guide">
+  href="/guides/reference-architecture/example-usage-guide">
 See a preview of how to use your customized Reference Architecture once we've delivered it in your repo.
 </Card>
 
@@ -24,5 +24,5 @@ See a preview of how to use your customized Reference Architecture once we've de
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"2f17db19758f8477ead61801bae97e9c"}
+{"sourcePlugin":"local-copier","hash":"21aa6a8e8b5ae6d1b2c9cb6b1e8d5a37"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.3.0/deployment-walkthrough/step-1-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.3.0/deployment-walkthrough/step-1-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -18,7 +18,7 @@ To update to the CIS AWS Foundations Benchmark v1.3.0, you need to update your r
 Infrastructure as Code Library to use compatible versions. We (Gruntwork) have reviewed and updated all the library modules for compatibility with the new version of the Benchmark. As a customer, you need to update to
 the proper versions of the Gruntwork library to pick up the fixes/changes made to be compatible. Refer to
 [the
-"Updating to new versions" section of "Stay Up to Date"](/docs/guides/working-with-code/versioning#updating-to-new-versions) for instructions on how to update the
+"Updating to new versions" section of "Stay Up to Date"](/guides/working-with-code/versioning#updating-to-new-versions) for instructions on how to update the
 versions in your code.
 
 For the vast majority of the repos, the only change that will be necessary is a version number bump, but several repos
@@ -30,7 +30,7 @@ version.**
 
 Gruntwork follows
 [semantic
-versioning](/docs/guides/working-with-code/versioning#semantic-versioning). For any pre-1.0 modules, this means that version updates to the minor version are considered backward
+versioning](/guides/working-with-code/versioning#semantic-versioning). For any pre-1.0 modules, this means that version updates to the minor version are considered backward
 incompatible releases for any version updates before the 1.0.0 release. Make sure to read the release notes for the
 relevant modules any time you are updating minor versions! Note that you will want to read the release notes for each
 minor version that is updated (e.g., if you are going from v0.5.x to v0.9.x, you will want to read the notes for v0.6.0,
@@ -187,5 +187,5 @@ compatible with CIS AWS v1.3.0:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"eb861e0394f4d2313c7442d627edc531"}
+{"sourcePlugin":"local-copier","hash":"5d834f1ec7d61ca84a6b9c44079b4a27"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.3.0/index.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.3.0/index.md
@@ -7,7 +7,7 @@ pagination_label: Update to CIS AWS Foundations Benchmark 1.3.0
 This guide will walk you through how to update from version 1.2.0 to version 1.3.0 of the CIS AWS Foundations Benchmark.
 If your infrastructure is already compliant with the Benchmark's version 1.2.0, and you are looking to upgrade to v1.3.0,
 this guide is for you. If you are starting to work on compliance with this benchmark from scratch, check out our
-[How to achieve compliance with the CIS AWS Foundations Benchmark](/docs/guides/build-it-yourself/achieve-compliance/) guide instead.
+[How to achieve compliance with the CIS AWS Foundations Benchmark](/guides/build-it-yourself/achieve-compliance/) guide instead.
 
 This guide consists of two main sections:
 
@@ -27,5 +27,5 @@ tag is compatible with CIS AWS v1.3.0, as well as the manuals step you need to p
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ee59db2a24b566155720d7959c1b4e57"}
+{"sourcePlugin":"local-copier","hash":"7a21cb387673386ab7175df2fe650b7e"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.4.0/deployment-walkthrough/step-1-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.4.0/deployment-walkthrough/step-1-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -7,12 +7,12 @@ sidebar_label: Update references to the Gruntwork Infrastructure as Code Library
 To update to the CIS AWS Foundations Benchmark v1.4.0, you need to update your references to the Gruntwork
 Infrastructure as Code Library to use compatible versions. We (Gruntwork) have reviewed and updated all the library
 modules for compatibility with the new version of the benchmark. As a customer, you need to update to
-the proper versions of the Gruntwork library to pick up the fixes/changes made to be compatible. Refer to our ["Updating to new versions"](/docs/guides/working-with-code/versioning#updating-to-new-versions) guide for instructions on how to update the
+the proper versions of the Gruntwork library to pick up the fixes/changes made to be compatible. Refer to our ["Updating to new versions"](/guides/working-with-code/versioning#updating-to-new-versions) guide for instructions on how to update the
 versions in your code.
 
 Gruntwork follows
 [semantic
-versioning](/docs/guides/working-with-code/versioning#semantic-versioning). For any pre-1.0 modules, this means that version updates to the minor version are considered backward
+versioning](/guides/working-with-code/versioning#semantic-versioning). For any pre-1.0 modules, this means that version updates to the minor version are considered backward
 incompatible releases for any version updates before the 1.0.0 release. Make sure to read the release notes for the
 relevant modules any time you are updating minor versions! Note that you will want to read the release notes for each
 minor version that is updated (e.g., if you are going from v0.5.x to v0.9.x, you will want to read the notes for v0.6.0,
@@ -82,5 +82,5 @@ compatible with CIS AWS v1.4.0:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"c68835758e131f0afff528b2454fd43c"}
+{"sourcePlugin":"local-copier","hash":"a05d8f4802daa27e86b50cb1724ac7e8"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.4.0/index.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.4.0/index.md
@@ -23,9 +23,9 @@ CIS AWS Foundations Benchmark.
 
 ## Previous versions of this guide
 
-- [How to update to CIS AWS Foundations Benchmark v1.3.0](/docs/guides/stay-up-to-date/cis/cis-1.3.0)
+- [How to update to CIS AWS Foundations Benchmark v1.3.0](/guides/stay-up-to-date/cis/cis-1.3.0)
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"f6d60f7125da7ab7113175fd4d7f72c6"}
+{"sourcePlugin":"local-copier","hash":"17fec984c7dd73e582569161c07af67c"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/index.md
+++ b/docs/guides/stay-up-to-date/index.md
@@ -18,31 +18,31 @@ import CardGroup from "/src/components/CardGroup"
 
 <Card
   title="Update to version 1.X"
-  href="/docs/guides/stay-up-to-date/terraform/terraform-1.x"
+  href="/guides/stay-up-to-date/terraform/terraform-1.x"
   />
 <Card
   title="Update to Terraform 15"
-  href="/docs/guides/stay-up-to-date/terraform/terraform-15"
+  href="/guides/stay-up-to-date/terraform/terraform-15"
   />
 <Card
   title="Update to Terraform 14"
-  href="/docs/guides/stay-up-to-date/terraform/terraform-14"
+  href="/guides/stay-up-to-date/terraform/terraform-14"
   />
 <Card
   title="Update to Terraform 13"
-  href="/docs/guides/stay-up-to-date/terraform/terraform-13"
+  href="/guides/stay-up-to-date/terraform/terraform-13"
   />
 <Card
   title="Update to Terraform 12"
-  href="/docs/guides/stay-up-to-date/terraform/terraform-12"
+  href="/guides/stay-up-to-date/terraform/terraform-12"
   />
 <Card
   title="Update to Version 3 of the Terraform provider"
-  href="/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3"
+  href="/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3"
   />
 <Card
   title="DRY your Reference Architecture"
-  href="/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture"
+  href="/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture"
   />
 
 </CardGroup>
@@ -57,11 +57,11 @@ import CardGroup from "/src/components/CardGroup"
 
 <Card
   title="Update to version 1.4.0"
-  href="/docs/guides/stay-up-to-date/cis/cis-1.4.0"
+  href="/guides/stay-up-to-date/cis/cis-1.4.0"
   />
 <Card
   title="Update to version 1.3.0"
-  href="/docs/guides/stay-up-to-date/cis/cis-1.3.0"
+  href="/guides/stay-up-to-date/cis/cis-1.3.0"
   />
 
 </CardGroup>
@@ -72,5 +72,5 @@ import CardGroup from "/src/components/CardGroup"
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"4e286a4930d5ff733245cc2fb2cc0843"}
+{"sourcePlugin":"local-copier","hash":"22ec7fce1c9d00548395baed02c4b112"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3/deployment-walkthrough.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3/deployment-walkthrough.md
@@ -8,7 +8,7 @@ library to test and update the code to be compatible with AWS provider version 3
 the proper versions of the Gruntwork library to pick up the fixes/changes that were made to be compatible. Be sure to
 read the release notes to know what changes need to be made to update to that version.
 
-Refer to our ["Updating to new versions"](/docs/guides/working-with-code/versioning#updating-to-new-versions) guide
+Refer to our ["Updating to new versions"](/guides/working-with-code/versioning#updating-to-new-versions) guide
 for instructions on how to update the versions in your code.
 
 The following table provides a summary of all the relevant Gruntwork AWS modules and the respective versions that are
@@ -17,7 +17,7 @@ compatible with AWS provider version 3.
 :::caution
 
 Gruntwork follows [semantic
-versioning](/docs/guides/working-with-code/versioning#semantic-versioning).
+versioning](/guides/working-with-code/versioning#semantic-versioning).
 For any pre-1.0 modules, this means that version updates to the minor version
 are considered backwards incompatible releases for any version updates prior to
 1.0.0 release. Make sure to read the release notes for the relevant modules any
@@ -182,5 +182,5 @@ on how to update your components to be compatible with AWS provider v3.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"17a025af41678a561f54d802977e6f36"}
+{"sourcePlugin":"local-copier","hash":"ab6bc780e5dab16724fdb9635ba78a15"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-15.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-15.md
@@ -22,10 +22,10 @@ If you haven’t already, you need to:
         [Terraform 0.15 upgrade guide](../../terraform-15).
 
 2.  Update all your Gruntwork modules to the latest versions just _before_ the TF 1.x versions in the [compatibility
-    table](/docs/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library#version-compatibility-table). The upgrade will be much easier and less error prone if you keep the number of version jumps as small
+    table](/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library#version-compatibility-table). The upgrade will be much easier and less error prone if you keep the number of version jumps as small
     as possible.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"df6b1ac72fe80e1fc8beb0fc68620d0b"}
+{"sourcePlugin":"local-copier","hash":"d3f009fff9110c29a0a429084bf3d87a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -10,7 +10,7 @@ version. We (Gruntwork) have gone through all our modules in the library to test
 and update the code to be compatible with Terraform 1.x. As a customer, you need
 to update to the proper versions of the Gruntwork library to pick up the
 fixes/changes that we made to be compatible. Refer to [the "Updating to new versions" section of
-"Stay Up to Date"](/docs/guides/working-with-code/versioning#updating-to-new-versions#updating)
+"Stay Up to Date"](/guides/working-with-code/versioning#updating-to-new-versions#updating)
 for instructions on how to update the versions in your code.
 
 For the vast majority of the repos, the only change that will be necessary is a
@@ -22,7 +22,7 @@ changes need to be made to update to the new version.**
 :::caution
 
 Gruntwork follows [semantic
-versioning](/docs/guides/working-with-code/versioning#semantic-versioning).
+versioning](/guides/working-with-code/versioning#semantic-versioning).
 For any pre-1.0 modules, this means that version updates to the minor version
 are considered backwards incompatible releases for any version updates prior to
 1.0.0 release. Make sure to read the release notes for the relevant modules any
@@ -174,5 +174,5 @@ and the respective versions that are compatible with Terraform 1.x:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"7450e6f808684bc6e4cd854ceb5038c7"}
+{"sourcePlugin":"local-copier","hash":"5de71c86b2c7405e338748eee98f96ce"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -7,7 +7,7 @@ sidebar_label: Update Gruntwork IaC module references
 In order to take advantage of the Terraform 0.13, you need to update your references to the Gruntwork
 Infrastructure as Code Library to use a compatible version. We (Gruntwork) have gone through all our modules in the
 library to test and update the code to be compatible with Terraform 0.13. As a customer, you need to update to
-the proper versions of the Gruntwork library to pick up the fixes/changes that were made to be compatible. Refer to our ["Updating to new versions"](/docs/guides/working-with-code/versioning#updating-to-new-versions) guide for instructions on how to update the
+the proper versions of the Gruntwork library to pick up the fixes/changes that were made to be compatible. Refer to our ["Updating to new versions"](/guides/working-with-code/versioning#updating-to-new-versions) guide for instructions on how to update the
 versions in your code.
 
 For the vast majority of the repos, the only change that will be necessary is a version number bump, but several repos
@@ -19,7 +19,7 @@ user, pay special attention to the release notes!
 :::caution
 
 Gruntwork follows [semantic
-versioning](/docs/guides/working-with-code/versioning#semantic-versioning).
+versioning](/guides/working-with-code/versioning#semantic-versioning).
 For any pre-1.0 modules, this means that version updates to the minor version
 are considered backwards incompatible releases for any version updates prior to
 1.0.0 release. Make sure to read the release notes for the relevant modules any
@@ -171,5 +171,5 @@ compatible with Terraform 0.13:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"3d36f6d104c93218baa8a6d4f4dcc960"}
+{"sourcePlugin":"local-copier","hash":"df2574e2ef9ba51262631488b3dc0ae2"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -7,7 +7,7 @@ sidebar_label: Update Gruntwork IaC module references
 In order to take advantage of the Terraform 0.14, you need to update your references to the Gruntwork
 Infrastructure as Code Library to use a compatible version. We (Gruntwork) have gone through all our modules in the
 library to test and update the code to be compatible with Terraform 0.14. As a customer, you need to update to
-the proper versions of the Gruntwork library to pick up the fixes/changes that we made to be compatible. Refer to our ["Updating to new versions"](/docs/guides/working-with-code/versioning#updating-to-new-versions) guide for instructions on how to update the
+the proper versions of the Gruntwork library to pick up the fixes/changes that we made to be compatible. Refer to our ["Updating to new versions"](/guides/working-with-code/versioning#updating-to-new-versions) guide for instructions on how to update the
 versions in your code.
 
 For the vast majority of the repos, the only change that will be necessary is a version number bump, but several repos
@@ -18,7 +18,7 @@ version.**
 :::caution
 
 Gruntwork follows [semantic
-versioning](/docs/guides/working-with-code/versioning#semantic-versioning).
+versioning](/guides/working-with-code/versioning#semantic-versioning).
 For any pre-1.0 modules, this means that version updates to the minor version
 are considered backwards incompatible releases for any version updates prior to
 1.0.0 release. Make sure to read the release notes for the relevant modules any
@@ -170,5 +170,5 @@ compatible with Terraform 0.14:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"799a70cb9897fbf5b9a490af58512667"}
+{"sourcePlugin":"local-copier","hash":"fe5c67ca172107229a89899b73efc1ce"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-15/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-15/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -7,7 +7,7 @@ sidebar_label: Update Gruntwork IaC module references
 In order to take advantage of the Terraform 0.15, you need to update your references to the Gruntwork
 Infrastructure as Code Library to use a compatible version. We (Gruntwork) have gone through all our modules in the
 library to test and update the code to be compatible with Terraform 0.15. As a customer, you need to update to
-the proper versions of the Gruntwork library to pick up the fixes/changes that we made to be compatible. Refer to our ["Updating to new versions"](/docs/guides/working-with-code/versioning#updating-to-new-versions) guide for instructions on how to update the
+the proper versions of the Gruntwork library to pick up the fixes/changes that we made to be compatible. Refer to our ["Updating to new versions"](/guides/working-with-code/versioning#updating-to-new-versions) guide for instructions on how to update the
 versions in your code.
 
 For the vast majority of the repos, the only change that will be necessary is a version number bump, but several repos
@@ -18,7 +18,7 @@ version.**
 :::caution
 
 Gruntwork follows [semantic
-versioning](/docs/guides/working-with-code/versioning#semantic-versioning).
+versioning](/guides/working-with-code/versioning#semantic-versioning).
 For any pre-1.0 modules, this means that version updates to the minor version
 are considered backwards incompatible releases for any version updates prior to
 1.0.0 release. Make sure to read the release notes for the relevant modules any
@@ -170,5 +170,5 @@ compatible with Terraform 0.15:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a7e5a70ab7a4d449a1b8b22f734b3ccc"}
+{"sourcePlugin":"local-copier","hash":"358211de8f59ad73100aa258a90b9d32"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/style/index.md
+++ b/docs/guides/style/index.md
@@ -7,12 +7,12 @@ import CardGroup from "/src/components/CardGroup"
 
 <Card
   title="Terraform Style Guide"
-  href="/docs/guides/style/terraform-style-guide">
+  href="/guides/style/terraform-style-guide">
 Learn Gruntwork's Terraform coding style.
 </Card>
 <Card
   title="Go Style Guide"
-  href="/docs/guides/style/golang-style-guide">
+  href="/guides/style/golang-style-guide">
 Learn Gruntwork's Go coding style.
 </Card>
 
@@ -20,5 +20,5 @@ Learn Gruntwork's Go coding style.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"3fcd5f49a3d53d4bcb70065ea2bf83b6"}
+{"sourcePlugin":"local-copier","hash":"43ecd69204c9e64dda7b7fd30291c64b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/support.mdx
+++ b/docs/guides/support.mdx
@@ -114,7 +114,7 @@ We’re here to help you with:
 
 - **Bug fixes** — Raise concerns regarding any bugs you find, and help us understand how they impact you.
 
-- **DevOps guidance** — While we don’t provide DevOps training beyond our [video training courses](/docs/courses), we can help you understand how to apply general DevOps principles to devise the right infrastructure for your needs.
+- **DevOps guidance** — While we don’t provide DevOps training beyond our [video training courses](/courses), we can help you understand how to apply general DevOps principles to devise the right infrastructure for your needs.
 
 ### How to reach us
 
@@ -151,7 +151,7 @@ We’re here to help you with:
 
 - **Code reviews** — Get another pair of eyes on any changes you make to your infrastructure so you can have confidence taking them live.
 
-- **DevOps guidance** — While we don’t provide DevOps training beyond our [video training courses](/docs/courses), we can help you understand how to apply general DevOps principles to devise the right infrastructure for your needs.
+- **DevOps guidance** — While we don’t provide DevOps training beyond our [video training courses](/courses), we can help you understand how to apply general DevOps principles to devise the right infrastructure for your needs.
 
 ### How to reach us
 
@@ -184,5 +184,5 @@ Looking for more personalized assistance using a particular Gruntwork product? O
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"f82912ac466b3e9c200254f4478b87b2"}
+{"sourcePlugin":"local-copier","hash":"e1cbee1edc000586481ce97a59d2b8c0"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/working-with-code/forking.md
+++ b/docs/guides/working-with-code/forking.md
@@ -34,7 +34,7 @@ so you’ll want to pull in these updates as quickly as you can.
 
 ## How to use your forked code
 
-Once you’ve forked the code, using it is very similar to what is outlined in [Using Terraform Modules](/docs/intro/first-deployment/using-terraform-modules), except for the following differences:
+Once you’ve forked the code, using it is very similar to what is outlined in [Using Terraform Modules](/intro/first-deployment/using-terraform-modules), except for the following differences:
 
 1.  Point the `source` URLs of your Terraform modules to your own Git repos, rather than the `gruntwork-io` GitHub org.
 2.  Point the `--repo` parameter of `gruntwork-install` to your own Git repos, rather than the `gruntwork-io` GitHub org.
@@ -50,11 +50,11 @@ While forking is allowed under the Gruntwork Terms of Services, it has some down
   participate in issues and pull requests, and you won’t be benefiting as much from the Gruntwork community.
 
 So, whenever possible, use the code directly from the `gruntwork-io` GitHub org, as documented in
-[Using Terraform Modules](/docs/intro/first-deployment/using-terraform-modules). If your team relies on NPM, Docker Hub, Maven Central,
+[Using Terraform Modules](/intro/first-deployment/using-terraform-modules). If your team relies on NPM, Docker Hub, Maven Central,
 GitHub, or the Terraform Registry, using Gruntwork repos directly is no different. However, if your company completely
 bans all outside sources, then follow the instructions above to fork the code, and good luck!
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"97914adc87d6c65cb7c00383378e43b2"}
+{"sourcePlugin":"local-copier","hash":"030c7f00ebd4cafb747e934a52bc9170"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/working-with-code/versioning.md
+++ b/docs/guides/working-with-code/versioning.md
@@ -61,12 +61,12 @@ Follow the steps below to keep your code up to date:
     was increased (e.g., `v0.18.0` → `v0.19.0`), that implies a backwards incompatible change, and the release notes will
     explain what you need to do (e.g., you might have to add, remove, or change arguments you pass to the module).
 
-4.  Test your changes locally. You do this using the same process outlined in [Manual tests for Terraform code](/docs/intro/first-deployment/testing#manual-tests-for-terraform-code) and
-    [Automated tests for Terraform code](/docs/intro/first-deployment/testing#automated-tests-for-terraform-code).
+4.  Test your changes locally. You do this using the same process outlined in [Manual tests for Terraform code](/intro/first-deployment/testing#manual-tests-for-terraform-code) and
+    [Automated tests for Terraform code](/intro/first-deployment/testing#automated-tests-for-terraform-code).
 
 5.  Deploy your changes to each environment. You do this using the same process outlined in [Deploying Terraform code](#deploy_terraform).
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"b2db9c198c60896ee871fe9017008760"}
+{"sourcePlugin":"local-copier","hash":"fe3d9c21b5e21502aaef662e2618482f"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/core-concepts/production-framework.md
+++ b/docs/intro/core-concepts/production-framework.md
@@ -12,9 +12,9 @@ cloud:
 
 If you'd like to build your mental model on how to think about cloud usage, and you're looking for a set of steps you
 can follow to make better use of the cloud at your company, read the [Gruntwork Production Framework
-Guide](/docs/guides/production-framework) for the full details.
+Guide](/guides/production-framework) for the full details.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"df8af2026c8b1a7733e12e71524c5b60"}
+{"sourcePlugin":"local-copier","hash":"4dda35c027cc8ed707d9bf946d096d9a"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/first-deployment/deploy.md
+++ b/docs/intro/first-deployment/deploy.md
@@ -144,7 +144,7 @@ balancers, and so on. Each module is configured via a `terragrunt.hcl` file.
 </div>
 
 For example, if you were using AWS, with separate accounts for staging and production (see
-[How to Configure a Production Grade AWS Account Structure](/docs/guides/build-it-yourself/landing-zone/)),
+[How to Configure a Production Grade AWS Account Structure](/guides/build-it-yourself/landing-zone/)),
 and you wanted to deploy the `vpc-app` module in the `us-east-2` region in
 each of these accounts, the folder structure would look like this:
 
@@ -261,5 +261,5 @@ terragrunt apply-all
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"3406efb5891f495c36e6ea111cec2aec"}
+{"sourcePlugin":"local-copier","hash":"7203857858fed888b41d453b81b3e12b"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/first-deployment/using-terraform-modules.md
+++ b/docs/intro/first-deployment/using-terraform-modules.md
@@ -10,7 +10,7 @@ You must be a <span class="js-subscribe-cta">Gruntwork subscriber</span> to acce
 :::
 
 You can use this module to deploy a production-grade VPC on AWS. For full background information on VPCs, check
-out [How to deploy a production-grade VPC on AWS](/docs/guides/build-it-yourself/vpc/).
+out [How to deploy a production-grade VPC on AWS](/guides/build-it-yourself/vpc/).
 
 ## Create a wrapper module
 
@@ -66,7 +66,7 @@ The code above will only allow you to run it against the AWS account with ID pas
 variable (you’ll declare this shortly). This is an extra safety measure to ensure you don’t accidentally authenticate
 to the wrong AWS account while deploying this code—e.g., so you don’t accidentally deploy changes intended for
 staging to production (for more info on working with multiple AWS accounts, see
-[How to Configure a Production Grade AWS Account Structure](/docs/guides/build-it-yourself/landing-zone/)).
+[How to Configure a Production Grade AWS Account Structure](/guides/build-it-yourself/landing-zone/)).
 
 </div>
 
@@ -158,7 +158,7 @@ This code pulls in a module using Terraform’s native `module` functionality. F
 
 The `source` URL in the code above uses a Git URL with SSH authentication (see
 [module sources](https://www.terraform.io/docs/modules/sources.html) for all the types of `source` URLs you can use).
-If you have established your account and linked your GitHub ID according to the instruction in [Accessing the Dev Portal](/docs/intro/dev-portal/create-account), this will allow you to access private repos in the Gruntwork
+If you have established your account and linked your GitHub ID according to the instruction in [Accessing the Dev Portal](/intro/dev-portal/create-account), this will allow you to access private repos in the Gruntwork
 Infrastructure as Code Library without having to hard-code a password in your Terraform code.
 
 #### Versioned URL
@@ -248,5 +248,5 @@ output "private_persistence_subnet_ids" {
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"c78de100bb6dcda611653f87e2d9ee1e"}
+{"sourcePlugin":"local-copier","hash":"2ab1d4784c7c5b3a7426615c1be3dd3f"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/next-steps.mdx
+++ b/docs/intro/next-steps.mdx
@@ -7,19 +7,19 @@ import Grid from "/src/components/Grid"
 
 # Next Steps
 
-Now that your foundational knowledge is in place and your workspace is configured, you’re ready to dive in and learn how to deploy production-grade infrastructure. If you’ve purchased a Gruntwork Reference Architecture, use [this guide](/docs/guides/reference-architecture) to get started. Otherwise, view our [courses](/docs/courses) and [guides](/docs/guides), or check out the [Service Catalog API reference](/docs/reference/services/intro/overview) to learn what’s available.
+Now that your foundational knowledge is in place and your workspace is configured, you’re ready to dive in and learn how to deploy production-grade infrastructure. If you’ve purchased a Gruntwork Reference Architecture, use [this guide](/guides/reference-architecture) to get started. Otherwise, view our [courses](/courses) and [guides](/guides), or check out the [Service Catalog API reference](/reference/services/intro/overview) to learn what’s available.
 
 <Grid cols={2}>
   <Card
     title="Set Up Your Reference Architecture"
-    href="/docs/guides/reference-architecture"
+    href="/guides/reference-architecture"
   >
     Learn how to use and administer a Reference Architecture which Gruntwork has
     deployed for you.
   </Card>
   <Card
     title="Build Your Own Architecture"
-    href="/docs/guides#build-your-own-architecture"
+    href="/guides#build-your-own-architecture"
   >
     Learn how to utilize our service modules to construct a world-class
     architecture on your own.
@@ -28,5 +28,5 @@ Now that your foundational knowledge is in place and your workspace is configure
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"bd84fe02cd2170f453385096dbcd93f4"}
+{"sourcePlugin":"local-copier","hash":"8b4b30eb4de0a60f5c7a7e3926cd771d"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/overview/getting-started.mdx
+++ b/docs/intro/overview/getting-started.mdx
@@ -2,26 +2,26 @@ import { CardList } from "/src/components/CardGroup"
 
 # Getting started
 
-In this introductory guide we’ll cover the fundamentals you'll need in order to be successful with Gruntwork. After setting up your account to gain access to Gruntwork products, we’ll help you install necessary tools and understand how they fit into the Gruntwork development workflow. Once finished, you’ll have the knowledge required to dive into our [guides](/docs/guides) and make full use of the IaC Library.
+In this introductory guide we’ll cover the fundamentals you'll need in order to be successful with Gruntwork. After setting up your account to gain access to Gruntwork products, we’ll help you install necessary tools and understand how they fit into the Gruntwork development workflow. Once finished, you’ll have the knowledge required to dive into our [guides](/guides) and make full use of the IaC Library.
 
 <CardList>
   <Card
     title="Gain access to Gruntwork’s products"
-    href="/docs/intro/dev-portal/create-account"
+    href="/intro/dev-portal/create-account"
   >
     Create an account with our Developer Portal to access the IaC Library and
     training courses.
   </Card>
   <Card
     title="Set up your environment"
-    href="/docs/intro/environment-setup/recommended_tools"
+    href="/intro/environment-setup/recommended_tools"
   >
     Prepare your local development environment for efficiently working with the
     industry standard DevOps tools.
   </Card>
   <Card
     title="Learn the tools of the trade"
-    href="/docs/intro/tool-fundamentals/docker"
+    href="/intro/tool-fundamentals/docker"
   >
     Learn how to leverage these tools with Gruntwork products to realize your
     infrastructure needs.
@@ -30,5 +30,5 @@ In this introductory guide we’ll cover the fundamentals you'll need in order t
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"b73debdfc576cc0b606d04650a933f9c"}
+{"sourcePlugin":"local-copier","hash":"2c594f2c6b6c5ab9e1c211a3475fa279"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/overview/how-it-works.md
+++ b/docs/intro/overview/how-it-works.md
@@ -5,7 +5,7 @@
 There are two fundamental ways to engage Gruntwork:
 
 1. **Gruntwork builds your architecture.** We generate the [Reference Architecture](https://gruntwork.io/reference-architecture/) based on your needs, deploy into your AWS accounts, and give you 100% of the code. Since you have all the code, you can extend, enhance, and customize the environment exactly according to your needs. The deploy process takes about one day.
-2. **Build it yourself.** The Gruntwork IaC library empowers you to [construct your own bespoke architecture](/docs/guides#build-your-own-architecture) in record time. By mix-and-matching our modules and services you can quickly define a custom architecture to suit your needs, all with the confidence of having world-class, battle-tested code running under the hood.
+2. **Build it yourself.** The Gruntwork IaC library empowers you to [construct your own bespoke architecture](/guides#build-your-own-architecture) in record time. By mix-and-matching our modules and services you can quickly define a custom architecture to suit your needs, all with the confidence of having world-class, battle-tested code running under the hood.
 
 ## What we provide
 
@@ -38,8 +38,8 @@ A team of experienced Gruntwork engineers who help you achieve success using Gru
 
 Gruntwork offers basic and paid support options:
 
-- **[Community support](/docs/guides/support#get-support).** Get help via a [Gruntwork Community Slack](https://gruntwork-community.slack.com/archives/CHH9Y3Z62) and our [Knowledge Base](https://github.com/gruntwork-io/knowledge-base/discussions).
-- **[Paid support](/docs/guides/support#paid-support-tiers).** Get help via email, a private Slack channel, or scheduled Zoom calls, with response times backed by SLAs.
+- **[Community support](/guides/support#get-support).** Get help via a [Gruntwork Community Slack](https://gruntwork-community.slack.com/archives/CHH9Y3Z62) and our [Knowledge Base](https://github.com/gruntwork-io/knowledge-base/discussions).
+- **[Paid support](/guides/support#paid-support-tiers).** Get help via email, a private Slack channel, or scheduled Zoom calls, with response times backed by SLAs.
 
 ## What you provide
 
@@ -55,5 +55,5 @@ Gruntwork products strike a balance between opinionatedness and configurability.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"73f4ba4dac9a385e9111d99c8dc110d7"}
+{"sourcePlugin":"local-copier","hash":"e551d32e89b0dc5fadeb1fa25b7d0f0a"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/tool-fundamentals/packer.md
+++ b/docs/intro/tool-fundamentals/packer.md
@@ -39,7 +39,7 @@ includes an `ssh-grunt` binary you can run on each server to manage SSH access t
 IAM users in specific IAM groups will be able to SSH to specific servers using their own usernames and SSH keys).
 
 To get these scripts and binaries onto your virtual servers (e.g., onto EC2 instances in AWS), we recommend using Packer to build VM images that have these scripts and binaries installed. You'll see an
-example of how to do this in our [Deploy Your First Module](/docs/intro/first-deployment/using-terraform-modules) section.
+example of how to do this in our [Deploy Your First Module](/intro/first-deployment/using-terraform-modules) section.
 
 :::note
 
@@ -52,5 +52,5 @@ its opinionated tools.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"d16b6f182cf597868cdbdf684097bce0"}
+{"sourcePlugin":"local-copier","hash":"1d077cb69e254937c2472634a22eff5d"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/intro/create-your-own-service-catalog.md
+++ b/docs/reference/services/intro/create-your-own-service-catalog.md
@@ -25,7 +25,7 @@ the Gruntwork Service Catalog? There are two things to check:
    common and likely affects many companies, we should support it! If that's the case, please [file a GitHub issue in
    this repo](https://github.com/gruntwork-io/terraform-aws-service-catalog/issues/new), and the Gruntwork team may be able to implement it for you. Also, pull requests are VERY welcome! See
    [Contributing to the Gruntwork Service
-   Catalog](/docs/guides/working-with-code/contributing)
+   Catalog](/guides/working-with-code/contributing)
    for instructions.
 
 If your use case isn't handled by the Gruntwork Service Catalog, and it's something fairly specific to your company,
@@ -99,13 +99,13 @@ One way to populate your Service Catalog is to extend Gruntwork Services. There 
 1. **(NOT RECOMMENDED) Copy a Gruntwork Service**. Another way to extend a Gruntwork Service is to copy all of the code
    for that one service into your own Git repo and modify the code directly. This is not recommended, as then you'll
    have to maintain all of the code for that service yourself, and won't benefit from all the [maintenance
-   work](/docs/reference/services/intro/overview#maintenance-and-versioning) done by the Gruntwork team. The only reason to copy the code this way is if you
+   work](/reference/services/intro/overview#maintenance-and-versioning) done by the Gruntwork team. The only reason to copy the code this way is if you
    need a significant change that cannot be done from outside the service.
 
 1. **(NOT RECOMMENDED) Fork the Gruntwork Service Catalog**. Yet another option is to
    [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the entire Gruntwork Service
    Catalog into a repo of your own. This is not recommended, as then you'll have to maintain all of that code yourself,
-   and won't benefit from all the [maintenance work](/docs/reference/services/intro/overview/#maintenance-and-versioning) done by the Gruntwork team. The only
+   and won't benefit from all the [maintenance work](/reference/services/intro/overview/#maintenance-and-versioning) done by the Gruntwork team. The only
    reason to fork the entire repo is if you have a company policy that only allows you consume code from your own
    repositories. Note that if you do end up forking the entire Service Catalog, you can use `git fetch` and `git merge`
    to [automatically pull in changes from
@@ -187,5 +187,5 @@ inputs = {
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ebab1908283ea942f6a6324444ee743b"}
+{"sourcePlugin":"local-copier","hash":"1f4ef9cbba76e05f0cc247508e82dc54"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/intro/deploy-new-infrastructure.md
+++ b/docs/reference/services/intro/deploy-new-infrastructure.md
@@ -118,7 +118,7 @@ deploy Terraform code from the Service Catalog. See
 
    1. **GitHub Authentication**: All of Gruntwork's code lives in GitHub, and as most of the repos are private, you must
       authenticate to GitHub to be able to access the code. For Terraform, we recommend using Git / SSH URLs and using
-      SSH keys for authentication. See [Link Your GitHub ID](/docs/intro/dev-portal/link-github-id)
+      SSH keys for authentication. See [Link Your GitHub ID](/intro/dev-portal/link-github-id)
       for instructions on linking your GitHub ID and gaining access.
 
 1. **Deploy**. You can now deploy the service as follows:
@@ -258,7 +258,7 @@ Now you can create child `terragrunt.hcl` files to deploy services as follows:
    1. **GitHub Authentication**: All of Gruntwork's code lives in GitHub, and as most of the repos are private, you must
       authenticate to GitHub to be able to access the code. For Terraform, we recommend using Git / SSH URLs and using
       SSH keys for authentication. See [How to get access to the Gruntwork Infrastructure as Code
-      Library](/docs/intro/dev-portal/create-account)
+      Library](/intro/dev-portal/create-account)
       for instructions on setting up your SSH key.
 
 1. **Deploy**. You can now deploy the service as follows:
@@ -315,7 +315,7 @@ Below are instructions on how to build an AMI using these Packer templates. We'l
       ```
 
       See [How to get access to the Gruntwork Infrastructure as Code
-      Library](/docs/intro/dev-portal/create-account)
+      Library](/intro/dev-portal/create-account)
       for instructions on setting up GitHub personal access token.
 
 1. **Set variables**. Each Packer template defines variables you can set in a `variables` block at the top, such as
@@ -356,5 +356,5 @@ Below are instructions on how to build an AMI using these Packer templates. We'l
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"39b464de3bd02d164cfc1f65c8087dcb"}
+{"sourcePlugin":"local-copier","hash":"40356c39e4d55f5f9e1f9b9b98fab377"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/intro/make-changes-to-your-infrastructure.md
+++ b/docs/reference/services/intro/make-changes-to-your-infrastructure.md
@@ -60,7 +60,7 @@ Now that your infrastructure is deployed, let's discuss how to make changes to i
 Whenever changing version numbers, make sure to read the [release
 notes](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases), especially if it's a backwards
 incompatible release (e.g., `v0.0.1` -> `v0.1.0`), to avoid errors and outages (see [maintenance and
-versioning](/docs/reference/services/intro/overview/#maintenance-and-versioning) for details)!
+versioning](/reference/services/intro/overview/#maintenance-and-versioning) for details)!
 
 :::
 
@@ -128,7 +128,7 @@ versioning](/docs/reference/services/intro/overview/#maintenance-and-versioning)
 Whenever changing version numbers, make sure to read the [release
 notes](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases), especially if it's a backwards
 incompatible release (e.g., `v0.0.1` -> `v0.1.0`), to avoid errors and outages (see [maintenance and
-versioning](/docs/reference/services/intro/overview/#maintenance-and-versioning) for details)!
+versioning](/reference/services/intro/overview/#maintenance-and-versioning) for details)!
 
 :::
 
@@ -173,7 +173,7 @@ _(Documentation coming soon. If you need help with this ASAP, please contact [su
    Whenever changing version numbers, make sure to read the [release
    notes](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases), especially if it's a backwards incompatible
    release (e.g., `v0.0.1` -> `v0.1.0`), to avoid errors and outages (see [maintenance and
-   versioning](/docs/reference/services/intro/overview/#maintenance-and-versioning) for details)!
+   versioning](/reference/services/intro/overview/#maintenance-and-versioning) for details)!
 
    :::
 
@@ -191,5 +191,5 @@ _(Documentation coming soon. If you need help with this ASAP, please contact [su
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"bbf58d35c7af9d23efff17b3f3383068"}
+{"sourcePlugin":"local-copier","hash":"9c1c897ca51d75cc9c36cb94c514a683"}
 ##DOCS-SOURCER-END -->

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -50,11 +50,12 @@ const config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       {
         docs: {
+          routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),
-          // Please change this to your repo.
-          // editUrl: "https://github.com/facebook/docusaurus/edit/main/website/",
+          // editUrl: "https://github.com/gruntwork-io/docs/edit/master/",
           beforeDefaultRemarkPlugins: [captionsPlugin],
         },
+        blog: false,
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
         },
@@ -101,14 +102,14 @@ const config = {
             label: "Service Catalog API",
             docId: "reference/services/intro/overview",
           },
-          { to: "/docs/courses", label: "Courses", position: "left" },
+          { to: "/courses", label: "Courses", position: "left" },
           {
             href: "https://github.com/gruntwork-io/knowledge-base/discussions",
             label: "Knowledge Base",
             position: "right",
           },
           {
-            href: "/docs/guides/support",
+            href: "/guides/support",
             label: "Support",
             position: "right",
           },
@@ -128,7 +129,7 @@ const config = {
                 label: "Knowledge Base",
               },
               {
-                href: "/docs/guides/support",
+                href: "/guides/support",
                 label: "Support",
               },
               {
@@ -201,7 +202,7 @@ const config = {
               },
               {
                 label: "Support",
-                href: "/docs/guides/support",
+                href: "/guides/support",
               },
             ],
           },

--- a/sidebars/compliance-guide.js
+++ b/sidebars/compliance-guide.js
@@ -2,7 +2,7 @@ const complianceGuide = [
   {
     label: "Build Your Own Architecture",
     type: "link",
-    href: "/docs/guides/build-it-yourself",
+    href: "/guides/build-it-yourself",
     className: "back-button",
   },
   {

--- a/sidebars/kubernetes-guide.js
+++ b/sidebars/kubernetes-guide.js
@@ -2,7 +2,7 @@ const vpcGuide = [
   {
     label: "Build Your Own Architecture",
     type: "link",
-    href: "/docs/guides/build-it-yourself",
+    href: "/guides/build-it-yourself",
     className: "back-button",
   },
   {

--- a/sidebars/landing-zone-guide.js
+++ b/sidebars/landing-zone-guide.js
@@ -2,7 +2,7 @@ const landingZoneGuide = [
   {
     label: "Build Your Own Architecture",
     type: "link",
-    href: "/docs/guides/build-it-yourself",
+    href: "/guides/build-it-yourself",
     className: "back-button",
   },
   {

--- a/sidebars/pipelines-guide.js
+++ b/sidebars/pipelines-guide.js
@@ -2,7 +2,7 @@ const pipelineGuide = [
   {
     label: "Build Your Own Architecture",
     type: "link",
-    href: "/docs/guides/build-it-yourself",
+    href: "/guides/build-it-yourself",
     className: "back-button",
   },
   {

--- a/sidebars/refarch-usage-guide.js
+++ b/sidebars/refarch-usage-guide.js
@@ -2,7 +2,7 @@ const refarchUsageSidebar = [
   {
     label: "Reference Architecture Guides",
     type: "link",
-    href: "/docs/guides/reference-architecture",
+    href: "/guides/reference-architecture",
     className: "back-button",
   },
   {

--- a/sidebars/update-guides.js
+++ b/sidebars/update-guides.js
@@ -1,7 +1,7 @@
 const backLink = {
   label: "Update Guides",
   type: "link",
-  href: "/docs/guides/stay-up-to-date",
+  href: "/guides/stay-up-to-date",
   className: "back-button",
 }
 

--- a/sidebars/vpc-guide.js
+++ b/sidebars/vpc-guide.js
@@ -2,7 +2,7 @@ const vpcGuide = [
   {
     label: "Build Your Own Architecture",
     type: "link",
-    href: "/docs/guides/build-it-yourself",
+    href: "/guides/build-it-yourself",
     className: "back-button",
   },
   {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,7 +17,7 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/intro/overview/intro-to-gruntwork"
+            to="/intro/overview/intro-to-gruntwork"
           >
             Get Started
           </Link>
@@ -38,7 +38,7 @@ export default function Home(): JSX.Element {
             <CardGroup>
               <Card
                 title="What is Gruntwork?"
-                href="/docs/intro/overview/intro-to-gruntwork"
+                href="/intro/overview/intro-to-gruntwork"
                 icon="/img/icons/learn.svg"
               >
                 Learn how Gruntwork products can help you deploy a world class
@@ -46,7 +46,7 @@ export default function Home(): JSX.Element {
               </Card>
               <Card
                 title="The Reference Architecture"
-                href="/docs/guides/reference-architecture/index"
+                href="/guides/reference-architecture/index"
                 icon="/img/icons/refarch.svg"
               >
                 Bought a Reference Architecture? Get your new infrastructure up
@@ -54,7 +54,7 @@ export default function Home(): JSX.Element {
               </Card>
               <Card
                 title="Deploy A Service"
-                href="/docs/guides/build-it-yourself"
+                href="/guides/build-it-yourself"
                 icon="/img/icons/deploy.svg"
               >
                 Follow our tutorials and learn how to deploy Gruntwork services
@@ -67,35 +67,35 @@ export default function Home(): JSX.Element {
             <CardGroup commonCardProps={{ appearance: "invisible" }}>
               <Card
                 title="Set Up Your Multi-account Structure"
-                href="/docs/guides/build-it-yourself/landing-zone"
+                href="/guides/build-it-yourself/landing-zone"
               >
                 Streamline how you create, configure, and secure your AWS
                 accounts using Gruntwork Landing Zone.
               </Card>
               <Card
                 title="Create an Infra CI/CD Pipeline"
-                href="/docs/guides/build-it-yourself/pipelines"
+                href="/guides/build-it-yourself/pipelines"
               >
                 Use your preferred CI tool to set up an end‑to‑end pipeline for
                 your infrastructure code.
               </Card>
               <Card
                 title="Configure Your Network"
-                href="/docs/guides/build-it-yourself/vpc"
+                href="/guides/build-it-yourself/vpc"
               >
                 Set up your network according to industry best practices using
                 our VPC service.
               </Card>
               <Card
                 title="Deploy a Kubernetes Cluster"
-                href="/docs/guides/build-it-yourself/kubernetes-cluster"
+                href="/guides/build-it-yourself/kubernetes-cluster"
               >
                 Deploy Kubernetes using EKS to host all of your apps and
                 services.
               </Card>
               <Card
                 title="Achieve Compliance"
-                href="/docs/guides/build-it-yourself/achieve-compliance"
+                href="/guides/build-it-yourself/achieve-compliance"
               >
                 Implement the CIS AWS Foundations Benchmark using our curated
                 collection of modules and services.


### PR DESCRIPTION
This takes advantage of the Docusaurus base page parameter to avoid the redundant "/docs/…" bit of the path for every file on the docs site. All internal links are updated accordingly.