### PR TITLE
Update macie settings for achieve compliance guide

### DIFF
--- a/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-app-to-logs-account.md
+++ b/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-app-to-logs-account.md
@@ -190,15 +190,7 @@ inputs = {
 
   # Join this account to the root account's Amazon Macie
   macie_administrator_account_id = local.accounts.root
-
-  # Configure Amazon Macie
-  create_macie_bucket            = true
-  macie_bucket_name              = "<your-macie-bucket-name>-security-macie-results"
-  macie_create_kms_key           = true
-  macie_kms_key_name             = "<your-macie-kms-key-name>-macie"
-  macie_kms_key_users            = ["arn:aws:iam::${local.accounts.root}:root"]
   macie_opt_in_regions           = local.opt_in_regions
-  macie_administrator_account_id = local.accounts.root
 
   # The variable below for Amazon Macie needs to be manually maintained. Please ensure you change the defaults.
   macie_buckets_to_analyze = {

--- a/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-security-to-security-account.md
+++ b/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-security-to-security-account.md
@@ -231,15 +231,8 @@ input = {
   security_hub_associate_to_master_account_id = local.accounts.root
 
   # Join this account to the root account's Amazon Macie
-
-  # Configure Amazon Macie
-  create_macie_bucket            = true
-  macie_bucket_name              = "<your-macie-bucket-name>-security-macie-results"
-  macie_create_kms_key           = true
-  macie_kms_key_name             = "<your-macie-kms-key-name>-macie"
-  macie_kms_key_users            = ["arn:aws:iam::${local.accounts.root}:root"]
-  macie_opt_in_regions           = local.opt_in_regions
   macie_administrator_account_id = local.accounts.root
+  macie_opt_in_regions           = local.opt_in_regions
 
   # The variable below for Amazon Macie needs to be manually maintained. Please ensure you change the defaults.
   macie_buckets_to_analyze = {

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-app-to-logs-account.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-app-to-logs-account.md
@@ -190,15 +190,7 @@ inputs = {
 
   # Join this account to the root account's Amazon Macie
   macie_administrator_account_id = local.accounts.root
-
-  # Configure Amazon Macie
-  create_macie_bucket            = true
-  macie_bucket_name              = "<your-macie-bucket-name>-security-macie-results"
-  macie_create_kms_key           = true
-  macie_kms_key_name             = "<your-macie-kms-key-name>-macie"
-  macie_kms_key_users            = ["arn:aws:iam::${local.accounts.root}:root"]
   macie_opt_in_regions           = local.opt_in_regions
-  macie_administrator_account_id = local.accounts.root
 
   # The variable below for Amazon Macie needs to be manually maintained. Please ensure you change the defaults.
   macie_buckets_to_analyze = {

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-app-to-logs-account.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-app-to-logs-account.md
@@ -271,5 +271,5 @@ On some operating systems, such as MacOS, you may also need to increase your ope
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"1e95d860557dc4159ade32bb1da1da32"}
+{"sourcePlugin":"local-copier","hash":"4b5387c63b27de9f1446fe439d6438af"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-security-to-security-account.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-security-to-security-account.md
@@ -330,5 +330,5 @@ echo "<PASSWORD>" | base64 --decode | keybase pgp decrypt
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"f468685e4e7a3c96e847d3353bb6c680"}
+{"sourcePlugin":"local-copier","hash":"defd1dc9d6c10d7c36b4bf207bfe074f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-security-to-security-account.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-security-to-security-account.md
@@ -231,15 +231,8 @@ input = {
   security_hub_associate_to_master_account_id = local.accounts.root
 
   # Join this account to the root account's Amazon Macie
-
-  # Configure Amazon Macie
-  create_macie_bucket            = true
-  macie_bucket_name              = "<your-macie-bucket-name>-security-macie-results"
-  macie_create_kms_key           = true
-  macie_kms_key_name             = "<your-macie-kms-key-name>-macie"
-  macie_kms_key_users            = ["arn:aws:iam::${local.accounts.root}:root"]
-  macie_opt_in_regions           = local.opt_in_regions
   macie_administrator_account_id = local.accounts.root
+  macie_opt_in_regions           = local.opt_in_regions
 
   # The variable below for Amazon Macie needs to be manually maintained. Please ensure you change the defaults.
   macie_buckets_to_analyze = {


### PR DESCRIPTION
This updates a bug in the macie settings for the achieve compliance guide, where it uses settings that don't make sense (creating a macie bucket in logs and security when they are rolling up to `root` account).