### PR TITLE
[APT-1669] Turn on Edit this Page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -56,7 +56,7 @@ const config = {
         docs: {
           routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),
-          // editUrl: "https://github.com/gruntwork-io/docs/edit/master/",
+          editUrl: "https://github.com/gruntwork-io/docs/edit/master/",
           beforeDefaultRemarkPlugins: [captionsPlugin],
         },
         blog: false,


### PR DESCRIPTION
This PR enables the "Edit this Page" functionality in our docs site. Note this PR is intended to coincide with [this PR](https://github.com/gruntwork-io/docs-sourcer/pull/14) in the docs-sourcer repo.