### PR TITLE
Implement FAQ page and categories

### DIFF
--- a/_docs-sources/faq/devops-general/index.md
+++ b/_docs-sources/faq/devops-general/index.md
@@ -1,0 +1,9 @@
+# DevOps Best Practices FAQ
+
+## App development
+
+- [ Can you recommend some best practices for app development? Where can I find a decent 12-factor sample app?](https://github.com/gruntwork-io/knowledge-base/discussions/62)
+
+## Secrets management
+
+- [Do you have a recommended strategy for secrets management?](https://github.com/gruntwork-io/knowledge-base/discussions/62)

--- a/_docs-sources/faq/eks/index.md
+++ b/_docs-sources/faq/eks/index.md
@@ -1,0 +1,13 @@
+# EKS FAQ
+
+## General questions
+
+- [How do I share Secrets Manager secrets with Kubernetes Pods through Terragrunt / Terraform?](https://github.com/gruntwork-io/knowledge-base/discussions/213)
+- [How do I upgrade the Kubernetes version of the EKS cluster?](https://github.com/gruntwork-io/knowledge-base/discussions/143)
+- [Do the Gruntwork EKS modules support spot instances?](https://github.com/gruntwork-io/knowledge-base/discussions/134)
+- [EKS cluster managed workers: customize auto scaling group (ASG) name](https://github.com/gruntwork-io/knowledge-base/discussions/131)
+
+## Errors
+
+- [Error when trying to create node labels with eks-cluster](https://github.com/gruntwork-io/knowledge-base/discussions/202)
+- [AWS CNI prefix not propagated to nodes](https://github.com/gruntwork-io/knowledge-base/discussions/196)

--- a/_docs-sources/faq/eks/index.md
+++ b/_docs-sources/faq/eks/index.md
@@ -5,7 +5,7 @@
 - [How do I share Secrets Manager secrets with Kubernetes Pods through Terragrunt / Terraform?](https://github.com/gruntwork-io/knowledge-base/discussions/213)
 - [How do I upgrade the Kubernetes version of the EKS cluster?](https://github.com/gruntwork-io/knowledge-base/discussions/143)
 - [Do the Gruntwork EKS modules support spot instances?](https://github.com/gruntwork-io/knowledge-base/discussions/134)
-- [EKS cluster managed workers: customize auto scaling group (ASG) name](https://github.com/gruntwork-io/knowledge-base/discussions/131)
+- [How to change EKS cluster managed workers auto scaling group (ASG) name?](https://github.com/gruntwork-io/knowledge-base/discussions/131)
 
 ## Errors
 

--- a/_docs-sources/faq/iac-general/index.md
+++ b/_docs-sources/faq/iac-general/index.md
@@ -1,0 +1,5 @@
+# Infrastructure as Code (IaC) FAQ
+
+## Destroying
+
+- [How do I destroy a module that has errors?](https://github.com/gruntwork-io/knowledge-base/discussions/144)

--- a/_docs-sources/faq/index.md
+++ b/_docs-sources/faq/index.md
@@ -1,0 +1,66 @@
+import Card from "/src/components/Card"
+import Grid from "/src/components/Grid"
+
+# Gruntwork FAQs
+
+Get answers to frequently asked questions, organized by category.
+
+## Categories
+
+<Grid cols={2}>
+  <Card
+    title="Reference Architecture Pre-Deployment"
+    href="/faq/ref-arch-predeployment"
+  >
+    Preparing for a deployment? We've got answers to common questions here. 
+  </Card>
+  <Card
+    title="Reference Architecture"
+    href="/faq/ref-arch"
+  >
+    Questions about working with a deployed Reference Architecture. 
+  </Card>
+  <Card
+    title="DevOps Best Practices"
+    href="/faq/devops-general"
+  >
+    Common advice, strategies, tooling, tips and tricks. 
+  </Card>
+  <Card
+    title="Service Catalog FAQ"
+    href="/faq/service-catalog"
+  >
+    Common questions about working with the Gruntwork Service Catalog
+  </Card>
+  <Card
+    title="Terragrunt"
+    href="/faq/terragrunt"
+  >
+    Common questions about Gruntwork's open-source library, Terragrunt 
+  </Card>
+  <Card
+    title="Terratest"
+    href="/faq/terratest"
+  >
+    Common questions about Gruntwork's open-source library, Terratest 
+  </Card>
+  <Card
+    title="Pipelines"
+    href="/faq/pipelines"
+  >
+    Common questions about Gruntwork's continuous integration and delivery (CI/CD) product, Pipelines.  
+  </Card>
+  <Card
+    title="EKS"
+    href="/faq/eks"
+  >
+    Common questions about Gruntwork's EKS modules, best practices and common tasks.  
+  </Card>
+<Card
+    title="Infrastructure as Code (IaC) and modules"
+    href="/faq/iac-general"
+  >
+    Common questions about working with modules, Infrastructure as code best practices, tips and tricks. 
+  </Card>
+
+</Grid>

--- a/_docs-sources/faq/index.md
+++ b/_docs-sources/faq/index.md
@@ -1,3 +1,7 @@
+---
+hide_table_of_contents: true
+---
+
 import Card from "/src/components/Card"
 import Grid from "/src/components/Grid"
 

--- a/_docs-sources/faq/index.md
+++ b/_docs-sources/faq/index.md
@@ -5,8 +5,6 @@ import Grid from "/src/components/Grid"
 
 Get answers to frequently asked questions, organized by category.
 
-## Categories
-
 <Grid cols={2}>
   <Card
     title="Reference Architecture Pre-Deployment"

--- a/_docs-sources/faq/pipelines/index.md
+++ b/_docs-sources/faq/pipelines/index.md
@@ -3,9 +3,9 @@
 ## General questions
 
 - [Why does `terraform-update-variable` default to skipping CI?](https://github.com/gruntwork-io/knowledge-base/discussions/200)
-- [ECS Deploy Runner permissions errors for new modules](https://github.com/gruntwork-io/knowledge-base/discussions/180)
-- [ECS Deploy Runner for multiple regions](https://github.com/gruntwork-io/knowledge-base/discussions/181)
-- [Applying changes to common.hcl or other root files](https://github.com/gruntwork-io/knowledge-base/discussions/133)
+- [How do I handle ECS Deploy Runner permissions errors for new modules?](https://github.com/gruntwork-io/knowledge-base/discussions/180)
+- [Can we run ECS Deploy Runner in multiple regions?](https://github.com/gruntwork-io/knowledge-base/discussions/181)
+- [How do I apply changes to common.hcl or other root files?](https://github.com/gruntwork-io/knowledge-base/discussions/133)
 
 ## Errors
 

--- a/_docs-sources/faq/pipelines/index.md
+++ b/_docs-sources/faq/pipelines/index.md
@@ -1,0 +1,12 @@
+# Pipelines FAQ
+
+## General questions
+
+- [Why does `terraform-update-variable` default to skipping CI?](https://github.com/gruntwork-io/knowledge-base/discussions/200)
+- [ECS Deploy Runner permissions errors for new modules](https://github.com/gruntwork-io/knowledge-base/discussions/180)
+- [ECS Deploy Runner for multiple regions](https://github.com/gruntwork-io/knowledge-base/discussions/181)
+- [Applying changes to common.hcl or other root files](https://github.com/gruntwork-io/knowledge-base/discussions/133)
+
+## Errors
+
+- [How to handle "Provided value for option repo does not match regex" in Pipelines?](https://github.com/gruntwork-io/knowledge-base/discussions/219)

--- a/_docs-sources/faq/ref-arch-predeployment/index.md
+++ b/_docs-sources/faq/ref-arch-predeployment/index.md
@@ -1,0 +1,25 @@
+# Reference Architecture Pre-deployment FAQ
+
+## General questions
+
+- [What are the steps to have a Reference Architecture deployed?](https://github.com/gruntwork-io/knowledge-base/discussions/203)
+
+## AWS accounts
+
+- [Can we use existing AWS accounts and organizations?](https://github.com/gruntwork-io/knowledge-base/discussions/207)
+- [What is the breakdown of accounts in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/57)
+- [Can I get a single account Reference Architecture?](https://github.com/gruntwork-io/knowledge-base/discussions/99)
+- [Why does the Ref Arch require us to create AWS accounts?](https://github.com/gruntwork-io/knowledge-base/discussions/20)
+
+## Regions
+
+- [Can we use a different primary region per environment?](https://github.com/gruntwork-io/knowledge-base/discussions/216)
+
+## CIS Benchmark compliant Reference Architecture
+
+- [What are the acceptable CIDRs / IP addresses for IPAllowList?](https://github.com/gruntwork-io/knowledge-base/discussions/206)
+- [Why does the CIS AWS Foundations Benchmark package cost additional money?](https://github.com/gruntwork-io/knowledge-base/discussions/69)
+
+## Gruntwork modules
+
+- [How do Gruntwork modules differ from the modules already available via the Terraform community?](https://github.com/gruntwork-io/knowledge-base/discussions/117)

--- a/_docs-sources/faq/ref-arch/index.md
+++ b/_docs-sources/faq/ref-arch/index.md
@@ -1,0 +1,30 @@
+# Reference Architecture FAQ
+
+## Behaviors and practices
+
+- [What is the tagging strategy for resources in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/54)
+- [How does the Ref Arch handle IPv6?](https://github.com/gruntwork-io/knowledge-base/discussions/54)
+- [How to best create a new IAM group with a specific role assigned?](https://github.com/gruntwork-io/knowledge-base/discussions/212)
+- [Service Quotas and Limits](https://github.com/gruntwork-io/knowledge-base/discussions/211)
+- [What are OpenVPN best practices in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/194)
+- [How do I switch accounts when working with the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/162)
+- [How do I deploy the same module in multiple regions?](https://github.com/gruntwork-io/knowledge-base/discussions/182)
+- [Best way of deploying KMS keys in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/189)
+- [How do I debug Security Checks failing in the CIS Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/135)
+
+## Versions and flavors
+
+- [How can I migrate from a single-account to a multi-accont Ref Arch in the future?](https://github.com/gruntwork-io/knowledge-base/discussions/101) -[Ref Arch 2.0 vs Ref Arch 1.0](https://github.com/gruntwork-io/knowledge-base/discussions/3)
+- [Can I follow a guide to build the Ref Arch from scratch?](https://github.com/gruntwork-io/knowledge-base/discussions/58)
+- [How do I lock the Terraform version being used in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/187)
+
+## Components and integrations
+
+- [Is Elasticsearch included in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/56)
+- [Do you support ECS service discovery and App Mesh?](https://github.com/gruntwork-io/knowledge-base/discussions/53)
+- [Do you have modules for Code pipelines or do you rely on CircleCI?](https://github.com/gruntwork-io/knowledge-base/discussions/60)
+- [How to forward CloudTrail logs to Datadog](https://github.com/gruntwork-io/knowledge-base/discussions/179)
+
+## Errors
+
+- [ Specified ReservedConcurrentExecutions for function descreased account's UnreservedConcurrentExecution below its minimum value of [x]](https://github.com/gruntwork-io/knowledge-base/discussions/215)

--- a/_docs-sources/faq/ref-arch/index.md
+++ b/_docs-sources/faq/ref-arch/index.md
@@ -5,16 +5,17 @@
 - [What is the tagging strategy for resources in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/54)
 - [How does the Ref Arch handle IPv6?](https://github.com/gruntwork-io/knowledge-base/discussions/54)
 - [How to best create a new IAM group with a specific role assigned?](https://github.com/gruntwork-io/knowledge-base/discussions/212)
-- [Service Quotas and Limits](https://github.com/gruntwork-io/knowledge-base/discussions/211)
+- [What do I need to understand about Service Quotas and Limits?](https://github.com/gruntwork-io/knowledge-base/discussions/211)
 - [What are OpenVPN best practices in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/194)
 - [How do I switch accounts when working with the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/162)
 - [How do I deploy the same module in multiple regions?](https://github.com/gruntwork-io/knowledge-base/discussions/182)
-- [Best way of deploying KMS keys in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/189)
+- [What's the best way to deploy KMS keys in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/189)
 - [How do I debug Security Checks failing in the CIS Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/135)
 
 ## Versions and flavors
 
-- [How can I migrate from a single-account to a multi-accont Ref Arch in the future?](https://github.com/gruntwork-io/knowledge-base/discussions/101) -[Ref Arch 2.0 vs Ref Arch 1.0](https://github.com/gruntwork-io/knowledge-base/discussions/3)
+- [How can I migrate from a single-account to a multi-accont Ref Arch in the future?](https://github.com/gruntwork-io/knowledge-base/discussions/101)
+- [What are the differences between Ref Arch 2.0 vs Ref Arch 1.0?](https://github.com/gruntwork-io/knowledge-base/discussions/3)
 - [Can I follow a guide to build the Ref Arch from scratch?](https://github.com/gruntwork-io/knowledge-base/discussions/58)
 - [How do I lock the Terraform version being used in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/187)
 
@@ -23,7 +24,7 @@
 - [Is Elasticsearch included in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/56)
 - [Do you support ECS service discovery and App Mesh?](https://github.com/gruntwork-io/knowledge-base/discussions/53)
 - [Do you have modules for Code pipelines or do you rely on CircleCI?](https://github.com/gruntwork-io/knowledge-base/discussions/60)
-- [How to forward CloudTrail logs to Datadog](https://github.com/gruntwork-io/knowledge-base/discussions/179)
+- [How do I forward CloudTrail logs to Datadog?](https://github.com/gruntwork-io/knowledge-base/discussions/179)
 
 ## Errors
 

--- a/_docs-sources/faq/service-catalog/index.md
+++ b/_docs-sources/faq/service-catalog/index.md
@@ -1,0 +1,9 @@
+# Service Catalog FAQ
+
+## Core concepts
+
+- [Where can I get a comprehensive introduction to modules, the service catalog and how they fit together?](https://github.com/gruntwork-io/knowledge-base/discussions/54)
+
+## Daily tasks
+
+- [How do I build new AMIs from the Service Catalog?](https://github.com/gruntwork-io/knowledge-base/discussions/218)

--- a/_docs-sources/faq/terragrunt/index.md
+++ b/_docs-sources/faq/terragrunt/index.md
@@ -2,8 +2,8 @@
 
 ## General questions
 
-- [Passing variables between Terragrunt and Terraform](https://github.com/gruntwork-io/knowledge-base/discussions/137)
-- [Mocking large sets of outputs with Terragrunt](https://github.com/gruntwork-io/knowledge-base/discussions/109)
+- [How do I pass variables between Terragrunt and Terraform?](https://github.com/gruntwork-io/knowledge-base/discussions/137)
+- [How do I mock large sets of outputs with Terragrunt?](https://github.com/gruntwork-io/knowledge-base/discussions/109)
 
 ## Versions
 

--- a/_docs-sources/faq/terragrunt/index.md
+++ b/_docs-sources/faq/terragrunt/index.md
@@ -1,0 +1,15 @@
+# Terragrunt FAQ
+
+## General questions
+
+- [Passing variables between Terragrunt and Terraform](https://github.com/gruntwork-io/knowledge-base/discussions/137)
+- [Mocking large sets of outputs with Terragrunt](https://github.com/gruntwork-io/knowledge-base/discussions/109)
+
+## Versions
+
+- [How do I lock the version of Terraform being used?](https://github.com/gruntwork-io/knowledge-base/discussions/187)
+
+## Dependencies
+
+- [How do you override a dependency block in Terragrunt?](https://github.com/gruntwork-io/knowledge-base/discussions/172)
+- [How can you conditionally include a provider in a generate block?](https://github.com/gruntwork-io/knowledge-base/discussions/205)

--- a/_docs-sources/faq/terratest/index.md
+++ b/_docs-sources/faq/terratest/index.md
@@ -1,0 +1,11 @@
+# Terratest FAQ
+
+## General questions
+
+- [How to use a field from a Terraform multi-fields output in Terratest](https://github.com/gruntwork-io/knowledge-base/discussions/217)
+- [How to create an S3 bucket with SSL enabled using aws.CreateS3Bucket function in Terratest](https://github.com/gruntwork-io/knowledge-base/discussions/195)
+- [How do I get S3 bucket folder structure using Terratest?](https://github.com/gruntwork-io/knowledge-base/discussions/173)
+
+## Kubeconfig
+
+- [Can I pass kubeconfig options into Terratest](https://github.com/gruntwork-io/knowledge-base/discussions/191)

--- a/_docs-sources/faq/terratest/index.md
+++ b/_docs-sources/faq/terratest/index.md
@@ -2,10 +2,10 @@
 
 ## General questions
 
-- [How to use a field from a Terraform multi-fields output in Terratest](https://github.com/gruntwork-io/knowledge-base/discussions/217)
-- [How to create an S3 bucket with SSL enabled using aws.CreateS3Bucket function in Terratest](https://github.com/gruntwork-io/knowledge-base/discussions/195)
+- [How to use a field from a Terraform multi-fields output in Terratest?](https://github.com/gruntwork-io/knowledge-base/discussions/217)
+- [How to create an S3 bucket with SSL enabled using aws.CreateS3Bucket function in Terratest?](https://github.com/gruntwork-io/knowledge-base/discussions/195)
 - [How do I get S3 bucket folder structure using Terratest?](https://github.com/gruntwork-io/knowledge-base/discussions/173)
 
 ## Kubeconfig
 
-- [Can I pass kubeconfig options into Terratest](https://github.com/gruntwork-io/knowledge-base/discussions/191)
+- [Can I pass kubeconfig options into Terratest?](https://github.com/gruntwork-io/knowledge-base/discussions/191)

--- a/docs/faq/devops-general/index.md
+++ b/docs/faq/devops-general/index.md
@@ -1,0 +1,14 @@
+# DevOps Best Practices FAQ
+
+## App development
+
+- [ Can you recommend some best practices for app development? Where can I find a decent 12-factor sample app?](https://github.com/gruntwork-io/knowledge-base/discussions/62)
+
+## Secrets management
+
+- [Do you have a recommended strategy for secrets management?](https://github.com/gruntwork-io/knowledge-base/discussions/62)
+
+
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"local-copier","hash":"edc21b0a2f48bdf03447da1c1cb9ac21"}
+##DOCS-SOURCER-END -->

--- a/docs/faq/eks/index.md
+++ b/docs/faq/eks/index.md
@@ -5,7 +5,7 @@
 - [How do I share Secrets Manager secrets with Kubernetes Pods through Terragrunt / Terraform?](https://github.com/gruntwork-io/knowledge-base/discussions/213)
 - [How do I upgrade the Kubernetes version of the EKS cluster?](https://github.com/gruntwork-io/knowledge-base/discussions/143)
 - [Do the Gruntwork EKS modules support spot instances?](https://github.com/gruntwork-io/knowledge-base/discussions/134)
-- [EKS cluster managed workers: customize auto scaling group (ASG) name](https://github.com/gruntwork-io/knowledge-base/discussions/131)
+- [How to change EKS cluster managed workers auto scaling group (ASG) name?](https://github.com/gruntwork-io/knowledge-base/discussions/131)
 
 ## Errors
 
@@ -14,5 +14,5 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"6c047072784aa71182055a1771aeb266"}
+{"sourcePlugin":"local-copier","hash":"d95f4a0a70695a6733735a2c67f6bd4e"}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/eks/index.md
+++ b/docs/faq/eks/index.md
@@ -1,0 +1,18 @@
+# EKS FAQ
+
+## General questions
+
+- [How do I share Secrets Manager secrets with Kubernetes Pods through Terragrunt / Terraform?](https://github.com/gruntwork-io/knowledge-base/discussions/213)
+- [How do I upgrade the Kubernetes version of the EKS cluster?](https://github.com/gruntwork-io/knowledge-base/discussions/143)
+- [Do the Gruntwork EKS modules support spot instances?](https://github.com/gruntwork-io/knowledge-base/discussions/134)
+- [EKS cluster managed workers: customize auto scaling group (ASG) name](https://github.com/gruntwork-io/knowledge-base/discussions/131)
+
+## Errors
+
+- [Error when trying to create node labels with eks-cluster](https://github.com/gruntwork-io/knowledge-base/discussions/202)
+- [AWS CNI prefix not propagated to nodes](https://github.com/gruntwork-io/knowledge-base/discussions/196)
+
+
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"local-copier","hash":"6c047072784aa71182055a1771aeb266"}
+##DOCS-SOURCER-END -->

--- a/docs/faq/iac-general/index.md
+++ b/docs/faq/iac-general/index.md
@@ -1,0 +1,10 @@
+# Infrastructure as Code (IaC) FAQ
+
+## Destroying
+
+- [How do I destroy a module that has errors?](https://github.com/gruntwork-io/knowledge-base/discussions/144)
+
+
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"local-copier","hash":"36bb7ec496d13c871b1259ef31ea7b1f"}
+##DOCS-SOURCER-END -->

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -1,3 +1,7 @@
+---
+hide_table_of_contents: true
+---
+
 import Card from "/src/components/Card"
 import Grid from "/src/components/Grid"
 
@@ -65,5 +69,5 @@ Get answers to frequently asked questions, organized by category.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"3885b46059cdb4616ceddbe9b2c7c100"}
+{"sourcePlugin":"local-copier","hash":"dbdf6417d65b463c42d8decdbed70717"}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -1,0 +1,71 @@
+import Card from "/src/components/Card"
+import Grid from "/src/components/Grid"
+
+# Gruntwork FAQs
+
+Get answers to frequently asked questions, organized by category.
+
+## Categories
+
+<Grid cols={2}>
+  <Card
+    title="Reference Architecture Pre-Deployment"
+    href="/faq/ref-arch-predeployment"
+  >
+    Preparing for a deployment? We've got answers to common questions here. 
+  </Card>
+  <Card
+    title="Reference Architecture"
+    href="/faq/ref-arch"
+  >
+    Questions about working with a deployed Reference Architecture. 
+  </Card>
+  <Card
+    title="DevOps Best Practices"
+    href="/faq/devops-general"
+  >
+    Common advice, strategies, tooling, tips and tricks. 
+  </Card>
+  <Card
+    title="Service Catalog FAQ"
+    href="/faq/service-catalog"
+  >
+    Common questions about working with the Gruntwork Service Catalog
+  </Card>
+  <Card
+    title="Terragrunt"
+    href="/faq/terragrunt"
+  >
+    Common questions about Gruntwork's open-source library, Terragrunt 
+  </Card>
+  <Card
+    title="Terratest"
+    href="/faq/terratest"
+  >
+    Common questions about Gruntwork's open-source library, Terratest 
+  </Card>
+  <Card
+    title="Pipelines"
+    href="/faq/pipelines"
+  >
+    Common questions about Gruntwork's continuous integration and delivery (CI/CD) product, Pipelines.  
+  </Card>
+  <Card
+    title="EKS"
+    href="/faq/eks"
+  >
+    Common questions about Gruntwork's EKS modules, best practices and common tasks.  
+  </Card>
+<Card
+    title="Infrastructure as Code (IaC) and modules"
+    href="/faq/iac-general"
+  >
+    Common questions about working with modules, Infrastructure as code best practices, tips and tricks. 
+  </Card>
+
+</Grid>
+
+
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"local-copier","hash":"0b8f77571f8605ab889f2025e98bf11b"}
+##DOCS-SOURCER-END -->

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -5,8 +5,6 @@ import Grid from "/src/components/Grid"
 
 Get answers to frequently asked questions, organized by category.
 
-## Categories
-
 <Grid cols={2}>
   <Card
     title="Reference Architecture Pre-Deployment"
@@ -67,5 +65,5 @@ Get answers to frequently asked questions, organized by category.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"0b8f77571f8605ab889f2025e98bf11b"}
+{"sourcePlugin":"local-copier","hash":"3885b46059cdb4616ceddbe9b2c7c100"}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/pipelines/index.md
+++ b/docs/faq/pipelines/index.md
@@ -1,0 +1,17 @@
+# Pipelines FAQ
+
+## General questions
+
+- [Why does `terraform-update-variable` default to skipping CI?](https://github.com/gruntwork-io/knowledge-base/discussions/200)
+- [ECS Deploy Runner permissions errors for new modules](https://github.com/gruntwork-io/knowledge-base/discussions/180)
+- [ECS Deploy Runner for multiple regions](https://github.com/gruntwork-io/knowledge-base/discussions/181)
+- [Applying changes to common.hcl or other root files](https://github.com/gruntwork-io/knowledge-base/discussions/133)
+
+## Errors
+
+- [How to handle "Provided value for option repo does not match regex" in Pipelines?](https://github.com/gruntwork-io/knowledge-base/discussions/219)
+
+
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"local-copier","hash":"7ada5c285fb65499008589a61615af8c"}
+##DOCS-SOURCER-END -->

--- a/docs/faq/pipelines/index.md
+++ b/docs/faq/pipelines/index.md
@@ -3,9 +3,9 @@
 ## General questions
 
 - [Why does `terraform-update-variable` default to skipping CI?](https://github.com/gruntwork-io/knowledge-base/discussions/200)
-- [ECS Deploy Runner permissions errors for new modules](https://github.com/gruntwork-io/knowledge-base/discussions/180)
-- [ECS Deploy Runner for multiple regions](https://github.com/gruntwork-io/knowledge-base/discussions/181)
-- [Applying changes to common.hcl or other root files](https://github.com/gruntwork-io/knowledge-base/discussions/133)
+- [How do I handle ECS Deploy Runner permissions errors for new modules?](https://github.com/gruntwork-io/knowledge-base/discussions/180)
+- [Can we run ECS Deploy Runner in multiple regions?](https://github.com/gruntwork-io/knowledge-base/discussions/181)
+- [How do I apply changes to common.hcl or other root files?](https://github.com/gruntwork-io/knowledge-base/discussions/133)
 
 ## Errors
 
@@ -13,5 +13,5 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"7ada5c285fb65499008589a61615af8c"}
+{"sourcePlugin":"local-copier","hash":"a07af15175a16401cffba58d7eb21ef0"}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/ref-arch-predeployment/index.md
+++ b/docs/faq/ref-arch-predeployment/index.md
@@ -1,0 +1,30 @@
+# Reference Architecture Pre-deployment FAQ
+
+## General questions
+
+- [What are the steps to have a Reference Architecture deployed?](https://github.com/gruntwork-io/knowledge-base/discussions/203)
+
+## AWS accounts
+
+- [Can we use existing AWS accounts and organizations?](https://github.com/gruntwork-io/knowledge-base/discussions/207)
+- [What is the breakdown of accounts in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/57)
+- [Can I get a single account Reference Architecture?](https://github.com/gruntwork-io/knowledge-base/discussions/99)
+- [Why does the Ref Arch require us to create AWS accounts?](https://github.com/gruntwork-io/knowledge-base/discussions/20)
+
+## Regions
+
+- [Can we use a different primary region per environment?](https://github.com/gruntwork-io/knowledge-base/discussions/216)
+
+## CIS Benchmark compliant Reference Architecture
+
+- [What are the acceptable CIDRs / IP addresses for IPAllowList?](https://github.com/gruntwork-io/knowledge-base/discussions/206)
+- [Why does the CIS AWS Foundations Benchmark package cost additional money?](https://github.com/gruntwork-io/knowledge-base/discussions/69)
+
+## Gruntwork modules
+
+- [How do Gruntwork modules differ from the modules already available via the Terraform community?](https://github.com/gruntwork-io/knowledge-base/discussions/117)
+
+
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"local-copier","hash":"dc57285f55e7caced69fdb4052fa6264"}
+##DOCS-SOURCER-END -->

--- a/docs/faq/ref-arch/index.md
+++ b/docs/faq/ref-arch/index.md
@@ -1,0 +1,35 @@
+# Reference Architecture FAQ
+
+## Behaviors and practices
+
+- [What is the tagging strategy for resources in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/54)
+- [How does the Ref Arch handle IPv6?](https://github.com/gruntwork-io/knowledge-base/discussions/54)
+- [How to best create a new IAM group with a specific role assigned?](https://github.com/gruntwork-io/knowledge-base/discussions/212)
+- [Service Quotas and Limits](https://github.com/gruntwork-io/knowledge-base/discussions/211)
+- [What are OpenVPN best practices in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/194)
+- [How do I switch accounts when working with the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/162)
+- [How do I deploy the same module in multiple regions?](https://github.com/gruntwork-io/knowledge-base/discussions/182)
+- [Best way of deploying KMS keys in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/189)
+- [How do I debug Security Checks failing in the CIS Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/135)
+
+## Versions and flavors
+
+- [How can I migrate from a single-account to a multi-accont Ref Arch in the future?](https://github.com/gruntwork-io/knowledge-base/discussions/101) -[Ref Arch 2.0 vs Ref Arch 1.0](https://github.com/gruntwork-io/knowledge-base/discussions/3)
+- [Can I follow a guide to build the Ref Arch from scratch?](https://github.com/gruntwork-io/knowledge-base/discussions/58)
+- [How do I lock the Terraform version being used in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/187)
+
+## Components and integrations
+
+- [Is Elasticsearch included in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/56)
+- [Do you support ECS service discovery and App Mesh?](https://github.com/gruntwork-io/knowledge-base/discussions/53)
+- [Do you have modules for Code pipelines or do you rely on CircleCI?](https://github.com/gruntwork-io/knowledge-base/discussions/60)
+- [How to forward CloudTrail logs to Datadog](https://github.com/gruntwork-io/knowledge-base/discussions/179)
+
+## Errors
+
+- [ Specified ReservedConcurrentExecutions for function descreased account's UnreservedConcurrentExecution below its minimum value of [x]](https://github.com/gruntwork-io/knowledge-base/discussions/215)
+
+
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"local-copier","hash":"5d1fb935e0f6290830996e146289155b"}
+##DOCS-SOURCER-END -->

--- a/docs/faq/ref-arch/index.md
+++ b/docs/faq/ref-arch/index.md
@@ -5,16 +5,17 @@
 - [What is the tagging strategy for resources in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/54)
 - [How does the Ref Arch handle IPv6?](https://github.com/gruntwork-io/knowledge-base/discussions/54)
 - [How to best create a new IAM group with a specific role assigned?](https://github.com/gruntwork-io/knowledge-base/discussions/212)
-- [Service Quotas and Limits](https://github.com/gruntwork-io/knowledge-base/discussions/211)
+- [What do I need to understand about Service Quotas and Limits?](https://github.com/gruntwork-io/knowledge-base/discussions/211)
 - [What are OpenVPN best practices in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/194)
 - [How do I switch accounts when working with the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/162)
 - [How do I deploy the same module in multiple regions?](https://github.com/gruntwork-io/knowledge-base/discussions/182)
-- [Best way of deploying KMS keys in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/189)
+- [What's the best way to deploy KMS keys in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/189)
 - [How do I debug Security Checks failing in the CIS Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/135)
 
 ## Versions and flavors
 
-- [How can I migrate from a single-account to a multi-accont Ref Arch in the future?](https://github.com/gruntwork-io/knowledge-base/discussions/101) -[Ref Arch 2.0 vs Ref Arch 1.0](https://github.com/gruntwork-io/knowledge-base/discussions/3)
+- [How can I migrate from a single-account to a multi-accont Ref Arch in the future?](https://github.com/gruntwork-io/knowledge-base/discussions/101)
+- [What are the differences between Ref Arch 2.0 vs Ref Arch 1.0?](https://github.com/gruntwork-io/knowledge-base/discussions/3)
 - [Can I follow a guide to build the Ref Arch from scratch?](https://github.com/gruntwork-io/knowledge-base/discussions/58)
 - [How do I lock the Terraform version being used in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/187)
 
@@ -23,7 +24,7 @@
 - [Is Elasticsearch included in the Ref Arch?](https://github.com/gruntwork-io/knowledge-base/discussions/56)
 - [Do you support ECS service discovery and App Mesh?](https://github.com/gruntwork-io/knowledge-base/discussions/53)
 - [Do you have modules for Code pipelines or do you rely on CircleCI?](https://github.com/gruntwork-io/knowledge-base/discussions/60)
-- [How to forward CloudTrail logs to Datadog](https://github.com/gruntwork-io/knowledge-base/discussions/179)
+- [How do I forward CloudTrail logs to Datadog?](https://github.com/gruntwork-io/knowledge-base/discussions/179)
 
 ## Errors
 
@@ -31,5 +32,5 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"5d1fb935e0f6290830996e146289155b"}
+{"sourcePlugin":"local-copier","hash":"613ecde6c13ca14adbc92aac692f90bf"}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/service-catalog/index.md
+++ b/docs/faq/service-catalog/index.md
@@ -1,0 +1,14 @@
+# Service Catalog FAQ
+
+## Core concepts
+
+- [Where can I get a comprehensive introduction to modules, the service catalog and how they fit together?](https://github.com/gruntwork-io/knowledge-base/discussions/54)
+
+## Daily tasks
+
+- [How do I build new AMIs from the Service Catalog?](https://github.com/gruntwork-io/knowledge-base/discussions/218)
+
+
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"local-copier","hash":"1ab393265d039a3821716343f10c0e0b"}
+##DOCS-SOURCER-END -->

--- a/docs/faq/terragrunt/index.md
+++ b/docs/faq/terragrunt/index.md
@@ -1,0 +1,20 @@
+# Terragrunt FAQ
+
+## General questions
+
+- [Passing variables between Terragrunt and Terraform](https://github.com/gruntwork-io/knowledge-base/discussions/137)
+- [Mocking large sets of outputs with Terragrunt](https://github.com/gruntwork-io/knowledge-base/discussions/109)
+
+## Versions
+
+- [How do I lock the version of Terraform being used?](https://github.com/gruntwork-io/knowledge-base/discussions/187)
+
+## Dependencies
+
+- [How do you override a dependency block in Terragrunt?](https://github.com/gruntwork-io/knowledge-base/discussions/172)
+- [How can you conditionally include a provider in a generate block?](https://github.com/gruntwork-io/knowledge-base/discussions/205)
+
+
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"local-copier","hash":"55235a63630ca8c14f555aba4f1213d6"}
+##DOCS-SOURCER-END -->

--- a/docs/faq/terragrunt/index.md
+++ b/docs/faq/terragrunt/index.md
@@ -2,8 +2,8 @@
 
 ## General questions
 
-- [Passing variables between Terragrunt and Terraform](https://github.com/gruntwork-io/knowledge-base/discussions/137)
-- [Mocking large sets of outputs with Terragrunt](https://github.com/gruntwork-io/knowledge-base/discussions/109)
+- [How do I pass variables between Terragrunt and Terraform?](https://github.com/gruntwork-io/knowledge-base/discussions/137)
+- [How do I mock large sets of outputs with Terragrunt?](https://github.com/gruntwork-io/knowledge-base/discussions/109)
 
 ## Versions
 
@@ -16,5 +16,5 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"55235a63630ca8c14f555aba4f1213d6"}
+{"sourcePlugin":"local-copier","hash":"98df4b23885f621d3307a6112f2c6c9b"}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/terratest/index.md
+++ b/docs/faq/terratest/index.md
@@ -2,15 +2,15 @@
 
 ## General questions
 
-- [How to use a field from a Terraform multi-fields output in Terratest](https://github.com/gruntwork-io/knowledge-base/discussions/217)
-- [How to create an S3 bucket with SSL enabled using aws.CreateS3Bucket function in Terratest](https://github.com/gruntwork-io/knowledge-base/discussions/195)
+- [How to use a field from a Terraform multi-fields output in Terratest?](https://github.com/gruntwork-io/knowledge-base/discussions/217)
+- [How to create an S3 bucket with SSL enabled using aws.CreateS3Bucket function in Terratest?](https://github.com/gruntwork-io/knowledge-base/discussions/195)
 - [How do I get S3 bucket folder structure using Terratest?](https://github.com/gruntwork-io/knowledge-base/discussions/173)
 
 ## Kubeconfig
 
-- [Can I pass kubeconfig options into Terratest](https://github.com/gruntwork-io/knowledge-base/discussions/191)
+- [Can I pass kubeconfig options into Terratest?](https://github.com/gruntwork-io/knowledge-base/discussions/191)
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"f2cf9c560de97d6050e9e6696b8fc0fd"}
+{"sourcePlugin":"local-copier","hash":"6d88bf0ee938daacc5ee3c6547d45d3d"}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/terratest/index.md
+++ b/docs/faq/terratest/index.md
@@ -1,0 +1,16 @@
+# Terratest FAQ
+
+## General questions
+
+- [How to use a field from a Terraform multi-fields output in Terratest](https://github.com/gruntwork-io/knowledge-base/discussions/217)
+- [How to create an S3 bucket with SSL enabled using aws.CreateS3Bucket function in Terratest](https://github.com/gruntwork-io/knowledge-base/discussions/195)
+- [How do I get S3 bucket folder structure using Terratest?](https://github.com/gruntwork-io/knowledge-base/discussions/173)
+
+## Kubeconfig
+
+- [Can I pass kubeconfig options into Terratest](https://github.com/gruntwork-io/knowledge-base/discussions/191)
+
+
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"local-copier","hash":"f2cf9c560de97d6050e9e6696b8fc0fd"}
+##DOCS-SOURCER-END -->

--- a/sidebars.js
+++ b/sidebars.js
@@ -20,6 +20,7 @@ const kubernetesSidebar = require("./sidebars/kubernetes-guide.js")
 const complianceSidebar = require("./sidebars/compliance-guide.js")
 const updateGuideSidebars = require("./sidebars/update-guides.js")
 const apiSidebars = require("./sidebars/api-reference.js")
+const faqSidebars = require("./sidebars/faq.js")
 
 // @ts-check
 
@@ -36,6 +37,7 @@ const sidebars = {
   complianceSidebar,
   ...updateGuideSidebars,
   ...apiSidebars,
+  faqSidebars,
 }
 
 module.exports = sidebars

--- a/sidebars/faq.js
+++ b/sidebars/faq.js
@@ -1,5 +1,11 @@
 const sidebar = [
   {
+    label: "FAQ",
+    type: "link",
+    href: "/faq",
+    className: "back-button",
+  },
+  {
     label: "Ref Arch Pre-deployment",
     type: "doc",
     id: "faq/ref-arch-predeployment/index",

--- a/sidebars/faq.js
+++ b/sidebars/faq.js
@@ -1,0 +1,49 @@
+const sidebar = [
+  {
+    label: "Ref Arch Pre-deployment",
+    type: "doc",
+    id: "faq/ref-arch-predeployment/index",
+  },
+  {
+    label: "Reference Architecture",
+    type: "doc",
+    id: "faq/ref-arch/index",
+  },
+  {
+    label: "Service Catalog",
+    type: "doc",
+    id: "faq/service-catalog/index",
+  },
+  {
+    label: "Gruntwork Pipelines",
+    type: "doc",
+    id: "faq/pipelines/index",
+  },
+  {
+    label: "Terragrunt",
+    type: "doc",
+    id: "faq/terragrunt/index",
+  },
+  {
+    label: "Terratest",
+    type: "doc",
+    id: "faq/terratest/index",
+  },
+  {
+    label: "EKS",
+    type: "doc",
+    id: "faq/eks/index",
+  },
+  {
+    label: "Infrastructure as Code",
+    type: "doc",
+    id: "faq/iac-general/index",
+  },
+  {
+    label: "DevOps Best Practices",
+    type: "doc",
+    id: "faq/devops-general/index",
+  },
+]
+
+module.exports = sidebar


### PR DESCRIPTION
These changes introduce a new path to the docs site: `docs.gruntwork.io/faq`. 

The FAQ landing page displays several categories of FAQ. Each category is its own page. 

The categories are: 
* Ref Arch Pre-deployment
* Ref Arch 
* Service Catalog
* Gruntwork Pipelines
* Terragrunt
* Terratest
* EKS
* IAC
* DevOps (general / best practice questions)

Each page is a simple index that links off to answered questions in our public knowledge base. In one case I link to the Gruntwork Blog because I believe it has the best intro for the service catalog. 

The hope is that these pages are useful for us as we're meeting with prospects, preparing customers for a deployment, doing support rotations, etc. 

I'm not sure how I feel about the sidebar yet, but it is functional. I would probably prefer having a title above that helps ground the viewer in the fact that they're deep into the FAQs at this point. 

![faq-index](https://user-images.githubusercontent.com/1769996/155430298-e61022f8-925d-4584-9022-aac4b4f6c912.png)
![pre-deploy-faq](https://user-images.githubusercontent.com/1769996/155430308-cbcf89cc-ed9b-487b-b415-117930a784fb.png)
![refarch-faq](https://user-images.githubusercontent.com/1769996/155430317-9b3eb798-21cb-4965-826f-d7a9dba2dc82.png)

Thanks for the intro to the docs site today, Eugene and Eben!