### PR TITLE
[APT-1729] [APT-1730] Show service-catalog api input types and defaults

### DIFF
--- a/docs/reference/services/app-orchestration/amazon-ecs-cluster.md
+++ b/docs/reference/services/app-orchestration/amazon-ecs-cluster.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -146,283 +147,694 @@ For information on how to manage your ECS cluster, see the documentation in the
 
 ### Required
 
-<a name="cluster_instance_ami" className="snap-top"></a>
+<HclListItem name="cluster_instance_ami" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`cluster_instance_ami`**](#cluster_instance_ami) &mdash; The AMI to run on each instance in the ECS cluster. You can build the AMI using the Packer template ecs-node-al2.json. One of [`cluster_instance_ami`](#cluster_instance_ami) or [`cluster_instance_ami_filters`](#cluster_instance_ami_filters) is required.
+The AMI to run on each instance in the ECS cluster. You can build the AMI using the Packer template ecs-node-al2.json. One of <a href="#cluster_instance_ami"><code>cluster_instance_ami</code></a> or <a href="#cluster_instance_ami_filters"><code>cluster_instance_ami_filters</code></a> is required.
 
-<a name="cluster_instance_ami_filters" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cluster_instance_ami_filters`**](#cluster_instance_ami_filters) &mdash; Properties on the AMI that can be used to lookup a prebuilt AMI for use with ECS workers. You can build the AMI using the Packer template ecs-node-al2.json. Only used if [`cluster_instance_ami`](#cluster_instance_ami) is null. One of [`cluster_instance_ami`](#cluster_instance_ami) or [`cluster_instance_ami_filters`](#cluster_instance_ami_filters) is required. Set to null if [`cluster_instance_ami`](#cluster_instance_ami) is set.
+<HclListItem name="cluster_instance_ami_filters" requirement="required" type="object">
+<HclListItemDescription>
 
-<a name="cluster_instance_type" className="snap-top"></a>
+Properties on the AMI that can be used to lookup a prebuilt AMI for use with ECS workers. You can build the AMI using the Packer template ecs-node-al2.json. Only used if <a href="#cluster_instance_ami"><code>cluster_instance_ami</code></a> is null. One of <a href="#cluster_instance_ami"><code>cluster_instance_ami</code></a> or <a href="#cluster_instance_ami_filters"><code>cluster_instance_ami_filters</code></a> is required. Set to null if cluster_instance_ami is set.
 
-* [**`cluster_instance_type`**](#cluster_instance_type) &mdash; The type of instances to run in the ECS cluster (e.g. t2.medium)
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="cluster_max_size" className="snap-top"></a>
+```hcl
+object({
+    # List of owners to limit the search. Set to null if you do not wish to limit the search by AMI owners.
+    owners = list(string)
 
-* [**`cluster_max_size`**](#cluster_max_size) &mdash; The maxiumum number of instances to run in the ECS cluster
+    # Name/Value pairs to filter the AMI off of. There are several valid keys, for a full reference, check out the
+    # documentation for describe-images in the AWS CLI reference
+    # (https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html).
+    filters = list(object({
+      name   = string
+      values = list(string)
+    }))
+  })
+```
 
-<a name="cluster_min_size" className="snap-top"></a>
+</HclListItemTypeDetails>
+</HclListItem>
 
-* [**`cluster_min_size`**](#cluster_min_size) &mdash; The minimum number of instances to run in the ECS cluster
+<HclListItem name="cluster_instance_type" requirement="required" type="string">
+<HclListItemDescription>
 
-<a name="cluster_name" className="snap-top"></a>
+The type of instances to run in the ECS cluster (e.g. t2.medium)
 
-* [**`cluster_name`**](#cluster_name) &mdash; The name of the ECS cluster
+</HclListItemDescription>
+</HclListItem>
 
-<a name="vpc_id" className="snap-top"></a>
+<HclListItem name="cluster_max_size" requirement="required" type="number">
+<HclListItemDescription>
 
-* [**`vpc_id`**](#vpc_id) &mdash; The ID of the VPC in which the ECS cluster should be launched
+The maxiumum number of instances to run in the ECS cluster
 
-<a name="vpc_subnet_ids" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`vpc_subnet_ids`**](#vpc_subnet_ids) &mdash; The IDs of the subnets in which to deploy the ECS cluster instances
+<HclListItem name="cluster_min_size" requirement="required" type="number">
+<HclListItemDescription>
+
+The minimum number of instances to run in the ECS cluster
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="cluster_name" requirement="required" type="string">
+<HclListItemDescription>
+
+The name of the ECS cluster
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="vpc_id" requirement="required" type="string">
+<HclListItemDescription>
+
+The ID of the VPC in which the ECS cluster should be launched
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="vpc_subnet_ids" requirement="required" type="list">
+<HclListItemDescription>
+
+The IDs of the subnets in which to deploy the ECS cluster instances
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
 
 ### Optional
 
-<a name="alarms_sns_topic_arn" className="snap-top"></a>
+<HclListItem name="alarms_sns_topic_arn" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`alarms_sns_topic_arn`**](#alarms_sns_topic_arn) &mdash; The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications
+The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications
 
-<a name="allow_ssh_from_cidr_blocks" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`allow_ssh_from_cidr_blocks`**](#allow_ssh_from_cidr_blocks) &mdash; The IP address ranges in CIDR format from which to allow incoming SSH requests to the ECS instances.
+```hcl
+list(string)
+```
 
-<a name="allow_ssh_from_security_group_ids" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`allow_ssh_from_security_group_ids`**](#allow_ssh_from_security_group_ids) &mdash; The IDs of security groups from which to allow incoming SSH requests to the ECS instances.
+<HclListItem name="allow_ssh_from_cidr_blocks" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="autoscaling_termination_protection" className="snap-top"></a>
+The IP address ranges in CIDR format from which to allow incoming SSH requests to the ECS instances.
 
-* [**`autoscaling_termination_protection`**](#autoscaling_termination_protection) &mdash; Protect EC2 instances running ECS tasks from being terminated due to scale in (spot instances do not support lifecycle modifications). Note that the behavior of termination protection differs between clusters with capacity providers and clusters without. When capacity providers is turned on and this flag is true, only instances that have 0 ECS tasks running will be scaled in, regardless of [`capacity_provider_target`](#capacity_provider_target). If capacity providers is turned off and this flag is true, this will prevent ANY instances from being scaled in.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="capacity_provider_enabled" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`capacity_provider_enabled`**](#capacity_provider_enabled) &mdash; Enable a capacity provider to autoscale the EC2 ASG created for this ECS cluster.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="capacity_provider_max_scale_step" className="snap-top"></a>
+<HclListItem name="allow_ssh_from_security_group_ids" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`capacity_provider_max_scale_step`**](#capacity_provider_max_scale_step) &mdash; Maximum step adjustment size to the ASG's desired instance count. A number between 1 and 10000.
+The IDs of security groups from which to allow incoming SSH requests to the ECS instances.
 
-<a name="capacity_provider_min_scale_step" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`capacity_provider_min_scale_step`**](#capacity_provider_min_scale_step) &mdash; Minimum step adjustment size to the ASG's desired instance count. A number between 1 and 10000.
+```hcl
+list(string)
+```
 
-<a name="capacity_provider_target" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`capacity_provider_target`**](#capacity_provider_target) &mdash; Target cluster utilization for the ASG capacity provider; a number from 1 to 100. This number influences when scale out happens, and when instances should be scaled in. For example, a setting of 90 means that new instances will be provisioned when all instances are at 90% utilization, while instances that are only 10% utilized (CPU and Memory usage from tasks = 10%) will be scaled in.
+<HclListItem name="autoscaling_termination_protection" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="cloud_init_parts" className="snap-top"></a>
+Protect EC2 instances running ECS tasks from being terminated due to scale in (spot instances do not support lifecycle modifications). Note that the behavior of termination protection differs between clusters with capacity providers and clusters without. When capacity providers is turned on and this flag is true, only instances that have 0 ECS tasks running will be scaled in, regardless of capacity_provider_target. If capacity providers is turned off and this flag is true, this will prevent ANY instances from being scaled in.
 
-* [**`cloud_init_parts`**](#cloud_init_parts) &mdash; Cloud init scripts to run on the ECS cluster instances during boot. See the part blocks in [`https://www.terraform.io/docs/providers/template/d/cloudinit_config`](#https://www.terraform.io/docs/providers/template/d/cloudinit_config).html for syntax
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="cloudwatch_log_group_kms_key_id" className="snap-top"></a>
+<HclListItem name="capacity_provider_enabled" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`cloudwatch_log_group_kms_key_id`**](#cloudwatch_log_group_kms_key_id) &mdash; The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data.
+Enable a capacity provider to autoscale the EC2 ASG created for this ECS cluster.
 
-<a name="cloudwatch_log_group_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`cloudwatch_log_group_name`**](#cloudwatch_log_group_name) &mdash; The name of the log group to create in CloudWatch. Defaults to [``var.cluster_name`](#`var.cluster_name)-logs`.
+<HclListItem name="capacity_provider_max_scale_step" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="cloudwatch_log_group_retention_in_days" className="snap-top"></a>
+Maximum step adjustment size to the ASG's desired instance count. A number between 1 and 10000.
 
-* [**`cloudwatch_log_group_retention_in_days`**](#cloudwatch_log_group_retention_in_days) &mdash; The number of days to retain log events in the log group. Refer to [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days) for all the valid values. When null, the log events are retained forever.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="cloudwatch_log_group_tags" className="snap-top"></a>
+<HclListItem name="capacity_provider_min_scale_step" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`cloudwatch_log_group_tags`**](#cloudwatch_log_group_tags) &mdash; Tags to apply on the CloudWatch Log Group, encoded as a map where the keys are tag keys and values are tag values.
+Minimum step adjustment size to the ASG's desired instance count. A number between 1 and 10000.
 
-<a name="cluster_access_from_sgs" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`cluster_access_from_sgs`**](#cluster_access_from_sgs) &mdash; Specify a list of Security Groups that will have access to the ECS cluster. Only used if [`enable_cluster_access_ports`](#enable_cluster_access_ports) is set to true
+<HclListItem name="capacity_provider_target" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="cluster_instance_associate_public_ip_address" className="snap-top"></a>
+Target cluster utilization for the ASG capacity provider; a number from 1 to 100. This number influences when scale out happens, and when instances should be scaled in. For example, a setting of 90 means that new instances will be provisioned when all instances are at 90% utilization, while instances that are only 10% utilized (CPU and Memory usage from tasks = 10%) will be scaled in.
 
-* [**`cluster_instance_associate_public_ip_address`**](#cluster_instance_associate_public_ip_address) &mdash; Whether to associate a public IP address with an instance in a VPC
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="cluster_instance_keypair_name" className="snap-top"></a>
+<HclListItem name="cloud_init_parts" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`cluster_instance_keypair_name`**](#cluster_instance_keypair_name) &mdash; The name of the Key Pair that can be used to SSH to each instance in the ECS cluster
+Cloud init scripts to run on the ECS cluster instances during boot. See the part blocks in https://www.terraform.io/docs/providers/template/d/cloudinit_config.html for syntax
 
-<a name="default_user" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`default_user`**](#default_user) &mdash; The default OS user for the ECS worker AMI. For AWS Amazon Linux AMIs, which is what the Packer template in ecs-node-al2.json uses, the default OS user is 'ec2-user'.
+```hcl
+map(object({
+    filename     = string
+    content_type = string
+    content      = string
+  }))
+```
 
-<a name="disallowed_availability_zones" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`disallowed_availability_zones`**](#disallowed_availability_zones) &mdash; A list of availability zones in the region that should be skipped when deploying ECS. You can use this to avoid availability zones that may not be able to provision the resources (e.g instance type does not exist). If empty, allows all availability zones.
+<HclListItem name="cloudwatch_log_group_kms_key_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="enable_cloudwatch_log_aggregation" className="snap-top"></a>
+The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data.
 
-* [**`enable_cloudwatch_log_aggregation`**](#enable_cloudwatch_log_aggregation) &mdash; Set to true to enable Cloudwatch log aggregation for the ECS cluster
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="enable_cloudwatch_metrics" className="snap-top"></a>
+<HclListItem name="cloudwatch_log_group_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`enable_cloudwatch_metrics`**](#enable_cloudwatch_metrics) &mdash; Set to true to enable Cloudwatch metrics collection for the ECS cluster
+The name of the log group to create in CloudWatch. Defaults to `<a href="#cluster_name"><code>cluster_name</code></a>-logs`.
 
-<a name="enable_cluster_access_ports" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
 
-* [**`enable_cluster_access_ports`**](#enable_cluster_access_ports) &mdash; Specify a list of ECS Cluster ports which should be accessible from the security groups given in [`cluster_access_from_sgs`](#cluster_access_from_sgs)
+<HclListItem name="cloudwatch_log_group_retention_in_days" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="enable_ecs_cloudwatch_alarms" className="snap-top"></a>
+The number of days to retain log events in the log group. Refer to https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days for all the valid values. When null, the log events are retained forever.
 
-* [**`enable_ecs_cloudwatch_alarms`**](#enable_ecs_cloudwatch_alarms) &mdash; Set to true to enable several basic Cloudwatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using [`alarms_sns_topic_arn`](#alarms_sns_topic_arn)
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="enable_fail2ban" className="snap-top"></a>
+<HclListItem name="cloudwatch_log_group_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`enable_fail2ban`**](#enable_fail2ban) &mdash; Enable fail2ban to block brute force log in attempts. Defaults to true
+Tags to apply on the CloudWatch Log Group, encoded as a map where the keys are tag keys and values are tag values.
 
-<a name="enable_ip_lockdown" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`enable_ip_lockdown`**](#enable_ip_lockdown) &mdash; Enable ip-lockdown to block access to the instance metadata. Defaults to true
+```hcl
+map(string)
+```
 
-<a name="enable_ssh_grunt" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`enable_ssh_grunt`**](#enable_ssh_grunt) &mdash; Set to true to add IAM permissions for ssh-grunt (https://github.com/gruntwork-io/terraform-aws-security/tree/master/modules/ssh-grunt), which will allow you to manage SSH access via IAM groups.
+<HclListItem name="cluster_access_from_sgs" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="external_account_ssh_grunt_role_arn" className="snap-top"></a>
+Specify a list of Security Groups that will have access to the ECS cluster. Only used if <a href="#enable_cluster_access_ports"><code>enable_cluster_access_ports</code></a> is set to true
 
-* [**`external_account_ssh_grunt_role_arn`**](#external_account_ssh_grunt_role_arn) &mdash; Since our IAM users are defined in a separate AWS account, this variable is used to specify the ARN of an IAM role that allows ssh-grunt to retrieve IAM group and public SSH key info from that account.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="high_cpu_utilization_evaluation_periods" className="snap-top"></a>
+```hcl
+list(any)
+```
 
-* [**`high_cpu_utilization_evaluation_periods`**](#high_cpu_utilization_evaluation_periods) &mdash; The number of periods over which data is compared to the specified threshold
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="high_cpu_utilization_period" className="snap-top"></a>
+<HclListItem name="cluster_instance_associate_public_ip_address" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`high_cpu_utilization_period`**](#high_cpu_utilization_period) &mdash; The period, in seconds, over which to measure the CPU utilization percentage. Only used if [`enable_ecs_cloudwatch_alarms`](#enable_ecs_cloudwatch_alarms) is set to true
+Whether to associate a public IP address with an instance in a VPC
 
-<a name="high_cpu_utilization_statistic" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`high_cpu_utilization_statistic`**](#high_cpu_utilization_statistic) &mdash; The statistic to apply to the alarm's high CPU metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum
+<HclListItem name="cluster_instance_keypair_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="high_cpu_utilization_threshold" className="snap-top"></a>
+The name of the Key Pair that can be used to SSH to each instance in the ECS cluster
 
-* [**`high_cpu_utilization_threshold`**](#high_cpu_utilization_threshold) &mdash; Trigger an alarm if the ECS Cluster has a CPU utilization percentage above this threshold. Only used if [`enable_ecs_cloudwatch_alarms`](#enable_ecs_cloudwatch_alarms) is set to true
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="high_disk_utilization_period" className="snap-top"></a>
+<HclListItem name="default_user" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`high_disk_utilization_period`**](#high_disk_utilization_period) &mdash; The period, in seconds, over which to measure the disk utilization percentage. Only used if [`enable_ecs_cloudwatch_alarms`](#enable_ecs_cloudwatch_alarms) is set to true
+The default OS user for the ECS worker AMI. For AWS Amazon Linux AMIs, which is what the Packer template in ecs-node-al2.json uses, the default OS user is 'ec2-user'.
 
-<a name="high_disk_utilization_threshold" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ec2-user"/>
+</HclListItem>
 
-* [**`high_disk_utilization_threshold`**](#high_disk_utilization_threshold) &mdash; Trigger an alarm if the EC2 instances in the ECS Cluster have a disk utilization percentage above this threshold. Only used if [`enable_ecs_cloudwatch_alarms`](#enable_ecs_cloudwatch_alarms) is set to true
+<HclListItem name="disallowed_availability_zones" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="high_memory_utilization_evaluation_periods" className="snap-top"></a>
+A list of availability zones in the region that should be skipped when deploying ECS. You can use this to avoid availability zones that may not be able to provision the resources (e.g instance type does not exist). If empty, allows all availability zones.
 
-* [**`high_memory_utilization_evaluation_periods`**](#high_memory_utilization_evaluation_periods) &mdash; The number of periods over which data is compared to the specified threshold
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="high_memory_utilization_period" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`high_memory_utilization_period`**](#high_memory_utilization_period) &mdash; The period, in seconds, over which to measure the memory utilization percentage. Only used if [`enable_ecs_cloudwatch_alarms`](#enable_ecs_cloudwatch_alarms) is set to true
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="high_memory_utilization_statistic" className="snap-top"></a>
+<HclListItem name="enable_cloudwatch_log_aggregation" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`high_memory_utilization_statistic`**](#high_memory_utilization_statistic) &mdash; The statistic to apply to the alarm's high CPU metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum
+Set to true to enable Cloudwatch log aggregation for the ECS cluster
 
-<a name="high_memory_utilization_threshold" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`high_memory_utilization_threshold`**](#high_memory_utilization_threshold) &mdash; Trigger an alarm if the ECS Cluster has a memory utilization percentage above this threshold. Only used if [`enable_ecs_cloudwatch_alarms`](#enable_ecs_cloudwatch_alarms) is set to true
+<HclListItem name="enable_cloudwatch_metrics" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="internal_alb_sg_ids" className="snap-top"></a>
+Set to true to enable Cloudwatch metrics collection for the ECS cluster
 
-* [**`internal_alb_sg_ids`**](#internal_alb_sg_ids) &mdash; The Security Group ID for the internal ALB
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="multi_az_capacity_provider" className="snap-top"></a>
+<HclListItem name="enable_cluster_access_ports" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`multi_az_capacity_provider`**](#multi_az_capacity_provider) &mdash; Enable a multi-az capacity provider to autoscale the EC2 ASGs created for this ECS cluster, only if [`capacity_provider_enabled`](#capacity_provider_enabled) = true
+Specify a list of ECS Cluster ports which should be accessible from the security groups given in cluster_access_from_sgs
 
-<a name="public_alb_sg_ids" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`public_alb_sg_ids`**](#public_alb_sg_ids) &mdash; The Security Group ID for the public ALB
+```hcl
+list(any)
+```
 
-<a name="should_create_cloudwatch_log_group" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`should_create_cloudwatch_log_group`**](#should_create_cloudwatch_log_group) &mdash; When true, precreate the CloudWatch Log Group to use for log aggregation from the EC2 instances. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, the CloudWatch agent will automatically create a basic log group to use.
+<HclListItem name="enable_ecs_cloudwatch_alarms" requirement="optional">
+<HclListItemDescription>
 
-<a name="ssh_grunt_iam_group" className="snap-top"></a>
+Set to true to enable several basic Cloudwatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using <a href="#alarms_sns_topic_arn"><code>alarms_sns_topic_arn</code></a>
 
-* [**`ssh_grunt_iam_group`**](#ssh_grunt_iam_group) &mdash; If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to the nodes in this ECS cluster. This value is only used if [`enable_ssh_grunt`](#enable_ssh_grunt)=true.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="ssh_grunt_iam_group_sudo" className="snap-top"></a>
+<HclListItem name="enable_fail2ban" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`ssh_grunt_iam_group_sudo`**](#ssh_grunt_iam_group_sudo) &mdash; If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to the nodes in this ECS cluster with sudo permissions. This value is only used if [`enable_ssh_grunt`](#enable_ssh_grunt)=true.
+Enable fail2ban to block brute force log in attempts. Defaults to true
 
-<a name="tenancy" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`tenancy`**](#tenancy) &mdash; The tenancy of this server. Must be one of: default, dedicated, or host.
+<HclListItem name="enable_ip_lockdown" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="use_managed_iam_policies" className="snap-top"></a>
+Enable ip-lockdown to block access to the instance metadata. Defaults to true
 
-* [**`use_managed_iam_policies`**](#use_managed_iam_policies) &mdash; When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_ssh_grunt" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to add IAM permissions for ssh-grunt (https://github.com/gruntwork-io/terraform-aws-security/tree/master/modules/ssh-grunt), which will allow you to manage SSH access via IAM groups.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="external_account_ssh_grunt_role_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+Since our IAM users are defined in a separate AWS account, this variable is used to specify the ARN of an IAM role that allows ssh-grunt to retrieve IAM group and public SSH key info from that account.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="high_cpu_utilization_evaluation_periods" requirement="optional" type="number">
+<HclListItemDescription>
+
+The number of periods over which data is compared to the specified threshold
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="2"/>
+</HclListItem>
+
+<HclListItem name="high_cpu_utilization_period" requirement="optional" type="number">
+<HclListItemDescription>
+
+The period, in seconds, over which to measure the CPU utilization percentage. Only used if <a href="#enable_ecs_cloudwatch_alarms"><code>enable_ecs_cloudwatch_alarms</code></a> is set to true
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="300"/>
+</HclListItem>
+
+<HclListItem name="high_cpu_utilization_statistic" requirement="optional" type="string">
+<HclListItemDescription>
+
+The statistic to apply to the alarm's high CPU metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="Average"/>
+</HclListItem>
+
+<HclListItem name="high_cpu_utilization_threshold" requirement="optional" type="number">
+<HclListItemDescription>
+
+Trigger an alarm if the ECS Cluster has a CPU utilization percentage above this threshold. Only used if <a href="#enable_ecs_cloudwatch_alarms"><code>enable_ecs_cloudwatch_alarms</code></a> is set to true
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="90"/>
+</HclListItem>
+
+<HclListItem name="high_disk_utilization_period" requirement="optional" type="number">
+<HclListItemDescription>
+
+The period, in seconds, over which to measure the disk utilization percentage. Only used if <a href="#enable_ecs_cloudwatch_alarms"><code>enable_ecs_cloudwatch_alarms</code></a> is set to true
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="300"/>
+</HclListItem>
+
+<HclListItem name="high_disk_utilization_threshold" requirement="optional" type="number">
+<HclListItemDescription>
+
+Trigger an alarm if the EC2 instances in the ECS Cluster have a disk utilization percentage above this threshold. Only used if <a href="#enable_ecs_cloudwatch_alarms"><code>enable_ecs_cloudwatch_alarms</code></a> is set to true
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="90"/>
+</HclListItem>
+
+<HclListItem name="high_memory_utilization_evaluation_periods" requirement="optional" type="number">
+<HclListItemDescription>
+
+The number of periods over which data is compared to the specified threshold
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="2"/>
+</HclListItem>
+
+<HclListItem name="high_memory_utilization_period" requirement="optional" type="number">
+<HclListItemDescription>
+
+The period, in seconds, over which to measure the memory utilization percentage. Only used if <a href="#enable_ecs_cloudwatch_alarms"><code>enable_ecs_cloudwatch_alarms</code></a> is set to true
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="300"/>
+</HclListItem>
+
+<HclListItem name="high_memory_utilization_statistic" requirement="optional" type="string">
+<HclListItemDescription>
+
+The statistic to apply to the alarm's high CPU metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="Average"/>
+</HclListItem>
+
+<HclListItem name="high_memory_utilization_threshold" requirement="optional" type="number">
+<HclListItemDescription>
+
+Trigger an alarm if the ECS Cluster has a memory utilization percentage above this threshold. Only used if <a href="#enable_ecs_cloudwatch_alarms"><code>enable_ecs_cloudwatch_alarms</code></a> is set to true
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="90"/>
+</HclListItem>
+
+<HclListItem name="internal_alb_sg_ids" requirement="optional" type="list">
+<HclListItemDescription>
+
+The Security Group ID for the internal ALB
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="multi_az_capacity_provider" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Enable a multi-az capacity provider to autoscale the EC2 ASGs created for this ECS cluster, only if capacity_provider_enabled = true
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="public_alb_sg_ids" requirement="optional" type="list">
+<HclListItemDescription>
+
+The Security Group ID for the public ALB
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="should_create_cloudwatch_log_group" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, precreate the CloudWatch Log Group to use for log aggregation from the EC2 instances. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, the CloudWatch agent will automatically create a basic log group to use.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="ssh_grunt_iam_group" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to the nodes in this ECS cluster. This value is only used if enable_ssh_grunt=true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ssh-grunt-users"/>
+</HclListItem>
+
+<HclListItem name="ssh_grunt_iam_group_sudo" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to the nodes in this ECS cluster with sudo permissions. This value is only used if enable_ssh_grunt=true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ssh-grunt-sudo-users"/>
+</HclListItem>
+
+<HclListItem name="tenancy" requirement="optional" type="string">
+<HclListItemDescription>
+
+The tenancy of this server. Must be one of: default, dedicated, or host.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="default"/>
+</HclListItem>
+
+<HclListItem name="use_managed_iam_policies" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="all_metric_widgets" className="snap-top"></a>
+<HclListItem name="all_metric_widgets">
+<HclListItemDescription>
 
-* [**`all_metric_widgets`**](#all_metric_widgets) &mdash; A list of all the CloudWatch Dashboard metric widgets available in this module.
+A list of all the CloudWatch Dashboard metric widgets available in this module.
 
-<a name="ecs_cluster_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`ecs_cluster_arn`**](#ecs_cluster_arn) &mdash; The ID of the ECS cluster
+<HclListItem name="ecs_cluster_arn">
+<HclListItemDescription>
 
-<a name="ecs_cluster_asg_name" className="snap-top"></a>
+The ID of the ECS cluster
 
-* [**`ecs_cluster_asg_name`**](#ecs_cluster_asg_name) &mdash; The name of the ECS cluster's autoscaling group (ASG)
+</HclListItemDescription>
+</HclListItem>
 
-<a name="ecs_cluster_asg_names" className="snap-top"></a>
+<HclListItem name="ecs_cluster_asg_name">
+<HclListItemDescription>
 
-* [**`ecs_cluster_asg_names`**](#ecs_cluster_asg_names) &mdash; For configurations with multiple ASGs, this contains a list of ASG names.
+The name of the ECS cluster's autoscaling group (ASG)
 
-<a name="ecs_cluster_capacity_provider_names" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`ecs_cluster_capacity_provider_names`**](#ecs_cluster_capacity_provider_names) &mdash; For configurations with multiple capacity providers, this contains a list of all capacity provider names.
+<HclListItem name="ecs_cluster_asg_names">
+<HclListItemDescription>
 
-<a name="ecs_cluster_launch_configuration_id" className="snap-top"></a>
+For configurations with multiple ASGs, this contains a list of ASG names.
 
-* [**`ecs_cluster_launch_configuration_id`**](#ecs_cluster_launch_configuration_id) &mdash; The ID of the launch configuration used by the ECS cluster's auto scaling group (ASG)
+</HclListItemDescription>
+</HclListItem>
 
-<a name="ecs_cluster_name" className="snap-top"></a>
+<HclListItem name="ecs_cluster_capacity_provider_names">
+<HclListItemDescription>
 
-* [**`ecs_cluster_name`**](#ecs_cluster_name) &mdash; The name of the ECS cluster
+For configurations with multiple capacity providers, this contains a list of all capacity provider names.
 
-<a name="ecs_cluster_vpc_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`ecs_cluster_vpc_id`**](#ecs_cluster_vpc_id) &mdash; The ID of the VPC into which the ECS cluster is launched
+<HclListItem name="ecs_cluster_launch_configuration_id">
+<HclListItemDescription>
 
-<a name="ecs_cluster_vpc_subnet_ids" className="snap-top"></a>
+The ID of the launch configuration used by the ECS cluster's auto scaling group (ASG)
 
-* [**`ecs_cluster_vpc_subnet_ids`**](#ecs_cluster_vpc_subnet_ids) &mdash; The VPC subnet IDs into which the ECS cluster can launch resources into
+</HclListItemDescription>
+</HclListItem>
 
-<a name="ecs_instance_iam_role_arn" className="snap-top"></a>
+<HclListItem name="ecs_cluster_name">
+<HclListItemDescription>
 
-* [**`ecs_instance_iam_role_arn`**](#ecs_instance_iam_role_arn) &mdash; The ARN of the IAM role applied to ECS instances
+The name of the ECS cluster
 
-<a name="ecs_instance_iam_role_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`ecs_instance_iam_role_id`**](#ecs_instance_iam_role_id) &mdash; The ID of the IAM role applied to ECS instances
+<HclListItem name="ecs_cluster_vpc_id">
+<HclListItemDescription>
 
-<a name="ecs_instance_iam_role_name" className="snap-top"></a>
+The ID of the VPC into which the ECS cluster is launched
 
-* [**`ecs_instance_iam_role_name`**](#ecs_instance_iam_role_name) &mdash; The name of the IAM role applied to ECS instances
+</HclListItemDescription>
+</HclListItem>
 
-<a name="ecs_instance_security_group_id" className="snap-top"></a>
+<HclListItem name="ecs_cluster_vpc_subnet_ids">
+<HclListItemDescription>
 
-* [**`ecs_instance_security_group_id`**](#ecs_instance_security_group_id) &mdash; The ID of the security group applied to ECS instances
+The VPC subnet IDs into which the ECS cluster can launch resources into
 
-<a name="metric_widget_ecs_cluster_cpu_usage" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`metric_widget_ecs_cluster_cpu_usage`**](#metric_widget_ecs_cluster_cpu_usage) &mdash; The CloudWatch Dashboard metric widget for the ECS cluster workers' CPU utilization metric.
+<HclListItem name="ecs_instance_iam_role_arn">
+<HclListItemDescription>
 
-<a name="metric_widget_ecs_cluster_memory_usage" className="snap-top"></a>
+The ARN of the IAM role applied to ECS instances
 
-* [**`metric_widget_ecs_cluster_memory_usage`**](#metric_widget_ecs_cluster_memory_usage) &mdash; The CloudWatch Dashboard metric widget for the ECS cluster workers' Memory utilization metric.
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="ecs_instance_iam_role_id">
+<HclListItemDescription>
+
+The ID of the IAM role applied to ECS instances
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="ecs_instance_iam_role_name">
+<HclListItemDescription>
+
+The name of the IAM role applied to ECS instances
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="ecs_instance_security_group_id">
+<HclListItemDescription>
+
+The ID of the security group applied to ECS instances
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="metric_widget_ecs_cluster_cpu_usage">
+<HclListItemDescription>
+
+The CloudWatch Dashboard metric widget for the ECS cluster workers' CPU utilization metric.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="metric_widget_ecs_cluster_memory_usage">
+<HclListItemDescription>
+
+The CloudWatch Dashboard metric widget for the ECS cluster workers' Memory utilization metric.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"ad5644b19bdade5d75af8d8de1dfc8ba"}
+{"sourcePlugin":"service-catalog-api","hash":"a815cd878c403173ad13acb9c63c1e67"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/app-orchestration/amazon-ecs-fargate-cluster.md
+++ b/docs/reference/services/app-orchestration/amazon-ecs-fargate-cluster.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.66.0"/>
 
@@ -99,35 +100,64 @@ For information on how to manage your ECS cluster, see the documentation in the
 
 ### Required
 
-<a name="cluster_name" className="snap-top"></a>
+<HclListItem name="cluster_name" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`cluster_name`**](#cluster_name) &mdash; The name of the ECS cluster
+The name of the ECS cluster
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="custom_tags" className="snap-top"></a>
+<HclListItem name="custom_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`custom_tags`**](#custom_tags) &mdash; A map of custom tags to apply to the ECS Cluster. The key is the tag name and the value is the tag value.
+A map of custom tags to apply to the ECS Cluster. The key is the tag name and the value is the tag value.
 
-<a name="enable_container_insights" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`enable_container_insights`**](#enable_container_insights) &mdash; Whether or not to enable container insights monitoring on the ECS cluster.
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="enable_container_insights" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Whether or not to enable container insights monitoring on the ECS cluster.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="arn" className="snap-top"></a>
+<HclListItem name="arn">
+<HclListItemDescription>
 
-* [**`arn`**](#arn) &mdash; ARN of the ECS cluster that was created.
+ARN of the ECS cluster that was created.
 
-<a name="name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`name`**](#name) &mdash; The name of the ECS cluster.
+<HclListItem name="name">
+<HclListItemDescription>
+
+The name of the ECS cluster.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"515d701940d60810a1823cfbc9ca0f87"}
+{"sourcePlugin":"service-catalog-api","hash":"9e62fb0f1f86b9023d6916a9ce211f84"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/app-orchestration/amazon-ecs-service.md
+++ b/docs/reference/services/app-orchestration/amazon-ecs-service.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -98,499 +99,1224 @@ For information on how to manage your ECS service, see the documentation in the
 
 ### Required
 
-<a name="container_definitions" className="snap-top"></a>
+<HclListItem name="container_definitions" requirement="required" type="any">
+<HclListItemDescription>
 
-* [**`container_definitions`**](#container_definitions) &mdash; List of container definitions to use for the ECS task. Each entry corresponds to a different ECS container definition.
+List of container definitions to use for the ECS task. Each entry corresponds to a different ECS container definition.
 
-<a name="default_listener_arns" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`default_listener_arns`**](#default_listener_arns) &mdash; A map of all the listeners on the load balancer. The keys should be the port numbers and the values should be the ARN of the listener for that port.
+<HclListItem name="default_listener_arns" requirement="required" type="map">
+<HclListItemDescription>
 
-<a name="default_listener_ports" className="snap-top"></a>
+A map of all the listeners on the load balancer. The keys should be the port numbers and the values should be the ARN of the listener for that port.
 
-* [**`default_listener_ports`**](#default_listener_ports) &mdash; The default port numbers on the load balancer to attach listener rules to. You can override this default on a rule-by-rule basis by setting the [`listener_ports`](#listener_ports) parameter in each rule. The port numbers specified in this variable and the [`listener_ports`](#listener_ports) parameter must exist in [`listener_arns`](#listener_arns).
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="ecs_cluster_arn" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`ecs_cluster_arn`**](#ecs_cluster_arn) &mdash; The ARN of the cluster to which the ecs service should be deployed.
+</HclListItemTypeDetails>
+</HclListItem>
 
-<a name="ecs_cluster_name" className="snap-top"></a>
+<HclListItem name="default_listener_ports" requirement="required" type="list">
+<HclListItemDescription>
 
-* [**`ecs_cluster_name`**](#ecs_cluster_name) &mdash; The name of the ecs cluster to deploy the ecs service onto.
+The default port numbers on the load balancer to attach listener rules to. You can override this default on a rule-by-rule basis by setting the listener_ports parameter in each rule. The port numbers specified in this variable and the listener_ports parameter must exist in <a href="#listener_arns"><code>listener_arns</code></a>.
 
-<a name="service_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`service_name`**](#service_name) &mdash; The name of the ECS service (e.g. my-service-stage)
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="ecs_cluster_arn" requirement="required" type="string">
+<HclListItemDescription>
+
+The ARN of the cluster to which the ecs service should be deployed.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="ecs_cluster_name" requirement="required" type="string">
+<HclListItemDescription>
+
+The name of the ecs cluster to deploy the ecs service onto.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="service_name" requirement="required" type="string">
+<HclListItemDescription>
+
+The name of the ECS service (e.g. my-service-stage)
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="alarm_sns_topic_arns" className="snap-top"></a>
+<HclListItem name="alarm_sns_topic_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`alarm_sns_topic_arns`**](#alarm_sns_topic_arns) &mdash; A list of ARNs of the SNS topic(s) to write alarm events to
+A list of ARNs of the SNS topic(s) to write alarm events to
 
-<a name="alarm_sns_topic_arns_us_east_1" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`alarm_sns_topic_arns_us_east_1`**](#alarm_sns_topic_arns_us_east_1) &mdash; A list of SNS topic ARNs to notify when the route53 health check changes to ALARM, OK, or [`INSUFFICIENT_DATA`](#INSUFFICIENT_DATA) state. Note: these SNS topics MUST be in us-east-1! This is because Route 53 only sends CloudWatch metrics to us-east-1, so we must create the alarm in that region, and therefore, can only notify SNS topics in that region
+```hcl
+list(string)
+```
 
-<a name="alb_sticky_session_cookie_duration" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`alb_sticky_session_cookie_duration`**](#alb_sticky_session_cookie_duration) &mdash; The time period, in seconds, during which requests from a client should be routed to the same Target. After this time period expires, the load balancer-generated cookie is considered stale. The acceptable range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds). Only used if [`elb_target_groups`](#elb_target_groups) is set.
+<HclListItem name="alarm_sns_topic_arns_us_east_1" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="alb_sticky_session_type" className="snap-top"></a>
+A list of SNS topic ARNs to notify when the route53 health check changes to ALARM, OK, or INSUFFICIENT_DATA state. Note: these SNS topics MUST be in us-east-1! This is because Route 53 only sends CloudWatch metrics to us-east-1, so we must create the alarm in that region, and therefore, can only notify SNS topics in that region
 
-* [**`alb_sticky_session_type`**](#alb_sticky_session_type) &mdash; The type of Sticky Sessions to use. See https://goo.gl/MNwqNu for possible values. Only used if [`elb_target_groups`](#elb_target_groups) is set.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="canary_container_definitions" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`canary_container_definitions`**](#canary_container_definitions) &mdash; List of container definitions to use for the canary ECS task. Each entry corresponds to a different ECS container definition.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="canary_version" className="snap-top"></a>
+<HclListItem name="alb_sticky_session_cookie_duration" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`canary_version`**](#canary_version) &mdash; Which version of the ECS Service Docker container to deploy as a canary (e.g. 0.57)
+The time period, in seconds, during which requests from a client should be routed to the same Target. After this time period expires, the load balancer-generated cookie is considered stale. The acceptable range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds). Only used if <a href="#elb_target_groups"><code>elb_target_groups</code></a> is set.
 
-<a name="capacity_provider_strategy" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="86400"/>
+</HclListItem>
 
-* [**`capacity_provider_strategy`**](#capacity_provider_strategy) &mdash; The capacity provider strategy to use for the service. Note that the capacity providers have to be present on the ECS cluster before deploying the ECS service. When provided, [`launch_type`](#launch_type) is ignored.
+<HclListItem name="alb_sticky_session_type" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="clb_container_name" className="snap-top"></a>
+The type of Sticky Sessions to use. See https://goo.gl/MNwqNu for possible values. Only used if <a href="#elb_target_groups"><code>elb_target_groups</code></a> is set.
 
-* [**`clb_container_name`**](#clb_container_name) &mdash; The name of the container, as it appears in the [`task_arn`](#task_arn) Task definition, to associate with a CLB. Currently, ECS can only associate a CLB with a single container per service. Only used if [`clb_name`](#clb_name) is set.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="lb_cookie"/>
+</HclListItem>
 
-<a name="clb_container_port" className="snap-top"></a>
+<HclListItem name="canary_container_definitions" requirement="optional" type="any">
+<HclListItemDescription>
 
-* [**`clb_container_port`**](#clb_container_port) &mdash; The port on the container in [`clb_container_name`](#clb_container_name) to associate with an CLB. Currently, ECS can only associate a CLB with a single container per service. Only used if [`clb_name`](#clb_name) is set.
+List of container definitions to use for the canary ECS task. Each entry corresponds to a different ECS container definition.
 
-<a name="clb_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`clb_name`**](#clb_name) &mdash; The name of a Classic Load Balancer (CLB) to associate with this service. Containers in the service will automatically register with the CLB when booting up. Set to null if using ELBv2.
+<HclListItem name="canary_version" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="cloudwatch_log_group_kms_key_id" className="snap-top"></a>
+Which version of the ECS Service Docker container to deploy as a canary (e.g. 0.57)
 
-* [**`cloudwatch_log_group_kms_key_id`**](#cloudwatch_log_group_kms_key_id) &mdash; The ARN of a KMS CMK to use for encrypting log events in the CloudWatch Logs. Set to null to disable encryption. Only used if [`create_cloudwatch_log_group`](#create_cloudwatch_log_group) is true.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="cloudwatch_log_group_name" className="snap-top"></a>
+<HclListItem name="capacity_provider_strategy" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`cloudwatch_log_group_name`**](#cloudwatch_log_group_name) &mdash; The name for the Cloudwatch logs that will be generated by the ecs service. Only used (and required) if [`create_cloudwatch_log_group`](#create_cloudwatch_log_group) is true.
+The capacity provider strategy to use for the service. Note that the capacity providers have to be present on the ECS cluster before deploying the ECS service. When provided, <a href="#launch_type"><code>launch_type</code></a> is ignored.
 
-<a name="cloudwatch_log_group_retention" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`cloudwatch_log_group_retention`**](#cloudwatch_log_group_retention) &mdash; Number of days to retain log events. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. Select 0 to never expire. Only used if [`create_cloudwatch_log_group`](#create_cloudwatch_log_group) is true.
+```hcl
+list(object({
+    capacity_provider = string
+    weight            = number
+    base              = number
+  }))
+```
 
-<a name="cpu" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`cpu`**](#cpu) &mdash; The number of CPU units to allocate to the ECS Service.
+<HclListItem name="clb_container_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="create_cloudwatch_log_group" className="snap-top"></a>
+The name of the container, as it appears in the <a href="#task_arn"><code>task_arn</code></a> Task definition, to associate with a CLB. Currently, ECS can only associate a CLB with a single container per service. Only used if clb_name is set.
 
-* [**`create_cloudwatch_log_group`**](#create_cloudwatch_log_group) &mdash; When true, create and manage the CloudWatch Log Group in the Terraform module instead of relying on ECS. This is useful for configuring options that are not available in the ECS native feature of managing the Log Group (e.g., encryption support).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="create_route53_entry" className="snap-top"></a>
+<HclListItem name="clb_container_port" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`create_route53_entry`**](#create_route53_entry) &mdash; Set to true if you want a DNS record automatically created and pointed at the the load balancer for the ECS service
+The port on the container in <a href="#clb_container_name"><code>clb_container_name</code></a> to associate with an CLB. Currently, ECS can only associate a CLB with a single container per service. Only used if clb_name is set.
 
-<a name="custom_docker_command" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`custom_docker_command`**](#custom_docker_command) &mdash; If [`use_custom_docker_run_command`](#use_custom_docker_run_command) is set to true, set this variable to the custom docker run command you want to provide
+<HclListItem name="clb_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="custom_ecs_service_role_name" className="snap-top"></a>
+The name of a Classic Load Balancer (CLB) to associate with this service. Containers in the service will automatically register with the CLB when booting up. Set to null if using ELBv2.
 
-* [**`custom_ecs_service_role_name`**](#custom_ecs_service_role_name) &mdash; The name to use for the ECS Service IAM role, which is used to grant permissions to the ECS service to register the task IPs to ELBs.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="custom_iam_policy_prefix" className="snap-top"></a>
+<HclListItem name="cloudwatch_log_group_kms_key_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`custom_iam_policy_prefix`**](#custom_iam_policy_prefix) &mdash; Prefix for name of the custom IAM policies created by this module (those resulting from [`iam_policy`](#iam_policy) and [`secrets_access`](#secrets_access)). If omitted, defaults to [`service_name`](#service_name).
+The ARN of a KMS CMK to use for encrypting log events in the CloudWatch Logs. Set to null to disable encryption. Only used if <a href="#create_cloudwatch_log_group"><code>create_cloudwatch_log_group</code></a> is true.
 
-<a name="custom_iam_role_name_prefix" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`custom_iam_role_name_prefix`**](#custom_iam_role_name_prefix) &mdash; Prefix for name of the IAM role used by the ECS task.
+<HclListItem name="cloudwatch_log_group_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="custom_task_execution_iam_role_name_prefix" className="snap-top"></a>
+The name for the Cloudwatch logs that will be generated by the ecs service. Only used (and required) if <a href="#create_cloudwatch_log_group"><code>create_cloudwatch_log_group</code></a> is true.
 
-* [**`custom_task_execution_iam_role_name_prefix`**](#custom_task_execution_iam_role_name_prefix) &mdash; Prefix for name of task execution IAM role and policy that grants access to CloudWatch and ECR.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="dependencies" className="snap-top"></a>
+<HclListItem name="cloudwatch_log_group_retention" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`dependencies`**](#dependencies) &mdash; Create a dependency between the resources in this module to the interpolated values in this list (and thus the source resources). In other words, the resources in this module will now depend on the resources backing the values in this list such that those resources need to be created before the resources in this module, and the resources in this module need to be destroyed before the resources in the list.
+Number of days to retain log events. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. Select 0 to never expire. Only used if <a href="#create_cloudwatch_log_group"><code>create_cloudwatch_log_group</code></a> is true.
 
-<a name="deployment_check_loglevel" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`deployment_check_loglevel`**](#deployment_check_loglevel) &mdash; Set the logging level of the deployment check script. You can set this to `error`, `warn`, or `info`, in increasing verbosity.
+<HclListItem name="cpu" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="deployment_check_timeout_seconds" className="snap-top"></a>
+The number of CPU units to allocate to the ECS Service.
 
-* [**`deployment_check_timeout_seconds`**](#deployment_check_timeout_seconds) &mdash; Seconds to wait before timing out each check for verifying ECS service deployment. See [`ecs_deploy_check_binaries`](#ecs_deploy_check_binaries) for more details.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1"/>
+</HclListItem>
 
-<a name="deployment_circuit_breaker_enabled" className="snap-top"></a>
+<HclListItem name="create_cloudwatch_log_group" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`deployment_circuit_breaker_enabled`**](#deployment_circuit_breaker_enabled) &mdash; Set to 'true' to prevent the task from attempting to continuously redeploy after a failed health check.
+When true, create and manage the CloudWatch Log Group in the Terraform module instead of relying on ECS. This is useful for configuring options that are not available in the ECS native feature of managing the Log Group (e.g., encryption support).
 
-<a name="deployment_circuit_breaker_rollback" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`deployment_circuit_breaker_rollback`**](#deployment_circuit_breaker_rollback) &mdash; Set to 'true' to also automatically roll back to the last successful deployment. [`deploy_circuit_breaker_enabled`](#deploy_circuit_breaker_enabled) must also be true to enable this behavior.
+<HclListItem name="create_route53_entry" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="deployment_maximum_percent" className="snap-top"></a>
+Set to true if you want a DNS record automatically created and pointed at the the load balancer for the ECS service
 
-* [**`deployment_maximum_percent`**](#deployment_maximum_percent) &mdash; The upper limit, as a percentage of [`desired_number_of_tasks`](#desired_number_of_tasks), of the number of running tasks that can be running in a service during a deployment. Setting this to more than 100 means that during deployment, ECS will deploy new instances of a Task before undeploying the old ones.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="deployment_minimum_healthy_percent" className="snap-top"></a>
+<HclListItem name="custom_docker_command" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`deployment_minimum_healthy_percent`**](#deployment_minimum_healthy_percent) &mdash; The lower limit, as a percentage of [`desired_number_of_tasks`](#desired_number_of_tasks), of the number of running tasks that must remain running and healthy in a service during a deployment. Setting this to less than 100 means that during deployment, ECS may undeploy old instances of a Task before deploying new ones.
+If <a href="#use_custom_docker_run_command"><code>use_custom_docker_run_command</code></a> is set to true, set this variable to the custom docker run command you want to provide
 
-<a name="desired_number_of_canary_tasks" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`desired_number_of_canary_tasks`**](#desired_number_of_canary_tasks) &mdash; How many instances of the ECS Service to run across the ECS cluster for a canary deployment. Typically, only 0 or 1 should be used.
+<HclListItem name="custom_ecs_service_role_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="desired_number_of_tasks" className="snap-top"></a>
+The name to use for the ECS Service IAM role, which is used to grant permissions to the ECS service to register the task IPs to ELBs.
 
-* [**`desired_number_of_tasks`**](#desired_number_of_tasks) &mdash; How many instances of the ECS Service to run across the ECS cluster
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="domain_name" className="snap-top"></a>
+<HclListItem name="custom_iam_policy_prefix" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`domain_name`**](#domain_name) &mdash; The domain name to create a route 53 record for. This DNS record will point to the load balancer for the ECS service
+Prefix for name of the custom IAM policies created by this module (those resulting from <a href="#iam_policy"><code>iam_policy</code></a> and <a href="#secrets_access"><code>secrets_access</code></a>). If omitted, defaults to <a href="#service_name"><code>service_name</code></a>.
 
-<a name="ecs_instance_security_group_id" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`ecs_instance_security_group_id`**](#ecs_instance_security_group_id) &mdash; The ID of the security group that should be applied to ecs service instances
+<HclListItem name="custom_iam_role_name_prefix" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="ecs_node_port_mappings" className="snap-top"></a>
+Prefix for name of the IAM role used by the ECS task.
 
-* [**`ecs_node_port_mappings`**](#ecs_node_port_mappings) &mdash; A map of ports to be opened via security groups applied to the EC2 instances that back the ECS cluster, when not using fargate. The key should be the container port and the value should be what host port to map it to.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="efs_volumes" className="snap-top"></a>
+<HclListItem name="custom_task_execution_iam_role_name_prefix" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`efs_volumes`**](#efs_volumes) &mdash; (Optional) A map of EFS volumes that containers in your task may use. Each item in the list should be a map compatible with [`https://www.terraform.io/docs/providers/aws/r/ecs_task_definition`](#https://www.terraform.io/docs/providers/aws/r/ecs_task_definition).html#efs-volume-configuration-arguments.
+Prefix for name of task execution IAM role and policy that grants access to CloudWatch and ECR.
 
-<a name="elb_slow_start" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`elb_slow_start`**](#elb_slow_start) &mdash; The amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0 seconds. Only used if [`elb_target_groups`](#elb_target_groups) is set.
+<HclListItem name="dependencies" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="elb_target_group_deregistration_delay" className="snap-top"></a>
+Create a dependency between the resources in this module to the interpolated values in this list (and thus the source resources). In other words, the resources in this module will now depend on the resources backing the values in this list such that those resources need to be created before the resources in this module, and the resources in this module need to be destroyed before the resources in the list.
 
-* [**`elb_target_group_deregistration_delay`**](#elb_target_group_deregistration_delay) &mdash; The amount of time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. Only used if [`elb_target_groups`](#elb_target_groups) is set.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="elb_target_group_vpc_id" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`elb_target_group_vpc_id`**](#elb_target_group_vpc_id) &mdash; The ID of the VPC in which to create the target group. Only used if [`elb_target_groups`](#elb_target_groups) is set.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="elb_target_groups" className="snap-top"></a>
+<HclListItem name="deployment_check_loglevel" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`elb_target_groups`**](#elb_target_groups) &mdash; Configurations for ELB target groups for ALBs and NLBs that should be associated with the ECS Tasks. Each entry corresponds to a separate target group. Set to the empty object ({}) if you are not using an ALB or NLB.
+Set the logging level of the deployment check script. You can set this to `error`, `warn`, or `info`, in increasing verbosity.
 
-<a name="enable_cloudwatch_alarms" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="info"/>
+</HclListItem>
 
-* [**`enable_cloudwatch_alarms`**](#enable_cloudwatch_alarms) &mdash; Set to true to enable Cloudwatch alarms on the ecs service instances
+<HclListItem name="deployment_check_timeout_seconds" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="enable_ecs_deployment_check" className="snap-top"></a>
+Seconds to wait before timing out each check for verifying ECS service deployment. See ecs_deploy_check_binaries for more details.
 
-* [**`enable_ecs_deployment_check`**](#enable_ecs_deployment_check) &mdash; Whether or not to enable the ECS deployment check binary to make terraform wait for the task to be deployed. See [`ecs_deploy_check_binaries`](#ecs_deploy_check_binaries) for more details. You must install the companion binary before the check can be used. Refer to the README for more details.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="600"/>
+</HclListItem>
 
-<a name="enable_execute_command" className="snap-top"></a>
+<HclListItem name="deployment_circuit_breaker_enabled" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`enable_execute_command`**](#enable_execute_command) &mdash; Specifies whether to enable Amazon ECS Exec for the tasks within the service.
+Set to 'true' to prevent the task from attempting to continuously redeploy after a failed health check.
 
-<a name="enable_route53_health_check" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`enable_route53_health_check`**](#enable_route53_health_check) &mdash; Set this to true to create a route 53 health check and Cloudwatch alarm that will alert if your domain becomes unreachable
+<HclListItem name="deployment_circuit_breaker_rollback" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="expose_ecs_service_to_other_ecs_nodes" className="snap-top"></a>
+Set to 'true' to also automatically roll back to the last successful deployment. deploy_circuit_breaker_enabled must also be true to enable this behavior.
 
-* [**`expose_ecs_service_to_other_ecs_nodes`**](#expose_ecs_service_to_other_ecs_nodes) &mdash; Set this to true to allow the ecs service to be accessed by other ecs nodes
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="fixed_response_rules" className="snap-top"></a>
+<HclListItem name="deployment_maximum_percent" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`fixed_response_rules`**](#fixed_response_rules) &mdash; 
+The upper limit, as a percentage of <a href="#desired_number_of_tasks"><code>desired_number_of_tasks</code></a>, of the number of running tasks that can be running in a service during a deployment. Setting this to more than 100 means that during deployment, ECS will deploy new instances of a Task before undeploying the old ones.
 
-<a name="forward_rules" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="200"/>
+</HclListItem>
 
-* [**`forward_rules`**](#forward_rules) &mdash; 
+<HclListItem name="deployment_minimum_healthy_percent" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="health_check_enabled" className="snap-top"></a>
+The lower limit, as a percentage of <a href="#desired_number_of_tasks"><code>desired_number_of_tasks</code></a>, of the number of running tasks that must remain running and healthy in a service during a deployment. Setting this to less than 100 means that during deployment, ECS may undeploy old instances of a Task before deploying new ones.
 
-* [**`health_check_enabled`**](#health_check_enabled) &mdash; If true, enable health checks on the target group. Only applies to ELBv2. For CLBs, health checks are not configurable.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="100"/>
+</HclListItem>
 
-<a name="health_check_grace_period_seconds" className="snap-top"></a>
+<HclListItem name="desired_number_of_canary_tasks" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`health_check_grace_period_seconds`**](#health_check_grace_period_seconds) &mdash; Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2,147,483,647. Only valid for services configured to use load balancers.
+How many instances of the ECS Service to run across the ECS cluster for a canary deployment. Typically, only 0 or 1 should be used.
 
-<a name="health_check_healthy_threshold" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="0"/>
+</HclListItem>
 
-* [**`health_check_healthy_threshold`**](#health_check_healthy_threshold) &mdash; The number of consecutive successful health checks required before considering an unhealthy Target healthy. The acceptable range is 2 to 10.
+<HclListItem name="desired_number_of_tasks" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="health_check_interval" className="snap-top"></a>
+How many instances of the ECS Service to run across the ECS cluster
 
-* [**`health_check_interval`**](#health_check_interval) &mdash; The approximate amount of time, in seconds, between health checks of an individual Target. Minimum value 5 seconds, Maximum value 300 seconds.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1"/>
+</HclListItem>
 
-<a name="health_check_matcher" className="snap-top"></a>
+<HclListItem name="domain_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`health_check_matcher`**](#health_check_matcher) &mdash; The HTTP codes to use when checking for a successful response from a Target. You can specify multiple values (e.g. '200,202') or a range of values (e.g. '200-299'). Required when using ALBs.
+The domain name to create a route 53 record for. This DNS record will point to the load balancer for the ECS service
 
-<a name="health_check_path" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`health_check_path`**](#health_check_path) &mdash; The ping path that is the destination on the Targets for health checks. Required when using ALBs.
+<HclListItem name="ecs_instance_security_group_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="health_check_port" className="snap-top"></a>
+The ID of the security group that should be applied to ecs service instances
 
-* [**`health_check_port`**](#health_check_port) &mdash; The port the ELB uses when performing health checks on Targets. The default is to use the port on which each target receives traffic from the load balancer, indicated by the value 'traffic-port'.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="health_check_timeout" className="snap-top"></a>
+<HclListItem name="ecs_node_port_mappings" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`health_check_timeout`**](#health_check_timeout) &mdash; The amount of time, in seconds, during which no response from a Target means a failed health check. The acceptable range is 2 to 60 seconds.
+A map of ports to be opened via security groups applied to the EC2 instances that back the ECS cluster, when not using fargate. The key should be the container port and the value should be what host port to map it to.
 
-<a name="health_check_unhealthy_threshold" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`health_check_unhealthy_threshold`**](#health_check_unhealthy_threshold) &mdash; The number of consecutive failed health checks required before considering a target unhealthy. The acceptable range is 2 to 10. For NLBs, this value must be the same as the [`health_check_healthy_threshold`](#health_check_healthy_threshold).
+```hcl
+map(number)
+```
 
-<a name="high_cpu_utilization_period" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`high_cpu_utilization_period`**](#high_cpu_utilization_period) &mdash; The period, in seconds, over which to measure the CPU utilization percentage
+<HclListItem name="efs_volumes" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="high_cpu_utilization_threshold" className="snap-top"></a>
+(Optional) A map of EFS volumes that containers in your task may use. Each item in the list should be a map compatible with https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#efs-volume-configuration-arguments.
 
-* [**`high_cpu_utilization_threshold`**](#high_cpu_utilization_threshold) &mdash; Trigger an alarm if the ECS Service has a CPU utilization percentage above this threshold
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="high_memory_utilization_period" className="snap-top"></a>
+```hcl
+map(object({
+    file_system_id          = string # required
+    container_path          = string # required
+    root_directory          = string
+    transit_encryption      = string
+    transit_encryption_port = number
+    access_point_id         = string
+    iam                     = string
+  }))
+```
 
-* [**`high_memory_utilization_period`**](#high_memory_utilization_period) &mdash; The period, in seconds, over which to measure the memory utilization percentage
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="high_memory_utilization_threshold" className="snap-top"></a>
+<HclListItem name="elb_slow_start" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`high_memory_utilization_threshold`**](#high_memory_utilization_threshold) &mdash; Trigger an alarm if the ECS Service has a memory utilization percentage above this threshold
+The amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0 seconds. Only used if <a href="#elb_target_groups"><code>elb_target_groups</code></a> is set.
 
-<a name="hosted_zone_id" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="0"/>
+</HclListItem>
 
-* [**`hosted_zone_id`**](#hosted_zone_id) &mdash; The ID of the Route 53 hosted zone into which the Route 53 DNS record should be written
+<HclListItem name="elb_target_group_deregistration_delay" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="iam_policy" className="snap-top"></a>
+The amount of time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. Only used if <a href="#elb_target_groups"><code>elb_target_groups</code></a> is set.
 
-* [**`iam_policy`**](#iam_policy) &mdash; An object defining the policy to attach to the ECS task. Accepts a map of objects, where the map keys are sids for IAM policy statements, and the object fields are the resources, actions, and the effect ("Allow" or "Deny") of the statement.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="300"/>
+</HclListItem>
 
-<a name="launch_type" className="snap-top"></a>
+<HclListItem name="elb_target_group_vpc_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`launch_type`**](#launch_type) &mdash; The launch type of the ECS service. Must be one of EC2 or FARGATE. When using FARGATE, you must set the network mode to awsvpc and configure it. When using EC2, you can configure the placement strategy using the variables [`placement_strategy_type`](#placement_strategy_type), [`placement_strategy_field`](#placement_strategy_field), [`placement_constraint_type`](#placement_constraint_type), [`placement_constraint_expression`](#placement_constraint_expression). This variable is ignored if [`capacity_provider_strategy`](#capacity_provider_strategy) is provided.
+The ID of the VPC in which to create the target group. Only used if <a href="#elb_target_groups"><code>elb_target_groups</code></a> is set.
 
-<a name="lb_hosted_zone_id" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`lb_hosted_zone_id`**](#lb_hosted_zone_id) &mdash; The ID of the Route 53 Hosted Zone in which to create a DNS A record pointed to the ECS service's load balancer
+<HclListItem name="elb_target_groups" requirement="optional" type="any">
+<HclListItemDescription>
 
-<a name="max_number_of_tasks" className="snap-top"></a>
+Configurations for ELB target groups for ALBs and NLBs that should be associated with the ECS Tasks. Each entry corresponds to a separate target group. Set to the empty object ({}) if you are not using an ALB or NLB.
 
-* [**`max_number_of_tasks`**](#max_number_of_tasks) &mdash; The maximum number of instances of the ECS Service to run. Auto scaling will never scale out above this number.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="memory" className="snap-top"></a>
+<HclListItem name="enable_cloudwatch_alarms" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`memory`**](#memory) &mdash; How much memory, in MB, to give the ECS Service.
+Set to true to enable Cloudwatch alarms on the ecs service instances
 
-<a name="min_number_of_tasks" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`min_number_of_tasks`**](#min_number_of_tasks) &mdash; The minimum number of instances of the ECS Service to run. Auto scaling will never scale in below this number.
+<HclListItem name="enable_ecs_deployment_check" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="network_configuration" className="snap-top"></a>
+Whether or not to enable the ECS deployment check binary to make terraform wait for the task to be deployed. See ecs_deploy_check_binaries for more details. You must install the companion binary before the check can be used. Refer to the README for more details.
 
-* [**`network_configuration`**](#network_configuration) &mdash; The configuration to use when setting up the VPC network mode. Required and only used if [`network_mode`](#network_mode) is awsvpc.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="network_mode" className="snap-top"></a>
+<HclListItem name="enable_execute_command" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`network_mode`**](#network_mode) &mdash; The Docker networking mode to use for the containers in the task. The valid values are none, bridge, awsvpc, and host. If the [`network_mode`](#network_mode) is set to awsvpc, you must configure [`network_configuration`](#network_configuration).
+Specifies whether to enable Amazon ECS Exec for the tasks within the service.
 
-<a name="original_lb_dns_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`original_lb_dns_name`**](#original_lb_dns_name) &mdash; The DNS name that was assigned by AWS to the load balancer upon creation
+<HclListItem name="enable_route53_health_check" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="placement_constraint_expression" className="snap-top"></a>
+Set this to true to create a route 53 health check and Cloudwatch alarm that will alert if your domain becomes unreachable
 
-* [**`placement_constraint_expression`**](#placement_constraint_expression) &mdash; Cluster Query Language expression to apply to the constraint for matching. Does not need to be specified for the distinctInstance constraint type.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="placement_constraint_type" className="snap-top"></a>
+<HclListItem name="expose_ecs_service_to_other_ecs_nodes" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`placement_constraint_type`**](#placement_constraint_type) &mdash; The type of constraint to apply for container instance placement. The only valid values at this time are memberOf and distinctInstance.
+Set this to true to allow the ecs service to be accessed by other ecs nodes
 
-<a name="placement_strategy_field" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`placement_strategy_field`**](#placement_strategy_field) &mdash; The field to apply the placement strategy against. For the spread placement strategy, valid values are instanceId (or host, which has the same effect), or any platform or custom attribute that is applied to a container instance, such as attribute:ecs.availability-zone. For the binpack placement strategy, valid values are cpu and memory. For the random placement strategy, this field is not used.
+<HclListItem name="fixed_response_rules" requirement="optional" type="map">
+<HclListItemTypeDetails>
 
-<a name="placement_strategy_type" className="snap-top"></a>
+```hcl
+map(any)
+```
 
-* [**`placement_strategy_type`**](#placement_strategy_type) &mdash; The strategy to use when placing ECS tasks on EC2 instances. Can be binpack (default), random, or spread.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="propagate_tags" className="snap-top"></a>
+<HclListItem name="forward_rules" requirement="optional" type="any">
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`propagate_tags`**](#propagate_tags) &mdash; Whether tags should be propogated to the tasks from the service or from the task definition. Valid values are SERVICE and [`TASK_DEFINITION`](#TASK_DEFINITION). Defaults to SERVICE. If set to null, no tags are created for tasks.
+<HclListItem name="health_check_enabled" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="proxy_configuration_container_name" className="snap-top"></a>
+If true, enable health checks on the target group. Only applies to ELBv2. For CLBs, health checks are not configurable.
 
-* [**`proxy_configuration_container_name`**](#proxy_configuration_container_name) &mdash; Use the name of the Envoy proxy container from [``container_definitions`](#`container_definitions)` as the container name.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="proxy_configuration_properties" className="snap-top"></a>
+<HclListItem name="health_check_grace_period_seconds" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`proxy_configuration_properties`**](#proxy_configuration_properties) &mdash; A map of network configuration parameters to provide the Container Network Interface (CNI) plugin.
+Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2,147,483,647. Only valid for services configured to use load balancers.
 
-<a name="redirect_rules" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="0"/>
+</HclListItem>
 
-* [**`redirect_rules`**](#redirect_rules) &mdash; 
+<HclListItem name="health_check_healthy_threshold" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="route53_health_check_path" className="snap-top"></a>
+The number of consecutive successful health checks required before considering an unhealthy Target healthy. The acceptable range is 2 to 10.
 
-* [**`route53_health_check_path`**](#route53_health_check_path) &mdash; The path, without any leading slash, that can be used as a health check (e.g. healthcheck) by Route 53. Should return a 200 OK when the service is up and running.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="5"/>
+</HclListItem>
 
-<a name="route53_health_check_port" className="snap-top"></a>
+<HclListItem name="health_check_interval" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`route53_health_check_port`**](#route53_health_check_port) &mdash; The port to use for Route 53 health checks. This should be the port for the service that is available at the publicly accessible domain name [`(var.domain_name`](#(var.domain_name)).
+The approximate amount of time, in seconds, between health checks of an individual Target. Minimum value 5 seconds, Maximum value 300 seconds.
 
-<a name="route53_health_check_protocol" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="30"/>
+</HclListItem>
 
-* [**`route53_health_check_protocol`**](#route53_health_check_protocol) &mdash; The protocol to use for Route 53 health checks. Should be one of HTTP, HTTPS.
+<HclListItem name="health_check_matcher" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="route53_health_check_provider_external_id" className="snap-top"></a>
+The HTTP codes to use when checking for a successful response from a Target. You can specify multiple values (e.g. '200,202') or a range of values (e.g. '200-299'). Required when using ALBs.
 
-* [**`route53_health_check_provider_external_id`**](#route53_health_check_provider_external_id) &mdash; The optional [`external_id`](#external_id) to be used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="200"/>
+</HclListItem>
 
-<a name="route53_health_check_provider_profile" className="snap-top"></a>
+<HclListItem name="health_check_path" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`route53_health_check_provider_profile`**](#route53_health_check_provider_profile) &mdash; The optional AWS profile to be used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+The ping path that is the destination on the Targets for health checks. Required when using ALBs.
 
-<a name="route53_health_check_provider_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="/"/>
+</HclListItem>
 
-* [**`route53_health_check_provider_role_arn`**](#route53_health_check_provider_role_arn) &mdash; The optional [`role_arn`](#role_arn) to be used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+<HclListItem name="health_check_port" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="route53_health_check_provider_session_name" className="snap-top"></a>
+The port the ELB uses when performing health checks on Targets. The default is to use the port on which each target receives traffic from the load balancer, indicated by the value 'traffic-port'.
 
-* [**`route53_health_check_provider_session_name`**](#route53_health_check_provider_session_name) &mdash; The optional [`session_name`](#session_name) to be used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="traffic-port"/>
+</HclListItem>
 
-<a name="route53_health_check_provider_shared_credentials_file" className="snap-top"></a>
+<HclListItem name="health_check_timeout" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`route53_health_check_provider_shared_credentials_file`**](#route53_health_check_provider_shared_credentials_file) &mdash; The optional path to a credentials file used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+The amount of time, in seconds, during which no response from a Target means a failed health check. The acceptable range is 2 to 60 seconds.
 
-<a name="secrets_access" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="5"/>
+</HclListItem>
 
-* [**`secrets_access`**](#secrets_access) &mdash; A list of ARNs of Secrets Manager secrets that the task should have permissions to read. The IAM role for the task will be granted `secretsmanager:GetSecretValue` for each secret in the list. The ARN can be either the complete ARN, including the randomly generated suffix, or the ARN without the suffix. If the latter, the module will look up the full ARN automatically. This is helpful in cases where you don't yet know the randomly generated suffix because the rest of the ARN is a predictable value.
+<HclListItem name="health_check_unhealthy_threshold" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="secrets_manager_arns" className="snap-top"></a>
+The number of consecutive failed health checks required before considering a target unhealthy. The acceptable range is 2 to 10. For NLBs, this value must be the same as the health_check_healthy_threshold.
 
-* [**`secrets_manager_arns`**](#secrets_manager_arns) &mdash; A list of ARNs for Secrets Manager secrets that the ECS execution IAM policy should be granted access to read. Note that this is different from the ECS task IAM policy. The execution policy is concerned with permissions required to run the ECS task.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="2"/>
+</HclListItem>
 
-<a name="secrets_manager_kms_key_arn" className="snap-top"></a>
+<HclListItem name="high_cpu_utilization_period" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`secrets_manager_kms_key_arn`**](#secrets_manager_kms_key_arn) &mdash; The ARN of the kms key associated with secrets manager
+The period, in seconds, over which to measure the CPU utilization percentage
 
-<a name="service_tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="300"/>
+</HclListItem>
 
-* [**`service_tags`**](#service_tags) &mdash; A map of tags to apply to the ECS service. Each item in this list should be a map with the parameters key and value.
+<HclListItem name="high_cpu_utilization_threshold" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="task_cpu" className="snap-top"></a>
+Trigger an alarm if the ECS Service has a CPU utilization percentage above this threshold
 
-* [**`task_cpu`**](#task_cpu) &mdash; The CPU units for the instances that Fargate will spin up. Options here: [`https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate`](#https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate).html#fargate-tasks-size. Required when using FARGATE launch type.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="90"/>
+</HclListItem>
 
-<a name="task_definition_tags" className="snap-top"></a>
+<HclListItem name="high_memory_utilization_period" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`task_definition_tags`**](#task_definition_tags) &mdash; A map of tags to apply to the task definition. Each item in this list should be a map with the parameters key and value.
+The period, in seconds, over which to measure the memory utilization percentage
 
-<a name="task_memory" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="300"/>
+</HclListItem>
 
-* [**`task_memory`**](#task_memory) &mdash; The memory units for the instances that Fargate will spin up. Options here: [`https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate`](#https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate).html#fargate-tasks-size. Required when using FARGATE launch type.
+<HclListItem name="high_memory_utilization_threshold" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="use_alb_sticky_sessions" className="snap-top"></a>
+Trigger an alarm if the ECS Service has a memory utilization percentage above this threshold
 
-* [**`use_alb_sticky_sessions`**](#use_alb_sticky_sessions) &mdash; If true, the ALB will use use Sticky Sessions as described at https://goo.gl/VLcNbk. Only used if [`elb_target_groups`](#elb_target_groups) is set. Note that this can only be true when associating with an ALB. This cannot be used with CLBs or NLBs.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="90"/>
+</HclListItem>
 
-<a name="use_auto_scaling" className="snap-top"></a>
+<HclListItem name="hosted_zone_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`use_auto_scaling`**](#use_auto_scaling) &mdash; Whether or not to enable auto scaling for the ecs service
+The ID of the Route 53 hosted zone into which the Route 53 DNS record should be written
 
-<a name="use_custom_docker_run_command" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`use_custom_docker_run_command`**](#use_custom_docker_run_command) &mdash; Set this to true if you want to pass a custom docker run command. If you set this to true, you must supply [`custom_docker_command`](#custom_docker_command)
+<HclListItem name="iam_policy" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="volumes" className="snap-top"></a>
+An object defining the policy to attach to the ECS task. Accepts a map of objects, where the map keys are sids for IAM policy statements, and the object fields are the resources, actions, and the effect ('Allow' or 'Deny') of the statement.
 
-* [**`volumes`**](#volumes) &mdash; (Optional) A map of volume blocks that containers in your task may use. The key should be the name of the volume and the value should be a map compatible with [`https://www.terraform.io/docs/providers/aws/r/ecs_task_definition`](#https://www.terraform.io/docs/providers/aws/r/ecs_task_definition).html#volume-block-arguments, but not including the name parameter.
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(object({
+    resources = list(string)
+    actions   = list(string)
+    effect    = string
+  }))
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="launch_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+The launch type of the ECS service. Must be one of EC2 or FARGATE. When using FARGATE, you must set the network mode to awsvpc and configure it. When using EC2, you can configure the placement strategy using the variables <a href="#placement_strategy_type"><code>placement_strategy_type</code></a>, <a href="#placement_strategy_field"><code>placement_strategy_field</code></a>, <a href="#placement_constraint_type"><code>placement_constraint_type</code></a>, <a href="#placement_constraint_expression"><code>placement_constraint_expression</code></a>. This variable is ignored if <a href="#capacity_provider_strategy"><code>capacity_provider_strategy</code></a> is provided.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="EC2"/>
+</HclListItem>
+
+<HclListItem name="lb_hosted_zone_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ID of the Route 53 Hosted Zone in which to create a DNS A record pointed to the ECS service's load balancer
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="max_number_of_tasks" requirement="optional" type="number">
+<HclListItemDescription>
+
+The maximum number of instances of the ECS Service to run. Auto scaling will never scale out above this number.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="3"/>
+</HclListItem>
+
+<HclListItem name="memory" requirement="optional" type="number">
+<HclListItemDescription>
+
+How much memory, in MB, to give the ECS Service.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="500"/>
+</HclListItem>
+
+<HclListItem name="min_number_of_tasks" requirement="optional" type="number">
+<HclListItemDescription>
+
+The minimum number of instances of the ECS Service to run. Auto scaling will never scale in below this number.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1"/>
+</HclListItem>
+
+<HclListItem name="network_configuration" requirement="optional" type="object">
+<HclListItemDescription>
+
+The configuration to use when setting up the VPC network mode. Required and only used if network_mode is awsvpc.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+object({
+    # IDs of VPC Subnets to allocate fargate worker network from.
+    subnets = list(string)
+
+    # The ID of the VPC used for the Fargate worker network. Must be non-null when security_group_rules are provided.
+    vpc_id = string
+
+    # Security Group Rules to apply to the ECS Fargate worker. This module will create a new security group for the
+    # worker and attach these rules. Each entry accepts the same attributes as the aws_security_group_rule resource,
+    # except for security_group_id which will be set to the security group created within the module.
+    # Each entry corresponds to a rule. The key is a unique, user provided, arbitrary value that can be used by
+    # Terraform to know which rules to update across changes.
+    security_group_rules = map(object({
+      type                     = string
+      from_port                = number
+      to_port                  = number
+      protocol                 = string
+      source_security_group_id = string
+      cidr_blocks              = list(string)
+    }))
+
+    # Additional existing Security Groups that should be bound to the ECS Fargate worker.
+    additional_security_group_ids = list(string)
+
+    # Whether or not the ECS Fargate worker should get a public IP address.
+    assign_public_ip = bool
+  })
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="network_mode" requirement="optional" type="string">
+<HclListItemDescription>
+
+The Docker networking mode to use for the containers in the task. The valid values are none, bridge, awsvpc, and host. If the network_mode is set to awsvpc, you must configure <a href="#network_configuration"><code>network_configuration</code></a>.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="bridge"/>
+</HclListItem>
+
+<HclListItem name="original_lb_dns_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The DNS name that was assigned by AWS to the load balancer upon creation
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="placement_constraint_expression" requirement="optional" type="string">
+<HclListItemDescription>
+
+Cluster Query Language expression to apply to the constraint for matching. Does not need to be specified for the distinctInstance constraint type.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="attribute:ecs.ami-id != 'ami-fake'"/>
+</HclListItem>
+
+<HclListItem name="placement_constraint_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+The type of constraint to apply for container instance placement. The only valid values at this time are memberOf and distinctInstance.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="memberOf"/>
+</HclListItem>
+
+<HclListItem name="placement_strategy_field" requirement="optional" type="string">
+<HclListItemDescription>
+
+The field to apply the placement strategy against. For the spread placement strategy, valid values are instanceId (or host, which has the same effect), or any platform or custom attribute that is applied to a container instance, such as attribute:ecs.availability-zone. For the binpack placement strategy, valid values are cpu and memory. For the random placement strategy, this field is not used.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="cpu"/>
+</HclListItem>
+
+<HclListItem name="placement_strategy_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+The strategy to use when placing ECS tasks on EC2 instances. Can be binpack (default), random, or spread.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="binpack"/>
+</HclListItem>
+
+<HclListItem name="propagate_tags" requirement="optional" type="string">
+<HclListItemDescription>
+
+Whether tags should be propogated to the tasks from the service or from the task definition. Valid values are SERVICE and TASK_DEFINITION. Defaults to SERVICE. If set to null, no tags are created for tasks.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="SERVICE"/>
+</HclListItem>
+
+<HclListItem name="proxy_configuration_container_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+Use the name of the Envoy proxy container from `container_definitions` as the container name.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="proxy_configuration_properties" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of network configuration parameters to provide the Container Network Interface (CNI) plugin.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="redirect_rules" requirement="optional" type="map">
+<HclListItemTypeDetails>
+
+```hcl
+map(any)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="route53_health_check_path" requirement="optional" type="string">
+<HclListItemDescription>
+
+The path, without any leading slash, that can be used as a health check (e.g. healthcheck) by Route 53. Should return a 200 OK when the service is up and running.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="/"/>
+</HclListItem>
+
+<HclListItem name="route53_health_check_port" requirement="optional" type="number">
+<HclListItemDescription>
+
+The port to use for Route 53 health checks. This should be the port for the service that is available at the publicly accessible domain name (<a href="#domain_name"><code>domain_name</code></a>).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="80"/>
+</HclListItem>
+
+<HclListItem name="route53_health_check_protocol" requirement="optional" type="string">
+<HclListItemDescription>
+
+The protocol to use for Route 53 health checks. Should be one of HTTP, HTTPS.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="HTTP"/>
+</HclListItem>
+
+<HclListItem name="route53_health_check_provider_external_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+The optional external_id to be used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="route53_health_check_provider_profile" requirement="optional" type="string">
+<HclListItemDescription>
+
+The optional AWS profile to be used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="route53_health_check_provider_role_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+The optional role_arn to be used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="route53_health_check_provider_session_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The optional session_name to be used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="route53_health_check_provider_shared_credentials_file" requirement="optional" type="string">
+<HclListItemDescription>
+
+The optional path to a credentials file used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="secrets_access" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of ARNs of Secrets Manager secrets that the task should have permissions to read. The IAM role for the task will be granted `secretsmanager:GetSecretValue` for each secret in the list. The ARN can be either the complete ARN, including the randomly generated suffix, or the ARN without the suffix. If the latter, the module will look up the full ARN automatically. This is helpful in cases where you don't yet know the randomly generated suffix because the rest of the ARN is a predictable value.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="secrets_manager_arns" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of ARNs for Secrets Manager secrets that the ECS execution IAM policy should be granted access to read. Note that this is different from the ECS task IAM policy. The execution policy is concerned with permissions required to run the ECS task.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="secrets_manager_kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ARN of the kms key associated with secrets manager
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="service_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of tags to apply to the ECS service. Each item in this list should be a map with the parameters key and value.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="task_cpu" requirement="optional" type="number">
+<HclListItemDescription>
+
+The CPU units for the instances that Fargate will spin up. Options here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size. Required when using FARGATE launch type.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="task_definition_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of tags to apply to the task definition. Each item in this list should be a map with the parameters key and value.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="task_memory" requirement="optional" type="number">
+<HclListItemDescription>
+
+The memory units for the instances that Fargate will spin up. Options here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size. Required when using FARGATE launch type.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="use_alb_sticky_sessions" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If true, the ALB will use use Sticky Sessions as described at https://goo.gl/VLcNbk. Only used if <a href="#elb_target_groups"><code>elb_target_groups</code></a> is set. Note that this can only be true when associating with an ALB. This cannot be used with CLBs or NLBs.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="use_auto_scaling" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Whether or not to enable auto scaling for the ecs service
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="use_custom_docker_run_command" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set this to true if you want to pass a custom docker run command. If you set this to true, you must supply <a href="#custom_docker_command"><code>custom_docker_command</code></a>
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="volumes" requirement="optional" type="any">
+<HclListItemDescription>
+
+(Optional) A map of volume blocks that containers in your task may use. The key should be the name of the volume and the value should be a map compatible with https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#volume-block-arguments, but not including the name parameter.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="all_metric_widgets" className="snap-top"></a>
+<HclListItem name="all_metric_widgets">
+<HclListItemDescription>
 
-* [**`all_metric_widgets`**](#all_metric_widgets) &mdash; A list of all the CloudWatch Dashboard metric widgets available in this module.
+A list of all the CloudWatch Dashboard metric widgets available in this module.
 
-<a name="aws_ecs_task_definition_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`aws_ecs_task_definition_arn`**](#aws_ecs_task_definition_arn) &mdash; The ARN of the ECS task definition
+<HclListItem name="aws_ecs_task_definition_arn">
+<HclListItemDescription>
 
-<a name="aws_ecs_task_definition_canary_arn" className="snap-top"></a>
+The ARN of the ECS task definition
 
-* [**`aws_ecs_task_definition_canary_arn`**](#aws_ecs_task_definition_canary_arn) &mdash; The ARN of the canary ECS task definition
+</HclListItemDescription>
+</HclListItem>
 
-<a name="canary_service_arn" className="snap-top"></a>
+<HclListItem name="aws_ecs_task_definition_canary_arn">
+<HclListItemDescription>
 
-* [**`canary_service_arn`**](#canary_service_arn) &mdash; The ARN of the canary service. Canary services are optional and can be helpful when you're attempting to verify a release candidate
+The ARN of the canary ECS task definition
 
-<a name="capacity_provider_strategy" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`capacity_provider_strategy`**](#capacity_provider_strategy) &mdash; The capacity provider strategy determines how infrastructure (such as EC2 instances or Fargate) that backs your ECS service is managed. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-capacity-providers.html for more information
+<HclListItem name="canary_service_arn">
+<HclListItemDescription>
 
-<a name="ecs_node_port_mappings" className="snap-top"></a>
+The ARN of the canary service. Canary services are optional and can be helpful when you're attempting to verify a release candidate
 
-* [**`ecs_node_port_mappings`**](#ecs_node_port_mappings) &mdash; A map representing the instance host and container ports that should be opened
+</HclListItemDescription>
+</HclListItem>
 
-<a name="ecs_task_execution_iam_role_arn" className="snap-top"></a>
+<HclListItem name="capacity_provider_strategy">
+<HclListItemDescription>
 
-* [**`ecs_task_execution_iam_role_arn`**](#ecs_task_execution_iam_role_arn) &mdash; The ARN of the ECS task's IAM role
+The capacity provider strategy determines how infrastructure (such as EC2 instances or Fargate) that backs your ECS service is managed. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-capacity-providers.html for more information
 
-<a name="ecs_task_execution_iam_role_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`ecs_task_execution_iam_role_name`**](#ecs_task_execution_iam_role_name) &mdash; The name of the ECS task execution IAM role. The execution role is used by the ECS container agent to make calls to the ECS API, pull container images from ECR, use the logs driver, etc
+<HclListItem name="ecs_node_port_mappings">
+<HclListItemDescription>
 
-<a name="ecs_task_iam_role_arn" className="snap-top"></a>
+A map representing the instance host and container ports that should be opened
 
-* [**`ecs_task_iam_role_arn`**](#ecs_task_iam_role_arn) &mdash; The ARN of the IAM role associated with the ECS task
+</HclListItemDescription>
+</HclListItem>
 
-<a name="ecs_task_iam_role_name" className="snap-top"></a>
+<HclListItem name="ecs_task_execution_iam_role_arn">
+<HclListItemDescription>
 
-* [**`ecs_task_iam_role_name`**](#ecs_task_iam_role_name) &mdash; The name of the IAM role granting permissions to the running ECS task itself. Note this role is separate from the execution role which is assumed by the ECS container agent
+The ARN of the ECS task's IAM role
 
-<a name="metric_widget_ecs_service_cpu_usage" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`metric_widget_ecs_service_cpu_usage`**](#metric_widget_ecs_service_cpu_usage) &mdash; The metric widget for the ECS service's CPU usage 
+<HclListItem name="ecs_task_execution_iam_role_name">
+<HclListItemDescription>
 
-<a name="metric_widget_ecs_service_memory_usage" className="snap-top"></a>
+The name of the ECS task execution IAM role. The execution role is used by the ECS container agent to make calls to the ECS API, pull container images from ECR, use the logs driver, etc
 
-* [**`metric_widget_ecs_service_memory_usage`**](#metric_widget_ecs_service_memory_usage) &mdash; The metric widget for the ECS service's memory usage
+</HclListItemDescription>
+</HclListItem>
 
-<a name="route53_domain_name" className="snap-top"></a>
+<HclListItem name="ecs_task_iam_role_arn">
+<HclListItemDescription>
 
-* [**`route53_domain_name`**](#route53_domain_name) &mdash; The domain name of the optional route53 record, which points at the load balancer for the ECS service
+The ARN of the IAM role associated with the ECS task
 
-<a name="service_app_autoscaling_target_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`service_app_autoscaling_target_arn`**](#service_app_autoscaling_target_arn) &mdash; The ARN of the app autoscaling target
+<HclListItem name="ecs_task_iam_role_name">
+<HclListItemDescription>
 
-<a name="service_app_autoscaling_target_resource_id" className="snap-top"></a>
+The name of the IAM role granting permissions to the running ECS task itself. Note this role is separate from the execution role which is assumed by the ECS container agent
 
-* [**`service_app_autoscaling_target_resource_id`**](#service_app_autoscaling_target_resource_id) &mdash; The resource ID of the autoscaling target
+</HclListItemDescription>
+</HclListItem>
 
-<a name="service_arn" className="snap-top"></a>
+<HclListItem name="metric_widget_ecs_service_cpu_usage">
+<HclListItemDescription>
 
-* [**`service_arn`**](#service_arn) &mdash; The ARN of the ECS service
+The metric widget for the ECS service's CPU usage 
 
-<a name="service_iam_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`service_iam_role_arn`**](#service_iam_role_arn) &mdash; The ARN of the service role associated with the ELB of the ECS service
+<HclListItem name="metric_widget_ecs_service_memory_usage">
+<HclListItemDescription>
 
-<a name="service_iam_role_name" className="snap-top"></a>
+The metric widget for the ECS service's memory usage
 
-* [**`service_iam_role_name`**](#service_iam_role_name) &mdash; The name of the service role associated with the ELB of the ECS service
+</HclListItemDescription>
+</HclListItem>
 
-<a name="target_group_arns" className="snap-top"></a>
+<HclListItem name="route53_domain_name">
+<HclListItemDescription>
 
-* [**`target_group_arns`**](#target_group_arns) &mdash; The ARNs of the ECS service's load balancer's target groups
+The domain name of the optional route53 record, which points at the load balancer for the ECS service
 
-<a name="target_group_names" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`target_group_names`**](#target_group_names) &mdash; The names of the ECS service's load balancer's target groups
+<HclListItem name="service_app_autoscaling_target_arn">
+<HclListItemDescription>
+
+The ARN of the app autoscaling target
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="service_app_autoscaling_target_resource_id">
+<HclListItemDescription>
+
+The resource ID of the autoscaling target
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="service_arn">
+<HclListItemDescription>
+
+The ARN of the ECS service
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="service_iam_role_arn">
+<HclListItemDescription>
+
+The ARN of the service role associated with the ELB of the ECS service
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="service_iam_role_name">
+<HclListItemDescription>
+
+The name of the service role associated with the ELB of the ECS service
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="target_group_arns">
+<HclListItemDescription>
+
+The ARNs of the ECS service's load balancer's target groups
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="target_group_names">
+<HclListItemDescription>
+
+The names of the ECS service's load balancer's target groups
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"ddeff99411ad2915eb47666a867af01e"}
+{"sourcePlugin":"service-catalog-api","hash":"36da9325a5bfd779d7672900d4710a51"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/app-orchestration/amazon-eks-core-services.md
+++ b/docs/reference/services/app-orchestration/amazon-eks-core-services.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.84.0"/>
 
@@ -101,271 +102,800 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="aws_region" className="snap-top"></a>
+<HclListItem name="aws_region" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`aws_region`**](#aws_region) &mdash; The AWS region in which all resources will be created
+The AWS region in which all resources will be created
 
-<a name="eks_cluster_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`eks_cluster_name`**](#eks_cluster_name) &mdash; The name of the EKS cluster where the core services will be deployed into.
+<HclListItem name="eks_cluster_name" requirement="required" type="string">
+<HclListItemDescription>
 
-<a name="eks_iam_role_for_service_accounts_config" className="snap-top"></a>
+The name of the EKS cluster where the core services will be deployed into.
 
-* [**`eks_iam_role_for_service_accounts_config`**](#eks_iam_role_for_service_accounts_config) &mdash; Configuration for using the IAM role with Service Accounts feature to provide permissions to the applications. This expects a map with two properties: [``openid_connect_provider_arn`](#`openid_connect_provider_arn)` and [``openid_connect_provider_url`](#`openid_connect_provider_url)`. The [``openid_connect_provider_arn`](#`openid_connect_provider_arn)` is the ARN of the OpenID Connect Provider for EKS to retrieve IAM credentials, while [``openid_connect_provider_url`](#`openid_connect_provider_url)` is the URL. Set to null if you do not wish to use IAM role with Service Accounts.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="pod_execution_iam_role_arn" className="snap-top"></a>
+<HclListItem name="eks_iam_role_for_service_accounts_config" requirement="required" type="object">
+<HclListItemDescription>
 
-* [**`pod_execution_iam_role_arn`**](#pod_execution_iam_role_arn) &mdash; ARN of IAM Role to use as the Pod execution role for Fargate. Required if any of the services are being scheduled on Fargate. Set to null if none of the Pods are being scheduled on Fargate.
+Configuration for using the IAM role with Service Accounts feature to provide permissions to the applications. This expects a map with two properties: `openid_connect_provider_arn` and `openid_connect_provider_url`. The `openid_connect_provider_arn` is the ARN of the OpenID Connect Provider for EKS to retrieve IAM credentials, while `openid_connect_provider_url` is the URL. Set to null if you do not wish to use IAM role with Service Accounts.
 
-<a name="vpc_id" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`vpc_id`**](#vpc_id) &mdash; The ID of the VPC where the EKS cluster is deployed.
+```hcl
+object({
+    openid_connect_provider_arn = string
+    openid_connect_provider_url = string
+  })
+```
 
-<a name="worker_vpc_subnet_ids" className="snap-top"></a>
+</HclListItemTypeDetails>
+</HclListItem>
 
-* [**`worker_vpc_subnet_ids`**](#worker_vpc_subnet_ids) &mdash; The subnet IDs to use for EKS worker nodes. Used when provisioning Pods on to Fargate. Required if any of the services are being scheduled on Fargate. Set to empty list if none of the Pods are being scheduled on Fargate.
+<HclListItem name="pod_execution_iam_role_arn" requirement="required" type="string">
+<HclListItemDescription>
+
+ARN of IAM Role to use as the Pod execution role for Fargate. Required if any of the services are being scheduled on Fargate. Set to null if none of the Pods are being scheduled on Fargate.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="vpc_id" requirement="required" type="string">
+<HclListItemDescription>
+
+The ID of the VPC where the EKS cluster is deployed.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="worker_vpc_subnet_ids" requirement="required" type="list">
+<HclListItemDescription>
+
+The subnet IDs to use for EKS worker nodes. Used when provisioning Pods on to Fargate. Required if any of the services are being scheduled on Fargate. Set to empty list if none of the Pods are being scheduled on Fargate.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
 
 ### Optional
 
-<a name="alb_ingress_controller_pod_node_affinity" className="snap-top"></a>
+<HclListItem name="alb_ingress_controller_pod_node_affinity" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`alb_ingress_controller_pod_node_affinity`**](#alb_ingress_controller_pod_node_affinity) &mdash; Configure affinity rules for the ALB Ingress Controller Pod to control which nodes to schedule on. Each item in the list should be a map with the keys `key`, `values`, and `operator`, corresponding to the 3 properties of matchExpressions. Note that all expressions must be satisfied to schedule on the node.
+Configure affinity rules for the ALB Ingress Controller Pod to control which nodes to schedule on. Each item in the list should be a map with the keys `key`, `values`, and `operator`, corresponding to the 3 properties of matchExpressions. Note that all expressions must be satisfied to schedule on the node.
 
-<a name="alb_ingress_controller_pod_tolerations" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`alb_ingress_controller_pod_tolerations`**](#alb_ingress_controller_pod_tolerations) &mdash; Configure tolerations rules to allow the ALB Ingress Controller Pod to schedule on nodes that have been tainted. Each item in the list specifies a toleration rule.
+```hcl
+list(object({
+    key      = string
+    values   = list(string)
+    operator = string
+  }))
+```
 
-<a name="autoscaler_down_delay_after_add" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`autoscaler_down_delay_after_add`**](#autoscaler_down_delay_after_add) &mdash; Minimum time to wait after a scale up event before any node is considered for scale down.
+<HclListItem name="alb_ingress_controller_pod_tolerations" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="autoscaler_scale_down_unneeded_time" className="snap-top"></a>
+Configure tolerations rules to allow the ALB Ingress Controller Pod to schedule on nodes that have been tainted. Each item in the list specifies a toleration rule.
 
-* [**`autoscaler_scale_down_unneeded_time`**](#autoscaler_scale_down_unneeded_time) &mdash; Minimum time to wait since the node became unused before the node is considered for scale down by the autoscaler.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="autoscaler_skip_nodes_with_local_storage" className="snap-top"></a>
+```hcl
+list(map(any))
+```
 
-* [**`autoscaler_skip_nodes_with_local_storage`**](#autoscaler_skip_nodes_with_local_storage) &mdash; If true cluster autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="aws_cloudwatch_agent_image_repository" className="snap-top"></a>
+<HclListItem name="autoscaler_down_delay_after_add" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`aws_cloudwatch_agent_image_repository`**](#aws_cloudwatch_agent_image_repository) &mdash; The Container repository to use for looking up the cloudwatch-agent Container image when deploying the pods. When null, uses the default repository set in the chart. Only applies to non-fargate workers.
+Minimum time to wait after a scale up event before any node is considered for scale down.
 
-<a name="aws_cloudwatch_agent_pod_node_affinity" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="10m"/>
+</HclListItem>
 
-* [**`aws_cloudwatch_agent_pod_node_affinity`**](#aws_cloudwatch_agent_pod_node_affinity) &mdash; Configure affinity rules for the AWS CloudWatch Agent Pod to control which nodes to schedule on. Each item in the list should be a map with the keys `key`, `values`, and `operator`, corresponding to the 3 properties of matchExpressions. Note that all expressions must be satisfied to schedule on the node.
+<HclListItem name="autoscaler_scale_down_unneeded_time" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="aws_cloudwatch_agent_pod_resources" className="snap-top"></a>
+Minimum time to wait since the node became unused before the node is considered for scale down by the autoscaler.
 
-* [**`aws_cloudwatch_agent_pod_resources`**](#aws_cloudwatch_agent_pod_resources) &mdash; Pod resource requests and limits to use. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="10m"/>
+</HclListItem>
 
-<a name="aws_cloudwatch_agent_pod_tolerations" className="snap-top"></a>
+<HclListItem name="autoscaler_skip_nodes_with_local_storage" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`aws_cloudwatch_agent_pod_tolerations`**](#aws_cloudwatch_agent_pod_tolerations) &mdash; Configure tolerations rules to allow the AWS CloudWatch Agent Pods to schedule on nodes that have been tainted. Each item in the list specifies a toleration rule.
+If true cluster autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath
 
-<a name="aws_cloudwatch_agent_version" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`aws_cloudwatch_agent_version`**](#aws_cloudwatch_agent_version) &mdash; Which version of amazon/cloudwatch-agent to install. When null, uses the default version set in the chart. Only applies to non-fargate workers.
+<HclListItem name="aws_cloudwatch_agent_image_repository" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="cluster_autoscaler_pod_annotations" className="snap-top"></a>
+The Container repository to use for looking up the cloudwatch-agent Container image when deploying the pods. When null, uses the default repository set in the chart. Only applies to non-fargate workers.
 
-* [**`cluster_autoscaler_pod_annotations`**](#cluster_autoscaler_pod_annotations) &mdash; Annotations to apply to the cluster autoscaler pod(s), as key value pairs.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="cluster_autoscaler_pod_labels" className="snap-top"></a>
+<HclListItem name="aws_cloudwatch_agent_pod_node_affinity" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`cluster_autoscaler_pod_labels`**](#cluster_autoscaler_pod_labels) &mdash; Labels to apply to the cluster autoscaler pod(s), as key value pairs.
+Configure affinity rules for the AWS CloudWatch Agent Pod to control which nodes to schedule on. Each item in the list should be a map with the keys `key`, `values`, and `operator`, corresponding to the 3 properties of matchExpressions. Note that all expressions must be satisfied to schedule on the node.
 
-<a name="cluster_autoscaler_pod_node_affinity" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`cluster_autoscaler_pod_node_affinity`**](#cluster_autoscaler_pod_node_affinity) &mdash; Configure affinity rules for the cluster-autoscaler Pod to control which nodes to schedule on. Each item in the list should be a map with the keys `key`, `values`, and `operator`, corresponding to the 3 properties of matchExpressions. Note that all expressions must be satisfied to schedule on the node.
+```hcl
+list(object({
+    key      = string
+    values   = list(string)
+    operator = string
+  }))
+```
 
-<a name="cluster_autoscaler_pod_resources" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`cluster_autoscaler_pod_resources`**](#cluster_autoscaler_pod_resources) &mdash; Pod resource requests and limits to use. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information. This is most useful for configuring CPU+Memory availability for Fargate, which defaults to 0.25 vCPU and 256MB RAM.
+<HclListItem name="aws_cloudwatch_agent_pod_resources" requirement="optional" type="any">
+<HclListItemDescription>
 
-<a name="cluster_autoscaler_pod_tolerations" className="snap-top"></a>
+Pod resource requests and limits to use. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information.
 
-* [**`cluster_autoscaler_pod_tolerations`**](#cluster_autoscaler_pod_tolerations) &mdash; Configure tolerations rules to allow the cluster-autoscaler Pod to schedule on nodes that have been tainted. Each item in the list specifies a toleration rule.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="cluster_autoscaler_release_name" className="snap-top"></a>
+<HclListItem name="aws_cloudwatch_agent_pod_tolerations" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`cluster_autoscaler_release_name`**](#cluster_autoscaler_release_name) &mdash; The name to use for the helm release for cluster-autoscaler. This is useful to force a redeployment of the cluster-autoscaler component.
+Configure tolerations rules to allow the AWS CloudWatch Agent Pods to schedule on nodes that have been tainted. Each item in the list specifies a toleration rule.
 
-<a name="cluster_autoscaler_repository" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`cluster_autoscaler_repository`**](#cluster_autoscaler_repository) &mdash; Which docker repository to use to install the cluster autoscaler. Check the following link for valid repositories to use https://github.com/kubernetes/autoscaler/releases
+```hcl
+list(map(any))
+```
 
-<a name="cluster_autoscaler_scaling_strategy" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`cluster_autoscaler_scaling_strategy`**](#cluster_autoscaler_scaling_strategy) &mdash; Specifies an 'expander' for the cluster autoscaler. This helps determine which ASG to scale when additional resource capacity is needed.
+<HclListItem name="aws_cloudwatch_agent_version" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="cluster_autoscaler_version" className="snap-top"></a>
+Which version of amazon/cloudwatch-agent to install. When null, uses the default version set in the chart. Only applies to non-fargate workers.
 
-* [**`cluster_autoscaler_version`**](#cluster_autoscaler_version) &mdash; Which version of the cluster autoscaler to install. This should match the major/minor version (e.g., v1.20) of your Kubernetes Installation. See https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#releases for a list of versions.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="enable_alb_ingress_controller" className="snap-top"></a>
+<HclListItem name="cluster_autoscaler_pod_annotations" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`enable_alb_ingress_controller`**](#enable_alb_ingress_controller) &mdash; Whether or not to enable the AWS LB Ingress controller.
+Annotations to apply to the cluster autoscaler pod(s), as key value pairs.
 
-<a name="enable_aws_cloudwatch_agent" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`enable_aws_cloudwatch_agent`**](#enable_aws_cloudwatch_agent) &mdash; Whether to enable the AWS CloudWatch Agent DaemonSet for collecting container and node metrics from worker nodes (self-managed ASG or managed node groups).
+```hcl
+map(string)
+```
 
-<a name="enable_cluster_autoscaler" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`enable_cluster_autoscaler`**](#enable_cluster_autoscaler) &mdash; Whether or not to enable cluster-autoscaler for Autoscaling EKS worker nodes.
+<HclListItem name="cluster_autoscaler_pod_labels" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="enable_external_dns" className="snap-top"></a>
+Labels to apply to the cluster autoscaler pod(s), as key value pairs.
 
-* [**`enable_external_dns`**](#enable_external_dns) &mdash; Whether or not to enable external-dns for DNS entry syncing with Route 53 for Services and Ingresses.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="enable_fargate_fluent_bit" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`enable_fargate_fluent_bit`**](#enable_fargate_fluent_bit) &mdash; Whether or not to enable fluent-bit on EKS Fargate workers for log aggregation.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="enable_fluent_bit" className="snap-top"></a>
+<HclListItem name="cluster_autoscaler_pod_node_affinity" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`enable_fluent_bit`**](#enable_fluent_bit) &mdash; Whether or not to enable fluent-bit for log aggregation.
+Configure affinity rules for the cluster-autoscaler Pod to control which nodes to schedule on. Each item in the list should be a map with the keys `key`, `values`, and `operator`, corresponding to the 3 properties of matchExpressions. Note that all expressions must be satisfied to schedule on the node.
 
-<a name="external_dns_pod_node_affinity" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`external_dns_pod_node_affinity`**](#external_dns_pod_node_affinity) &mdash; Configure affinity rules for the external-dns Pod to control which nodes to schedule on. Each item in the list should be a map with the keys `key`, `values`, and `operator`, corresponding to the 3 properties of matchExpressions. Note that all expressions must be satisfied to schedule on the node.
+```hcl
+list(object({
+    key      = string
+    values   = list(string)
+    operator = string
+  }))
+```
 
-<a name="external_dns_pod_tolerations" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`external_dns_pod_tolerations`**](#external_dns_pod_tolerations) &mdash; Configure tolerations rules to allow the external-dns Pod to schedule on nodes that have been tainted. Each item in the list specifies a toleration rule.
+<HclListItem name="cluster_autoscaler_pod_resources" requirement="optional" type="any">
+<HclListItemDescription>
 
-<a name="external_dns_route53_hosted_zone_domain_filters" className="snap-top"></a>
+Pod resource requests and limits to use. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information. This is most useful for configuring CPU+Memory availability for Fargate, which defaults to 0.25 vCPU and 256MB RAM.
 
-* [**`external_dns_route53_hosted_zone_domain_filters`**](#external_dns_route53_hosted_zone_domain_filters) &mdash; Only create records in hosted zones that match the provided domain names. Empty list (default) means match all zones. Zones must satisfy all three constraints [`(var.external_dns_route53_hosted_zone_tag_filters`](#(var.external_dns_route53_hosted_zone_tag_filters), [`external_dns_route53_hosted_zone_id_filters`](#external_dns_route53_hosted_zone_id_filters), and [`external_dns_route53_hosted_zone_domain_filters`](#external_dns_route53_hosted_zone_domain_filters)).
+</HclListItemDescription>
+<HclListItemDefaultValue>
 
-<a name="external_dns_route53_hosted_zone_id_filters" className="snap-top"></a>
+```hcl
+{
+  limits = {
+    cpu = "250m",
+    memory = "1024Mi"
+  },
+  requests = {
+    cpu = "250m",
+    memory = "1024Mi"
+  }
+}
+```
 
-* [**`external_dns_route53_hosted_zone_id_filters`**](#external_dns_route53_hosted_zone_id_filters) &mdash; Only create records in hosted zones that match the provided IDs. Empty list (default) means match all zones. Zones must satisfy all three constraints [`(var.external_dns_route53_hosted_zone_tag_filters`](#(var.external_dns_route53_hosted_zone_tag_filters), [`external_dns_route53_hosted_zone_id_filters`](#external_dns_route53_hosted_zone_id_filters), and [`external_dns_route53_hosted_zone_domain_filters`](#external_dns_route53_hosted_zone_domain_filters)).
+</HclListItemDefaultValue>
+</HclListItem>
 
-<a name="external_dns_route53_hosted_zone_tag_filters" className="snap-top"></a>
+<HclListItem name="cluster_autoscaler_pod_tolerations" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`external_dns_route53_hosted_zone_tag_filters`**](#external_dns_route53_hosted_zone_tag_filters) &mdash; Only create records in hosted zones that match the provided tags. Each item in the list should specify tag key and tag value as a map. Empty list (default) means match all zones. Zones must satisfy all three constraints [`(var.external_dns_route53_hosted_zone_tag_filters`](#(var.external_dns_route53_hosted_zone_tag_filters), [`external_dns_route53_hosted_zone_id_filters`](#external_dns_route53_hosted_zone_id_filters), and [`external_dns_route53_hosted_zone_domain_filters`](#external_dns_route53_hosted_zone_domain_filters)).
+Configure tolerations rules to allow the cluster-autoscaler Pod to schedule on nodes that have been tainted. Each item in the list specifies a toleration rule.
 
-<a name="external_dns_sources" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`external_dns_sources`**](#external_dns_sources) &mdash; K8s resources type to be observed for new DNS entries by ExternalDNS.
+```hcl
+list(map(any))
+```
 
-<a name="fargate_fluent_bit_execution_iam_role_arns" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`fargate_fluent_bit_execution_iam_role_arns`**](#fargate_fluent_bit_execution_iam_role_arns) &mdash; List of ARNs of Fargate execution IAM Roles that should get permissions to ship logs using fluent-bit. This must be provided if [`enable_fargate_fluent_bit`](#enable_fargate_fluent_bit) is true.
+<HclListItem name="cluster_autoscaler_release_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="fargate_fluent_bit_extra_filters" className="snap-top"></a>
+The name to use for the helm release for cluster-autoscaler. This is useful to force a redeployment of the cluster-autoscaler component.
 
-* [**`fargate_fluent_bit_extra_filters`**](#fargate_fluent_bit_extra_filters) &mdash; Additional filters that fluent-bit should apply to log output. This string should be formatted according to the Fluent-bit docs [`(https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_filter`](#(https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_filter)).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="cluster-autoscaler"/>
+</HclListItem>
 
-<a name="fargate_fluent_bit_extra_parsers" className="snap-top"></a>
+<HclListItem name="cluster_autoscaler_repository" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`fargate_fluent_bit_extra_parsers`**](#fargate_fluent_bit_extra_parsers) &mdash; Additional parsers that fluent-bit should export logs to. This string should be formatted according to the Fluent-bit docs [`(https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_output`](#(https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_output)).
+Which docker repository to use to install the cluster autoscaler. Check the following link for valid repositories to use https://github.com/kubernetes/autoscaler/releases
 
-<a name="fargate_fluent_bit_log_stream_prefix" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler"/>
+</HclListItem>
 
-* [**`fargate_fluent_bit_log_stream_prefix`**](#fargate_fluent_bit_log_stream_prefix) &mdash; Prefix string to use for the CloudWatch Log Stream that gets created for each Fargate pod.
+<HclListItem name="cluster_autoscaler_scaling_strategy" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="fargate_worker_disallowed_availability_zones" className="snap-top"></a>
+Specifies an 'expander' for the cluster autoscaler. This helps determine which ASG to scale when additional resource capacity is needed.
 
-* [**`fargate_worker_disallowed_availability_zones`**](#fargate_worker_disallowed_availability_zones) &mdash; A list of availability zones in the region that we CANNOT use to deploy the EKS Fargate workers. You can use this to avoid availability zones that may not be able to provision the resources (e.g ran out of capacity). If empty, will allow all availability zones.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="least-waste"/>
+</HclListItem>
 
-<a name="fluent_bit_extra_filters" className="snap-top"></a>
+<HclListItem name="cluster_autoscaler_version" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`fluent_bit_extra_filters`**](#fluent_bit_extra_filters) &mdash; Additional filters that fluent-bit should apply to log output. This string should be formatted according to the Fluent-bit docs [`(https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_filter`](#(https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_filter)).
+Which version of the cluster autoscaler to install. This should match the major/minor version (e.g., v1.20) of your Kubernetes Installation. See https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#releases for a list of versions.
 
-<a name="fluent_bit_extra_outputs" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="v1.21.0"/>
+</HclListItem>
 
-* [**`fluent_bit_extra_outputs`**](#fluent_bit_extra_outputs) &mdash; Additional output streams that fluent-bit should export logs to. This string should be formatted according to the Fluent-bit docs [`(https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_output`](#(https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_output)).
+<HclListItem name="enable_alb_ingress_controller" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="fluent_bit_image_repository" className="snap-top"></a>
+Whether or not to enable the AWS LB Ingress controller.
 
-* [**`fluent_bit_image_repository`**](#fluent_bit_image_repository) &mdash; The Container repository to use for looking up the aws-for-fluent-bit Container image when deploying the pods. When null, uses the default repository set in the chart. Only applies to non-fargate workers.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="fluent_bit_log_group_already_exists" className="snap-top"></a>
+<HclListItem name="enable_aws_cloudwatch_agent" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`fluent_bit_log_group_already_exists`**](#fluent_bit_log_group_already_exists) &mdash; If set to true, that means that the CloudWatch Log Group fluent-bit should use for streaming logs already exists and does not need to be created.
+Whether to enable the AWS CloudWatch Agent DaemonSet for collecting container and node metrics from worker nodes (self-managed ASG or managed node groups).
 
-<a name="fluent_bit_log_group_kms_key_id" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`fluent_bit_log_group_kms_key_id`**](#fluent_bit_log_group_kms_key_id) &mdash; The ARN of the KMS key to use to encrypt the logs in the CloudWatch Log Group used for storing container logs streamed with FluentBit. Set to null to disable encryption.
+<HclListItem name="enable_cluster_autoscaler" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="fluent_bit_log_group_name" className="snap-top"></a>
+Whether or not to enable cluster-autoscaler for Autoscaling EKS worker nodes.
 
-* [**`fluent_bit_log_group_name`**](#fluent_bit_log_group_name) &mdash; Name of the CloudWatch Log Group fluent-bit should use to stream logs to. When null (default), uses the [`eks_cluster_name`](#eks_cluster_name) as the Log Group name.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="fluent_bit_log_group_retention" className="snap-top"></a>
+<HclListItem name="enable_external_dns" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`fluent_bit_log_group_retention`**](#fluent_bit_log_group_retention) &mdash; number of days to retain log events. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. Select 0 to never expire.
+Whether or not to enable external-dns for DNS entry syncing with Route 53 for Services and Ingresses.
 
-<a name="fluent_bit_log_group_subscription_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`fluent_bit_log_group_subscription_arn`**](#fluent_bit_log_group_subscription_arn) &mdash; ARN of the lambda function to trigger when events arrive at the fluent bit log group.
+<HclListItem name="enable_fargate_fluent_bit" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="fluent_bit_log_group_subscription_filter" className="snap-top"></a>
+Whether or not to enable fluent-bit on EKS Fargate workers for log aggregation.
 
-* [**`fluent_bit_log_group_subscription_filter`**](#fluent_bit_log_group_subscription_filter) &mdash; Filter pattern for the CloudWatch subscription. Only used if [`fluent_bit_log_group_subscription_arn`](#fluent_bit_log_group_subscription_arn) is set.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="fluent_bit_log_stream_prefix" className="snap-top"></a>
+<HclListItem name="enable_fluent_bit" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`fluent_bit_log_stream_prefix`**](#fluent_bit_log_stream_prefix) &mdash; Prefix string to use for the CloudWatch Log Stream that gets created for each pod. When null (default), the prefix is set to 'fluentbit'.
+Whether or not to enable fluent-bit for log aggregation.
 
-<a name="fluent_bit_pod_node_affinity" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`fluent_bit_pod_node_affinity`**](#fluent_bit_pod_node_affinity) &mdash; Configure affinity rules for the fluent-bit Pods to control which nodes to schedule on. Each item in the list should be a map with the keys `key`, `values`, and `operator`, corresponding to the 3 properties of matchExpressions. Note that all expressions must be satisfied to schedule on the node.
+<HclListItem name="external_dns_pod_node_affinity" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="fluent_bit_pod_tolerations" className="snap-top"></a>
+Configure affinity rules for the external-dns Pod to control which nodes to schedule on. Each item in the list should be a map with the keys `key`, `values`, and `operator`, corresponding to the 3 properties of matchExpressions. Note that all expressions must be satisfied to schedule on the node.
 
-* [**`fluent_bit_pod_tolerations`**](#fluent_bit_pod_tolerations) &mdash; Configure tolerations rules to allow the fluent-bit Pods to schedule on nodes that have been tainted. Each item in the list specifies a toleration rule.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="fluent_bit_version" className="snap-top"></a>
+```hcl
+list(object({
+    key      = string
+    values   = list(string)
+    operator = string
+  }))
+```
 
-* [**`fluent_bit_version`**](#fluent_bit_version) &mdash; Which version of aws-for-fluent-bit to install. When null, uses the default version set in the chart. Only applies to non-fargate workers.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="route53_record_update_policy" className="snap-top"></a>
+<HclListItem name="external_dns_pod_tolerations" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`route53_record_update_policy`**](#route53_record_update_policy) &mdash; Policy for how DNS records are sychronized between sources and providers (options: sync, upsert-only).
+Configure tolerations rules to allow the external-dns Pod to schedule on nodes that have been tainted. Each item in the list specifies a toleration rule.
 
-<a name="schedule_alb_ingress_controller_on_fargate" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`schedule_alb_ingress_controller_on_fargate`**](#schedule_alb_ingress_controller_on_fargate) &mdash; When true, the ALB ingress controller pods will be scheduled on Fargate.
+```hcl
+list(map(any))
+```
 
-<a name="schedule_cluster_autoscaler_on_fargate" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`schedule_cluster_autoscaler_on_fargate`**](#schedule_cluster_autoscaler_on_fargate) &mdash; When true, the cluster autoscaler pods will be scheduled on Fargate. It is recommended to run the cluster autoscaler on Fargate to avoid the autoscaler scaling down a node where it is running (and thus shutting itself down during a scale down event). However, since Fargate is only supported on a handful of regions, we don't default to true here.
+<HclListItem name="external_dns_route53_hosted_zone_domain_filters" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="schedule_external_dns_on_fargate" className="snap-top"></a>
+Only create records in hosted zones that match the provided domain names. Empty list (default) means match all zones. Zones must satisfy all three constraints (<a href="#external_dns_route53_hosted_zone_tag_filters"><code>external_dns_route53_hosted_zone_tag_filters</code></a>, <a href="#external_dns_route53_hosted_zone_id_filters"><code>external_dns_route53_hosted_zone_id_filters</code></a>, and <a href="#external_dns_route53_hosted_zone_domain_filters"><code>external_dns_route53_hosted_zone_domain_filters</code></a>).
 
-* [**`schedule_external_dns_on_fargate`**](#schedule_external_dns_on_fargate) &mdash; When true, the external-dns pods will be scheduled on Fargate.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="service_dns_mappings" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`service_dns_mappings`**](#service_dns_mappings) &mdash; Configure Kubernetes Services to lookup external DNS records. This can be useful to bind friendly internal service names to domains (e.g. the RDS database endpoint).
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="use_exec_plugin_for_auth" className="snap-top"></a>
+<HclListItem name="external_dns_route53_hosted_zone_id_filters" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`use_exec_plugin_for_auth`**](#use_exec_plugin_for_auth) &mdash; If this variable is set to true, then use an exec-based plugin to authenticate and fetch tokens for EKS. This is useful because EKS clusters use short-lived authentication tokens that can expire in the middle of an 'apply' or 'destroy', and since the native Kubernetes provider in Terraform doesn't have a way to fetch up-to-date tokens, we recommend using an exec-based provider as a workaround. Use the [`use_kubergrunt_to_fetch_token`](#use_kubergrunt_to_fetch_token) input variable to control whether kubergrunt or aws is used to fetch tokens.
+Only create records in hosted zones that match the provided IDs. Empty list (default) means match all zones. Zones must satisfy all three constraints (<a href="#external_dns_route53_hosted_zone_tag_filters"><code>external_dns_route53_hosted_zone_tag_filters</code></a>, <a href="#external_dns_route53_hosted_zone_id_filters"><code>external_dns_route53_hosted_zone_id_filters</code></a>, and <a href="#external_dns_route53_hosted_zone_domain_filters"><code>external_dns_route53_hosted_zone_domain_filters</code></a>).
 
-<a name="use_kubergrunt_to_fetch_token" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`use_kubergrunt_to_fetch_token`**](#use_kubergrunt_to_fetch_token) &mdash; EKS clusters use short-lived authentication tokens that can expire in the middle of an 'apply' or 'destroy'. To avoid this issue, we use an exec-based plugin to fetch an up-to-date token. If this variable is set to true, we'll use kubergrunt to fetch the token (in which case, kubergrunt must be installed and on PATH); if this variable is set to false, we'll use the aws CLI to fetch the token (in which case, aws must be installed and on PATH). Note this functionality is only enabled if [`use_exec_plugin_for_auth`](#use_exec_plugin_for_auth) is set to true.
+```hcl
+list(string)
+```
 
-<a name="use_managed_iam_policies" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`use_managed_iam_policies`**](#use_managed_iam_policies) &mdash; When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+<HclListItem name="external_dns_route53_hosted_zone_tag_filters" requirement="optional" type="list">
+<HclListItemDescription>
+
+Only create records in hosted zones that match the provided tags. Each item in the list should specify tag key and tag value as a map. Empty list (default) means match all zones. Zones must satisfy all three constraints (<a href="#external_dns_route53_hosted_zone_tag_filters"><code>external_dns_route53_hosted_zone_tag_filters</code></a>, <a href="#external_dns_route53_hosted_zone_id_filters"><code>external_dns_route53_hosted_zone_id_filters</code></a>, and <a href="#external_dns_route53_hosted_zone_domain_filters"><code>external_dns_route53_hosted_zone_domain_filters</code></a>).
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(object({
+    key   = string
+    value = string
+  }))
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="external_dns_sources" requirement="optional" type="list">
+<HclListItemDescription>
+
+K8s resources type to be observed for new DNS entries by ExternalDNS.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
+
+```hcl
+[
+  "ingress",
+  "service"
+]
+```
+
+</HclListItemDefaultValue>
+</HclListItem>
+
+<HclListItem name="fargate_fluent_bit_execution_iam_role_arns" requirement="optional" type="list">
+<HclListItemDescription>
+
+List of ARNs of Fargate execution IAM Roles that should get permissions to ship logs using fluent-bit. This must be provided if enable_fargate_fluent_bit is true.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="fargate_fluent_bit_extra_filters" requirement="optional" type="string">
+<HclListItemDescription>
+
+Additional filters that fluent-bit should apply to log output. This string should be formatted according to the Fluent-bit docs (https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_filter).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="fargate_fluent_bit_extra_parsers" requirement="optional" type="string">
+<HclListItemDescription>
+
+Additional parsers that fluent-bit should export logs to. This string should be formatted according to the Fluent-bit docs (https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_output).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="fargate_fluent_bit_log_stream_prefix" requirement="optional" type="string">
+<HclListItemDescription>
+
+Prefix string to use for the CloudWatch Log Stream that gets created for each Fargate pod.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="fargate"/>
+</HclListItem>
+
+<HclListItem name="fargate_worker_disallowed_availability_zones" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of availability zones in the region that we CANNOT use to deploy the EKS Fargate workers. You can use this to avoid availability zones that may not be able to provision the resources (e.g ran out of capacity). If empty, will allow all availability zones.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
+
+```hcl
+[
+  "us-east-1d",
+  "us-east-1e",
+  "ca-central-1d"
+]
+```
+
+</HclListItemDefaultValue>
+</HclListItem>
+
+<HclListItem name="fluent_bit_extra_filters" requirement="optional" type="string">
+<HclListItemDescription>
+
+Additional filters that fluent-bit should apply to log output. This string should be formatted according to the Fluent-bit docs (https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_filter).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="fluent_bit_extra_outputs" requirement="optional" type="string">
+<HclListItemDescription>
+
+Additional output streams that fluent-bit should export logs to. This string should be formatted according to the Fluent-bit docs (https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_output).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="fluent_bit_image_repository" requirement="optional" type="string">
+<HclListItemDescription>
+
+The Container repository to use for looking up the aws-for-fluent-bit Container image when deploying the pods. When null, uses the default repository set in the chart. Only applies to non-fargate workers.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="fluent_bit_log_group_already_exists" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If set to true, that means that the CloudWatch Log Group fluent-bit should use for streaming logs already exists and does not need to be created.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="fluent_bit_log_group_kms_key_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ARN of the KMS key to use to encrypt the logs in the CloudWatch Log Group used for storing container logs streamed with FluentBit. Set to null to disable encryption.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="fluent_bit_log_group_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+Name of the CloudWatch Log Group fluent-bit should use to stream logs to. When null (default), uses the eks_cluster_name as the Log Group name.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="fluent_bit_log_group_retention" requirement="optional" type="number">
+<HclListItemDescription>
+
+number of days to retain log events. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. Select 0 to never expire.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="0"/>
+</HclListItem>
+
+<HclListItem name="fluent_bit_log_group_subscription_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+ARN of the lambda function to trigger when events arrive at the fluent bit log group.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="fluent_bit_log_group_subscription_filter" requirement="optional" type="string">
+<HclListItemDescription>
+
+Filter pattern for the CloudWatch subscription. Only used if <a href="#fluent_bit_log_group_subscription_arn"><code>fluent_bit_log_group_subscription_arn</code></a> is set.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="fluent_bit_log_stream_prefix" requirement="optional" type="string">
+<HclListItemDescription>
+
+Prefix string to use for the CloudWatch Log Stream that gets created for each pod. When null (default), the prefix is set to 'fluentbit'.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="fluent_bit_pod_node_affinity" requirement="optional" type="list">
+<HclListItemDescription>
+
+Configure affinity rules for the fluent-bit Pods to control which nodes to schedule on. Each item in the list should be a map with the keys `key`, `values`, and `operator`, corresponding to the 3 properties of matchExpressions. Note that all expressions must be satisfied to schedule on the node.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(object({
+    key      = string
+    values   = list(string)
+    operator = string
+  }))
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="fluent_bit_pod_tolerations" requirement="optional" type="list">
+<HclListItemDescription>
+
+Configure tolerations rules to allow the fluent-bit Pods to schedule on nodes that have been tainted. Each item in the list specifies a toleration rule.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(map(any))
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="fluent_bit_version" requirement="optional" type="string">
+<HclListItemDescription>
+
+Which version of aws-for-fluent-bit to install. When null, uses the default version set in the chart. Only applies to non-fargate workers.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="route53_record_update_policy" requirement="optional" type="string">
+<HclListItemDescription>
+
+Policy for how DNS records are sychronized between sources and providers (options: sync, upsert-only).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="sync"/>
+</HclListItem>
+
+<HclListItem name="schedule_alb_ingress_controller_on_fargate" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, the ALB ingress controller pods will be scheduled on Fargate.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="schedule_cluster_autoscaler_on_fargate" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, the cluster autoscaler pods will be scheduled on Fargate. It is recommended to run the cluster autoscaler on Fargate to avoid the autoscaler scaling down a node where it is running (and thus shutting itself down during a scale down event). However, since Fargate is only supported on a handful of regions, we don't default to true here.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="schedule_external_dns_on_fargate" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, the external-dns pods will be scheduled on Fargate.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="service_dns_mappings" requirement="optional" type="map">
+<HclListItemDescription>
+
+Configure Kubernetes Services to lookup external DNS records. This can be useful to bind friendly internal service names to domains (e.g. the RDS database endpoint).
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(object({
+    # DNS record to route requests to the Kubernetes Service to.
+    target_dns = string
+
+    # Port to route requests
+    target_port = number
+
+    # Namespace to create the underlying Kubernetes Service in.
+    namespace = string
+  }))
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="use_exec_plugin_for_auth" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If this variable is set to true, then use an exec-based plugin to authenticate and fetch tokens for EKS. This is useful because EKS clusters use short-lived authentication tokens that can expire in the middle of an 'apply' or 'destroy', and since the native Kubernetes provider in Terraform doesn't have a way to fetch up-to-date tokens, we recommend using an exec-based provider as a workaround. Use the use_kubergrunt_to_fetch_token input variable to control whether kubergrunt or aws is used to fetch tokens.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="use_kubergrunt_to_fetch_token" requirement="optional" type="bool">
+<HclListItemDescription>
+
+EKS clusters use short-lived authentication tokens that can expire in the middle of an 'apply' or 'destroy'. To avoid this issue, we use an exec-based plugin to fetch an up-to-date token. If this variable is set to true, we'll use kubergrunt to fetch the token (in which case, kubergrunt must be installed and on PATH); if this variable is set to false, we'll use the aws CLI to fetch the token (in which case, aws must be installed and on PATH). Note this functionality is only enabled if use_exec_plugin_for_auth is set to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="use_managed_iam_policies" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="container_logs_cloudwatch_log_group_name" className="snap-top"></a>
+<HclListItem name="container_logs_cloudwatch_log_group_name">
+<HclListItemDescription>
 
-* [**`container_logs_cloudwatch_log_group_name`**](#container_logs_cloudwatch_log_group_name) &mdash; Name of the CloudWatch Log Group used to store the container logs.
+Name of the CloudWatch Log Group used to store the container logs.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"0ed3f1a06b22a99cbb8786dd432dff34"}
+{"sourcePlugin":"service-catalog-api","hash":"e462345e2656af39b09cf7f8d15449d2"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/app-orchestration/amazon-eks-workers.md
+++ b/docs/reference/services/app-orchestration/amazon-eks-workers.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -114,379 +115,1044 @@ to Pod, how to upgrade your EKS cluster, and more, see the documentation in the
 
 ### Required
 
-<a name="autoscaling_group_configurations" className="snap-top"></a>
+<HclListItem name="autoscaling_group_configurations" requirement="required" type="any">
+<HclListItemDescription>
 
-* [**`autoscaling_group_configurations`**](#autoscaling_group_configurations) &mdash; Configure one or more self-managed Auto Scaling Groups (ASGs) to manage the EC2 instances in this cluster. Set to empty object ({}) if you do not wish to configure self-managed ASGs.
+Configure one or more self-managed Auto Scaling Groups (ASGs) to manage the EC2 instances in this cluster. Set to empty object ({}) if you do not wish to configure self-managed ASGs.
 
-<a name="cluster_instance_ami" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cluster_instance_ami`**](#cluster_instance_ami) &mdash; The AMI to run on each instance in the EKS cluster. You can build the AMI using the Packer template eks-node-al2.json. One of [`cluster_instance_ami`](#cluster_instance_ami) or [`cluster_instance_ami_filters`](#cluster_instance_ami_filters) is required. Only used if [`cluster_instance_ami_filters`](#cluster_instance_ami_filters) is null. Set to null if [`cluster_instance_ami_filters`](#cluster_instance_ami_filters) is set.
+<HclListItem name="cluster_instance_ami" requirement="required" type="string">
+<HclListItemDescription>
 
-<a name="cluster_instance_ami_filters" className="snap-top"></a>
+The AMI to run on each instance in the EKS cluster. You can build the AMI using the Packer template eks-node-al2.json. One of <a href="#cluster_instance_ami"><code>cluster_instance_ami</code></a> or <a href="#cluster_instance_ami_filters"><code>cluster_instance_ami_filters</code></a> is required. Only used if <a href="#cluster_instance_ami_filters"><code>cluster_instance_ami_filters</code></a> is null. Set to null if cluster_instance_ami_filters is set.
 
-* [**`cluster_instance_ami_filters`**](#cluster_instance_ami_filters) &mdash; Properties on the AMI that can be used to lookup a prebuilt AMI for use with self managed workers. You can build the AMI using the Packer template eks-node-al2.json. One of [`cluster_instance_ami`](#cluster_instance_ami) or [`cluster_instance_ami_filters`](#cluster_instance_ami_filters) is required. If both are defined, [`cluster_instance_ami_filters`](#cluster_instance_ami_filters) will be used. Set to null if [`cluster_instance_ami`](#cluster_instance_ami) is set.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="eks_cluster_name" className="snap-top"></a>
+<HclListItem name="cluster_instance_ami_filters" requirement="required" type="object">
+<HclListItemDescription>
 
-* [**`eks_cluster_name`**](#eks_cluster_name) &mdash; The name of the EKS cluster. The cluster must exist/already be deployed.
+Properties on the AMI that can be used to lookup a prebuilt AMI for use with self managed workers. You can build the AMI using the Packer template eks-node-al2.json. One of <a href="#cluster_instance_ami"><code>cluster_instance_ami</code></a> or <a href="#cluster_instance_ami_filters"><code>cluster_instance_ami_filters</code></a> is required. If both are defined, <a href="#cluster_instance_ami_filters"><code>cluster_instance_ami_filters</code></a> will be used. Set to null if cluster_instance_ami is set.
 
-<a name="managed_node_group_configurations" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`managed_node_group_configurations`**](#managed_node_group_configurations) &mdash; Configure one or more Node Groups to manage the EC2 instances in this cluster. Set to empty object ({}) if you do not wish to configure managed node groups.
+```hcl
+object({
+    # List of owners to limit the search. Set to null if you do not wish to limit the search by AMI owners.
+    owners = list(string)
+
+    # Name/Value pairs to filter the AMI off of. There are several valid keys, for a full reference, check out the
+    # documentation for describe-images in the AWS CLI reference
+    # (https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html).
+    filters = list(object({
+      name   = string
+      values = list(string)
+    }))
+  })
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="eks_cluster_name" requirement="required" type="string">
+<HclListItemDescription>
+
+The name of the EKS cluster. The cluster must exist/already be deployed.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="managed_node_group_configurations" requirement="required" type="any">
+<HclListItemDescription>
+
+Configure one or more Node Groups to manage the EC2 instances in this cluster. Set to empty object ({}) if you do not wish to configure managed node groups.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="additional_security_groups_for_workers" className="snap-top"></a>
+<HclListItem name="additional_security_groups_for_workers" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`additional_security_groups_for_workers`**](#additional_security_groups_for_workers) &mdash; A list of additional security group IDs to be attached on worker groups.
+A list of additional security group IDs to be attached on worker groups.
 
-<a name="alarms_sns_topic_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`alarms_sns_topic_arn`**](#alarms_sns_topic_arn) &mdash; The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications.
+```hcl
+list(string)
+```
 
-<a name="allow_inbound_ssh_from_cidr_blocks" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`allow_inbound_ssh_from_cidr_blocks`**](#allow_inbound_ssh_from_cidr_blocks) &mdash; The list of CIDR blocks to allow inbound SSH access to the worker groups.
+<HclListItem name="alarms_sns_topic_arn" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="allow_inbound_ssh_from_security_groups" className="snap-top"></a>
+The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications.
 
-* [**`allow_inbound_ssh_from_security_groups`**](#allow_inbound_ssh_from_security_groups) &mdash; The list of security group IDs to allow inbound SSH access to the worker groups.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="asg_custom_iam_role_name" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`asg_custom_iam_role_name`**](#asg_custom_iam_role_name) &mdash; Custom name for the IAM role for the Self-managed workers. When null, a default name based on [`worker_name_prefix`](#worker_name_prefix) will be used. One of [`asg_custom_iam_role_name`](#asg_custom_iam_role_name) and [`asg_iam_role_arn`](#asg_iam_role_arn) is required (must be non-null) if [`asg_iam_role_already_exists`](#asg_iam_role_already_exists) is true.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="asg_default_enable_detailed_monitoring" className="snap-top"></a>
+<HclListItem name="allow_inbound_ssh_from_cidr_blocks" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`asg_default_enable_detailed_monitoring`**](#asg_default_enable_detailed_monitoring) &mdash; Default value for [`enable_detailed_monitoring`](#enable_detailed_monitoring) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations).
+The list of CIDR blocks to allow inbound SSH access to the worker groups.
 
-<a name="asg_default_instance_root_volume_encryption" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`asg_default_instance_root_volume_encryption`**](#asg_default_instance_root_volume_encryption) &mdash; Default value for the [`asg_instance_root_volume_encryption`](#asg_instance_root_volume_encryption) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`asg_instance_root_volume_encryption`](#asg_instance_root_volume_encryption) will use this value.
+```hcl
+list(string)
+```
 
-<a name="asg_default_instance_root_volume_iops" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`asg_default_instance_root_volume_iops`**](#asg_default_instance_root_volume_iops) &mdash; Default value for the [`asg_instance_root_volume_iops`](#asg_instance_root_volume_iops) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`asg_instance_root_volume_iops`](#asg_instance_root_volume_iops) will use this value.
+<HclListItem name="allow_inbound_ssh_from_security_groups" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="asg_default_instance_root_volume_size" className="snap-top"></a>
+The list of security group IDs to allow inbound SSH access to the worker groups.
 
-* [**`asg_default_instance_root_volume_size`**](#asg_default_instance_root_volume_size) &mdash; Default value for the [`asg_instance_root_volume_size`](#asg_instance_root_volume_size) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`asg_instance_root_volume_size`](#asg_instance_root_volume_size) will use this value.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="asg_default_instance_root_volume_throughput" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`asg_default_instance_root_volume_throughput`**](#asg_default_instance_root_volume_throughput) &mdash; Default value for the [`asg_instance_root_volume_throughput`](#asg_instance_root_volume_throughput) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`asg_instance_root_volume_throughput`](#asg_instance_root_volume_throughput) will use this value.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="asg_default_instance_root_volume_type" className="snap-top"></a>
+<HclListItem name="asg_custom_iam_role_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`asg_default_instance_root_volume_type`**](#asg_default_instance_root_volume_type) &mdash; Default value for the [`asg_instance_root_volume_type`](#asg_instance_root_volume_type) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`asg_instance_root_volume_type`](#asg_instance_root_volume_type) will use this value.
+Custom name for the IAM role for the Self-managed workers. When null, a default name based on worker_name_prefix will be used. One of asg_custom_iam_role_name and asg_iam_role_arn is required (must be non-null) if asg_iam_role_already_exists is true.
 
-<a name="asg_default_instance_type" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`asg_default_instance_type`**](#asg_default_instance_type) &mdash; Default value for the [`asg_instance_type`](#asg_instance_type) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`asg_instance_type`](#asg_instance_type) will use this value.
+<HclListItem name="asg_default_enable_detailed_monitoring" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="asg_default_max_pods_allowed" className="snap-top"></a>
+Default value for enable_detailed_monitoring field of autoscaling_group_configurations.
 
-* [**`asg_default_max_pods_allowed`**](#asg_default_max_pods_allowed) &mdash; Default value for the [`max_pods_allowed`](#max_pods_allowed) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`max_pods_allowed`](#max_pods_allowed) will use this value.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="asg_default_max_size" className="snap-top"></a>
+<HclListItem name="asg_default_instance_root_volume_encryption" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`asg_default_max_size`**](#asg_default_max_size) &mdash; Default value for the [`max_size`](#max_size) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`max_size`](#max_size) will use this value.
+Default value for the asg_instance_root_volume_encryption field of autoscaling_group_configurations. Any map entry that does not specify asg_instance_root_volume_encryption will use this value.
 
-<a name="asg_default_min_size" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`asg_default_min_size`**](#asg_default_min_size) &mdash; Default value for the [`min_size`](#min_size) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`min_size`](#min_size) will use this value.
+<HclListItem name="asg_default_instance_root_volume_iops" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="asg_default_multi_instance_overrides" className="snap-top"></a>
+Default value for the asg_instance_root_volume_iops field of autoscaling_group_configurations. Any map entry that does not specify asg_instance_root_volume_iops will use this value.
 
-* [**`asg_default_multi_instance_overrides`**](#asg_default_multi_instance_overrides) &mdash; Default value for the [`multi_instance_overrides`](#multi_instance_overrides) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`multi_instance_overrides`](#multi_instance_overrides) will use this value.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="asg_default_on_demand_allocation_strategy" className="snap-top"></a>
+<HclListItem name="asg_default_instance_root_volume_size" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`asg_default_on_demand_allocation_strategy`**](#asg_default_on_demand_allocation_strategy) &mdash; Default value for the [`on_demand_allocation_strategy`](#on_demand_allocation_strategy) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`on_demand_allocation_strategy`](#on_demand_allocation_strategy) will use this value.
+Default value for the asg_instance_root_volume_size field of autoscaling_group_configurations. Any map entry that does not specify asg_instance_root_volume_size will use this value.
 
-<a name="asg_default_on_demand_base_capacity" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="40"/>
+</HclListItem>
 
-* [**`asg_default_on_demand_base_capacity`**](#asg_default_on_demand_base_capacity) &mdash; Default value for the [`on_demand_base_capacity`](#on_demand_base_capacity) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`on_demand_base_capacity`](#on_demand_base_capacity) will use this value.
+<HclListItem name="asg_default_instance_root_volume_throughput" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="asg_default_on_demand_percentage_above_base_capacity" className="snap-top"></a>
+Default value for the asg_instance_root_volume_throughput field of autoscaling_group_configurations. Any map entry that does not specify asg_instance_root_volume_throughput will use this value.
 
-* [**`asg_default_on_demand_percentage_above_base_capacity`**](#asg_default_on_demand_percentage_above_base_capacity) &mdash; Default value for the [`on_demand_percentage_above_base_capacity`](#on_demand_percentage_above_base_capacity) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`on_demand_percentage_above_base_capacity`](#on_demand_percentage_above_base_capacity) will use this value.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="asg_default_spot_allocation_strategy" className="snap-top"></a>
+<HclListItem name="asg_default_instance_root_volume_type" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`asg_default_spot_allocation_strategy`**](#asg_default_spot_allocation_strategy) &mdash; Default value for the [`spot_allocation_strategy`](#spot_allocation_strategy) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`spot_allocation_strategy`](#spot_allocation_strategy) will use this value.
+Default value for the asg_instance_root_volume_type field of autoscaling_group_configurations. Any map entry that does not specify asg_instance_root_volume_type will use this value.
 
-<a name="asg_default_spot_instance_pools" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="standard"/>
+</HclListItem>
 
-* [**`asg_default_spot_instance_pools`**](#asg_default_spot_instance_pools) &mdash; Default value for the [`spot_instance_pools`](#spot_instance_pools) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`spot_instance_pools`](#spot_instance_pools) will use this value.
+<HclListItem name="asg_default_instance_type" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="asg_default_spot_max_price" className="snap-top"></a>
+Default value for the asg_instance_type field of autoscaling_group_configurations. Any map entry that does not specify asg_instance_type will use this value.
 
-* [**`asg_default_spot_max_price`**](#asg_default_spot_max_price) &mdash; Default value for the [`spot_max_price`](#spot_max_price) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`spot_max_price`](#spot_max_price) will use this value. Set to empty string (default) to mean on-demand price.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="t3.medium"/>
+</HclListItem>
 
-<a name="asg_default_tags" className="snap-top"></a>
+<HclListItem name="asg_default_max_pods_allowed" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`asg_default_tags`**](#asg_default_tags) &mdash; Default value for the tags field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify tags will use this value.
+Default value for the max_pods_allowed field of autoscaling_group_configurations. Any map entry that does not specify max_pods_allowed will use this value.
 
-<a name="asg_default_use_multi_instances_policy" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`asg_default_use_multi_instances_policy`**](#asg_default_use_multi_instances_policy) &mdash; Default value for the [`use_multi_instances_policy`](#use_multi_instances_policy) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`use_multi_instances_policy`](#use_multi_instances_policy) will use this value.
+<HclListItem name="asg_default_max_size" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="asg_iam_instance_profile_name" className="snap-top"></a>
+Default value for the max_size field of autoscaling_group_configurations. Any map entry that does not specify max_size will use this value.
 
-* [**`asg_iam_instance_profile_name`**](#asg_iam_instance_profile_name) &mdash; Custom name for the IAM instance profile for the Self-managed workers. When null, the IAM role name will be used. If [`asg_use_resource_name_prefix`](#asg_use_resource_name_prefix) is true, this will be used as a name prefix.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="2"/>
+</HclListItem>
 
-<a name="asg_iam_role_already_exists" className="snap-top"></a>
+<HclListItem name="asg_default_min_size" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`asg_iam_role_already_exists`**](#asg_iam_role_already_exists) &mdash; Whether or not the IAM role used for the Self-managed workers already exists. When false, this module will create a new IAM role.
+Default value for the min_size field of autoscaling_group_configurations. Any map entry that does not specify min_size will use this value.
 
-<a name="asg_iam_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1"/>
+</HclListItem>
 
-* [**`asg_iam_role_arn`**](#asg_iam_role_arn) &mdash; ARN of the IAM role to use if [`iam_role_already_exists`](#iam_role_already_exists) = true. When null, uses [`asg_custom_iam_role_name`](#asg_custom_iam_role_name) to lookup the ARN. One of [`asg_custom_iam_role_name`](#asg_custom_iam_role_name) and [`asg_iam_role_arn`](#asg_iam_role_arn) is required (must be non-null) if [`asg_iam_role_already_exists`](#asg_iam_role_already_exists) is true.
+<HclListItem name="asg_default_multi_instance_overrides" requirement="optional" type="any">
+<HclListItemDescription>
 
-<a name="asg_security_group_tags" className="snap-top"></a>
+Default value for the multi_instance_overrides field of autoscaling_group_configurations. Any map entry that does not specify multi_instance_overrides will use this value.
 
-* [**`asg_security_group_tags`**](#asg_security_group_tags) &mdash; A map of tags to apply to the Security Group of the ASG for the self managed worker pool. The key is the tag name and the value is the tag value.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="asg_use_resource_name_prefix" className="snap-top"></a>
+<HclListItem name="asg_default_on_demand_allocation_strategy" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`asg_use_resource_name_prefix`**](#asg_use_resource_name_prefix) &mdash; When true, all the relevant resources for self managed workers will be set to use the [`name_prefix`](#name_prefix) attribute so that unique names are generated for them. This allows those resources to support recreation through [`create_before_destroy`](#create_before_destroy) lifecycle rules. Set to false if you were using any version before 0.65.0 and wish to avoid recreating the entire worker pool on your cluster.
+Default value for the on_demand_allocation_strategy field of autoscaling_group_configurations. Any map entry that does not specify on_demand_allocation_strategy will use this value.
 
-<a name="autoscaling_group_include_autoscaler_discovery_tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`autoscaling_group_include_autoscaler_discovery_tags`**](#autoscaling_group_include_autoscaler_discovery_tags) &mdash; Adds additional tags to each ASG that allow a cluster autoscaler to auto-discover them. Only used for self-managed workers.
+<HclListItem name="asg_default_on_demand_base_capacity" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="aws_auth_merger_namespace" className="snap-top"></a>
+Default value for the on_demand_base_capacity field of autoscaling_group_configurations. Any map entry that does not specify on_demand_base_capacity will use this value.
 
-* [**`aws_auth_merger_namespace`**](#aws_auth_merger_namespace) &mdash; Namespace where the AWS Auth Merger is deployed. If configured, the worker IAM role will be mapped to the Kubernetes RBAC group for Nodes using a ConfigMap in the auth merger namespace.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="cloud_init_parts" className="snap-top"></a>
+<HclListItem name="asg_default_on_demand_percentage_above_base_capacity" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`cloud_init_parts`**](#cloud_init_parts) &mdash; Cloud init scripts to run on the EKS worker nodes when it is booting. See the part blocks in [`https://www.terraform.io/docs/providers/template/d/cloudinit_config`](#https://www.terraform.io/docs/providers/template/d/cloudinit_config).html for syntax. To override the default boot script installed as part of the module, use the key `default`.
+Default value for the on_demand_percentage_above_base_capacity field of autoscaling_group_configurations. Any map entry that does not specify on_demand_percentage_above_base_capacity will use this value.
 
-<a name="cluster_instance_associate_public_ip_address" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`cluster_instance_associate_public_ip_address`**](#cluster_instance_associate_public_ip_address) &mdash; Whether or not to associate a public IP address to the instances of the self managed ASGs. Will only work if the instances are launched in a public subnet.
+<HclListItem name="asg_default_spot_allocation_strategy" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="cluster_instance_keypair_name" className="snap-top"></a>
+Default value for the spot_allocation_strategy field of autoscaling_group_configurations. Any map entry that does not specify spot_allocation_strategy will use this value.
 
-* [**`cluster_instance_keypair_name`**](#cluster_instance_keypair_name) &mdash; The name of the Key Pair that can be used to SSH to each instance in the EKS cluster.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="custom_egress_security_group_rules" className="snap-top"></a>
+<HclListItem name="asg_default_spot_instance_pools" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`custom_egress_security_group_rules`**](#custom_egress_security_group_rules) &mdash; A map of unique identifiers to egress security group rules to attach to the worker groups.
+Default value for the spot_instance_pools field of autoscaling_group_configurations. Any map entry that does not specify spot_instance_pools will use this value.
 
-<a name="custom_ingress_security_group_rules" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`custom_ingress_security_group_rules`**](#custom_ingress_security_group_rules) &mdash; A map of unique identifiers to ingress security group rules to attach to the worker groups.
+<HclListItem name="asg_default_spot_max_price" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="dashboard_cpu_usage_widget_parameters" className="snap-top"></a>
+Default value for the spot_max_price field of autoscaling_group_configurations. Any map entry that does not specify spot_max_price will use this value. Set to empty string (default) to mean on-demand price.
 
-* [**`dashboard_cpu_usage_widget_parameters`**](#dashboard_cpu_usage_widget_parameters) &mdash; Parameters for the worker cpu usage widget to output for use in a CloudWatch dashboard.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="dashboard_disk_usage_widget_parameters" className="snap-top"></a>
+<HclListItem name="asg_default_tags" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`dashboard_disk_usage_widget_parameters`**](#dashboard_disk_usage_widget_parameters) &mdash; Parameters for the worker disk usage widget to output for use in a CloudWatch dashboard.
+Default value for the tags field of autoscaling_group_configurations. Any map entry that does not specify tags will use this value.
 
-<a name="dashboard_memory_usage_widget_parameters" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`dashboard_memory_usage_widget_parameters`**](#dashboard_memory_usage_widget_parameters) &mdash; Parameters for the worker memory usage widget to output for use in a CloudWatch dashboard.
+```hcl
+list(object({
+    key                 = string
+    value               = string
+    propagate_at_launch = bool
+  }))
+```
 
-<a name="enable_cloudwatch_alarms" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`enable_cloudwatch_alarms`**](#enable_cloudwatch_alarms) &mdash; Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using [`alarms_sns_topic_arn`](#alarms_sns_topic_arn).
+<HclListItem name="asg_default_use_multi_instances_policy" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="enable_cloudwatch_metrics" className="snap-top"></a>
+Default value for the use_multi_instances_policy field of autoscaling_group_configurations. Any map entry that does not specify use_multi_instances_policy will use this value.
 
-* [**`enable_cloudwatch_metrics`**](#enable_cloudwatch_metrics) &mdash; Set to true to add IAM permissions to send custom metrics to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/agents/cloudwatch-agent to get memory and disk metrics in CloudWatch for your Bastion host.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="enable_fail2ban" className="snap-top"></a>
+<HclListItem name="asg_iam_instance_profile_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`enable_fail2ban`**](#enable_fail2ban) &mdash; Enable fail2ban to block brute force log in attempts. Defaults to true.
+Custom name for the IAM instance profile for the Self-managed workers. When null, the IAM role name will be used. If <a href="#asg_use_resource_name_prefix"><code>asg_use_resource_name_prefix</code></a> is true, this will be used as a name prefix.
 
-<a name="external_account_ssh_grunt_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`external_account_ssh_grunt_role_arn`**](#external_account_ssh_grunt_role_arn) &mdash; If you are using ssh-grunt and your IAM users / groups are defined in a separate AWS account, you can use this variable to specify the ARN of an IAM role that ssh-grunt can assume to retrieve IAM group and public SSH key info from that account. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+<HclListItem name="asg_iam_role_already_exists" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="managed_node_group_custom_iam_role_name" className="snap-top"></a>
+Whether or not the IAM role used for the Self-managed workers already exists. When false, this module will create a new IAM role.
 
-* [**`managed_node_group_custom_iam_role_name`**](#managed_node_group_custom_iam_role_name) &mdash; Custom name for the IAM role for the Managed Node Groups. When null, a default name based on [`worker_name_prefix`](#worker_name_prefix) will be used. One of [`managed_node_group_custom_iam_role_name`](#managed_node_group_custom_iam_role_name) and [`managed_node_group_iam_role_arn`](#managed_node_group_iam_role_arn) is required (must be non-null) if [`managed_node_group_iam_role_already_exists`](#managed_node_group_iam_role_already_exists) is true.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="managed_node_group_iam_role_already_exists" className="snap-top"></a>
+<HclListItem name="asg_iam_role_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`managed_node_group_iam_role_already_exists`**](#managed_node_group_iam_role_already_exists) &mdash; Whether or not the IAM role used for the Managed Node Group workers already exists. When false, this module will create a new IAM role.
+ARN of the IAM role to use if iam_role_already_exists = true. When null, uses asg_custom_iam_role_name to lookup the ARN. One of asg_custom_iam_role_name and asg_iam_role_arn is required (must be non-null) if asg_iam_role_already_exists is true.
 
-<a name="managed_node_group_iam_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`managed_node_group_iam_role_arn`**](#managed_node_group_iam_role_arn) &mdash; ARN of the IAM role to use if [`iam_role_already_exists`](#iam_role_already_exists) = true. When null, uses [`managed_node_group_custom_iam_role_name`](#managed_node_group_custom_iam_role_name) to lookup the ARN. One of [`managed_node_group_custom_iam_role_name`](#managed_node_group_custom_iam_role_name) and [`managed_node_group_iam_role_arn`](#managed_node_group_iam_role_arn) is required (must be non-null) if [`managed_node_group_iam_role_already_exists`](#managed_node_group_iam_role_already_exists) is true.
+<HclListItem name="asg_security_group_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="node_group_default_capacity_type" className="snap-top"></a>
+A map of tags to apply to the Security Group of the ASG for the self managed worker pool. The key is the tag name and the value is the tag value.
 
-* [**`node_group_default_capacity_type`**](#node_group_default_capacity_type) &mdash; Default value for [`capacity_type`](#capacity_type) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="node_group_default_desired_size" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`node_group_default_desired_size`**](#node_group_default_desired_size) &mdash; Default value for [`desired_size`](#desired_size) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="node_group_default_enable_detailed_monitoring" className="snap-top"></a>
+<HclListItem name="asg_use_resource_name_prefix" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`node_group_default_enable_detailed_monitoring`**](#node_group_default_enable_detailed_monitoring) &mdash; Default value for [`enable_detailed_monitoring`](#enable_detailed_monitoring) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+When true, all the relevant resources for self managed workers will be set to use the name_prefix attribute so that unique names are generated for them. This allows those resources to support recreation through create_before_destroy lifecycle rules. Set to false if you were using any version before 0.65.0 and wish to avoid recreating the entire worker pool on your cluster.
 
-<a name="node_group_default_instance_root_volume_encryption" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`node_group_default_instance_root_volume_encryption`**](#node_group_default_instance_root_volume_encryption) &mdash; Default value for the [`instance_root_volume_encryption`](#instance_root_volume_encryption) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+<HclListItem name="autoscaling_group_include_autoscaler_discovery_tags" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="node_group_default_instance_root_volume_size" className="snap-top"></a>
+Adds additional tags to each ASG that allow a cluster autoscaler to auto-discover them. Only used for self-managed workers.
 
-* [**`node_group_default_instance_root_volume_size`**](#node_group_default_instance_root_volume_size) &mdash; Default value for the [`instance_root_volume_size`](#instance_root_volume_size) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="node_group_default_instance_root_volume_type" className="snap-top"></a>
+<HclListItem name="aws_auth_merger_namespace" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`node_group_default_instance_root_volume_type`**](#node_group_default_instance_root_volume_type) &mdash; Default value for the [`instance_root_volume_type`](#instance_root_volume_type) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+Namespace where the AWS Auth Merger is deployed. If configured, the worker IAM role will be mapped to the Kubernetes RBAC group for Nodes using a ConfigMap in the auth merger namespace.
 
-<a name="node_group_default_instance_types" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`node_group_default_instance_types`**](#node_group_default_instance_types) &mdash; Default value for [`instance_types`](#instance_types) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+<HclListItem name="cloud_init_parts" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="node_group_default_labels" className="snap-top"></a>
+Cloud init scripts to run on the EKS worker nodes when it is booting. See the part blocks in https://www.terraform.io/docs/providers/template/d/cloudinit_config.html for syntax. To override the default boot script installed as part of the module, use the key `default`.
 
-* [**`node_group_default_labels`**](#node_group_default_labels) &mdash; Default value for labels field of [`managed_node_group_configurations`](#managed_node_group_configurations). Unlike [`common_labels`](#common_labels) which will always be merged in, these labels are only used if the labels field is omitted from the configuration.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="node_group_default_max_pods_allowed" className="snap-top"></a>
+```hcl
+map(object({
+    # A filename to report in the header for the part. Should be unique across all cloud-init parts.
+    filename = string
 
-* [**`node_group_default_max_pods_allowed`**](#node_group_default_max_pods_allowed) &mdash; Default value for the [`max_pods_allowed`](#max_pods_allowed) field of [`managed_node_group_configurations`](#managed_node_group_configurations). Any map entry that does not specify [`max_pods_allowed`](#max_pods_allowed) will use this value.
+    # A MIME-style content type to report in the header for the part. For example, use "text/x-shellscript" for a shell
+    # script.
+    content_type = string
 
-<a name="node_group_default_max_size" className="snap-top"></a>
+    # The contents of the boot script to be called. This should be the full text of the script as a raw string.
+    content = string
+  }))
+```
 
-* [**`node_group_default_max_size`**](#node_group_default_max_size) &mdash; Default value for [`max_size`](#max_size) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="node_group_default_min_size" className="snap-top"></a>
+<HclListItem name="cluster_instance_associate_public_ip_address" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`node_group_default_min_size`**](#node_group_default_min_size) &mdash; Default value for [`min_size`](#min_size) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+Whether or not to associate a public IP address to the instances of the self managed ASGs. Will only work if the instances are launched in a public subnet.
 
-<a name="node_group_default_subnet_ids" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`node_group_default_subnet_ids`**](#node_group_default_subnet_ids) &mdash; Default value for [`subnet_ids`](#subnet_ids) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+<HclListItem name="cluster_instance_keypair_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="node_group_default_tags" className="snap-top"></a>
+The name of the Key Pair that can be used to SSH to each instance in the EKS cluster.
 
-* [**`node_group_default_tags`**](#node_group_default_tags) &mdash; Default value for tags field of [`managed_node_group_configurations`](#managed_node_group_configurations). Unlike [`common_tags`](#common_tags) which will always be merged in, these tags are only used if the tags field is omitted from the configuration.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="node_group_launch_template_instance_type" className="snap-top"></a>
+<HclListItem name="custom_egress_security_group_rules" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`node_group_launch_template_instance_type`**](#node_group_launch_template_instance_type) &mdash; The instance type to configure in the launch template. This value will be used when the [`instance_types`](#instance_types) field is set to null (NOT omitted, in which case [`node_group_default_instance_types`](#node_group_default_instance_types) will be used).
+A map of unique identifiers to egress security group rules to attach to the worker groups.
 
-<a name="node_group_names" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`node_group_names`**](#node_group_names) &mdash; The names of the node groups. When null, this value is automatically calculated from the [`managed_node_group_configurations`](#managed_node_group_configurations) map. This variable must be set if any of the values of the [`managed_node_group_configurations`](#managed_node_group_configurations) map depends on a resource that is not available at plan time to work around terraform limitations with [`for_each`](#for_each).
+```hcl
+map(object({
+    # The network ports and protocol (tcp, udp, all) for which the security group rule applies to.
+    from_port = number
+    to_port   = number
+    protocol  = string
 
-<a name="node_group_security_group_tags" className="snap-top"></a>
+    # The target of the traffic. Only one of the following can be defined; the others must be configured to null.
+    target_security_group_id = string       # The ID of the security group to which the traffic goes to.
+    cidr_blocks              = list(string) # The list of IP CIDR blocks to which the traffic goes to.
+  }))
+```
 
-* [**`node_group_security_group_tags`**](#node_group_security_group_tags) &mdash; A map of tags to apply to the Security Group of the ASG for the managed node group pool. The key is the tag name and the value is the tag value.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="ssh_grunt_iam_group" className="snap-top"></a>
+<HclListItem name="custom_ingress_security_group_rules" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`ssh_grunt_iam_group`**](#ssh_grunt_iam_group) &mdash; If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to the EKS workers. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+A map of unique identifiers to ingress security group rules to attach to the worker groups.
 
-<a name="ssh_grunt_iam_group_sudo" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`ssh_grunt_iam_group_sudo`**](#ssh_grunt_iam_group_sudo) &mdash; If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to the EKS workers with sudo permissions. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+```hcl
+map(object({
+    # The network ports and protocol (tcp, udp, all) for which the security group rule applies to.
+    from_port = number
+    to_port   = number
+    protocol  = string
 
-<a name="tenancy" className="snap-top"></a>
+    # The source of the traffic. Only one of the following can be defined; the others must be configured to null.
+    source_security_group_id = string       # The ID of the security group from which the traffic originates from.
+    cidr_blocks              = list(string) # The list of IP CIDR blocks from which the traffic originates from.
+  }))
+```
 
-* [**`tenancy`**](#tenancy) &mdash; The tenancy of the servers in the self-managed worker ASG. Must be one of: default, dedicated, or host.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="use_exec_plugin_for_auth" className="snap-top"></a>
+<HclListItem name="dashboard_cpu_usage_widget_parameters" requirement="optional" type="object">
+<HclListItemDescription>
 
-* [**`use_exec_plugin_for_auth`**](#use_exec_plugin_for_auth) &mdash; If this variable is set to true, then use an exec-based plugin to authenticate and fetch tokens for EKS. This is useful because EKS clusters use short-lived authentication tokens that can expire in the middle of an 'apply' or 'destroy', and since the native Kubernetes provider in Terraform doesn't have a way to fetch up-to-date tokens, we recommend using an exec-based provider as a workaround. Use the [`use_kubergrunt_to_fetch_token`](#use_kubergrunt_to_fetch_token) input variable to control whether kubergrunt or aws is used to fetch tokens.
+Parameters for the worker cpu usage widget to output for use in a CloudWatch dashboard.
 
-<a name="use_kubergrunt_to_fetch_token" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`use_kubergrunt_to_fetch_token`**](#use_kubergrunt_to_fetch_token) &mdash; EKS clusters use short-lived authentication tokens that can expire in the middle of an 'apply' or 'destroy'. To avoid this issue, we use an exec-based plugin to fetch an up-to-date token. If this variable is set to true, we'll use kubergrunt to fetch the token (in which case, kubergrunt must be installed and on PATH); if this variable is set to false, we'll use the aws CLI to fetch the token (in which case, aws must be installed and on PATH). Note this functionality is only enabled if [`use_exec_plugin_for_auth`](#use_exec_plugin_for_auth) is set to true.
+```hcl
+object({
+    # The period in seconds for metrics to sample across.
+    period = number
 
-<a name="use_managed_iam_policies" className="snap-top"></a>
+    # The width and height of the widget in grid units in a 24 column grid. E.g., a value of 12 will take up half the
+    # space.
+    width  = number
+    height = number
+  })
+```
 
-* [**`use_managed_iam_policies`**](#use_managed_iam_policies) &mdash; When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-<a name="use_prefix_mode_to_calculate_max_pods" className="snap-top"></a>
+```hcl
+{
+  height = 6,
+  period = 60,
+  width = 8
+}
+```
 
-* [**`use_prefix_mode_to_calculate_max_pods`**](#use_prefix_mode_to_calculate_max_pods) &mdash; When true, assumes prefix delegation mode is in use for the AWS VPC CNI component of the EKS cluster when computing max pods allowed on the node. In prefix delegation mode, each ENI will be allocated 16 IP addresses (/28) instead of 1, allowing you to pack more Pods per node.
+</HclListItemDefaultValue>
+</HclListItem>
 
-<a name="worker_k8s_role_mapping_name" className="snap-top"></a>
+<HclListItem name="dashboard_disk_usage_widget_parameters" requirement="optional" type="object">
+<HclListItemDescription>
 
-* [**`worker_k8s_role_mapping_name`**](#worker_k8s_role_mapping_name) &mdash; Name of the IAM role to Kubernetes RBAC group mapping ConfigMap. Only used if [`aws_auth_merger_namespace`](#aws_auth_merger_namespace) is not null.
+Parameters for the worker disk usage widget to output for use in a CloudWatch dashboard.
 
-<a name="worker_name_prefix" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`worker_name_prefix`**](#worker_name_prefix) &mdash; Prefix EKS worker resource names with this string. When you have multiple worker groups for the cluster, you can use this to namespace the resources. Defaults to empty string so that resource names are not excessively long by default.
+```hcl
+object({
+    # The period in seconds for metrics to sample across.
+    period = number
+
+    # The width and height of the widget in grid units in a 24 column grid. E.g., a value of 12 will take up half the
+    # space.
+    width  = number
+    height = number
+  })
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
+
+```hcl
+{
+  height = 6,
+  period = 60,
+  width = 8
+}
+```
+
+</HclListItemDefaultValue>
+</HclListItem>
+
+<HclListItem name="dashboard_memory_usage_widget_parameters" requirement="optional" type="object">
+<HclListItemDescription>
+
+Parameters for the worker memory usage widget to output for use in a CloudWatch dashboard.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+object({
+    # The period in seconds for metrics to sample across.
+    period = number
+
+    # The width and height of the widget in grid units in a 24 column grid. E.g., a value of 12 will take up half the
+    # space.
+    width  = number
+    height = number
+  })
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
+
+```hcl
+{
+  height = 6,
+  period = 60,
+  width = 8
+}
+```
+
+</HclListItemDefaultValue>
+</HclListItem>
+
+<HclListItem name="enable_cloudwatch_alarms" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using <a href="#alarms_sns_topic_arn"><code>alarms_sns_topic_arn</code></a>.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_cloudwatch_metrics" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to add IAM permissions to send custom metrics to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/agents/cloudwatch-agent to get memory and disk metrics in CloudWatch for your Bastion host.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_fail2ban" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Enable fail2ban to block brute force log in attempts. Defaults to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="external_account_ssh_grunt_role_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt and your IAM users / groups are defined in a separate AWS account, you can use this variable to specify the ARN of an IAM role that ssh-grunt can assume to retrieve IAM group and public SSH key info from that account. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="managed_node_group_custom_iam_role_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+Custom name for the IAM role for the Managed Node Groups. When null, a default name based on worker_name_prefix will be used. One of managed_node_group_custom_iam_role_name and managed_node_group_iam_role_arn is required (must be non-null) if managed_node_group_iam_role_already_exists is true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="managed_node_group_iam_role_already_exists" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Whether or not the IAM role used for the Managed Node Group workers already exists. When false, this module will create a new IAM role.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="managed_node_group_iam_role_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+ARN of the IAM role to use if iam_role_already_exists = true. When null, uses managed_node_group_custom_iam_role_name to lookup the ARN. One of managed_node_group_custom_iam_role_name and managed_node_group_iam_role_arn is required (must be non-null) if managed_node_group_iam_role_already_exists is true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_capacity_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+Default value for capacity_type field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ON_DEMAND"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_desired_size" requirement="optional" type="number">
+<HclListItemDescription>
+
+Default value for desired_size field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_enable_detailed_monitoring" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Default value for enable_detailed_monitoring field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_instance_root_volume_encryption" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Default value for the instance_root_volume_encryption field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_instance_root_volume_size" requirement="optional" type="number">
+<HclListItemDescription>
+
+Default value for the instance_root_volume_size field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="40"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_instance_root_volume_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+Default value for the instance_root_volume_type field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="gp3"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_instance_types" requirement="optional" type="list">
+<HclListItemDescription>
+
+Default value for instance_types field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_labels" requirement="optional" type="map">
+<HclListItemDescription>
+
+Default value for labels field of managed_node_group_configurations. Unlike common_labels which will always be merged in, these labels are only used if the labels field is omitted from the configuration.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_max_pods_allowed" requirement="optional" type="number">
+<HclListItemDescription>
+
+Default value for the max_pods_allowed field of managed_node_group_configurations. Any map entry that does not specify max_pods_allowed will use this value.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_max_size" requirement="optional" type="number">
+<HclListItemDescription>
+
+Default value for max_size field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_min_size" requirement="optional" type="number">
+<HclListItemDescription>
+
+Default value for min_size field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_subnet_ids" requirement="optional" type="list">
+<HclListItemDescription>
+
+Default value for subnet_ids field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+Default value for tags field of managed_node_group_configurations. Unlike common_tags which will always be merged in, these tags are only used if the tags field is omitted from the configuration.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="node_group_launch_template_instance_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+The instance type to configure in the launch template. This value will be used when the instance_types field is set to null (NOT omitted, in which case <a href="#node_group_default_instance_types"><code>node_group_default_instance_types</code></a> will be used).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="node_group_names" requirement="optional" type="list">
+<HclListItemDescription>
+
+The names of the node groups. When null, this value is automatically calculated from the managed_node_group_configurations map. This variable must be set if any of the values of the managed_node_group_configurations map depends on a resource that is not available at plan time to work around terraform limitations with for_each.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="node_group_security_group_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of tags to apply to the Security Group of the ASG for the managed node group pool. The key is the tag name and the value is the tag value.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="ssh_grunt_iam_group" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to the EKS workers. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ssh-grunt-users"/>
+</HclListItem>
+
+<HclListItem name="ssh_grunt_iam_group_sudo" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to the EKS workers with sudo permissions. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ssh-grunt-sudo-users"/>
+</HclListItem>
+
+<HclListItem name="tenancy" requirement="optional" type="string">
+<HclListItemDescription>
+
+The tenancy of the servers in the self-managed worker ASG. Must be one of: default, dedicated, or host.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="default"/>
+</HclListItem>
+
+<HclListItem name="use_exec_plugin_for_auth" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If this variable is set to true, then use an exec-based plugin to authenticate and fetch tokens for EKS. This is useful because EKS clusters use short-lived authentication tokens that can expire in the middle of an 'apply' or 'destroy', and since the native Kubernetes provider in Terraform doesn't have a way to fetch up-to-date tokens, we recommend using an exec-based provider as a workaround. Use the use_kubergrunt_to_fetch_token input variable to control whether kubergrunt or aws is used to fetch tokens.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="use_kubergrunt_to_fetch_token" requirement="optional" type="bool">
+<HclListItemDescription>
+
+EKS clusters use short-lived authentication tokens that can expire in the middle of an 'apply' or 'destroy'. To avoid this issue, we use an exec-based plugin to fetch an up-to-date token. If this variable is set to true, we'll use kubergrunt to fetch the token (in which case, kubergrunt must be installed and on PATH); if this variable is set to false, we'll use the aws CLI to fetch the token (in which case, aws must be installed and on PATH). Note this functionality is only enabled if use_exec_plugin_for_auth is set to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="use_managed_iam_policies" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="use_prefix_mode_to_calculate_max_pods" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, assumes prefix delegation mode is in use for the AWS VPC CNI component of the EKS cluster when computing max pods allowed on the node. In prefix delegation mode, each ENI will be allocated 16 IP addresses (/28) instead of 1, allowing you to pack more Pods per node.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="worker_k8s_role_mapping_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+Name of the IAM role to Kubernetes RBAC group mapping ConfigMap. Only used if aws_auth_merger_namespace is not null.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="eks-cluster-worker-iam-mapping"/>
+</HclListItem>
+
+<HclListItem name="worker_name_prefix" requirement="optional" type="string">
+<HclListItemDescription>
+
+Prefix EKS worker resource names with this string. When you have multiple worker groups for the cluster, you can use this to namespace the resources. Defaults to empty string so that resource names are not excessively long by default.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="managed_node_group_arns" className="snap-top"></a>
+<HclListItem name="managed_node_group_arns">
+<HclListItemDescription>
 
-* [**`managed_node_group_arns`**](#managed_node_group_arns) &mdash; Map of Node Group names to ARNs of the created EKS Node Groups.
+Map of Node Group names to ARNs of the created EKS Node Groups.
 
-<a name="managed_node_group_worker_iam_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`managed_node_group_worker_iam_role_arn`**](#managed_node_group_worker_iam_role_arn) &mdash; The ARN of the IAM role associated with the Managed Node Group EKS workers.
+<HclListItem name="managed_node_group_worker_iam_role_arn">
+<HclListItemDescription>
 
-<a name="managed_node_group_worker_iam_role_name" className="snap-top"></a>
+The ARN of the IAM role associated with the Managed Node Group EKS workers.
 
-* [**`managed_node_group_worker_iam_role_name`**](#managed_node_group_worker_iam_role_name) &mdash; The name of the IAM role associated with the Managed Node Group EKS workers.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="managed_node_group_worker_security_group_ids" className="snap-top"></a>
+<HclListItem name="managed_node_group_worker_iam_role_name">
+<HclListItemDescription>
 
-* [**`managed_node_group_worker_security_group_ids`**](#managed_node_group_worker_security_group_ids) &mdash; Map of Node Group names to Auto Scaling Group security group IDs. Empty if [`cluster_instance_keypair_name`](#cluster_instance_keypair_name) is not set.
+The name of the IAM role associated with the Managed Node Group EKS workers.
 
-<a name="managed_node_group_worker_shared_security_group_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`managed_node_group_worker_shared_security_group_id`**](#managed_node_group_worker_shared_security_group_id) &mdash; The ID of the common AWS Security Group associated with all the managed EKS workers.
+<HclListItem name="managed_node_group_worker_security_group_ids">
+<HclListItemDescription>
 
-<a name="metric_widget_managed_node_group_worker_cpu_usage" className="snap-top"></a>
+Map of Node Group names to Auto Scaling Group security group IDs. Empty if <a href="#cluster_instance_keypair_name"><code>cluster_instance_keypair_name</code></a> is not set.
 
-* [**`metric_widget_managed_node_group_worker_cpu_usage`**](#metric_widget_managed_node_group_worker_cpu_usage) &mdash; A CloudWatch Dashboard widget that graphs CPU usage (percentage) of the Managed Node Group EKS workers.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="metric_widget_managed_node_group_worker_disk_usage" className="snap-top"></a>
+<HclListItem name="managed_node_group_worker_shared_security_group_id">
+<HclListItemDescription>
 
-* [**`metric_widget_managed_node_group_worker_disk_usage`**](#metric_widget_managed_node_group_worker_disk_usage) &mdash; A CloudWatch Dashboard widget that graphs disk usage (percentage) of the Managed Node Group EKS workers.
+The ID of the common AWS Security Group associated with all the managed EKS workers.
 
-<a name="metric_widget_managed_node_group_worker_memory_usage" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`metric_widget_managed_node_group_worker_memory_usage`**](#metric_widget_managed_node_group_worker_memory_usage) &mdash; A CloudWatch Dashboard widget that graphs memory usage (percentage) of the Managed Node Group EKS workers.
+<HclListItem name="metric_widget_managed_node_group_worker_cpu_usage">
+<HclListItemDescription>
 
-<a name="metric_widget_self_managed_worker_cpu_usage" className="snap-top"></a>
+A CloudWatch Dashboard widget that graphs CPU usage (percentage) of the Managed Node Group EKS workers.
 
-* [**`metric_widget_self_managed_worker_cpu_usage`**](#metric_widget_self_managed_worker_cpu_usage) &mdash; A CloudWatch Dashboard widget that graphs CPU usage (percentage) of the self-managed EKS workers.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="metric_widget_self_managed_worker_disk_usage" className="snap-top"></a>
+<HclListItem name="metric_widget_managed_node_group_worker_disk_usage">
+<HclListItemDescription>
 
-* [**`metric_widget_self_managed_worker_disk_usage`**](#metric_widget_self_managed_worker_disk_usage) &mdash; A CloudWatch Dashboard widget that graphs disk usage (percentage) of the self-managed EKS workers.
+A CloudWatch Dashboard widget that graphs disk usage (percentage) of the Managed Node Group EKS workers.
 
-<a name="metric_widget_self_managed_worker_memory_usage" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`metric_widget_self_managed_worker_memory_usage`**](#metric_widget_self_managed_worker_memory_usage) &mdash; A CloudWatch Dashboard widget that graphs memory usage (percentage) of the self-managed EKS workers.
+<HclListItem name="metric_widget_managed_node_group_worker_memory_usage">
+<HclListItemDescription>
 
-<a name="self_managed_worker_iam_role_arn" className="snap-top"></a>
+A CloudWatch Dashboard widget that graphs memory usage (percentage) of the Managed Node Group EKS workers.
 
-* [**`self_managed_worker_iam_role_arn`**](#self_managed_worker_iam_role_arn) &mdash; The ARN of the IAM role associated with the self-managed EKS workers.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="self_managed_worker_iam_role_name" className="snap-top"></a>
+<HclListItem name="metric_widget_self_managed_worker_cpu_usage">
+<HclListItemDescription>
 
-* [**`self_managed_worker_iam_role_name`**](#self_managed_worker_iam_role_name) &mdash; The name of the IAM role associated with the self-managed EKS workers.
+A CloudWatch Dashboard widget that graphs CPU usage (percentage) of the self-managed EKS workers.
 
-<a name="self_managed_worker_security_group_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`self_managed_worker_security_group_id`**](#self_managed_worker_security_group_id) &mdash; The ID of the AWS Security Group associated with the self-managed EKS workers.
+<HclListItem name="metric_widget_self_managed_worker_disk_usage">
+<HclListItemDescription>
 
-<a name="worker_asg_names" className="snap-top"></a>
+A CloudWatch Dashboard widget that graphs disk usage (percentage) of the self-managed EKS workers.
 
-* [**`worker_asg_names`**](#worker_asg_names) &mdash; The list of names of the ASGs that were deployed to act as EKS workers.
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="metric_widget_self_managed_worker_memory_usage">
+<HclListItemDescription>
+
+A CloudWatch Dashboard widget that graphs memory usage (percentage) of the self-managed EKS workers.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="self_managed_worker_iam_role_arn">
+<HclListItemDescription>
+
+The ARN of the IAM role associated with the self-managed EKS workers.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="self_managed_worker_iam_role_name">
+<HclListItemDescription>
+
+The name of the IAM role associated with the self-managed EKS workers.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="self_managed_worker_security_group_id">
+<HclListItemDescription>
+
+The ID of the AWS Security Group associated with the self-managed EKS workers.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="worker_asg_names">
+<HclListItemDescription>
+
+The list of names of the ASGs that were deployed to act as EKS workers.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"9c7ed05a7218877b61c66873a051d1f2"}
+{"sourcePlugin":"service-catalog-api","hash":"72b20e5751be8aeed0c0aebc815c0497"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/app-orchestration/amazon-eks.md
+++ b/docs/reference/services/app-orchestration/amazon-eks.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -109,511 +110,1480 @@ To add and manage additional worker groups, refer to the [eks-workers module](ht
 
 ### Required
 
-<a name="allow_inbound_api_access_from_cidr_blocks" className="snap-top"></a>
+<HclListItem name="allow_inbound_api_access_from_cidr_blocks" requirement="required" type="list">
+<HclListItemDescription>
 
-* [**`allow_inbound_api_access_from_cidr_blocks`**](#allow_inbound_api_access_from_cidr_blocks) &mdash; The list of CIDR blocks to allow inbound access to the Kubernetes API.
+The list of CIDR blocks to allow inbound access to the Kubernetes API.
 
-<a name="cluster_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`cluster_name`**](#cluster_name) &mdash; The name of the EKS cluster
+```hcl
+list(string)
+```
 
-<a name="control_plane_vpc_subnet_ids" className="snap-top"></a>
+</HclListItemTypeDetails>
+</HclListItem>
 
-* [**`control_plane_vpc_subnet_ids`**](#control_plane_vpc_subnet_ids) &mdash; List of IDs of the subnets that can be used for the EKS Control Plane.
+<HclListItem name="cluster_name" requirement="required" type="string">
+<HclListItemDescription>
 
-<a name="vpc_id" className="snap-top"></a>
+The name of the EKS cluster
 
-* [**`vpc_id`**](#vpc_id) &mdash; ID of the VPC where the EKS resources will be deployed.
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="control_plane_vpc_subnet_ids" requirement="required" type="list">
+<HclListItemDescription>
+
+List of IDs of the subnets that can be used for the EKS Control Plane.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="vpc_id" requirement="required" type="string">
+<HclListItemDescription>
+
+ID of the VPC where the EKS resources will be deployed.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="additional_security_groups_for_control_plane" className="snap-top"></a>
+<HclListItem name="additional_security_groups_for_control_plane" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`additional_security_groups_for_control_plane`**](#additional_security_groups_for_control_plane) &mdash; A list of additional security group IDs to attach to the control plane.
+A list of additional security group IDs to attach to the control plane.
 
-<a name="additional_security_groups_for_workers" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`additional_security_groups_for_workers`**](#additional_security_groups_for_workers) &mdash; A list of additional security group IDs to attach to the worker nodes.
+```hcl
+list(string)
+```
 
-<a name="alarms_sns_topic_arn" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`alarms_sns_topic_arn`**](#alarms_sns_topic_arn) &mdash; The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications.
+<HclListItem name="additional_security_groups_for_workers" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="allow_inbound_ssh_from_cidr_blocks" className="snap-top"></a>
+A list of additional security group IDs to attach to the worker nodes.
 
-* [**`allow_inbound_ssh_from_cidr_blocks`**](#allow_inbound_ssh_from_cidr_blocks) &mdash; The list of CIDR blocks to allow inbound SSH access to the worker groups.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="allow_inbound_ssh_from_security_groups" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`allow_inbound_ssh_from_security_groups`**](#allow_inbound_ssh_from_security_groups) &mdash; The list of security group IDs to allow inbound SSH access to the worker groups.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="allow_private_api_access_from_cidr_blocks" className="snap-top"></a>
+<HclListItem name="alarms_sns_topic_arn" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`allow_private_api_access_from_cidr_blocks`**](#allow_private_api_access_from_cidr_blocks) &mdash; The list of CIDR blocks to allow inbound access to the private Kubernetes API endpoint (e.g. the endpoint within the VPC, not the public endpoint).
+The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications.
 
-<a name="allow_private_api_access_from_security_groups" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`allow_private_api_access_from_security_groups`**](#allow_private_api_access_from_security_groups) &mdash; The list of security groups to allow inbound access to the private Kubernetes API endpoint (e.g. the endpoint within the VPC, not the public endpoint).
+```hcl
+list(string)
+```
 
-<a name="asg_default_enable_detailed_monitoring" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`asg_default_enable_detailed_monitoring`**](#asg_default_enable_detailed_monitoring) &mdash; Default value for [`enable_detailed_monitoring`](#enable_detailed_monitoring) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations).
+<HclListItem name="allow_inbound_ssh_from_cidr_blocks" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="asg_default_instance_root_volume_encryption" className="snap-top"></a>
+The list of CIDR blocks to allow inbound SSH access to the worker groups.
 
-* [**`asg_default_instance_root_volume_encryption`**](#asg_default_instance_root_volume_encryption) &mdash; Default value for the [`asg_instance_root_volume_encryption`](#asg_instance_root_volume_encryption) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`asg_instance_root_volume_encryption`](#asg_instance_root_volume_encryption) will use this value.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="asg_default_instance_root_volume_iops" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`asg_default_instance_root_volume_iops`**](#asg_default_instance_root_volume_iops) &mdash; Default value for the [`asg_instance_root_volume_iops`](#asg_instance_root_volume_iops) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`asg_instance_root_volume_iops`](#asg_instance_root_volume_iops) will use this value.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="asg_default_instance_root_volume_size" className="snap-top"></a>
+<HclListItem name="allow_inbound_ssh_from_security_groups" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`asg_default_instance_root_volume_size`**](#asg_default_instance_root_volume_size) &mdash; Default value for the [`asg_instance_root_volume_size`](#asg_instance_root_volume_size) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`asg_instance_root_volume_size`](#asg_instance_root_volume_size) will use this value.
+The list of security group IDs to allow inbound SSH access to the worker groups.
 
-<a name="asg_default_instance_root_volume_throughput" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`asg_default_instance_root_volume_throughput`**](#asg_default_instance_root_volume_throughput) &mdash; Default value for the [`asg_instance_root_volume_throughput`](#asg_instance_root_volume_throughput) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`asg_instance_root_volume_throughput`](#asg_instance_root_volume_throughput) will use this value.
+```hcl
+list(string)
+```
 
-<a name="asg_default_instance_root_volume_type" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`asg_default_instance_root_volume_type`**](#asg_default_instance_root_volume_type) &mdash; Default value for the [`asg_instance_root_volume_type`](#asg_instance_root_volume_type) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`asg_instance_root_volume_type`](#asg_instance_root_volume_type) will use this value.
+<HclListItem name="allow_private_api_access_from_cidr_blocks" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="asg_default_instance_type" className="snap-top"></a>
+The list of CIDR blocks to allow inbound access to the private Kubernetes API endpoint (e.g. the endpoint within the VPC, not the public endpoint).
 
-* [**`asg_default_instance_type`**](#asg_default_instance_type) &mdash; Default value for the [`asg_instance_type`](#asg_instance_type) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`asg_instance_type`](#asg_instance_type) will use this value.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="asg_default_max_pods_allowed" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`asg_default_max_pods_allowed`**](#asg_default_max_pods_allowed) &mdash; Default value for the [`max_pods_allowed`](#max_pods_allowed) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`max_pods_allowed`](#max_pods_allowed) will use this value.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="asg_default_max_size" className="snap-top"></a>
+<HclListItem name="allow_private_api_access_from_security_groups" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`asg_default_max_size`**](#asg_default_max_size) &mdash; Default value for the [`max_size`](#max_size) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`max_size`](#max_size) will use this value.
+The list of security groups to allow inbound access to the private Kubernetes API endpoint (e.g. the endpoint within the VPC, not the public endpoint).
 
-<a name="asg_default_min_size" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`asg_default_min_size`**](#asg_default_min_size) &mdash; Default value for the [`min_size`](#min_size) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`min_size`](#min_size) will use this value.
+```hcl
+list(string)
+```
 
-<a name="asg_default_multi_instance_overrides" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`asg_default_multi_instance_overrides`**](#asg_default_multi_instance_overrides) &mdash; Default value for the [`multi_instance_overrides`](#multi_instance_overrides) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`multi_instance_overrides`](#multi_instance_overrides) will use this value.
+<HclListItem name="asg_default_enable_detailed_monitoring" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="asg_default_on_demand_allocation_strategy" className="snap-top"></a>
+Default value for enable_detailed_monitoring field of autoscaling_group_configurations.
 
-* [**`asg_default_on_demand_allocation_strategy`**](#asg_default_on_demand_allocation_strategy) &mdash; Default value for the [`on_demand_allocation_strategy`](#on_demand_allocation_strategy) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`on_demand_allocation_strategy`](#on_demand_allocation_strategy) will use this value.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="asg_default_on_demand_base_capacity" className="snap-top"></a>
+<HclListItem name="asg_default_instance_root_volume_encryption" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`asg_default_on_demand_base_capacity`**](#asg_default_on_demand_base_capacity) &mdash; Default value for the [`on_demand_base_capacity`](#on_demand_base_capacity) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`on_demand_base_capacity`](#on_demand_base_capacity) will use this value.
+Default value for the asg_instance_root_volume_encryption field of autoscaling_group_configurations. Any map entry that does not specify asg_instance_root_volume_encryption will use this value.
 
-<a name="asg_default_on_demand_percentage_above_base_capacity" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`asg_default_on_demand_percentage_above_base_capacity`**](#asg_default_on_demand_percentage_above_base_capacity) &mdash; Default value for the [`on_demand_percentage_above_base_capacity`](#on_demand_percentage_above_base_capacity) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`on_demand_percentage_above_base_capacity`](#on_demand_percentage_above_base_capacity) will use this value.
+<HclListItem name="asg_default_instance_root_volume_iops" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="asg_default_spot_allocation_strategy" className="snap-top"></a>
+Default value for the asg_instance_root_volume_iops field of autoscaling_group_configurations. Any map entry that does not specify asg_instance_root_volume_iops will use this value.
 
-* [**`asg_default_spot_allocation_strategy`**](#asg_default_spot_allocation_strategy) &mdash; Default value for the [`spot_allocation_strategy`](#spot_allocation_strategy) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`spot_allocation_strategy`](#spot_allocation_strategy) will use this value.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="asg_default_spot_instance_pools" className="snap-top"></a>
+<HclListItem name="asg_default_instance_root_volume_size" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`asg_default_spot_instance_pools`**](#asg_default_spot_instance_pools) &mdash; Default value for the [`spot_instance_pools`](#spot_instance_pools) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`spot_instance_pools`](#spot_instance_pools) will use this value.
+Default value for the asg_instance_root_volume_size field of autoscaling_group_configurations. Any map entry that does not specify asg_instance_root_volume_size will use this value.
 
-<a name="asg_default_spot_max_price" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="40"/>
+</HclListItem>
 
-* [**`asg_default_spot_max_price`**](#asg_default_spot_max_price) &mdash; Default value for the [`spot_max_price`](#spot_max_price) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`spot_max_price`](#spot_max_price) will use this value. Set to empty string (default) to mean on-demand price.
+<HclListItem name="asg_default_instance_root_volume_throughput" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="asg_default_tags" className="snap-top"></a>
+Default value for the asg_instance_root_volume_throughput field of autoscaling_group_configurations. Any map entry that does not specify asg_instance_root_volume_throughput will use this value.
 
-* [**`asg_default_tags`**](#asg_default_tags) &mdash; Default value for the tags field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify tags will use this value.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="asg_default_use_multi_instances_policy" className="snap-top"></a>
+<HclListItem name="asg_default_instance_root_volume_type" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`asg_default_use_multi_instances_policy`**](#asg_default_use_multi_instances_policy) &mdash; Default value for the [`use_multi_instances_policy`](#use_multi_instances_policy) field of [`autoscaling_group_configurations`](#autoscaling_group_configurations). Any map entry that does not specify [`use_multi_instances_policy`](#use_multi_instances_policy) will use this value.
+Default value for the asg_instance_root_volume_type field of autoscaling_group_configurations. Any map entry that does not specify asg_instance_root_volume_type will use this value.
 
-<a name="asg_iam_instance_profile_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="standard"/>
+</HclListItem>
 
-* [**`asg_iam_instance_profile_name`**](#asg_iam_instance_profile_name) &mdash; Custom name for the IAM instance profile for the Self-managed workers. When null, the IAM role name will be used. If [`asg_use_resource_name_prefix`](#asg_use_resource_name_prefix) is true, this will be used as a name prefix.
+<HclListItem name="asg_default_instance_type" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="asg_iam_permissions_boundary" className="snap-top"></a>
+Default value for the asg_instance_type field of autoscaling_group_configurations. Any map entry that does not specify asg_instance_type will use this value.
 
-* [**`asg_iam_permissions_boundary`**](#asg_iam_permissions_boundary) &mdash; ARN of a permission boundary to apply on the IAM role created for the self managed workers.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="t3.medium"/>
+</HclListItem>
 
-<a name="asg_security_group_tags" className="snap-top"></a>
+<HclListItem name="asg_default_max_pods_allowed" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`asg_security_group_tags`**](#asg_security_group_tags) &mdash; A map of tags to apply to the Security Group of the ASG for the self managed worker pool. The key is the tag name and the value is the tag value.
+Default value for the max_pods_allowed field of autoscaling_group_configurations. Any map entry that does not specify max_pods_allowed will use this value.
 
-<a name="asg_use_resource_name_prefix" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`asg_use_resource_name_prefix`**](#asg_use_resource_name_prefix) &mdash; When true, all the relevant resources for self managed workers will be set to use the [`name_prefix`](#name_prefix) attribute so that unique names are generated for them. This allows those resources to support recreation through [`create_before_destroy`](#create_before_destroy) lifecycle rules. Set to false if you were using any version before 0.65.0 and wish to avoid recreating the entire worker pool on your cluster.
+<HclListItem name="asg_default_max_size" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="autoscaling_group_configurations" className="snap-top"></a>
+Default value for the max_size field of autoscaling_group_configurations. Any map entry that does not specify max_size will use this value.
 
-* [**`autoscaling_group_configurations`**](#autoscaling_group_configurations) &mdash; Configure one or more Auto Scaling Groups (ASGs) to manage the EC2 instances in this cluster. If any of the values are not provided, the specified default variable will be used to lookup a default value.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="2"/>
+</HclListItem>
 
-<a name="autoscaling_group_include_autoscaler_discovery_tags" className="snap-top"></a>
+<HclListItem name="asg_default_min_size" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`autoscaling_group_include_autoscaler_discovery_tags`**](#autoscaling_group_include_autoscaler_discovery_tags) &mdash; Adds additional tags to each ASG that allow a cluster autoscaler to auto-discover them.
+Default value for the min_size field of autoscaling_group_configurations. Any map entry that does not specify min_size will use this value.
 
-<a name="aws_auth_merger_default_configmap_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1"/>
+</HclListItem>
 
-* [**`aws_auth_merger_default_configmap_name`**](#aws_auth_merger_default_configmap_name) &mdash; Name of the default aws-auth ConfigMap to use. This will be the name of the ConfigMap that gets created by this module in the aws-auth-merger namespace to seed the initial aws-auth ConfigMap.
+<HclListItem name="asg_default_multi_instance_overrides" requirement="optional" type="any">
+<HclListItemDescription>
 
-<a name="aws_auth_merger_image" className="snap-top"></a>
+Default value for the multi_instance_overrides field of autoscaling_group_configurations. Any map entry that does not specify multi_instance_overrides will use this value.
 
-* [**`aws_auth_merger_image`**](#aws_auth_merger_image) &mdash; Location of the container image to use for the aws-auth-merger app. You can use the Dockerfile provided in terraform-aws-eks to construct an image. See https://github.com/gruntwork-io/terraform-aws-eks/blob/master/modules/eks-aws-auth-merger/core-concepts.md#how-do-i-use-the-aws-auth-merger for more info.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="aws_auth_merger_namespace" className="snap-top"></a>
+<HclListItem name="asg_default_on_demand_allocation_strategy" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`aws_auth_merger_namespace`**](#aws_auth_merger_namespace) &mdash; Namespace to deploy the aws-auth-merger into. The app will watch for ConfigMaps in this Namespace to merge into the aws-auth ConfigMap.
+Default value for the on_demand_allocation_strategy field of autoscaling_group_configurations. Any map entry that does not specify on_demand_allocation_strategy will use this value.
 
-<a name="cloud_init_parts" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`cloud_init_parts`**](#cloud_init_parts) &mdash; Cloud init scripts to run on the EKS worker nodes when it is booting. See the part blocks in [`https://www.terraform.io/docs/providers/template/d/cloudinit_config`](#https://www.terraform.io/docs/providers/template/d/cloudinit_config).html for syntax. To override the default boot script installed as part of the module, use the key `default`.
+<HclListItem name="asg_default_on_demand_base_capacity" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="cluster_iam_role_permissions_boundary" className="snap-top"></a>
+Default value for the on_demand_base_capacity field of autoscaling_group_configurations. Any map entry that does not specify on_demand_base_capacity will use this value.
 
-* [**`cluster_iam_role_permissions_boundary`**](#cluster_iam_role_permissions_boundary) &mdash; ARN of permissions boundary to apply to the cluster IAM role - the IAM role created for the EKS cluster.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="cluster_instance_ami" className="snap-top"></a>
+<HclListItem name="asg_default_on_demand_percentage_above_base_capacity" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`cluster_instance_ami`**](#cluster_instance_ami) &mdash; The AMI to run on each instance in the EKS cluster. You can build the AMI using the Packer template eks-node-al2.json. One of [`cluster_instance_ami`](#cluster_instance_ami) or [`cluster_instance_ami_filters`](#cluster_instance_ami_filters) is required. Only used if [`cluster_instance_ami_filters`](#cluster_instance_ami_filters) is null. Set to null if [`cluster_instance_ami_filters`](#cluster_instance_ami_filters) is set.
+Default value for the on_demand_percentage_above_base_capacity field of autoscaling_group_configurations. Any map entry that does not specify on_demand_percentage_above_base_capacity will use this value.
 
-<a name="cluster_instance_ami_filters" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`cluster_instance_ami_filters`**](#cluster_instance_ami_filters) &mdash; Properties on the AMI that can be used to lookup a prebuilt AMI for use with self managed workers. You can build the AMI using the Packer template eks-node-al2.json. One of [`cluster_instance_ami`](#cluster_instance_ami) or [`cluster_instance_ami_filters`](#cluster_instance_ami_filters) is required. If both are defined, [`cluster_instance_ami_filters`](#cluster_instance_ami_filters) will be used. Set to null if [`cluster_instance_ami`](#cluster_instance_ami) is set.
+<HclListItem name="asg_default_spot_allocation_strategy" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="cluster_instance_associate_public_ip_address" className="snap-top"></a>
+Default value for the spot_allocation_strategy field of autoscaling_group_configurations. Any map entry that does not specify spot_allocation_strategy will use this value.
 
-* [**`cluster_instance_associate_public_ip_address`**](#cluster_instance_associate_public_ip_address) &mdash; Whether or not to associate a public IP address to the instances of the self managed ASGs. Will only work if the instances are launched in a public subnet.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="cluster_instance_keypair_name" className="snap-top"></a>
+<HclListItem name="asg_default_spot_instance_pools" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`cluster_instance_keypair_name`**](#cluster_instance_keypair_name) &mdash; The name of the Key Pair that can be used to SSH to each instance in the EKS cluster
+Default value for the spot_instance_pools field of autoscaling_group_configurations. Any map entry that does not specify spot_instance_pools will use this value.
 
-<a name="control_plane_cloudwatch_log_group_kms_key_id" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`control_plane_cloudwatch_log_group_kms_key_id`**](#control_plane_cloudwatch_log_group_kms_key_id) &mdash; The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data in the CloudWatch log group for EKS control plane logs.
+<HclListItem name="asg_default_spot_max_price" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="control_plane_cloudwatch_log_group_retention_in_days" className="snap-top"></a>
+Default value for the spot_max_price field of autoscaling_group_configurations. Any map entry that does not specify spot_max_price will use this value. Set to empty string (default) to mean on-demand price.
 
-* [**`control_plane_cloudwatch_log_group_retention_in_days`**](#control_plane_cloudwatch_log_group_retention_in_days) &mdash; The number of days to retain log events in the CloudWatch log group for EKS control plane logs. Refer to [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days) for all the valid values. When null, the log events are retained forever.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="control_plane_cloudwatch_log_group_tags" className="snap-top"></a>
+<HclListItem name="asg_default_tags" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`control_plane_cloudwatch_log_group_tags`**](#control_plane_cloudwatch_log_group_tags) &mdash; Tags to apply on the CloudWatch Log Group for EKS control plane logs, encoded as a map where the keys are tag keys and values are tag values.
+Default value for the tags field of autoscaling_group_configurations. Any map entry that does not specify tags will use this value.
 
-<a name="control_plane_disallowed_availability_zones" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`control_plane_disallowed_availability_zones`**](#control_plane_disallowed_availability_zones) &mdash; A list of availability zones in the region that we CANNOT use to deploy the EKS control plane. You can use this to avoid availability zones that may not be able to provision the resources (e.g ran out of capacity). If empty, will allow all availability zones.
+```hcl
+list(object({
+    key                 = string
+    value               = string
+    propagate_at_launch = bool
+  }))
+```
 
-<a name="create_default_fargate_iam_role" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`create_default_fargate_iam_role`**](#create_default_fargate_iam_role) &mdash; When true, IAM role will be created and attached to Fargate control plane services.
+<HclListItem name="asg_default_use_multi_instances_policy" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="custom_default_fargate_iam_role_name" className="snap-top"></a>
+Default value for the use_multi_instances_policy field of autoscaling_group_configurations. Any map entry that does not specify use_multi_instances_policy will use this value.
 
-* [**`custom_default_fargate_iam_role_name`**](#custom_default_fargate_iam_role_name) &mdash; The name to use for the default Fargate execution IAM role that is created when [`create_default_fargate_iam_role`](#create_default_fargate_iam_role) is true. When null, defaults to [`CLUSTER_NAME`](#CLUSTER_NAME)-fargate-role.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="custom_worker_egress_security_group_rules" className="snap-top"></a>
+<HclListItem name="asg_iam_instance_profile_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`custom_worker_egress_security_group_rules`**](#custom_worker_egress_security_group_rules) &mdash; A map of unique identifiers to egress security group rules to attach to the worker groups.
+Custom name for the IAM instance profile for the Self-managed workers. When null, the IAM role name will be used. If <a href="#asg_use_resource_name_prefix"><code>asg_use_resource_name_prefix</code></a> is true, this will be used as a name prefix.
 
-<a name="custom_worker_ingress_security_group_rules" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`custom_worker_ingress_security_group_rules`**](#custom_worker_ingress_security_group_rules) &mdash; A map of unique identifiers to ingress security group rules to attach to the worker groups.
+<HclListItem name="asg_iam_permissions_boundary" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="dashboard_cpu_usage_widget_parameters" className="snap-top"></a>
+ARN of a permission boundary to apply on the IAM role created for the self managed workers.
 
-* [**`dashboard_cpu_usage_widget_parameters`**](#dashboard_cpu_usage_widget_parameters) &mdash; Parameters for the worker cpu usage widget to output for use in a CloudWatch dashboard.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="dashboard_disk_usage_widget_parameters" className="snap-top"></a>
+<HclListItem name="asg_security_group_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`dashboard_disk_usage_widget_parameters`**](#dashboard_disk_usage_widget_parameters) &mdash; Parameters for the worker disk usage widget to output for use in a CloudWatch dashboard.
+A map of tags to apply to the Security Group of the ASG for the self managed worker pool. The key is the tag name and the value is the tag value.
 
-<a name="dashboard_memory_usage_widget_parameters" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`dashboard_memory_usage_widget_parameters`**](#dashboard_memory_usage_widget_parameters) &mdash; Parameters for the worker memory usage widget to output for use in a CloudWatch dashboard.
+```hcl
+map(string)
+```
 
-<a name="eks_cluster_security_group_tags" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`eks_cluster_security_group_tags`**](#eks_cluster_security_group_tags) &mdash; A map of custom tags to apply to the Security Group for the EKS Cluster Control Plane. The key is the tag name and the value is the tag value.
+<HclListItem name="asg_use_resource_name_prefix" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="eks_cluster_tags" className="snap-top"></a>
+When true, all the relevant resources for self managed workers will be set to use the name_prefix attribute so that unique names are generated for them. This allows those resources to support recreation through create_before_destroy lifecycle rules. Set to false if you were using any version before 0.65.0 and wish to avoid recreating the entire worker pool on your cluster.
 
-* [**`eks_cluster_tags`**](#eks_cluster_tags) &mdash; A map of custom tags to apply to the EKS Cluster Control Plane. The key is the tag name and the value is the tag value.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="enable_aws_auth_merger" className="snap-top"></a>
+<HclListItem name="autoscaling_group_configurations" requirement="optional" type="any">
+<HclListItemDescription>
 
-* [**`enable_aws_auth_merger`**](#enable_aws_auth_merger) &mdash; If set to true, installs the aws-auth-merger to manage the aws-auth configuration. When true, requires setting the [`aws_auth_merger_image`](#aws_auth_merger_image) variable.
+Configure one or more Auto Scaling Groups (ASGs) to manage the EC2 instances in this cluster. If any of the values are not provided, the specified default variable will be used to lookup a default value.
 
-<a name="enable_aws_auth_merger_fargate" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`enable_aws_auth_merger_fargate`**](#enable_aws_auth_merger_fargate) &mdash; When true, deploy the aws-auth-merger into Fargate. It is recommended to run the aws-auth-merger on Fargate to avoid chicken and egg issues between the aws-auth-merger and having an authenticated worker pool.
+<HclListItem name="autoscaling_group_include_autoscaler_discovery_tags" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="enable_cloudwatch_alarms" className="snap-top"></a>
+Adds additional tags to each ASG that allow a cluster autoscaler to auto-discover them.
 
-* [**`enable_cloudwatch_alarms`**](#enable_cloudwatch_alarms) &mdash; Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using [`alarms_sns_topic_arn`](#alarms_sns_topic_arn).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="enable_cloudwatch_metrics" className="snap-top"></a>
+<HclListItem name="aws_auth_merger_default_configmap_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`enable_cloudwatch_metrics`**](#enable_cloudwatch_metrics) &mdash; Set to true to add IAM permissions to send custom metrics to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/agents/cloudwatch-agent to get memory and disk metrics in CloudWatch for your Bastion host.
+Name of the default aws-auth ConfigMap to use. This will be the name of the ConfigMap that gets created by this module in the aws-auth-merger namespace to seed the initial aws-auth ConfigMap.
 
-<a name="enable_fail2ban" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="main-aws-auth"/>
+</HclListItem>
 
-* [**`enable_fail2ban`**](#enable_fail2ban) &mdash; Enable fail2ban to block brute force log in attempts. Defaults to true.
+<HclListItem name="aws_auth_merger_image" requirement="optional" type="object">
+<HclListItemDescription>
 
-<a name="enabled_control_plane_log_types" className="snap-top"></a>
+Location of the container image to use for the aws-auth-merger app. You can use the Dockerfile provided in terraform-aws-eks to construct an image. See https://github.com/gruntwork-io/terraform-aws-eks/blob/master/modules/eks-aws-auth-merger/core-concepts.md#how-do-i-use-the-aws-auth-merger for more info.
 
-* [**`enabled_control_plane_log_types`**](#enabled_control_plane_log_types) &mdash; A list of the desired control plane logging to enable. See https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html for the list of available logs.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="endpoint_public_access" className="snap-top"></a>
+```hcl
+object({
+    # Container image repository where the aws-auth-merger app container image lives
+    repo = string
+    # Tag of the aws-auth-merger container to deploy
+    tag = string
+  })
+```
 
-* [**`endpoint_public_access`**](#endpoint_public_access) &mdash; Whether or not to enable public API endpoints which allow access to the Kubernetes API from outside of the VPC. Note that private access within the VPC is always enabled.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="external_account_ssh_grunt_role_arn" className="snap-top"></a>
+<HclListItem name="aws_auth_merger_namespace" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`external_account_ssh_grunt_role_arn`**](#external_account_ssh_grunt_role_arn) &mdash; If you are using ssh-grunt and your IAM users / groups are defined in a separate AWS account, you can use this variable to specify the ARN of an IAM role that ssh-grunt can assume to retrieve IAM group and public SSH key info from that account. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+Namespace to deploy the aws-auth-merger into. The app will watch for ConfigMaps in this Namespace to merge into the aws-auth ConfigMap.
 
-<a name="fargate_profile_executor_iam_role_arns_for_k8s_role_mapping" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="aws-auth-merger"/>
+</HclListItem>
 
-* [**`fargate_profile_executor_iam_role_arns_for_k8s_role_mapping`**](#fargate_profile_executor_iam_role_arns_for_k8s_role_mapping) &mdash; List of ARNs of AWS IAM roles corresponding to Fargate Profiles that should be mapped as Kubernetes Nodes.
+<HclListItem name="cloud_init_parts" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="fargate_worker_disallowed_availability_zones" className="snap-top"></a>
+Cloud init scripts to run on the EKS worker nodes when it is booting. See the part blocks in https://www.terraform.io/docs/providers/template/d/cloudinit_config.html for syntax. To override the default boot script installed as part of the module, use the key `default`.
 
-* [**`fargate_worker_disallowed_availability_zones`**](#fargate_worker_disallowed_availability_zones) &mdash; A list of availability zones in the region that we CANNOT use to deploy the EKS Fargate workers. You can use this to avoid availability zones that may not be able to provision the resources (e.g ran out of capacity). If empty, will allow all availability zones.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="iam_role_to_rbac_group_mapping" className="snap-top"></a>
+```hcl
+map(object({
+    # A filename to report in the header for the part. Should be unique across all cloud-init parts.
+    filename = string
 
-* [**`iam_role_to_rbac_group_mapping`**](#iam_role_to_rbac_group_mapping) &mdash; Mapping of IAM role ARNs to Kubernetes RBAC groups that grant permissions to the user.
+    # A MIME-style content type to report in the header for the part. For example, use "text/x-shellscript" for a shell
+    # script.
+    content_type = string
 
-<a name="iam_user_to_rbac_group_mapping" className="snap-top"></a>
+    # The contents of the boot script to be called. This should be the full text of the script as a raw string.
+    content = string
+  }))
+```
 
-* [**`iam_user_to_rbac_group_mapping`**](#iam_user_to_rbac_group_mapping) &mdash; Mapping of IAM user ARNs to Kubernetes RBAC groups that grant permissions to the user.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="kubernetes_version" className="snap-top"></a>
+<HclListItem name="cluster_iam_role_permissions_boundary" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`kubernetes_version`**](#kubernetes_version) &mdash; Version of Kubernetes to use. Refer to EKS docs for list of available versions (https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html).
+ARN of permissions boundary to apply to the cluster IAM role - the IAM role created for the EKS cluster.
 
-<a name="managed_node_group_configurations" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`managed_node_group_configurations`**](#managed_node_group_configurations) &mdash; Configure one or more Node Groups to manage the EC2 instances in this cluster. Set to empty object ({}) if you do not wish to configure managed node groups.
+<HclListItem name="cluster_instance_ami" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="node_group_default_capacity_type" className="snap-top"></a>
+The AMI to run on each instance in the EKS cluster. You can build the AMI using the Packer template eks-node-al2.json. One of <a href="#cluster_instance_ami"><code>cluster_instance_ami</code></a> or <a href="#cluster_instance_ami_filters"><code>cluster_instance_ami_filters</code></a> is required. Only used if <a href="#cluster_instance_ami_filters"><code>cluster_instance_ami_filters</code></a> is null. Set to null if cluster_instance_ami_filters is set.
 
-* [**`node_group_default_capacity_type`**](#node_group_default_capacity_type) &mdash; Default value for [`capacity_type`](#capacity_type) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="node_group_default_desired_size" className="snap-top"></a>
+<HclListItem name="cluster_instance_ami_filters" requirement="optional" type="object">
+<HclListItemDescription>
 
-* [**`node_group_default_desired_size`**](#node_group_default_desired_size) &mdash; Default value for [`desired_size`](#desired_size) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+Properties on the AMI that can be used to lookup a prebuilt AMI for use with self managed workers. You can build the AMI using the Packer template eks-node-al2.json. One of <a href="#cluster_instance_ami"><code>cluster_instance_ami</code></a> or <a href="#cluster_instance_ami_filters"><code>cluster_instance_ami_filters</code></a> is required. If both are defined, <a href="#cluster_instance_ami_filters"><code>cluster_instance_ami_filters</code></a> will be used. Set to null if cluster_instance_ami is set.
 
-<a name="node_group_default_enable_detailed_monitoring" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`node_group_default_enable_detailed_monitoring`**](#node_group_default_enable_detailed_monitoring) &mdash; Default value for [`enable_detailed_monitoring`](#enable_detailed_monitoring) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+```hcl
+object({
+    # List of owners to limit the search. Set to null if you do not wish to limit the search by AMI owners.
+    owners = list(string)
 
-<a name="node_group_default_instance_root_volume_encryption" className="snap-top"></a>
+    # Name/Value pairs to filter the AMI off of. There are several valid keys, for a full reference, check out the
+    # documentation for describe-images in the AWS CLI reference
+    # (https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html).
+    filters = list(object({
+      name   = string
+      values = list(string)
+    }))
+  })
+```
 
-* [**`node_group_default_instance_root_volume_encryption`**](#node_group_default_instance_root_volume_encryption) &mdash; Default value for the [`instance_root_volume_encryption`](#instance_root_volume_encryption) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="node_group_default_instance_root_volume_size" className="snap-top"></a>
+<HclListItem name="cluster_instance_associate_public_ip_address" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`node_group_default_instance_root_volume_size`**](#node_group_default_instance_root_volume_size) &mdash; Default value for the [`instance_root_volume_size`](#instance_root_volume_size) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+Whether or not to associate a public IP address to the instances of the self managed ASGs. Will only work if the instances are launched in a public subnet.
 
-<a name="node_group_default_instance_root_volume_type" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`node_group_default_instance_root_volume_type`**](#node_group_default_instance_root_volume_type) &mdash; Default value for the [`instance_root_volume_type`](#instance_root_volume_type) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+<HclListItem name="cluster_instance_keypair_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="node_group_default_instance_types" className="snap-top"></a>
+The name of the Key Pair that can be used to SSH to each instance in the EKS cluster
 
-* [**`node_group_default_instance_types`**](#node_group_default_instance_types) &mdash; Default value for [`instance_types`](#instance_types) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="node_group_default_labels" className="snap-top"></a>
+<HclListItem name="control_plane_cloudwatch_log_group_kms_key_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`node_group_default_labels`**](#node_group_default_labels) &mdash; Default value for labels field of [`managed_node_group_configurations`](#managed_node_group_configurations). Unlike [`common_labels`](#common_labels) which will always be merged in, these labels are only used if the labels field is omitted from the configuration.
+The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data in the CloudWatch log group for EKS control plane logs.
 
-<a name="node_group_default_max_pods_allowed" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`node_group_default_max_pods_allowed`**](#node_group_default_max_pods_allowed) &mdash; Default value for the [`max_pods_allowed`](#max_pods_allowed) field of [`managed_node_group_configurations`](#managed_node_group_configurations). Any map entry that does not specify [`max_pods_allowed`](#max_pods_allowed) will use this value.
+<HclListItem name="control_plane_cloudwatch_log_group_retention_in_days" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="node_group_default_max_size" className="snap-top"></a>
+The number of days to retain log events in the CloudWatch log group for EKS control plane logs. Refer to https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days for all the valid values. When null, the log events are retained forever.
 
-* [**`node_group_default_max_size`**](#node_group_default_max_size) &mdash; Default value for [`max_size`](#max_size) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="node_group_default_min_size" className="snap-top"></a>
+<HclListItem name="control_plane_cloudwatch_log_group_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`node_group_default_min_size`**](#node_group_default_min_size) &mdash; Default value for [`min_size`](#min_size) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+Tags to apply on the CloudWatch Log Group for EKS control plane logs, encoded as a map where the keys are tag keys and values are tag values.
 
-<a name="node_group_default_subnet_ids" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`node_group_default_subnet_ids`**](#node_group_default_subnet_ids) &mdash; Default value for [`subnet_ids`](#subnet_ids) field of [`managed_node_group_configurations`](#managed_node_group_configurations).
+```hcl
+map(string)
+```
 
-<a name="node_group_default_tags" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`node_group_default_tags`**](#node_group_default_tags) &mdash; Default value for tags field of [`managed_node_group_configurations`](#managed_node_group_configurations). Unlike [`common_tags`](#common_tags) which will always be merged in, these tags are only used if the tags field is omitted from the configuration.
+<HclListItem name="control_plane_disallowed_availability_zones" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="node_group_iam_permissions_boundary" className="snap-top"></a>
+A list of availability zones in the region that we CANNOT use to deploy the EKS control plane. You can use this to avoid availability zones that may not be able to provision the resources (e.g ran out of capacity). If empty, will allow all availability zones.
 
-* [**`node_group_iam_permissions_boundary`**](#node_group_iam_permissions_boundary) &mdash; ARN of a permission boundary to apply on the IAM role created for the managed node groups.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="node_group_launch_template_instance_type" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`node_group_launch_template_instance_type`**](#node_group_launch_template_instance_type) &mdash; The instance type to configure in the launch template. This value will be used when the [`instance_types`](#instance_types) field is set to null (NOT omitted, in which case [`node_group_default_instance_types`](#node_group_default_instance_types) will be used).
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[
+  'us-east-1e'
+]"/>
+</HclListItem>
 
-<a name="node_group_security_group_tags" className="snap-top"></a>
+<HclListItem name="create_default_fargate_iam_role" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`node_group_security_group_tags`**](#node_group_security_group_tags) &mdash; A map of tags to apply to the Security Group of the ASG for the managed node group pool. The key is the tag name and the value is the tag value.
+When true, IAM role will be created and attached to Fargate control plane services.
 
-<a name="num_control_plane_vpc_subnet_ids" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`num_control_plane_vpc_subnet_ids`**](#num_control_plane_vpc_subnet_ids) &mdash; Number of subnets provided in the [`control_plane_vpc_subnet_ids`](#control_plane_vpc_subnet_ids) variable. When null (default), this is computed dynamically from the list. This is used to workaround terraform limitations where resource count and [`for_each`](#for_each) can not depend on dynamic resources (e.g., if you are creating the subnets and the EKS cluster in the same module).
+<HclListItem name="custom_default_fargate_iam_role_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="num_worker_vpc_subnet_ids" className="snap-top"></a>
+The name to use for the default Fargate execution IAM role that is created when create_default_fargate_iam_role is true. When null, defaults to CLUSTER_NAME-fargate-role.
 
-* [**`num_worker_vpc_subnet_ids`**](#num_worker_vpc_subnet_ids) &mdash; Number of subnets provided in the [`worker_vpc_subnet_ids`](#worker_vpc_subnet_ids) variable. When null (default), this is computed dynamically from the list. This is used to workaround terraform limitations where resource count and [`for_each`](#for_each) can not depend on dynamic resources (e.g., if you are creating the subnets and the EKS cluster in the same module).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="schedule_control_plane_services_on_fargate" className="snap-top"></a>
+<HclListItem name="custom_worker_egress_security_group_rules" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`schedule_control_plane_services_on_fargate`**](#schedule_control_plane_services_on_fargate) &mdash; When true, configures control plane services to run on Fargate so that the cluster can run without worker nodes. If true, requires kubergrunt to be available on the system, and [`create_default_fargate_iam_role`](#create_default_fargate_iam_role) be set to true.
+A map of unique identifiers to egress security group rules to attach to the worker groups.
 
-<a name="secret_envelope_encryption_kms_key_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`secret_envelope_encryption_kms_key_arn`**](#secret_envelope_encryption_kms_key_arn) &mdash; ARN for KMS Key to use for envelope encryption of Kubernetes Secrets. By default Secrets in EKS are encrypted at rest at the EBS layer in the managed etcd cluster using shared AWS managed keys. Setting this variable will configure Kubernetes to use envelope encryption to encrypt Secrets using this KMS key on top of the EBS layer encryption.
+```hcl
+map(object({
+    # The network ports and protocol (tcp, udp, all) for which the security group rule applies to.
+    from_port = number
+    to_port   = number
+    protocol  = string
 
-<a name="should_create_control_plane_cloudwatch_log_group" className="snap-top"></a>
+    # The target of the traffic. Only one of the following can be defined; the others must be configured to null.
+    target_security_group_id = string       # The ID of the security group to which the traffic goes to.
+    cidr_blocks              = list(string) # The list of IP CIDR blocks to which the traffic goes to.
+  }))
+```
 
-* [**`should_create_control_plane_cloudwatch_log_group`**](#should_create_control_plane_cloudwatch_log_group) &mdash; When true, precreate the CloudWatch Log Group to use for EKS control plane logging. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, EKS will automatically create a basic log group to use. Note that logs are only streamed to this group if [`enabled_cluster_log_types`](#enabled_cluster_log_types) is true.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="ssh_grunt_iam_group" className="snap-top"></a>
+<HclListItem name="custom_worker_ingress_security_group_rules" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`ssh_grunt_iam_group`**](#ssh_grunt_iam_group) &mdash; If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to the EKS workers. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+A map of unique identifiers to ingress security group rules to attach to the worker groups.
 
-<a name="ssh_grunt_iam_group_sudo" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`ssh_grunt_iam_group_sudo`**](#ssh_grunt_iam_group_sudo) &mdash; If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to the EKS workers with sudo permissions. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+```hcl
+map(object({
+    # The network ports and protocol (tcp, udp, all) for which the security group rule applies to.
+    from_port = number
+    to_port   = number
+    protocol  = string
 
-<a name="tenancy" className="snap-top"></a>
+    # The source of the traffic. Only one of the following can be defined; the others must be configured to null.
+    source_security_group_id = string       # The ID of the security group from which the traffic originates from.
+    cidr_blocks              = list(string) # The list of IP CIDR blocks from which the traffic originates from.
+  }))
+```
 
-* [**`tenancy`**](#tenancy) &mdash; The tenancy of this server. Must be one of: default, dedicated, or host.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="use_exec_plugin_for_auth" className="snap-top"></a>
+<HclListItem name="dashboard_cpu_usage_widget_parameters" requirement="optional" type="object">
+<HclListItemDescription>
 
-* [**`use_exec_plugin_for_auth`**](#use_exec_plugin_for_auth) &mdash; If this variable is set to true, then use an exec-based plugin to authenticate and fetch tokens for EKS. This is useful because EKS clusters use short-lived authentication tokens that can expire in the middle of an 'apply' or 'destroy', and since the native Kubernetes provider in Terraform doesn't have a way to fetch up-to-date tokens, we recommend using an exec-based provider as a workaround. Use the [`use_kubergrunt_to_fetch_token`](#use_kubergrunt_to_fetch_token) input variable to control whether kubergrunt or aws is used to fetch tokens.
+Parameters for the worker cpu usage widget to output for use in a CloudWatch dashboard.
 
-<a name="use_kubergrunt_sync_components" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`use_kubergrunt_sync_components`**](#use_kubergrunt_sync_components) &mdash; When set to true, this will enable kubergrunt based component syncing. This step ensures that the core EKS components that are installed are upgraded to a matching version everytime the cluster's Kubernetes version is updated.
+```hcl
+object({
+    # The period in seconds for metrics to sample across.
+    period = number
 
-<a name="use_kubergrunt_to_fetch_token" className="snap-top"></a>
+    # The width and height of the widget in grid units in a 24 column grid. E.g., a value of 12 will take up half the
+    # space.
+    width  = number
+    height = number
+  })
+```
 
-* [**`use_kubergrunt_to_fetch_token`**](#use_kubergrunt_to_fetch_token) &mdash; EKS clusters use short-lived authentication tokens that can expire in the middle of an 'apply' or 'destroy'. To avoid this issue, we use an exec-based plugin to fetch an up-to-date token. If this variable is set to true, we'll use kubergrunt to fetch the token (in which case, kubergrunt must be installed and on PATH); if this variable is set to false, we'll use the aws CLI to fetch the token (in which case, aws must be installed and on PATH). Note this functionality is only enabled if [`use_exec_plugin_for_auth`](#use_exec_plugin_for_auth) is set to true.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-<a name="use_kubergrunt_verification" className="snap-top"></a>
+```hcl
+{
+  height = 6,
+  period = 60,
+  width = 8
+}
+```
 
-* [**`use_kubergrunt_verification`**](#use_kubergrunt_verification) &mdash; When set to true, this will enable kubergrunt verification to wait for the Kubernetes API server to come up before completing. If false, reverts to a 30 second timed wait instead.
+</HclListItemDefaultValue>
+</HclListItem>
 
-<a name="use_managed_iam_policies" className="snap-top"></a>
+<HclListItem name="dashboard_disk_usage_widget_parameters" requirement="optional" type="object">
+<HclListItemDescription>
 
-* [**`use_managed_iam_policies`**](#use_managed_iam_policies) &mdash; When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+Parameters for the worker disk usage widget to output for use in a CloudWatch dashboard.
 
-<a name="use_vpc_cni_customize_script" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`use_vpc_cni_customize_script`**](#use_vpc_cni_customize_script) &mdash; When set to true, this will enable management of the aws-vpc-cni configuration options using kubergrunt running as a local-exec provisioner. If you set this to false, the [`vpc_cni_`](#vpc_cni_)* variables will be ignored.
+```hcl
+object({
+    # The period in seconds for metrics to sample across.
+    period = number
 
-<a name="vpc_cni_enable_prefix_delegation" className="snap-top"></a>
+    # The width and height of the widget in grid units in a 24 column grid. E.g., a value of 12 will take up half the
+    # space.
+    width  = number
+    height = number
+  })
+```
 
-* [**`vpc_cni_enable_prefix_delegation`**](#vpc_cni_enable_prefix_delegation) &mdash; When true, enable prefix delegation mode for the AWS VPC CNI component of the EKS cluster. In prefix delegation mode, each ENI will be allocated 16 IP addresses (/28) instead of 1, allowing you to pack more Pods per node. Note that by default, AWS VPC CNI will always preallocate 1 full prefix - this means that you can potentially take up 32 IP addresses from the VPC network space even if you only have 1 Pod on the node. You can tweak this behavior by configuring the [`vpc_cni_warm_ip_target`](#vpc_cni_warm_ip_target) input variable.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-<a name="vpc_cni_minimum_ip_target" className="snap-top"></a>
+```hcl
+{
+  height = 6,
+  period = 60,
+  width = 8
+}
+```
 
-* [**`vpc_cni_minimum_ip_target`**](#vpc_cni_minimum_ip_target) &mdash; The minimum number of IP addresses (free and used) each node should start with. When null, defaults to the aws-vpc-cni application setting (currently 16 as of version 1.9.0). For example, if this is set to 25, every node will allocate 2 prefixes (32 IP addresses). On the other hand, if this was set to the default value, then each node will allocate only 1 prefix (16 IP addresses).
+</HclListItemDefaultValue>
+</HclListItem>
 
-<a name="vpc_cni_warm_ip_target" className="snap-top"></a>
+<HclListItem name="dashboard_memory_usage_widget_parameters" requirement="optional" type="object">
+<HclListItemDescription>
 
-* [**`vpc_cni_warm_ip_target`**](#vpc_cni_warm_ip_target) &mdash; The number of free IP addresses each node should maintain. When null, defaults to the aws-vpc-cni application setting (currently 16 as of version 1.9.0). In prefix delegation mode, determines whether the node will preallocate another full prefix. For example, if this is set to 5 and a node is currently has 9 Pods scheduled, then the node will NOT preallocate a new prefix block of 16 IP addresses. On the other hand, if this was set to the default value, then the node will allocate a new block when the first pod is scheduled.
+Parameters for the worker memory usage widget to output for use in a CloudWatch dashboard.
 
-<a name="worker_iam_role_arns_for_k8s_role_mapping" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`worker_iam_role_arns_for_k8s_role_mapping`**](#worker_iam_role_arns_for_k8s_role_mapping) &mdash; List of ARNs of AWS IAM roles corresponding to EC2 instances that should be mapped as Kubernetes Nodes.
+```hcl
+object({
+    # The period in seconds for metrics to sample across.
+    period = number
 
-<a name="worker_name_prefix" className="snap-top"></a>
+    # The width and height of the widget in grid units in a 24 column grid. E.g., a value of 12 will take up half the
+    # space.
+    width  = number
+    height = number
+  })
+```
 
-* [**`worker_name_prefix`**](#worker_name_prefix) &mdash; Prefix EKS worker resource names with this string. When you have multiple worker groups for the cluster, you can use this to namespace the resources. Defaults to empty string so that resource names are not excessively long by default.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-<a name="worker_vpc_subnet_ids" className="snap-top"></a>
+```hcl
+{
+  height = 6,
+  period = 60,
+  width = 8
+}
+```
 
-* [**`worker_vpc_subnet_ids`**](#worker_vpc_subnet_ids) &mdash; A list of the subnets into which the EKS Cluster's administrative pods will be launched. These should usually be all private subnets and include one in each AWS Availability Zone. Required when [`schedule_control_plane_services_on_fargate`](#schedule_control_plane_services_on_fargate) is true.
+</HclListItemDefaultValue>
+</HclListItem>
+
+<HclListItem name="eks_cluster_security_group_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of custom tags to apply to the Security Group for the EKS Cluster Control Plane. The key is the tag name and the value is the tag value.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="eks_cluster_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of custom tags to apply to the EKS Cluster Control Plane. The key is the tag name and the value is the tag value.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="enable_aws_auth_merger" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If set to true, installs the aws-auth-merger to manage the aws-auth configuration. When true, requires setting the <a href="#aws_auth_merger_image"><code>aws_auth_merger_image</code></a> variable.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="enable_aws_auth_merger_fargate" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, deploy the aws-auth-merger into Fargate. It is recommended to run the aws-auth-merger on Fargate to avoid chicken and egg issues between the aws-auth-merger and having an authenticated worker pool.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_cloudwatch_alarms" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using <a href="#alarms_sns_topic_arn"><code>alarms_sns_topic_arn</code></a>.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_cloudwatch_metrics" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to add IAM permissions to send custom metrics to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/agents/cloudwatch-agent to get memory and disk metrics in CloudWatch for your Bastion host.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_fail2ban" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Enable fail2ban to block brute force log in attempts. Defaults to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enabled_control_plane_log_types" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of the desired control plane logging to enable. See https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html for the list of available logs.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
+
+```hcl
+[
+  "api",
+  "audit",
+  "authenticator"
+]
+```
+
+</HclListItemDefaultValue>
+</HclListItem>
+
+<HclListItem name="endpoint_public_access" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Whether or not to enable public API endpoints which allow access to the Kubernetes API from outside of the VPC. Note that private access within the VPC is always enabled.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="external_account_ssh_grunt_role_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt and your IAM users / groups are defined in a separate AWS account, you can use this variable to specify the ARN of an IAM role that ssh-grunt can assume to retrieve IAM group and public SSH key info from that account. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="fargate_profile_executor_iam_role_arns_for_k8s_role_mapping" requirement="optional" type="list">
+<HclListItemDescription>
+
+List of ARNs of AWS IAM roles corresponding to Fargate Profiles that should be mapped as Kubernetes Nodes.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="fargate_worker_disallowed_availability_zones" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of availability zones in the region that we CANNOT use to deploy the EKS Fargate workers. You can use this to avoid availability zones that may not be able to provision the resources (e.g ran out of capacity). If empty, will allow all availability zones.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
+
+```hcl
+[
+  "us-east-1d",
+  "us-east-1e",
+  "ca-central-1d"
+]
+```
+
+</HclListItemDefaultValue>
+</HclListItem>
+
+<HclListItem name="iam_role_to_rbac_group_mapping" requirement="optional" type="map">
+<HclListItemDescription>
+
+Mapping of IAM role ARNs to Kubernetes RBAC groups that grant permissions to the user.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(list(string))
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="iam_user_to_rbac_group_mapping" requirement="optional" type="map">
+<HclListItemDescription>
+
+Mapping of IAM user ARNs to Kubernetes RBAC groups that grant permissions to the user.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(list(string))
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="kubernetes_version" requirement="optional" type="string">
+<HclListItemDescription>
+
+Version of Kubernetes to use. Refer to EKS docs for list of available versions (https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1.21"/>
+</HclListItem>
+
+<HclListItem name="managed_node_group_configurations" requirement="optional" type="any">
+<HclListItemDescription>
+
+Configure one or more Node Groups to manage the EC2 instances in this cluster. Set to empty object ({}) if you do not wish to configure managed node groups.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_capacity_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+Default value for capacity_type field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ON_DEMAND"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_desired_size" requirement="optional" type="number">
+<HclListItemDescription>
+
+Default value for desired_size field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_enable_detailed_monitoring" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Default value for enable_detailed_monitoring field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_instance_root_volume_encryption" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Default value for the instance_root_volume_encryption field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_instance_root_volume_size" requirement="optional" type="number">
+<HclListItemDescription>
+
+Default value for the instance_root_volume_size field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="40"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_instance_root_volume_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+Default value for the instance_root_volume_type field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="gp3"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_instance_types" requirement="optional" type="list">
+<HclListItemDescription>
+
+Default value for instance_types field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_labels" requirement="optional" type="map">
+<HclListItemDescription>
+
+Default value for labels field of managed_node_group_configurations. Unlike common_labels which will always be merged in, these labels are only used if the labels field is omitted from the configuration.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_max_pods_allowed" requirement="optional" type="number">
+<HclListItemDescription>
+
+Default value for the max_pods_allowed field of managed_node_group_configurations. Any map entry that does not specify max_pods_allowed will use this value.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_max_size" requirement="optional" type="number">
+<HclListItemDescription>
+
+Default value for max_size field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_min_size" requirement="optional" type="number">
+<HclListItemDescription>
+
+Default value for min_size field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_subnet_ids" requirement="optional" type="list">
+<HclListItemDescription>
+
+Default value for subnet_ids field of managed_node_group_configurations.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="node_group_default_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+Default value for tags field of managed_node_group_configurations. Unlike common_tags which will always be merged in, these tags are only used if the tags field is omitted from the configuration.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="node_group_iam_permissions_boundary" requirement="optional" type="string">
+<HclListItemDescription>
+
+ARN of a permission boundary to apply on the IAM role created for the managed node groups.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="node_group_launch_template_instance_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+The instance type to configure in the launch template. This value will be used when the instance_types field is set to null (NOT omitted, in which case <a href="#node_group_default_instance_types"><code>node_group_default_instance_types</code></a> will be used).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="node_group_security_group_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of tags to apply to the Security Group of the ASG for the managed node group pool. The key is the tag name and the value is the tag value.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="num_control_plane_vpc_subnet_ids" requirement="optional" type="number">
+<HclListItemDescription>
+
+Number of subnets provided in the <a href="#control_plane_vpc_subnet_ids"><code>control_plane_vpc_subnet_ids</code></a> variable. When null (default), this is computed dynamically from the list. This is used to workaround terraform limitations where resource count and for_each can not depend on dynamic resources (e.g., if you are creating the subnets and the EKS cluster in the same module).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="num_worker_vpc_subnet_ids" requirement="optional" type="number">
+<HclListItemDescription>
+
+Number of subnets provided in the <a href="#worker_vpc_subnet_ids"><code>worker_vpc_subnet_ids</code></a> variable. When null (default), this is computed dynamically from the list. This is used to workaround terraform limitations where resource count and for_each can not depend on dynamic resources (e.g., if you are creating the subnets and the EKS cluster in the same module).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="schedule_control_plane_services_on_fargate" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, configures control plane services to run on Fargate so that the cluster can run without worker nodes. If true, requires kubergrunt to be available on the system, and create_default_fargate_iam_role be set to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="secret_envelope_encryption_kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+ARN for KMS Key to use for envelope encryption of Kubernetes Secrets. By default Secrets in EKS are encrypted at rest at the EBS layer in the managed etcd cluster using shared AWS managed keys. Setting this variable will configure Kubernetes to use envelope encryption to encrypt Secrets using this KMS key on top of the EBS layer encryption.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="should_create_control_plane_cloudwatch_log_group" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, precreate the CloudWatch Log Group to use for EKS control plane logging. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, EKS will automatically create a basic log group to use. Note that logs are only streamed to this group if <a href="#enabled_cluster_log_types"><code>enabled_cluster_log_types</code></a> is true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="ssh_grunt_iam_group" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to the EKS workers. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ssh-grunt-users"/>
+</HclListItem>
+
+<HclListItem name="ssh_grunt_iam_group_sudo" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to the EKS workers with sudo permissions. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ssh-grunt-sudo-users"/>
+</HclListItem>
+
+<HclListItem name="tenancy" requirement="optional" type="string">
+<HclListItemDescription>
+
+The tenancy of this server. Must be one of: default, dedicated, or host.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="default"/>
+</HclListItem>
+
+<HclListItem name="use_exec_plugin_for_auth" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If this variable is set to true, then use an exec-based plugin to authenticate and fetch tokens for EKS. This is useful because EKS clusters use short-lived authentication tokens that can expire in the middle of an 'apply' or 'destroy', and since the native Kubernetes provider in Terraform doesn't have a way to fetch up-to-date tokens, we recommend using an exec-based provider as a workaround. Use the use_kubergrunt_to_fetch_token input variable to control whether kubergrunt or aws is used to fetch tokens.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="use_kubergrunt_sync_components" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When set to true, this will enable kubergrunt based component syncing. This step ensures that the core EKS components that are installed are upgraded to a matching version everytime the cluster's Kubernetes version is updated.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="use_kubergrunt_to_fetch_token" requirement="optional" type="bool">
+<HclListItemDescription>
+
+EKS clusters use short-lived authentication tokens that can expire in the middle of an 'apply' or 'destroy'. To avoid this issue, we use an exec-based plugin to fetch an up-to-date token. If this variable is set to true, we'll use kubergrunt to fetch the token (in which case, kubergrunt must be installed and on PATH); if this variable is set to false, we'll use the aws CLI to fetch the token (in which case, aws must be installed and on PATH). Note this functionality is only enabled if use_exec_plugin_for_auth is set to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="use_kubergrunt_verification" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When set to true, this will enable kubergrunt verification to wait for the Kubernetes API server to come up before completing. If false, reverts to a 30 second timed wait instead.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="use_managed_iam_policies" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="use_vpc_cni_customize_script" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When set to true, this will enable management of the aws-vpc-cni configuration options using kubergrunt running as a local-exec provisioner. If you set this to false, the vpc_cni_* variables will be ignored.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="vpc_cni_enable_prefix_delegation" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, enable prefix delegation mode for the AWS VPC CNI component of the EKS cluster. In prefix delegation mode, each ENI will be allocated 16 IP addresses (/28) instead of 1, allowing you to pack more Pods per node. Note that by default, AWS VPC CNI will always preallocate 1 full prefix - this means that you can potentially take up 32 IP addresses from the VPC network space even if you only have 1 Pod on the node. You can tweak this behavior by configuring the <a href="#vpc_cni_warm_ip_target"><code>vpc_cni_warm_ip_target</code></a> input variable.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="vpc_cni_minimum_ip_target" requirement="optional" type="number">
+<HclListItemDescription>
+
+The minimum number of IP addresses (free and used) each node should start with. When null, defaults to the aws-vpc-cni application setting (currently 16 as of version 1.9.0). For example, if this is set to 25, every node will allocate 2 prefixes (32 IP addresses). On the other hand, if this was set to the default value, then each node will allocate only 1 prefix (16 IP addresses).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="vpc_cni_warm_ip_target" requirement="optional" type="number">
+<HclListItemDescription>
+
+The number of free IP addresses each node should maintain. When null, defaults to the aws-vpc-cni application setting (currently 16 as of version 1.9.0). In prefix delegation mode, determines whether the node will preallocate another full prefix. For example, if this is set to 5 and a node is currently has 9 Pods scheduled, then the node will NOT preallocate a new prefix block of 16 IP addresses. On the other hand, if this was set to the default value, then the node will allocate a new block when the first pod is scheduled.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="worker_iam_role_arns_for_k8s_role_mapping" requirement="optional" type="list">
+<HclListItemDescription>
+
+List of ARNs of AWS IAM roles corresponding to EC2 instances that should be mapped as Kubernetes Nodes.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="worker_name_prefix" requirement="optional" type="string">
+<HclListItemDescription>
+
+Prefix EKS worker resource names with this string. When you have multiple worker groups for the cluster, you can use this to namespace the resources. Defaults to empty string so that resource names are not excessively long by default.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="worker_vpc_subnet_ids" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of the subnets into which the EKS Cluster's administrative pods will be launched. These should usually be all private subnets and include one in each AWS Availability Zone. Required when <a href="#schedule_control_plane_services_on_fargate"><code>schedule_control_plane_services_on_fargate</code></a> is true.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="aws_auth_merger_namespace" className="snap-top"></a>
+<HclListItem name="aws_auth_merger_namespace">
+<HclListItemDescription>
 
-* [**`aws_auth_merger_namespace`**](#aws_auth_merger_namespace) &mdash; The namespace name for the aws-auth-merger add on, if created.
+The namespace name for the aws-auth-merger add on, if created.
 
-<a name="eks_cluster_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`eks_cluster_arn`**](#eks_cluster_arn) &mdash; The ARN of the EKS cluster that was deployed.
+<HclListItem name="eks_cluster_arn">
+<HclListItemDescription>
 
-<a name="eks_cluster_name" className="snap-top"></a>
+The ARN of the EKS cluster that was deployed.
 
-* [**`eks_cluster_name`**](#eks_cluster_name) &mdash; The name of the EKS cluster that was deployed.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="eks_default_fargate_execution_role_arn" className="snap-top"></a>
+<HclListItem name="eks_cluster_name">
+<HclListItemDescription>
 
-* [**`eks_default_fargate_execution_role_arn`**](#eks_default_fargate_execution_role_arn) &mdash; A basic IAM Role ARN that has the minimal permissions to pull images from ECR that can be used for most Pods as Fargate Execution Role that do not need to interact with AWS.
+The name of the EKS cluster that was deployed.
 
-<a name="eks_iam_role_for_service_accounts_config" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`eks_iam_role_for_service_accounts_config`**](#eks_iam_role_for_service_accounts_config) &mdash; Configuration for using the IAM role with Service Accounts feature to provide permissions to the applications. This outputs a map with two properties: [``openid_connect_provider_arn`](#`openid_connect_provider_arn)` and [``openid_connect_provider_url`](#`openid_connect_provider_url)`. The [``openid_connect_provider_arn`](#`openid_connect_provider_arn)` is the ARN of the OpenID Connect Provider for EKS to retrieve IAM credentials, while [``openid_connect_provider_url`](#`openid_connect_provider_url)` is the URL.
+<HclListItem name="eks_default_fargate_execution_role_arn">
+<HclListItemDescription>
 
-<a name="eks_kubeconfig" className="snap-top"></a>
+A basic IAM Role ARN that has the minimal permissions to pull images from ECR that can be used for most Pods as Fargate Execution Role that do not need to interact with AWS.
 
-* [**`eks_kubeconfig`**](#eks_kubeconfig) &mdash; Minimal configuration for kubectl to authenticate with the created EKS cluster.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="eks_worker_asg_names" className="snap-top"></a>
+<HclListItem name="eks_iam_role_for_service_accounts_config">
+<HclListItemDescription>
 
-* [**`eks_worker_asg_names`**](#eks_worker_asg_names) &mdash; The list of names of the ASGs that were deployed to act as EKS workers.
+Configuration for using the IAM role with Service Accounts feature to provide permissions to the applications. This outputs a map with two properties: `openid_connect_provider_arn` and `openid_connect_provider_url`. The `openid_connect_provider_arn` is the ARN of the OpenID Connect Provider for EKS to retrieve IAM credentials, while `openid_connect_provider_url` is the URL.
 
-<a name="managed_node_group_worker_iam_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`managed_node_group_worker_iam_role_arn`**](#managed_node_group_worker_iam_role_arn) &mdash; The ARN of the IAM role associated with the Managed Node Group EKS workers.
+<HclListItem name="eks_kubeconfig">
+<HclListItemDescription>
 
-<a name="managed_node_group_worker_iam_role_name" className="snap-top"></a>
+Minimal configuration for kubectl to authenticate with the created EKS cluster.
 
-* [**`managed_node_group_worker_iam_role_name`**](#managed_node_group_worker_iam_role_name) &mdash; The name of the IAM role associated with the Managed Node Group EKS workers.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="managed_node_group_worker_shared_security_group_id" className="snap-top"></a>
+<HclListItem name="eks_worker_asg_names">
+<HclListItemDescription>
 
-* [**`managed_node_group_worker_shared_security_group_id`**](#managed_node_group_worker_shared_security_group_id) &mdash; The ID of the common AWS Security Group associated with all the managed EKS workers.
+The list of names of the ASGs that were deployed to act as EKS workers.
 
-<a name="metric_widget_worker_cpu_usage" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`metric_widget_worker_cpu_usage`**](#metric_widget_worker_cpu_usage) &mdash; A CloudWatch Dashboard widget that graphs CPU usage (percentage) of the EKS workers (self-managed and managed node groups).
+<HclListItem name="managed_node_group_worker_iam_role_arn">
+<HclListItemDescription>
 
-<a name="metric_widget_worker_disk_usage" className="snap-top"></a>
+The ARN of the IAM role associated with the Managed Node Group EKS workers.
 
-* [**`metric_widget_worker_disk_usage`**](#metric_widget_worker_disk_usage) &mdash; A CloudWatch Dashboard widget that graphs disk usage (percentage) of the EKS workers (self-managed and managed node groups).
+</HclListItemDescription>
+</HclListItem>
 
-<a name="metric_widget_worker_memory_usage" className="snap-top"></a>
+<HclListItem name="managed_node_group_worker_iam_role_name">
+<HclListItemDescription>
 
-* [**`metric_widget_worker_memory_usage`**](#metric_widget_worker_memory_usage) &mdash; A CloudWatch Dashboard widget that graphs memory usage (percentage) of the EKS workers (self-managed and managed node groups).
+The name of the IAM role associated with the Managed Node Group EKS workers.
 
-<a name="self_managed_worker_iam_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`self_managed_worker_iam_role_arn`**](#self_managed_worker_iam_role_arn) &mdash; The ARN of the IAM role associated with the self-managed EKS workers.
+<HclListItem name="managed_node_group_worker_shared_security_group_id">
+<HclListItemDescription>
 
-<a name="self_managed_worker_iam_role_name" className="snap-top"></a>
+The ID of the common AWS Security Group associated with all the managed EKS workers.
 
-* [**`self_managed_worker_iam_role_name`**](#self_managed_worker_iam_role_name) &mdash; The name of the IAM role associated with the self-managed EKS workers.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="self_managed_worker_security_group_id" className="snap-top"></a>
+<HclListItem name="metric_widget_worker_cpu_usage">
+<HclListItemDescription>
 
-* [**`self_managed_worker_security_group_id`**](#self_managed_worker_security_group_id) &mdash; The ID of the AWS Security Group associated with the self-managed EKS workers.
+A CloudWatch Dashboard widget that graphs CPU usage (percentage) of the EKS workers (self-managed and managed node groups).
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="metric_widget_worker_disk_usage">
+<HclListItemDescription>
+
+A CloudWatch Dashboard widget that graphs disk usage (percentage) of the EKS workers (self-managed and managed node groups).
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="metric_widget_worker_memory_usage">
+<HclListItemDescription>
+
+A CloudWatch Dashboard widget that graphs memory usage (percentage) of the EKS workers (self-managed and managed node groups).
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="self_managed_worker_iam_role_arn">
+<HclListItemDescription>
+
+The ARN of the IAM role associated with the self-managed EKS workers.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="self_managed_worker_iam_role_name">
+<HclListItemDescription>
+
+The name of the IAM role associated with the self-managed EKS workers.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="self_managed_worker_security_group_id">
+<HclListItemDescription>
+
+The ID of the AWS Security Group associated with the self-managed EKS workers.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"b063a3f73ef34b151b42c8772173fb08"}
+{"sourcePlugin":"service-catalog-api","hash":"91dc3965d8d3289738189c21c478508e"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/app-orchestration/auto-scaling-group-asg.md
+++ b/docs/reference/services/app-orchestration/auto-scaling-group-asg.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -83,299 +84,813 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="ami" className="snap-top"></a>
+<HclListItem name="ami" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`ami`**](#ami) &mdash; The ID of the AMI to run on each instance in the ASG. The AMI needs to have `ec2-baseline` installed, since by default it will run [``start_ec2_baseline`](#`start_ec2_baseline)` on the User Data.
+The ID of the AMI to run on each instance in the ASG. The AMI needs to have `ec2-baseline` installed, since by default it will run `start_ec2_baseline` on the User Data.
 
-<a name="ami_filters" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`ami_filters`**](#ami_filters) &mdash; Properties on the AMI that can be used to lookup a prebuilt AMI for use with the Bastion Host. You can build the AMI using the Packer template bastion-host.json. Only used if var.ami is null. One of var.ami or [`ami_filters`](#ami_filters) is required. Set to null if passing the ami ID directly.
+<HclListItem name="ami_filters" requirement="required" type="object">
+<HclListItemDescription>
 
-<a name="instance_type" className="snap-top"></a>
+Properties on the AMI that can be used to lookup a prebuilt AMI for use with the Bastion Host. You can build the AMI using the Packer template bastion-host.json. Only used if var.ami is null. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if passing the ami ID directly.
 
-* [**`instance_type`**](#instance_type) &mdash; The type of instance to run in the ASG (e.g. t3.medium)
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="max_size" className="snap-top"></a>
+```hcl
+object({
+    # List of owners to limit the search. Set to null if you do not wish to limit the search by AMI owners.
+    owners = list(string)
 
-* [**`max_size`**](#max_size) &mdash; The maximum number of EC2 Instances to run in this ASG
+    # Name/Value pairs to filter the AMI off of. There are several valid keys, for a full reference, check out the
+    # documentation for describe-images in the AWS CLI reference
+    # (https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html).
+    filters = list(object({
+      name   = string
+      values = list(string)
+    }))
+  })
+```
 
-<a name="min_elb_capacity" className="snap-top"></a>
+</HclListItemTypeDetails>
+</HclListItem>
 
-* [**`min_elb_capacity`**](#min_elb_capacity) &mdash; Wait for this number of EC2 Instances to show up healthy in the load balancer on creation.
+<HclListItem name="instance_type" requirement="required" type="string">
+<HclListItemDescription>
 
-<a name="min_size" className="snap-top"></a>
+The type of instance to run in the ASG (e.g. t3.medium)
 
-* [**`min_size`**](#min_size) &mdash; The minimum number of EC2 Instances to run in this ASG
+</HclListItemDescription>
+</HclListItem>
 
-<a name="name" className="snap-top"></a>
+<HclListItem name="max_size" requirement="required" type="number">
+<HclListItemDescription>
 
-* [**`name`**](#name) &mdash; The name for the ASG and all other resources created by these templates.
+The maximum number of EC2 Instances to run in this ASG
 
-<a name="subnet_ids" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`subnet_ids`**](#subnet_ids) &mdash; The list of IDs of the subnets in which to deploy ASG. The list must only contain subnets in [`vpc_id`](#vpc_id).
+<HclListItem name="min_elb_capacity" requirement="required" type="number">
+<HclListItemDescription>
 
-<a name="vpc_id" className="snap-top"></a>
+Wait for this number of EC2 Instances to show up healthy in the load balancer on creation.
 
-* [**`vpc_id`**](#vpc_id) &mdash; The ID of the VPC in which to deploy the Auto Scaling Group
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="min_size" requirement="required" type="number">
+<HclListItemDescription>
+
+The minimum number of EC2 Instances to run in this ASG
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="name" requirement="required" type="string">
+<HclListItemDescription>
+
+The name for the ASG and all other resources created by these templates.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="subnet_ids" requirement="required" type="list">
+<HclListItemDescription>
+
+The list of IDs of the subnets in which to deploy ASG. The list must only contain subnets in <a href="#vpc_id"><code>vpc_id</code></a>.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="vpc_id" requirement="required" type="string">
+<HclListItemDescription>
+
+The ID of the VPC in which to deploy the Auto Scaling Group
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="alarm_sns_topic_arns_us_east_1" className="snap-top"></a>
+<HclListItem name="alarm_sns_topic_arns_us_east_1" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`alarm_sns_topic_arns_us_east_1`**](#alarm_sns_topic_arns_us_east_1) &mdash; A list of SNS topic ARNs to notify when the health check changes to ALARM, OK, or [`INSUFFICIENT_DATA`](#INSUFFICIENT_DATA) state. Note: these SNS topics MUST be in us-east-1! This is because Route 53 only sends CloudWatch metrics to us-east-1, so we must create the alarm in that region, and therefore, can only notify SNS topics in that region.
+A list of SNS topic ARNs to notify when the health check changes to ALARM, OK, or INSUFFICIENT_DATA state. Note: these SNS topics MUST be in us-east-1! This is because Route 53 only sends CloudWatch metrics to us-east-1, so we must create the alarm in that region, and therefore, can only notify SNS topics in that region.
 
-<a name="alarms_sns_topic_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`alarms_sns_topic_arn`**](#alarms_sns_topic_arn) &mdash; The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications. Also used for the alarms if the Jenkins backup job fails.
+```hcl
+list(string)
+```
 
-<a name="allow_inbound_from_cidr_blocks" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`allow_inbound_from_cidr_blocks`**](#allow_inbound_from_cidr_blocks) &mdash; The CIDR blocks from which to allow access to the ports in [`server_ports`](#server_ports)
+<HclListItem name="alarms_sns_topic_arn" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="allow_inbound_from_security_group_ids" className="snap-top"></a>
+The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications. Also used for the alarms if the Jenkins backup job fails.
 
-* [**`allow_inbound_from_security_group_ids`**](#allow_inbound_from_security_group_ids) &mdash; The security group IDs from which to allow access to the ports in [`server_ports`](#server_ports)
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="allow_ssh_from_cidr_blocks" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`allow_ssh_from_cidr_blocks`**](#allow_ssh_from_cidr_blocks) &mdash; The CIDR blocks from which to allow SSH access
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="allow_ssh_security_group_ids" className="snap-top"></a>
+<HclListItem name="allow_inbound_from_cidr_blocks" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`allow_ssh_security_group_ids`**](#allow_ssh_security_group_ids) &mdash; The security group IDs from which to allow SSH access
+The CIDR blocks from which to allow access to the ports in <a href="#server_ports"><code>server_ports</code></a>
 
-<a name="cloud_init_parts" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`cloud_init_parts`**](#cloud_init_parts) &mdash; Cloud init scripts to run on the ASG instances during boot. See the part blocks in [`https://www.terraform.io/docs/providers/template/d/cloudinit_config`](#https://www.terraform.io/docs/providers/template/d/cloudinit_config).html for syntax
+```hcl
+list(string)
+```
 
-<a name="cloudwatch_log_group_kms_key_id" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`cloudwatch_log_group_kms_key_id`**](#cloudwatch_log_group_kms_key_id) &mdash; The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data.
+<HclListItem name="allow_inbound_from_security_group_ids" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="cloudwatch_log_group_retention_in_days" className="snap-top"></a>
+The security group IDs from which to allow access to the ports in <a href="#server_ports"><code>server_ports</code></a>
 
-* [**`cloudwatch_log_group_retention_in_days`**](#cloudwatch_log_group_retention_in_days) &mdash; The number of days to retain log events in the log group. Refer to [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days) for all the valid values. When null, the log events are retained forever.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="cloudwatch_log_group_tags" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`cloudwatch_log_group_tags`**](#cloudwatch_log_group_tags) &mdash; Tags to apply on the CloudWatch Log Group, encoded as a map where the keys are tag keys and values are tag values.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="create_route53_entry" className="snap-top"></a>
+<HclListItem name="allow_ssh_from_cidr_blocks" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`create_route53_entry`**](#create_route53_entry) &mdash; Set to true to create a DNS A record in Route 53 for this service.
+The CIDR blocks from which to allow SSH access
 
-<a name="custom_tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`custom_tags`**](#custom_tags) &mdash; A list of custom tags to apply to the EC2 Instances in this ASG. Each item in this list should be a map with the parameters key, value, and [`propagate_at_launch`](#propagate_at_launch).
+```hcl
+list(string)
+```
 
-<a name="default_forward_target_group_arns" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`default_forward_target_group_arns`**](#default_forward_target_group_arns) &mdash; The ARN of the Target Group to which to route traffic.
+<HclListItem name="allow_ssh_security_group_ids" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="default_user" className="snap-top"></a>
+The security group IDs from which to allow SSH access
 
-* [**`default_user`**](#default_user) &mdash; The default OS user for the service AMI. For example, for AWS Ubuntu AMIs, the default OS user is 'ubuntu'.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="desired_capacity" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`desired_capacity`**](#desired_capacity) &mdash; The desired number of EC2 Instances to run in the ASG initially. Note that auto scaling policies may change this value. If you're using auto scaling policies to dynamically resize the cluster, you should actually leave this value as null.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="domain_name" className="snap-top"></a>
+<HclListItem name="cloud_init_parts" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`domain_name`**](#domain_name) &mdash; The domain name to register in [`hosted_zone_id`](#hosted_zone_id) (e.g. foo.example.com). Only used if [`create_route53_entry`](#create_route53_entry) is true.
+Cloud init scripts to run on the ASG instances during boot. See the part blocks in https://www.terraform.io/docs/providers/template/d/cloudinit_config.html for syntax
 
-<a name="enable_cloudwatch_alarms" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`enable_cloudwatch_alarms`**](#enable_cloudwatch_alarms) &mdash; Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using [`alarms_sns_topic_arn`](#alarms_sns_topic_arn).
+```hcl
+map(object({
+    filename     = string
+    content_type = string
+    content      = string
+  }))
+```
 
-<a name="enable_cloudwatch_log_aggregation" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`enable_cloudwatch_log_aggregation`**](#enable_cloudwatch_log_aggregation) &mdash; Set to true to add AIM permissions to send logs to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/logs/cloudwatch-log-aggregation-scripts to do log aggregation in CloudWatch.
+<HclListItem name="cloudwatch_log_group_kms_key_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="enable_cloudwatch_metrics" className="snap-top"></a>
+The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data.
 
-* [**`enable_cloudwatch_metrics`**](#enable_cloudwatch_metrics) &mdash; Set to true to add IAM permissions to send custom metrics to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/agents/cloudwatch-agent to get memory and disk metrics in CloudWatch for your Auto Scaling Group
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="enable_fail2ban" className="snap-top"></a>
+<HclListItem name="cloudwatch_log_group_retention_in_days" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`enable_fail2ban`**](#enable_fail2ban) &mdash; Enable fail2ban to block brute force log in attempts. Defaults to true
+The number of days to retain log events in the log group. Refer to https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days for all the valid values. When null, the log events are retained forever.
 
-<a name="enable_ip_lockdown" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`enable_ip_lockdown`**](#enable_ip_lockdown) &mdash; Enable ip-lockdown to block access to the instance metadata. Defaults to true
+<HclListItem name="cloudwatch_log_group_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="enable_route53_health_check" className="snap-top"></a>
+Tags to apply on the CloudWatch Log Group, encoded as a map where the keys are tag keys and values are tag values.
 
-* [**`enable_route53_health_check`**](#enable_route53_health_check) &mdash; If set to true, use Route 53 to perform health checks on [`domain_name`](#domain_name).
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="enabled_metrics" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`enabled_metrics`**](#enabled_metrics) &mdash; A list of metrics the ASG should enable for monitoring all instances in a group. The allowed values are GroupMinSize, GroupMaxSize, GroupDesiredCapacity, GroupInServiceInstances, GroupPendingInstances, GroupStandbyInstances, GroupTerminatingInstances, GroupTotalInstances.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="external_account_ssh_grunt_role_arn" className="snap-top"></a>
+<HclListItem name="create_route53_entry" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`external_account_ssh_grunt_role_arn`**](#external_account_ssh_grunt_role_arn) &mdash; Since our IAM users are defined in a separate AWS account, this variable is used to specify the ARN of an IAM role that allows ssh-grunt to retrieve IAM group and public SSH key info from that account.
+Set to true to create a DNS A record in Route 53 for this service.
 
-<a name="fixed_response_listener_rules" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`fixed_response_listener_rules`**](#fixed_response_listener_rules) &mdash; Listener rules for a fixed-response action. See comments below for information about the parameters.
+<HclListItem name="custom_tags" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="forward_listener_rules" className="snap-top"></a>
+A list of custom tags to apply to the EC2 Instances in this ASG. Each item in this list should be a map with the parameters key, value, and propagate_at_launch.
 
-* [**`forward_listener_rules`**](#forward_listener_rules) &mdash; Listener rules for a forward action that distributes requests among one or more target groups. By default, sends traffic to the target groups created for the ports in [`server_ports`](#server_ports). See comments below for information about the parameters.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="health_check_grace_period" className="snap-top"></a>
+```hcl
+list(object({
+    key                 = string
+    value               = string
+    propagate_at_launch = bool
+  }))
+```
 
-* [**`health_check_grace_period`**](#health_check_grace_period) &mdash; Time, in seconds, after an EC2 Instance comes into service before checking health.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="hosted_zone_id" className="snap-top"></a>
+<HclListItem name="default_forward_target_group_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`hosted_zone_id`**](#hosted_zone_id) &mdash; The ID of the Route 53 Hosted Zone in which to create a DNS A record for the Auto Scaling Group. Optional if [`create_route53_entry`](#create_route53_entry) = false.
+The ARN of the Target Group to which to route traffic.
 
-<a name="iam_policy" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`iam_policy`**](#iam_policy) &mdash; An object defining the policy to attach to [``iam_role_name`](#`iam_role_name)` if the IAM role is going to be created. Accepts a map of objects, where the map keys are sids for IAM policy statements, and the object fields are the resources, actions, and the effect ("Allow" or "Deny") of the statement. Ignored if [``iam_role_arn`](#`iam_role_arn)` is provided. Leave as null if you do not wish to use IAM role with Service Accounts.
+```hcl
+list(any)
+```
 
-<a name="key_pair_name" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`key_pair_name`**](#key_pair_name) &mdash; The name of a Key Pair that can be used to SSH to the EC2 Instances in the ASG. Set to null if you don't want to enable Key Pair auth.
+<HclListItem name="default_user" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="lb_hosted_zone_id" className="snap-top"></a>
+The default OS user for the service AMI. For example, for AWS Ubuntu AMIs, the default OS user is 'ubuntu'.
 
-* [**`lb_hosted_zone_id`**](#lb_hosted_zone_id) &mdash; The ID of the Route 53 Hosted Zone in which to create a DNS A record for the Auto Scaling Group. Optional if [`create_route53_entry`](#create_route53_entry) = false.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ubuntu"/>
+</HclListItem>
 
-<a name="listener_arns" className="snap-top"></a>
+<HclListItem name="desired_capacity" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`listener_arns`**](#listener_arns) &mdash; A map of all the listeners on the load balancer. The keys should be the port numbers and the values should be the ARN of the listener for that port.
+The desired number of EC2 Instances to run in the ASG initially. Note that auto scaling policies may change this value. If you're using auto scaling policies to dynamically resize the cluster, you should actually leave this value as null.
 
-<a name="listener_ports" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`listener_ports`**](#listener_ports) &mdash; The ports the ALB listens on for requests
+<HclListItem name="domain_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="load_balancers" className="snap-top"></a>
+The domain name to register in <a href="#hosted_zone_id"><code>hosted_zone_id</code></a> (e.g. foo.example.com). Only used if <a href="#create_route53_entry"><code>create_route53_entry</code></a> is true.
 
-* [**`load_balancers`**](#load_balancers) &mdash; A list of Elastic Load Balancer (ELB) names to associate with this ASG. If you're using the Application Load Balancer (ALB), see [`target_group_arns`](#target_group_arns).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="metadata_users" className="snap-top"></a>
+<HclListItem name="enable_cloudwatch_alarms" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`metadata_users`**](#metadata_users) &mdash; List of users on the ASG EC2 instances that should be permitted access to the EC2 metadata.
+Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using <a href="#alarms_sns_topic_arn"><code>alarms_sns_topic_arn</code></a>.
 
-<a name="original_lb_dns_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`original_lb_dns_name`**](#original_lb_dns_name) &mdash; The DNS name that was assigned by AWS to the load balancer upon creation
+<HclListItem name="enable_cloudwatch_log_aggregation" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="redirect_listener_rules" className="snap-top"></a>
+Set to true to add AIM permissions to send logs to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/logs/cloudwatch-log-aggregation-scripts to do log aggregation in CloudWatch.
 
-* [**`redirect_listener_rules`**](#redirect_listener_rules) &mdash; Listener rules for a redirect action. See comments below for information about the parameters.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="route53_health_check_provider_external_id" className="snap-top"></a>
+<HclListItem name="enable_cloudwatch_metrics" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`route53_health_check_provider_external_id`**](#route53_health_check_provider_external_id) &mdash; The optional [`external_id`](#external_id) to be used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+Set to true to add IAM permissions to send custom metrics to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/agents/cloudwatch-agent to get memory and disk metrics in CloudWatch for your Auto Scaling Group
 
-<a name="route53_health_check_provider_profile" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`route53_health_check_provider_profile`**](#route53_health_check_provider_profile) &mdash; The optional AWS profile to be used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+<HclListItem name="enable_fail2ban" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="route53_health_check_provider_role_arn" className="snap-top"></a>
+Enable fail2ban to block brute force log in attempts. Defaults to true
 
-* [**`route53_health_check_provider_role_arn`**](#route53_health_check_provider_role_arn) &mdash; The optional [`role_arn`](#role_arn) to be used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="route53_health_check_provider_session_name" className="snap-top"></a>
+<HclListItem name="enable_ip_lockdown" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`route53_health_check_provider_session_name`**](#route53_health_check_provider_session_name) &mdash; The optional [`session_name`](#session_name) to be used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+Enable ip-lockdown to block access to the instance metadata. Defaults to true
 
-<a name="route53_health_check_provider_shared_credentials_file" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`route53_health_check_provider_shared_credentials_file`**](#route53_health_check_provider_shared_credentials_file) &mdash; The optional path to a credentials file used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+<HclListItem name="enable_route53_health_check" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="secrets_access" className="snap-top"></a>
+If set to true, use Route 53 to perform health checks on <a href="#domain_name"><code>domain_name</code></a>.
 
-* [**`secrets_access`**](#secrets_access) &mdash; A list of ARNs of Secrets Manager secrets that the task should have permissions to read. The IAM role for the task will be granted `secretsmanager:GetSecretValue` for each secret in the list. The ARN can be either the complete ARN, including the randomly generated suffix, or the ARN without the suffix. If the latter, the module will look up the full ARN automatically. This is helpful in cases where you don't yet know the randomly generated suffix because the rest of the ARN is a predictable value.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="server_ports" className="snap-top"></a>
+<HclListItem name="enabled_metrics" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`server_ports`**](#server_ports) &mdash; The ports the EC2 instances listen on for requests. A Target Group will be created for each port and any rules specified in [`forward_rules`](#forward_rules) will forward traffic to these Target Groups.
+A list of metrics the ASG should enable for monitoring all instances in a group. The allowed values are GroupMinSize, GroupMaxSize, GroupDesiredCapacity, GroupInServiceInstances, GroupPendingInstances, GroupStandbyInstances, GroupTerminatingInstances, GroupTotalInstances.
 
-<a name="should_create_cloudwatch_log_group" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`should_create_cloudwatch_log_group`**](#should_create_cloudwatch_log_group) &mdash; When true, precreate the CloudWatch Log Group to use for log aggregation from the EC2 instances. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, the CloudWatch agent will automatically create a basic log group to use.
+```hcl
+list(string)
+```
 
-<a name="ssh_grunt_iam_group" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`ssh_grunt_iam_group`**](#ssh_grunt_iam_group) &mdash; If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to the instances. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+<HclListItem name="external_account_ssh_grunt_role_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="ssh_grunt_iam_group_sudo" className="snap-top"></a>
+Since our IAM users are defined in a separate AWS account, this variable is used to specify the ARN of an IAM role that allows ssh-grunt to retrieve IAM group and public SSH key info from that account.
 
-* [**`ssh_grunt_iam_group_sudo`**](#ssh_grunt_iam_group_sudo) &mdash; If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to the instances with sudo permissions. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
 
-<a name="ssh_port" className="snap-top"></a>
+<HclListItem name="fixed_response_listener_rules" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`ssh_port`**](#ssh_port) &mdash; The port at which SSH will be allowed from [`allow_ssh_from_cidr_blocks`](#allow_ssh_from_cidr_blocks) and [`allow_ssh_security_group_ids`](#allow_ssh_security_group_ids)
+Listener rules for a fixed-response action. See comments below for information about the parameters.
 
-<a name="tag_asg_id_key" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`tag_asg_id_key`**](#tag_asg_id_key) &mdash; The key for the tag that will be used to associate a unique identifier with this ASG. This identifier will persist between redeploys of the ASG, even though the underlying ASG is being deleted and replaced with a different one.
+```hcl
+map(any)
+```
 
-<a name="termination_policies" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`termination_policies`**](#termination_policies) &mdash; A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are OldestInstance, NewestInstance, OldestLaunchConfiguration, ClosestToNextInstanceHour, Default.
+<HclListItem name="forward_listener_rules" requirement="optional" type="any">
+<HclListItemDescription>
 
-<a name="use_elb_health_checks" className="snap-top"></a>
+Listener rules for a forward action that distributes requests among one or more target groups. By default, sends traffic to the target groups created for the ports in <a href="#server_ports"><code>server_ports</code></a>. See comments below for information about the parameters.
 
-* [**`use_elb_health_checks`**](#use_elb_health_checks) &mdash; Whether or not ELB or ALB health checks should be enabled. If set to true, the [`load_balancers`](#load_balancers) or [`target_groups_arns`](#target_groups_arns) variable should be set depending on the load balancer type you are using. Useful for testing connectivity before health check endpoints are available.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="use_managed_iam_policies" className="snap-top"></a>
+<HclListItem name="health_check_grace_period" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`use_managed_iam_policies`**](#use_managed_iam_policies) &mdash; When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+Time, in seconds, after an EC2 Instance comes into service before checking health.
 
-<a name="wait_for_capacity_timeout" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="300"/>
+</HclListItem>
 
-* [**`wait_for_capacity_timeout`**](#wait_for_capacity_timeout) &mdash; A maximum duration that Terraform should wait for the EC2 Instances to be healthy before timing out.
+<HclListItem name="hosted_zone_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ID of the Route 53 Hosted Zone in which to create a DNS A record for the Auto Scaling Group. Optional if create_route53_entry = false.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="iam_policy" requirement="optional" type="map">
+<HclListItemDescription>
+
+An object defining the policy to attach to `iam_role_name` if the IAM role is going to be created. Accepts a map of objects, where the map keys are sids for IAM policy statements, and the object fields are the resources, actions, and the effect ('Allow' or 'Deny') of the statement. Ignored if `iam_role_arn` is provided. Leave as null if you do not wish to use IAM role with Service Accounts.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(object({
+    resources = list(string)
+    actions   = list(string)
+    effect    = string
+  }))
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="key_pair_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of a Key Pair that can be used to SSH to the EC2 Instances in the ASG. Set to null if you don't want to enable Key Pair auth.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="lb_hosted_zone_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ID of the Route 53 Hosted Zone in which to create a DNS A record for the Auto Scaling Group. Optional if create_route53_entry = false.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="listener_arns" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of all the listeners on the load balancer. The keys should be the port numbers and the values should be the ARN of the listener for that port.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="listener_ports" requirement="optional" type="list">
+<HclListItemDescription>
+
+The ports the ALB listens on for requests
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(number)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="load_balancers" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of Elastic Load Balancer (ELB) names to associate with this ASG. If you're using the Application Load Balancer (ALB), see <a href="#target_group_arns"><code>target_group_arns</code></a>.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="metadata_users" requirement="optional" type="list">
+<HclListItemDescription>
+
+List of users on the ASG EC2 instances that should be permitted access to the EC2 metadata.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="original_lb_dns_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The DNS name that was assigned by AWS to the load balancer upon creation
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="redirect_listener_rules" requirement="optional" type="map">
+<HclListItemDescription>
+
+Listener rules for a redirect action. See comments below for information about the parameters.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(any)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="route53_health_check_provider_external_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+The optional external_id to be used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="route53_health_check_provider_profile" requirement="optional" type="string">
+<HclListItemDescription>
+
+The optional AWS profile to be used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="route53_health_check_provider_role_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+The optional role_arn to be used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="route53_health_check_provider_session_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The optional session_name to be used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="route53_health_check_provider_shared_credentials_file" requirement="optional" type="string">
+<HclListItemDescription>
+
+The optional path to a credentials file used in the us-east-1 provider block defined in the route53-health-check-alarms module.  This module configures its own AWS provider to ensure resources are created in us-east-1.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="secrets_access" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of ARNs of Secrets Manager secrets that the task should have permissions to read. The IAM role for the task will be granted `secretsmanager:GetSecretValue` for each secret in the list. The ARN can be either the complete ARN, including the randomly generated suffix, or the ARN without the suffix. If the latter, the module will look up the full ARN automatically. This is helpful in cases where you don't yet know the randomly generated suffix because the rest of the ARN is a predictable value.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="server_ports" requirement="optional" type="any">
+<HclListItemDescription>
+
+The ports the EC2 instances listen on for requests. A Target Group will be created for each port and any rules specified in <a href="#forward_rules"><code>forward_rules</code></a> will forward traffic to these Target Groups.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="should_create_cloudwatch_log_group" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, precreate the CloudWatch Log Group to use for log aggregation from the EC2 instances. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, the CloudWatch agent will automatically create a basic log group to use.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="ssh_grunt_iam_group" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to the instances. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ssh-grunt-sudo-users"/>
+</HclListItem>
+
+<HclListItem name="ssh_grunt_iam_group_sudo" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to the instances with sudo permissions. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ssh-grunt-sudo-users"/>
+</HclListItem>
+
+<HclListItem name="ssh_port" requirement="optional" type="string">
+<HclListItemDescription>
+
+The port at which SSH will be allowed from <a href="#allow_ssh_from_cidr_blocks"><code>allow_ssh_from_cidr_blocks</code></a> and <a href="#allow_ssh_security_group_ids"><code>allow_ssh_security_group_ids</code></a>
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="22"/>
+</HclListItem>
+
+<HclListItem name="tag_asg_id_key" requirement="optional" type="string">
+<HclListItemDescription>
+
+The key for the tag that will be used to associate a unique identifier with this ASG. This identifier will persist between redeploys of the ASG, even though the underlying ASG is being deleted and replaced with a different one.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="AsgId"/>
+</HclListItem>
+
+<HclListItem name="termination_policies" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are OldestInstance, NewestInstance, OldestLaunchConfiguration, ClosestToNextInstanceHour, Default.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="use_elb_health_checks" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Whether or not ELB or ALB health checks should be enabled. If set to true, the load_balancers or target_groups_arns variable should be set depending on the load balancer type you are using. Useful for testing connectivity before health check endpoints are available.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="use_managed_iam_policies" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="wait_for_capacity_timeout" requirement="optional" type="string">
+<HclListItemDescription>
+
+A maximum duration that Terraform should wait for the EC2 Instances to be healthy before timing out.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="10m"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="asg_name" className="snap-top"></a>
+<HclListItem name="asg_name">
+<HclListItemDescription>
 
-* [**`asg_name`**](#asg_name) &mdash; The name of the auto scaling group.
+The name of the auto scaling group.
 
-<a name="asg_unique_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`asg_unique_id`**](#asg_unique_id) &mdash; A unique ID common to all ASGs used for [`get_desired_capacity`](#get_desired_capacity) on new deploys.
+<HclListItem name="asg_unique_id">
+<HclListItemDescription>
 
-<a name="fully_qualified_domain_name" className="snap-top"></a>
+A unique ID common to all ASGs used for get_desired_capacity on new deploys.
 
-* [**`fully_qualified_domain_name`**](#fully_qualified_domain_name) &mdash; The Fully Qualified Domain Name built using the zone domain and name.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="launch_configuration_id" className="snap-top"></a>
+<HclListItem name="fully_qualified_domain_name">
+<HclListItemDescription>
 
-* [**`launch_configuration_id`**](#launch_configuration_id) &mdash; The ID of the launch configuration used for the ASG.
+The Fully Qualified Domain Name built using the zone domain and name.
 
-<a name="launch_configuration_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`launch_configuration_name`**](#launch_configuration_name) &mdash; The name of the launch configuration used for the ASG.
+<HclListItem name="launch_configuration_id">
+<HclListItemDescription>
 
-<a name="lb_listener_rule_fixed_response_arns" className="snap-top"></a>
+The ID of the launch configuration used for the ASG.
 
-* [**`lb_listener_rule_fixed_response_arns`**](#lb_listener_rule_fixed_response_arns) &mdash; The ARNs of the rules of type fixed-response. The key is the same key of the rule from the [``fixed_response_rules`](#`fixed_response_rules)` variable.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="lb_listener_rule_forward_arns" className="snap-top"></a>
+<HclListItem name="launch_configuration_name">
+<HclListItemDescription>
 
-* [**`lb_listener_rule_forward_arns`**](#lb_listener_rule_forward_arns) &mdash; The ARNs of the rules of type forward. The key is the same key of the rule from the [``forward_rules`](#`forward_rules)` variable.
+The name of the launch configuration used for the ASG.
 
-<a name="lb_listener_rule_redirect_arns" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`lb_listener_rule_redirect_arns`**](#lb_listener_rule_redirect_arns) &mdash; The ARNs of the rules of type redirect. The key is the same key of the rule from the [``redirect_rules`](#`redirect_rules)` variable.
+<HclListItem name="lb_listener_rule_fixed_response_arns">
+<HclListItemDescription>
 
-<a name="security_group_id" className="snap-top"></a>
+The ARNs of the rules of type fixed-response. The key is the same key of the rule from the `fixed_response_rules` variable.
 
-* [**`security_group_id`**](#security_group_id) &mdash; The ID of the Security Group that belongs to the ASG.
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="lb_listener_rule_forward_arns">
+<HclListItemDescription>
+
+The ARNs of the rules of type forward. The key is the same key of the rule from the `forward_rules` variable.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="lb_listener_rule_redirect_arns">
+<HclListItemDescription>
+
+The ARNs of the rules of type redirect. The key is the same key of the rule from the `redirect_rules` variable.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="security_group_id">
+<HclListItemDescription>
+
+The ID of the Security Group that belongs to the ASG.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"4ba98d6fcd74daffff6046a9e8dde5fc"}
+{"sourcePlugin":"service-catalog-api","hash":"6e0fe67e4011f23a7194fdcf2847ea68"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/app-orchestration/ec-2-instance.md
+++ b/docs/reference/services/app-orchestration/ec-2-instance.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.84.4"/>
 
@@ -106,231 +107,579 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="allow_port_from_cidr_blocks" className="snap-top"></a>
+<HclListItem name="allow_port_from_cidr_blocks" requirement="required" type="map">
+<HclListItemDescription>
 
-* [**`allow_port_from_cidr_blocks`**](#allow_port_from_cidr_blocks) &mdash; Accept inbound traffic on these port ranges from the specified CIDR blocks
+Accept inbound traffic on these port ranges from the specified CIDR blocks
 
-<a name="allow_port_from_security_group_ids" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`allow_port_from_security_group_ids`**](#allow_port_from_security_group_ids) &mdash; Accept inbound traffic on these port ranges from the specified security groups
+```hcl
+map(object({
+    from_port   = number
+    to_port     = number
+    protocol    = string
+    cidr_blocks = list(string)
+  }))
+```
 
-<a name="allow_ssh_from_cidr_blocks" className="snap-top"></a>
+</HclListItemTypeDetails>
+</HclListItem>
 
-* [**`allow_ssh_from_cidr_blocks`**](#allow_ssh_from_cidr_blocks) &mdash; Accept inbound SSH from these CIDR blocks
+<HclListItem name="allow_port_from_security_group_ids" requirement="required" type="map">
+<HclListItemDescription>
 
-<a name="allow_ssh_from_security_group_ids" className="snap-top"></a>
+Accept inbound traffic on these port ranges from the specified security groups
 
-* [**`allow_ssh_from_security_group_ids`**](#allow_ssh_from_security_group_ids) &mdash; Accept inbound SSH from these security groups
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="ami" className="snap-top"></a>
+```hcl
+map(object({
+    from_port                = number
+    to_port                  = number
+    protocol                 = string
+    source_security_group_id = string
+  }))
+```
 
-* [**`ami`**](#ami) &mdash; The AMI to run on the EC2 instance. This should be built from the Packer template under ec2-instance.json. One of var.ami or [`ami_filters`](#ami_filters) is required. Set to null if looking up the ami with filters.
+</HclListItemTypeDetails>
+</HclListItem>
 
-<a name="ami_filters" className="snap-top"></a>
+<HclListItem name="allow_ssh_from_cidr_blocks" requirement="required" type="list">
+<HclListItemDescription>
 
-* [**`ami_filters`**](#ami_filters) &mdash; Properties on the AMI that can be used to lookup a prebuilt AMI for use with the EC2 instance. You can build the AMI using the Packer template ec2-instance.json. Only used if var.ami is null. One of var.ami or [`ami_filters`](#ami_filters) is required. Set to null if passing the ami ID directly.
+Accept inbound SSH from these CIDR blocks
 
-<a name="dns_zone_is_private" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`dns_zone_is_private`**](#dns_zone_is_private) &mdash; Specify whether we're selecting a private or public Route 53 DNS Zone
+```hcl
+list(string)
+```
 
-<a name="ebs_volumes" className="snap-top"></a>
+</HclListItemTypeDetails>
+</HclListItem>
 
-* [**`ebs_volumes`**](#ebs_volumes) &mdash; The EBS volumes to attach to the instance. This must be a map of key/value pairs.
+<HclListItem name="allow_ssh_from_security_group_ids" requirement="required" type="list">
+<HclListItemDescription>
 
-<a name="instance_type" className="snap-top"></a>
+Accept inbound SSH from these security groups
 
-* [**`instance_type`**](#instance_type) &mdash; The type of instance to run for the EC2 instance
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="name" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`name`**](#name) &mdash; The name of the EC2 instance and the other resources created by these templates
+</HclListItemTypeDetails>
+</HclListItem>
 
-<a name="route53_lookup_domain_name" className="snap-top"></a>
+<HclListItem name="ami" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`route53_lookup_domain_name`**](#route53_lookup_domain_name) &mdash; The domain name to use to look up the Route 53 hosted zone. Will be a subset of [`fully_qualified_domain_name`](#fully_qualified_domain_name): e.g., my-company.com. Only one of [`route53_lookup_domain_name`](#route53_lookup_domain_name) or [`route53_zone_id`](#route53_zone_id) should be used.
+The AMI to run on the EC2 instance. This should be built from the Packer template under ec2-instance.json. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if looking up the ami with filters.
 
-<a name="route53_zone_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`route53_zone_id`**](#route53_zone_id) &mdash; The ID of the hosted zone to use. Allows specifying the hosted zone directly instead of looking it up via domain name. Only one of [`route53_lookup_domain_name`](#route53_lookup_domain_name) or [`route53_zone_id`](#route53_zone_id) should be used.
+<HclListItem name="ami_filters" requirement="required" type="object">
+<HclListItemDescription>
 
-<a name="subnet_id" className="snap-top"></a>
+Properties on the AMI that can be used to lookup a prebuilt AMI for use with the EC2 instance. You can build the AMI using the Packer template ec2-instance.json. Only used if var.ami is null. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if passing the ami ID directly.
 
-* [**`subnet_id`**](#subnet_id) &mdash; The ID of the subnet in which to deploy the EC2 instance. Must be a subnet in [`vpc_id`](#vpc_id).
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="vpc_id" className="snap-top"></a>
+```hcl
+object({
+    # List of owners to limit the search. Set to null if you do not wish to limit the search by AMI owners.
+    owners = list(string)
 
-* [**`vpc_id`**](#vpc_id) &mdash; The ID of the VPC in which to deploy the EC2 instance.
+    # Name/Value pairs to filter the AMI off of. There are several valid keys, for a full reference, check out the
+    # documentation for describe-images in the AWS CLI reference
+    # (https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html).
+    filters = list(object({
+      name   = string
+      values = list(string)
+    }))
+  })
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="dns_zone_is_private" requirement="required" type="bool">
+<HclListItemDescription>
+
+Specify whether we're selecting a private or public Route 53 DNS Zone
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="ebs_volumes" requirement="required" type="any">
+<HclListItemDescription>
+
+The EBS volumes to attach to the instance. This must be a map of key/value pairs.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="instance_type" requirement="required" type="string">
+<HclListItemDescription>
+
+The type of instance to run for the EC2 instance
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="name" requirement="required" type="string">
+<HclListItemDescription>
+
+The name of the EC2 instance and the other resources created by these templates
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="route53_lookup_domain_name" requirement="required">
+<HclListItemDescription>
+
+The domain name to use to look up the Route 53 hosted zone. Will be a subset of fully_qualified_domain_name: e.g., my-company.com. Only one of route53_lookup_domain_name or route53_zone_id should be used.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="route53_zone_id" requirement="required" type="string">
+<HclListItemDescription>
+
+The ID of the hosted zone to use. Allows specifying the hosted zone directly instead of looking it up via domain name. Only one of route53_lookup_domain_name or route53_zone_id should be used.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="subnet_id" requirement="required" type="string">
+<HclListItemDescription>
+
+The ID of the subnet in which to deploy the EC2 instance. Must be a subnet in <a href="#vpc_id"><code>vpc_id</code></a>.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="vpc_id" requirement="required" type="string">
+<HclListItemDescription>
+
+The ID of the VPC in which to deploy the EC2 instance.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="additional_security_group_ids" className="snap-top"></a>
+<HclListItem name="additional_security_group_ids" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`additional_security_group_ids`**](#additional_security_group_ids) &mdash; A list of optional additional security group ids to assign to the EC2 instance.
+A list of optional additional security group ids to assign to the EC2 instance.
 
-<a name="alarms_sns_topic_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`alarms_sns_topic_arn`**](#alarms_sns_topic_arn) &mdash; The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications.
+```hcl
+list(string)
+```
 
-<a name="attach_eip" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`attach_eip`**](#attach_eip) &mdash; Determines if an Elastic IP (EIP) will be created for this instance.
+<HclListItem name="alarms_sns_topic_arn" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="base_domain_name_tags" className="snap-top"></a>
+The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications.
 
-* [**`base_domain_name_tags`**](#base_domain_name_tags) &mdash; Tags to use to filter the Route 53 Hosted Zones that might match the hosted zone's name (use if you have multiple public hosted zones with the same name)
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="cloud_init_parts" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`cloud_init_parts`**](#cloud_init_parts) &mdash; Cloud init scripts to run on the EC2 instance while it boots. See the part blocks in [`https://www.terraform.io/docs/providers/template/d/cloudinit_config`](#https://www.terraform.io/docs/providers/template/d/cloudinit_config).html for syntax.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="cloudwatch_log_group_kms_key_id" className="snap-top"></a>
+<HclListItem name="attach_eip" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`cloudwatch_log_group_kms_key_id`**](#cloudwatch_log_group_kms_key_id) &mdash; The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data.
+Determines if an Elastic IP (EIP) will be created for this instance.
 
-<a name="cloudwatch_log_group_retention_in_days" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`cloudwatch_log_group_retention_in_days`**](#cloudwatch_log_group_retention_in_days) &mdash; The number of days to retain log events in the log group. Refer to [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days) for all the valid values. When null, the log events are retained forever.
+<HclListItem name="base_domain_name_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="cloudwatch_log_group_tags" className="snap-top"></a>
+Tags to use to filter the Route 53 Hosted Zones that might match the hosted zone's name (use if you have multiple public hosted zones with the same name)
 
-* [**`cloudwatch_log_group_tags`**](#cloudwatch_log_group_tags) &mdash; Tags to apply on the CloudWatch Log Group, encoded as a map where the keys are tag keys and values are tag values.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="create_dns_record" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`create_dns_record`**](#create_dns_record) &mdash; Set to true to create a DNS record in Route53 pointing to the EC2 instance. If true, be sure to set [`fully_qualified_domain_name`](#fully_qualified_domain_name).
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="default_user" className="snap-top"></a>
+<HclListItem name="cloud_init_parts" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`default_user`**](#default_user) &mdash; The default OS user for the EC2 instance AMI. For AWS Ubuntu AMIs, which is what the Packer template in ec2-instance.json uses, the default OS user is 'ubuntu'.
+Cloud init scripts to run on the EC2 instance while it boots. See the part blocks in https://www.terraform.io/docs/providers/template/d/cloudinit_config.html for syntax.
 
-<a name="dns_ttl" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`dns_ttl`**](#dns_ttl) &mdash; DNS Time To Live in seconds.
+```hcl
+map(object({
+    filename     = string
+    content_type = string
+    content      = string
+  }))
+```
 
-<a name="ebs_optimized" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`ebs_optimized`**](#ebs_optimized) &mdash; If true, the launched EC2 Instance will be EBS-optimized.
+<HclListItem name="cloudwatch_log_group_kms_key_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="enable_cloudwatch_alarms" className="snap-top"></a>
+The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data.
 
-* [**`enable_cloudwatch_alarms`**](#enable_cloudwatch_alarms) &mdash; Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using [`alarms_sns_topic_arn`](#alarms_sns_topic_arn).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="enable_cloudwatch_log_aggregation" className="snap-top"></a>
+<HclListItem name="cloudwatch_log_group_retention_in_days" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`enable_cloudwatch_log_aggregation`**](#enable_cloudwatch_log_aggregation) &mdash; Set to true to send logs to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/logs/cloudwatch-log-aggregation-scripts to do log aggregation in CloudWatch.
+The number of days to retain log events in the log group. Refer to https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days for all the valid values. When null, the log events are retained forever.
 
-<a name="enable_cloudwatch_metrics" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`enable_cloudwatch_metrics`**](#enable_cloudwatch_metrics) &mdash; Set to true to add IAM permissions to send custom metrics to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/metrics/cloudwatch-memory-disk-metrics-scripts to get memory and disk metrics in CloudWatch for your EC2 instance.
+<HclListItem name="cloudwatch_log_group_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="enable_fail2ban" className="snap-top"></a>
+Tags to apply on the CloudWatch Log Group, encoded as a map where the keys are tag keys and values are tag values.
 
-* [**`enable_fail2ban`**](#enable_fail2ban) &mdash; Enable fail2ban to block brute force log in attempts. Defaults to true.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="enable_ip_lockdown" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`enable_ip_lockdown`**](#enable_ip_lockdown) &mdash; Enable ip-lockdown to block access to the instance metadata. Defaults to true.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="enable_ssh_grunt" className="snap-top"></a>
+<HclListItem name="create_dns_record" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`enable_ssh_grunt`**](#enable_ssh_grunt) &mdash; Set to true to add IAM permissions for ssh-grunt (https://github.com/gruntwork-io/terraform-aws-security/tree/master/modules/ssh-grunt), which will allow you to manage SSH access via IAM groups.
+Set to true to create a DNS record in Route53 pointing to the EC2 instance. If true, be sure to set <a href="#fully_qualified_domain_name"><code>fully_qualified_domain_name</code></a>.
 
-<a name="external_account_ssh_grunt_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`external_account_ssh_grunt_role_arn`**](#external_account_ssh_grunt_role_arn) &mdash; If you are using ssh-grunt and your IAM users / groups are defined in a separate AWS account, you can use this variable to specify the ARN of an IAM role that ssh-grunt can assume to retrieve IAM group and public SSH key info from that account. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+<HclListItem name="default_user" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="fully_qualified_domain_name" className="snap-top"></a>
+The default OS user for the EC2 instance AMI. For AWS Ubuntu AMIs, which is what the Packer template in ec2-instance.json uses, the default OS user is 'ubuntu'.
 
-* [**`fully_qualified_domain_name`**](#fully_qualified_domain_name) &mdash; The apex domain of the hostname for the EC2 instance (e.g., example.com). The complete hostname for the EC2 instance will be [`name.var.fully_qualified_domain_name`](#name.var.fully_qualified_domain_name) (e.g., bastion.example.com). Only used if [`create_dns_record`](#create_dns_record) is true.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ubuntu"/>
+</HclListItem>
 
-<a name="keypair_name" className="snap-top"></a>
+<HclListItem name="dns_ttl" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`keypair_name`**](#keypair_name) &mdash; The name of a Key Pair that can be used to SSH to this instance. This instance may have ssh-grunt installed. The preferred way to do SSH access is with your own IAM user name and SSH key. This Key Pair is only as a fallback.
+DNS Time To Live in seconds.
 
-<a name="root_volume_delete_on_termination" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="300"/>
+</HclListItem>
 
-* [**`root_volume_delete_on_termination`**](#root_volume_delete_on_termination) &mdash; If set to true, the root volume will be deleted when the Instance is terminated.
+<HclListItem name="ebs_optimized" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="root_volume_size" className="snap-top"></a>
+If true, the launched EC2 Instance will be EBS-optimized.
 
-* [**`root_volume_size`**](#root_volume_size) &mdash; The size of the root volume, in gigabytes.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="root_volume_type" className="snap-top"></a>
+<HclListItem name="enable_cloudwatch_alarms" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`root_volume_type`**](#root_volume_type) &mdash; The root volume type. Must be one of: standard, gp2, io1.
+Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using <a href="#alarms_sns_topic_arn"><code>alarms_sns_topic_arn</code></a>.
 
-<a name="should_create_cloudwatch_log_group" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`should_create_cloudwatch_log_group`**](#should_create_cloudwatch_log_group) &mdash; When true, precreate the CloudWatch Log Group to use for log aggregation from the EC2 instances. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, the CloudWatch agent will automatically create a basic log group to use.
+<HclListItem name="enable_cloudwatch_log_aggregation" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="ssh_grunt_iam_group" className="snap-top"></a>
+Set to true to send logs to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/logs/cloudwatch-log-aggregation-scripts to do log aggregation in CloudWatch.
 
-* [**`ssh_grunt_iam_group`**](#ssh_grunt_iam_group) &mdash; If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to this EC2 instance. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="ssh_grunt_iam_group_sudo" className="snap-top"></a>
+<HclListItem name="enable_cloudwatch_metrics" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`ssh_grunt_iam_group_sudo`**](#ssh_grunt_iam_group_sudo) &mdash; If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to this EC2 instance. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+Set to true to add IAM permissions to send custom metrics to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/metrics/cloudwatch-memory-disk-metrics-scripts to get memory and disk metrics in CloudWatch for your EC2 instance.
 
-<a name="tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`tags`**](#tags) &mdash; A map of tags to apply to the EC2 instance and the S3 Buckets. The key is the tag name and the value is the tag value.
+<HclListItem name="enable_fail2ban" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="tenancy" className="snap-top"></a>
+Enable fail2ban to block brute force log in attempts. Defaults to true.
 
-* [**`tenancy`**](#tenancy) &mdash; The tenancy of this instance. Must be one of: default, dedicated, or host.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="use_managed_iam_policies" className="snap-top"></a>
+<HclListItem name="enable_ip_lockdown" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`use_managed_iam_policies`**](#use_managed_iam_policies) &mdash; When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+Enable ip-lockdown to block access to the instance metadata. Defaults to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_ssh_grunt" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to add IAM permissions for ssh-grunt (https://github.com/gruntwork-io/terraform-aws-security/tree/master/modules/ssh-grunt), which will allow you to manage SSH access via IAM groups.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="external_account_ssh_grunt_role_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt and your IAM users / groups are defined in a separate AWS account, you can use this variable to specify the ARN of an IAM role that ssh-grunt can assume to retrieve IAM group and public SSH key info from that account. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="fully_qualified_domain_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The apex domain of the hostname for the EC2 instance (e.g., example.com). The complete hostname for the EC2 instance will be var.name.<a href="#fully_qualified_domain_name"><code>fully_qualified_domain_name</code></a> (e.g., bastion.example.com). Only used if create_dns_record is true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="keypair_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of a Key Pair that can be used to SSH to this instance. This instance may have ssh-grunt installed. The preferred way to do SSH access is with your own IAM user name and SSH key. This Key Pair is only as a fallback.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="root_volume_delete_on_termination" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If set to true, the root volume will be deleted when the Instance is terminated.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="root_volume_size" requirement="optional" type="number">
+<HclListItemDescription>
+
+The size of the root volume, in gigabytes.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="8"/>
+</HclListItem>
+
+<HclListItem name="root_volume_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+The root volume type. Must be one of: standard, gp2, io1.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="standard"/>
+</HclListItem>
+
+<HclListItem name="should_create_cloudwatch_log_group" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, precreate the CloudWatch Log Group to use for log aggregation from the EC2 instances. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, the CloudWatch agent will automatically create a basic log group to use.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="ssh_grunt_iam_group" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to this EC2 instance. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="ssh_grunt_iam_group_sudo" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to this EC2 instance. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of tags to apply to the EC2 instance and the S3 Buckets. The key is the tag name and the value is the tag value.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="tenancy" requirement="optional" type="string">
+<HclListItemDescription>
+
+The tenancy of this instance. Must be one of: default, dedicated, or host.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="default"/>
+</HclListItem>
+
+<HclListItem name="use_managed_iam_policies" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="dns_name" className="snap-top"></a>
+<HclListItem name="dns_name">
+<HclListItemDescription>
 
-* [**`dns_name`**](#dns_name) &mdash; The fully qualified name of the EC2 server.
+The fully qualified name of the EC2 server.
 
-<a name="ec2_instance_iam_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`ec2_instance_iam_role_arn`**](#ec2_instance_iam_role_arn) &mdash; The ARN of the EC2 server's IAM role.
+<HclListItem name="ec2_instance_iam_role_arn">
+<HclListItemDescription>
 
-<a name="ec2_instance_iam_role_id" className="snap-top"></a>
+The ARN of the EC2 server's IAM role.
 
-* [**`ec2_instance_iam_role_id`**](#ec2_instance_iam_role_id) &mdash; The ID of the EC2 server's IAM role.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="ec2_instance_iam_role_name" className="snap-top"></a>
+<HclListItem name="ec2_instance_iam_role_id">
+<HclListItemDescription>
 
-* [**`ec2_instance_iam_role_name`**](#ec2_instance_iam_role_name) &mdash; The name of the EC2 server's IAM role.
+The ID of the EC2 server's IAM role.
 
-<a name="ec2_instance_instance_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`ec2_instance_instance_id`**](#ec2_instance_instance_id) &mdash; The EC2 instance ID of the EC2 server.
+<HclListItem name="ec2_instance_iam_role_name">
+<HclListItemDescription>
 
-<a name="ec2_instance_private_ip" className="snap-top"></a>
+The name of the EC2 server's IAM role.
 
-* [**`ec2_instance_private_ip`**](#ec2_instance_private_ip) &mdash; The private IP address of the EC2 server.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="ec2_instance_public_ip" className="snap-top"></a>
+<HclListItem name="ec2_instance_instance_id">
+<HclListItemDescription>
 
-* [**`ec2_instance_public_ip`**](#ec2_instance_public_ip) &mdash; The public IP address of the EC2 server.
+The EC2 instance ID of the EC2 server.
 
-<a name="ec2_instance_security_group_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`ec2_instance_security_group_id`**](#ec2_instance_security_group_id) &mdash; The ID of the EC2 servers's security group.
+<HclListItem name="ec2_instance_private_ip">
+<HclListItemDescription>
 
-<a name="ec2_instance_volume_info" className="snap-top"></a>
+The private IP address of the EC2 server.
 
-* [**`ec2_instance_volume_info`**](#ec2_instance_volume_info) &mdash; Info about the created EBS volumes.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="ec2_instance_volume_parameters" className="snap-top"></a>
+<HclListItem name="ec2_instance_public_ip">
+<HclListItemDescription>
 
-* [**`ec2_instance_volume_parameters`**](#ec2_instance_volume_parameters) &mdash; The input parameters for the EBS volumes.
+The public IP address of the EC2 server.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="ec2_instance_security_group_id">
+<HclListItemDescription>
+
+The ID of the EC2 servers's security group.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="ec2_instance_volume_info">
+<HclListItemDescription>
+
+Info about the created EBS volumes.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="ec2_instance_volume_parameters">
+<HclListItemDescription>
+
+The input parameters for the EBS volumes.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"a6efad463023687dc76b6c18ee1c571c"}
+{"sourcePlugin":"service-catalog-api","hash":"82cb1593fa3f63a7da97b27b3bc4eeca"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/app-orchestration/kubernetes-namespace.md
+++ b/docs/reference/services/app-orchestration/kubernetes-namespace.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.83.0"/>
 
@@ -95,63 +96,172 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="name" className="snap-top"></a>
+<HclListItem name="name" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`name`**](#name) &mdash; Name of the Namespace to create.
+Name of the Namespace to create.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="annotations" className="snap-top"></a>
+<HclListItem name="annotations" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`annotations`**](#annotations) &mdash; Map of string key default pairs that can be used to store arbitrary metadata on the namespace and roles. See the Kubernetes Reference for more info (https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
+Map of string key default pairs that can be used to store arbitrary metadata on the namespace and roles. See the Kubernetes Reference for more info (https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
 
-<a name="eks_cluster_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`eks_cluster_name`**](#eks_cluster_name) &mdash; Name of the EKS cluster where the Namespace will be created. Required when [`schedule_pods_on_fargate`](#schedule_pods_on_fargate) is `true`.
+```hcl
+map(string)
+```
 
-<a name="full_access_rbac_entities" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`full_access_rbac_entities`**](#full_access_rbac_entities) &mdash; The list of RBAC entities that should have full access to the Namespace.
+<HclListItem name="eks_cluster_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="labels" className="snap-top"></a>
+Name of the EKS cluster where the Namespace will be created. Required when <a href="#schedule_pods_on_fargate"><code>schedule_pods_on_fargate</code></a> is `true`.
 
-* [**`labels`**](#labels) &mdash; Map of string key value pairs that can be used to organize and categorize the namespace and roles. See the Kubernetes Reference for more info (https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="pod_execution_iam_role_arn" className="snap-top"></a>
+<HclListItem name="full_access_rbac_entities" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`pod_execution_iam_role_arn`**](#pod_execution_iam_role_arn) &mdash; ARN of IAM Role to use as the Pod execution role for Fargate. Required if [`schedule_pods_on_fargate`](#schedule_pods_on_fargate) is true.
+The list of RBAC entities that should have full access to the Namespace.
 
-<a name="read_only_access_rbac_entities" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`read_only_access_rbac_entities`**](#read_only_access_rbac_entities) &mdash; The list of RBAC entities that should have read only access to the Namespace.
+```hcl
+list(object({
+    # The type of entity. One of User, Group, or ServiceAccount
+    kind = string
 
-<a name="schedule_pods_on_fargate" className="snap-top"></a>
+    # The name of the entity (e.g., the username or group name, depending on kind).
+    name = string
 
-* [**`schedule_pods_on_fargate`**](#schedule_pods_on_fargate) &mdash; When true, will create a Fargate Profile that matches all Pods in the Namespace. This means that all Pods in the Namespace will be scheduled on Fargate. Note that this value is only used if [`kubeconfig_auth_type`](#kubeconfig_auth_type) is eks, as Fargate profiles can only be created against EKS clusters.
+    # The namespace where the entity is located. Only used for ServiceAccount.
+    namespace = string
+  }))
+```
 
-<a name="worker_vpc_subnet_ids" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`worker_vpc_subnet_ids`**](#worker_vpc_subnet_ids) &mdash; The subnet IDs to use for EKS worker nodes. Used when provisioning Pods on to Fargate. At least 1 subnet is required if [`schedule_pods_on_fargate`](#schedule_pods_on_fargate) is true.
+<HclListItem name="labels" requirement="optional" type="map">
+<HclListItemDescription>
+
+Map of string key value pairs that can be used to organize and categorize the namespace and roles. See the Kubernetes Reference for more info (https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="pod_execution_iam_role_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+ARN of IAM Role to use as the Pod execution role for Fargate. Required if <a href="#schedule_pods_on_fargate"><code>schedule_pods_on_fargate</code></a> is true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="read_only_access_rbac_entities" requirement="optional" type="list">
+<HclListItemDescription>
+
+The list of RBAC entities that should have read only access to the Namespace.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(object({
+    # The type of entity. One of User, Group, or ServiceAccount
+    kind = string
+
+    # The name of the entity (e.g., the username or group name, depending on kind).
+    name = string
+
+    # The namespace where the entity is located. Only used for ServiceAccount.
+    namespace = string
+  }))
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="schedule_pods_on_fargate" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, will create a Fargate Profile that matches all Pods in the Namespace. This means that all Pods in the Namespace will be scheduled on Fargate. Note that this value is only used if <a href="#kubeconfig_auth_type"><code>kubeconfig_auth_type</code></a> is eks, as Fargate profiles can only be created against EKS clusters.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="worker_vpc_subnet_ids" requirement="optional" type="list">
+<HclListItemDescription>
+
+The subnet IDs to use for EKS worker nodes. Used when provisioning Pods on to Fargate. At least 1 subnet is required if <a href="#schedule_pods_on_fargate"><code>schedule_pods_on_fargate</code></a> is true.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="namespace_name" className="snap-top"></a>
+<HclListItem name="namespace_name">
+<HclListItemDescription>
 
-* [**`namespace_name`**](#namespace_name) &mdash; The name of the created namespace.
+The name of the created namespace.
 
-<a name="namespace_rbac_access_all_role" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`namespace_rbac_access_all_role`**](#namespace_rbac_access_all_role) &mdash; The name of the rbac role that grants admin level permissions on the namespace.
+<HclListItem name="namespace_rbac_access_all_role">
+<HclListItemDescription>
 
-<a name="namespace_rbac_access_read_only_role" className="snap-top"></a>
+The name of the rbac role that grants admin level permissions on the namespace.
 
-* [**`namespace_rbac_access_read_only_role`**](#namespace_rbac_access_read_only_role) &mdash; The name of the rbac role that grants read only permissions on the namespace.
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="namespace_rbac_access_read_only_role">
+<HclListItemDescription>
+
+The name of the rbac role that grants read only permissions on the namespace.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"0908ca4f3ea00d22017927435e6325e4"}
+{"sourcePlugin":"service-catalog-api","hash":"59292fa9e2371a98e1ce702c193d839a"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/app-orchestration/kubernetes-service.md
+++ b/docs/reference/services/app-orchestration/kubernetes-service.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -102,291 +103,817 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="application_name" className="snap-top"></a>
+<HclListItem name="application_name" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`application_name`**](#application_name) &mdash; The name of the application (e.g. my-service-stage). Used for labeling Kubernetes resources.
+The name of the application (e.g. my-service-stage). Used for labeling Kubernetes resources.
 
-<a name="container_image" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`container_image`**](#container_image) &mdash; The Docker image to run.
+<HclListItem name="container_image" requirement="required" type="object">
+<HclListItemDescription>
 
-<a name="container_port" className="snap-top"></a>
+The Docker image to run.
 
-* [**`container_port`**](#container_port) &mdash; The port number on which this service's Docker container accepts incoming traffic.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="desired_number_of_pods" className="snap-top"></a>
+```hcl
+object({
+    # Repository of the docker image (e.g. gruntwork/frontend-service)
+    repository = string
+    # The tag of the docker image to deploy.
+    tag = string
+    # The image pull policy. Can be one of IfNotPresent, Always, or Never.
+    pull_policy = string
+  })
+```
 
-* [**`desired_number_of_pods`**](#desired_number_of_pods) &mdash; The number of Pods to run on the Kubernetes cluster for this service.
+</HclListItemTypeDetails>
+</HclListItem>
 
-<a name="namespace" className="snap-top"></a>
+<HclListItem name="container_port" requirement="required" type="number">
+<HclListItemDescription>
 
-* [**`namespace`**](#namespace) &mdash; The Kubernetes Namespace to deploy the application into.
+The port number on which this service's Docker container accepts incoming traffic.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="desired_number_of_pods" requirement="required" type="number">
+<HclListItemDescription>
+
+The number of Pods to run on the Kubernetes cluster for this service.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="namespace" requirement="required" type="string">
+<HclListItemDescription>
+
+The Kubernetes Namespace to deploy the application into.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="alb_acm_certificate_arns" className="snap-top"></a>
+<HclListItem name="alb_acm_certificate_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`alb_acm_certificate_arns`**](#alb_acm_certificate_arns) &mdash; A list of ACM certificate ARNs to attach to the ALB. The first certificate in the list will be added as default certificate.
+A list of ACM certificate ARNs to attach to the ALB. The first certificate in the list will be added as default certificate.
 
-<a name="alb_health_check_healthy_threshold" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`alb_health_check_healthy_threshold`**](#alb_health_check_healthy_threshold) &mdash; The number of consecutive health check successes required before considering an unhealthy target healthy.
+```hcl
+list(string)
+```
 
-<a name="alb_health_check_interval" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`alb_health_check_interval`**](#alb_health_check_interval) &mdash; Interval between ALB health checks in seconds.
+<HclListItem name="alb_health_check_healthy_threshold" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="alb_health_check_path" className="snap-top"></a>
+The number of consecutive health check successes required before considering an unhealthy target healthy.
 
-* [**`alb_health_check_path`**](#alb_health_check_path) &mdash; URL path for the endpoint that the ALB health check should ping. Defaults to /.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="2"/>
+</HclListItem>
 
-<a name="alb_health_check_port" className="snap-top"></a>
+<HclListItem name="alb_health_check_interval" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`alb_health_check_port`**](#alb_health_check_port) &mdash; String value specifying the port that the ALB health check should probe. By default, this will be set to the traffic port (the NodePort or port where the service receives traffic). This can also be set to a Kubernetes named port, or direct integer value. See https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/guide/ingress/annotations/#healthcheck-port for more information.
+Interval between ALB health checks in seconds.
 
-<a name="alb_health_check_protocol" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="30"/>
+</HclListItem>
 
-* [**`alb_health_check_protocol`**](#alb_health_check_protocol) &mdash; Protocol (HTTP or HTTPS) that the ALB health check should use to connect to the application container.
+<HclListItem name="alb_health_check_path" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="alb_health_check_success_codes" className="snap-top"></a>
+URL path for the endpoint that the ALB health check should ping. Defaults to /.
 
-* [**`alb_health_check_success_codes`**](#alb_health_check_success_codes) &mdash; The HTTP status code that should be expected when doing health checks against the specified health check path. Accepts a single value (200), multiple values (200,201), or a range of values (200-300).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="/"/>
+</HclListItem>
 
-<a name="alb_health_check_timeout" className="snap-top"></a>
+<HclListItem name="alb_health_check_port" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`alb_health_check_timeout`**](#alb_health_check_timeout) &mdash; The timeout, in seconds, during which no response from a target means a failed health check.
+String value specifying the port that the ALB health check should probe. By default, this will be set to the traffic port (the NodePort or port where the service receives traffic). This can also be set to a Kubernetes named port, or direct integer value. See https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/guide/ingress/annotations/#healthcheck-port for more information.
 
-<a name="canary_image" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="traffic-port"/>
+</HclListItem>
 
-* [**`canary_image`**](#canary_image) &mdash; The Docker image to use for the canary. Required if [`desired_number_of_canary_pods`](#desired_number_of_canary_pods) is greater than 0.
+<HclListItem name="alb_health_check_protocol" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="configmaps_as_env_vars" className="snap-top"></a>
+Protocol (HTTP or HTTPS) that the ALB health check should use to connect to the application container.
 
-* [**`configmaps_as_env_vars`**](#configmaps_as_env_vars) &mdash; Kubernetes ConfigMaps to be injected into the container. Each entry in the map represents a ConfigMap to be injected, with the key representing the name of the ConfigMap. The value is also a map, with each entry corresponding to an entry in the ConfigMap, with the key corresponding to the ConfigMap entry key and the value corresponding to the environment variable name.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="HTTP"/>
+</HclListItem>
 
-<a name="configmaps_as_volumes" className="snap-top"></a>
+<HclListItem name="alb_health_check_success_codes" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`configmaps_as_volumes`**](#configmaps_as_volumes) &mdash; Kubernetes ConfigMaps to be injected into the container as volume mounts. Each entry in the map represents a ConfigMap to be mounted, with the key representing the name of the ConfigMap and the value representing a file path on the container to mount the ConfigMap to.
+The HTTP status code that should be expected when doing health checks against the specified health check path. Accepts a single value (200), multiple values (200,201), or a range of values (200-300).
 
-<a name="container_protocol" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="200"/>
+</HclListItem>
 
-* [**`container_protocol`**](#container_protocol) &mdash; The protocol on which this service's Docker container accepts traffic. Must be one of the supported protocols: https://kubernetes.io/docs/concepts/services-networking/service/#protocol-support.
+<HclListItem name="alb_health_check_timeout" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="custom_resources" className="snap-top"></a>
+The timeout, in seconds, during which no response from a target means a failed health check.
 
-* [**`custom_resources`**](#custom_resources) &mdash; The map that lets you define Kubernetes resources you want installed and configured as part of the chart.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="10"/>
+</HclListItem>
 
-<a name="desired_number_of_canary_pods" className="snap-top"></a>
+<HclListItem name="canary_image" requirement="optional" type="object">
+<HclListItemDescription>
 
-* [**`desired_number_of_canary_pods`**](#desired_number_of_canary_pods) &mdash; The number of canary Pods to run on the Kubernetes cluster for this service. If greater than 0, you must provide [`canary_image`](#canary_image).
+The Docker image to use for the canary. Required if desired_number_of_canary_pods is greater than 0.
 
-<a name="domain_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`domain_name`**](#domain_name) &mdash; The domain name for the DNS A record to bind to the Ingress resource for this service (e.g. service.foo.com). Depending on your external-dns configuration, this will also create the DNS record in the configured DNS service (e.g., Route53).
+```hcl
+object({
+    # Repository of the docker image (e.g. gruntwork/frontend-service)
+    repository = string
+    # The tag of the docker image to deploy.
+    tag = string
+    # The image pull policy. Can be one of IfNotPresent, Always, or Never.
+    pull_policy = string
+  })
+```
 
-<a name="domain_propagation_ttl" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`domain_propagation_ttl`**](#domain_propagation_ttl) &mdash; The TTL value of the DNS A record that is bound to the Ingress resource. Only used if [`domain_name`](#domain_name) is set and external-dns is deployed.
+<HclListItem name="configmaps_as_env_vars" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="eks_iam_role_for_service_accounts_config" className="snap-top"></a>
+Kubernetes ConfigMaps to be injected into the container. Each entry in the map represents a ConfigMap to be injected, with the key representing the name of the ConfigMap. The value is also a map, with each entry corresponding to an entry in the ConfigMap, with the key corresponding to the ConfigMap entry key and the value corresponding to the environment variable name.
 
-* [**`eks_iam_role_for_service_accounts_config`**](#eks_iam_role_for_service_accounts_config) &mdash; Configuration for using the IAM role with Service Accounts feature to provide permissions to the applications. This expects a map with two properties: [``openid_connect_provider_arn`](#`openid_connect_provider_arn)` and [``openid_connect_provider_url`](#`openid_connect_provider_url)`. The [``openid_connect_provider_arn`](#`openid_connect_provider_arn)` is the ARN of the OpenID Connect Provider for EKS to retrieve IAM credentials, while [``openid_connect_provider_url`](#`openid_connect_provider_url)` is the URL. Leave as an empty string if you do not wish to use IAM role with Service Accounts.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="enable_liveness_probe" className="snap-top"></a>
+```hcl
+map(map(string))
+```
 
-* [**`enable_liveness_probe`**](#enable_liveness_probe) &mdash; Whether or not to enable liveness probe. Liveness checks indicate whether or not the container is alive. When these checks fail, the cluster will automatically rotate the Pod.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="enable_readiness_probe" className="snap-top"></a>
+<HclListItem name="configmaps_as_volumes" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`enable_readiness_probe`**](#enable_readiness_probe) &mdash; Whether or not to enable readiness probe. Readiness checks indicate whether or not the container can accept traffic. When these checks fail, the Pods are automatically removed from the Service (and added back in when they pass).
+Kubernetes ConfigMaps to be injected into the container as volume mounts. Each entry in the map represents a ConfigMap to be mounted, with the key representing the name of the ConfigMap and the value representing a file path on the container to mount the ConfigMap to.
 
-<a name="env_vars" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`env_vars`**](#env_vars) &mdash; A map of environment variable name to environment variable value that should be made available to the Docker container.
+```hcl
+map(string)
+```
 
-<a name="expose_type" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`expose_type`**](#expose_type) &mdash; How the service will be exposed in the cluster. Must be one of `external` (accessible over the public Internet), `internal` (only accessible from within the same VPC as the cluster), `cluster-internal` (only accessible within the Kubernetes network).
+<HclListItem name="container_protocol" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="force_destroy_ingress_access_logs" className="snap-top"></a>
+The protocol on which this service's Docker container accepts traffic. Must be one of the supported protocols: https://kubernetes.io/docs/concepts/services-networking/service/#protocol-support.
 
-* [**`force_destroy_ingress_access_logs`**](#force_destroy_ingress_access_logs) &mdash; A boolean that indicates whether the access logs bucket should be destroyed, even if there are files in it, when you run Terraform destroy. Unless you are using this bucket only for test purposes, you'll want to leave this variable set to false.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="TCP"/>
+</HclListItem>
 
-<a name="helm_chart_version" className="snap-top"></a>
+<HclListItem name="custom_resources" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`helm_chart_version`**](#helm_chart_version) &mdash; The version of the k8s-service helm chart to deploy.
+The map that lets you define Kubernetes resources you want installed and configured as part of the chart.
 
-<a name="horizontal_pod_autoscaler" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`horizontal_pod_autoscaler`**](#horizontal_pod_autoscaler) &mdash; Configure the Horizontal Pod Autoscaler information for the associated Deployment. HPA is disabled when this variable is set to null.
+```hcl
+map(string)
+```
 
-<a name="iam_policy" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`iam_policy`**](#iam_policy) &mdash; An object defining the policy to attach to [``iam_role_name`](#`iam_role_name)` if the IAM role is going to be created. Accepts a map of objects, where the map keys are sids for IAM policy statements, and the object fields are the resources, actions, and the effect ("Allow" or "Deny") of the statement. Ignored if [``iam_role_arn`](#`iam_role_arn)` is provided. Leave as null if you do not wish to use IAM role with Service Accounts.
+<HclListItem name="desired_number_of_canary_pods" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="iam_role_exists" className="snap-top"></a>
+The number of canary Pods to run on the Kubernetes cluster for this service. If greater than 0, you must provide <a href="#canary_image"><code>canary_image</code></a>.
 
-* [**`iam_role_exists`**](#iam_role_exists) &mdash; Whether or not the IAM role passed in [``iam_role_name`](#`iam_role_name)` already exists. Set to true if it exists, or false if it needs to be created. Defaults to false.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="0"/>
+</HclListItem>
 
-<a name="iam_role_name" className="snap-top"></a>
+<HclListItem name="domain_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`iam_role_name`**](#iam_role_name) &mdash; The name of an IAM role that will be used by the pod to access the AWS API. If [``iam_role_exists`](#`iam_role_exists)` is set to false, this role will be created. Leave as an empty string if you do not wish to use IAM role with Service Accounts.
+The domain name for the DNS A record to bind to the Ingress resource for this service (e.g. service.foo.com). Depending on your external-dns configuration, this will also create the DNS record in the configured DNS service (e.g., Route53).
 
-<a name="ingress_access_logs_s3_bucket_already_exists" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`ingress_access_logs_s3_bucket_already_exists`**](#ingress_access_logs_s3_bucket_already_exists) &mdash; Set to true if the S3 bucket to store the Ingress access logs is managed external to this module.
+<HclListItem name="domain_propagation_ttl" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="ingress_access_logs_s3_bucket_name" className="snap-top"></a>
+The TTL value of the DNS A record that is bound to the Ingress resource. Only used if <a href="#domain_name"><code>domain_name</code></a> is set and external-dns is deployed.
 
-* [**`ingress_access_logs_s3_bucket_name`**](#ingress_access_logs_s3_bucket_name) &mdash; The name to use for the S3 bucket where the Ingress access logs will be stored. If you leave this blank, a name will be generated automatically based on [`application_name`](#application_name).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="ingress_access_logs_s3_prefix" className="snap-top"></a>
+<HclListItem name="eks_iam_role_for_service_accounts_config" requirement="optional" type="object">
+<HclListItemDescription>
 
-* [**`ingress_access_logs_s3_prefix`**](#ingress_access_logs_s3_prefix) &mdash; The prefix to use for ingress access logs associated with the ALB. All logs will be stored in a key with this prefix. If null, the application name will be used.
+Configuration for using the IAM role with Service Accounts feature to provide permissions to the applications. This expects a map with two properties: `openid_connect_provider_arn` and `openid_connect_provider_url`. The `openid_connect_provider_arn` is the ARN of the OpenID Connect Provider for EKS to retrieve IAM credentials, while `openid_connect_provider_url` is the URL. Leave as an empty string if you do not wish to use IAM role with Service Accounts.
 
-<a name="ingress_annotations" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`ingress_annotations`**](#ingress_annotations) &mdash; A list of custom ingress annotations, such as health checks and TLS certificates, to add to the Helm chart. See: https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/
+```hcl
+object({
+    openid_connect_provider_arn = string
+    openid_connect_provider_url = string
+  })
+```
 
-<a name="ingress_backend_protocol" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-* [**`ingress_backend_protocol`**](#ingress_backend_protocol) &mdash; The protocol used by the Ingress ALB resource to communicate with the Service. Must be one of HTTP or HTTPS.
+```hcl
+{
+  openid_connect_provider_arn = "",
+  openid_connect_provider_url = ""
+}
+```
 
-<a name="ingress_configure_ssl_redirect" className="snap-top"></a>
+</HclListItemDefaultValue>
+</HclListItem>
 
-* [**`ingress_configure_ssl_redirect`**](#ingress_configure_ssl_redirect) &mdash; When true, HTTP requests will automatically be redirected to use SSL (HTTPS). Used only when [`expose_type`](#expose_type) is either external or internal.
+<HclListItem name="enable_liveness_probe" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="ingress_group" className="snap-top"></a>
+Whether or not to enable liveness probe. Liveness checks indicate whether or not the container is alive. When these checks fail, the cluster will automatically rotate the Pod.
 
-* [**`ingress_group`**](#ingress_group) &mdash; Assign the ingress resource to an IngressGroup. All Ingress rules of the group will be collapsed to a single ALB. The rules will be collapsed in priority order, with lower numbers being evaluated first.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="ingress_listener_protocol_ports" className="snap-top"></a>
+<HclListItem name="enable_readiness_probe" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`ingress_listener_protocol_ports`**](#ingress_listener_protocol_ports) &mdash; A list of maps of protocols and ports that the ALB should listen on.
+Whether or not to enable readiness probe. Readiness checks indicate whether or not the container can accept traffic. When these checks fail, the Pods are automatically removed from the Service (and added back in when they pass).
 
-<a name="ingress_path" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`ingress_path`**](#ingress_path) &mdash; Path prefix that should be matched to route to the service. For Kubernetes Versions &lt;1.19, Use /* to match all paths. For Kubernetes Versions >=1.19, use / with [`ingress_path_type`](#ingress_path_type) set to Prefix to match all paths.
+<HclListItem name="env_vars" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="ingress_path_type" className="snap-top"></a>
+A map of environment variable name to environment variable value that should be made available to the Docker container.
 
-* [**`ingress_path_type`**](#ingress_path_type) &mdash; The path type to use for the ingress rule. Refer to https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types for more information.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="ingress_ssl_redirect_rule_already_exists" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`ingress_ssl_redirect_rule_already_exists`**](#ingress_ssl_redirect_rule_already_exists) &mdash; Set to true if the Ingress SSL redirect rule is managed externally. This is useful when configuring Ingress grouping and you only want one service to be managing the SSL redirect rules. Only used if [`ingress_configure_ssl_redirect`](#ingress_configure_ssl_redirect) is true.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="ingress_ssl_redirect_rule_requires_path_type" className="snap-top"></a>
+<HclListItem name="expose_type" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`ingress_ssl_redirect_rule_requires_path_type`**](#ingress_ssl_redirect_rule_requires_path_type) &mdash; Whether or not the redirect rule requires setting path type. Set to true when deploying to Kubernetes clusters with version >=1.19. Only used if [`ingress_configure_ssl_redirect`](#ingress_configure_ssl_redirect) is true.
+How the service will be exposed in the cluster. Must be one of `external` (accessible over the public Internet), `internal` (only accessible from within the same VPC as the cluster), `cluster-internal` (only accessible within the Kubernetes network).
 
-<a name="ingress_target_type" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="cluster-internal"/>
+</HclListItem>
 
-* [**`ingress_target_type`**](#ingress_target_type) &mdash; Controls how the ALB routes traffic to the Pods. Supports 'instance' mode (route traffic to NodePort and load balance across all worker nodes, relying on Kubernetes Service networking to route to the pods), or 'ip' mode (route traffic directly to the pod IP - only works with AWS VPC CNI). Must be set to 'ip' if using Fargate. Only used if [`expose_type`](#expose_type) is not cluster-internal.
+<HclListItem name="force_destroy_ingress_access_logs" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="liveness_probe_grace_period_seconds" className="snap-top"></a>
+A boolean that indicates whether the access logs bucket should be destroyed, even if there are files in it, when you run Terraform destroy. Unless you are using this bucket only for test purposes, you'll want to leave this variable set to false.
 
-* [**`liveness_probe_grace_period_seconds`**](#liveness_probe_grace_period_seconds) &mdash; Seconds to wait after Pod creation before liveness probe has any effect. Any failures during this period are ignored.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="liveness_probe_interval_seconds" className="snap-top"></a>
+<HclListItem name="helm_chart_version" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`liveness_probe_interval_seconds`**](#liveness_probe_interval_seconds) &mdash; The approximate amount of time, in seconds, between liveness checks of an individual Target.
+The version of the k8s-service helm chart to deploy.
 
-<a name="liveness_probe_path" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="v0.2.12"/>
+</HclListItem>
 
-* [**`liveness_probe_path`**](#liveness_probe_path) &mdash; URL path for the endpoint that the liveness probe should ping.
+<HclListItem name="horizontal_pod_autoscaler" requirement="optional" type="object">
+<HclListItemDescription>
 
-<a name="liveness_probe_port" className="snap-top"></a>
+Configure the Horizontal Pod Autoscaler information for the associated Deployment. HPA is disabled when this variable is set to null.
 
-* [**`liveness_probe_port`**](#liveness_probe_port) &mdash; Port that the liveness probe should use to connect to the application container.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="liveness_probe_protocol" className="snap-top"></a>
+```hcl
+object({
+    # The minimum amount of replicas allowed
+    min_replicas = number
+    # The maximum amount of replicas allowed
+    max_replicas = number
+    # The target average CPU utilization (as a percentage) to be used with the metrics. E.g., setting this to 60 means
+    # that the HPA controller will keep the average utilization of the CPU in Pods in the scaling target at 60%.
+    avg_cpu_utilization = number
+    # The target average Memory utilization (as a percentage) to be used with the metrics. Works the same as
+    # avg_cpu_utilization.
+    avg_mem_utilization = number
+  })
+```
 
-* [**`liveness_probe_protocol`**](#liveness_probe_protocol) &mdash; Protocol (HTTP or HTTPS) that the liveness probe should use to connect to the application container.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="min_number_of_pods_available" className="snap-top"></a>
+<HclListItem name="iam_policy" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`min_number_of_pods_available`**](#min_number_of_pods_available) &mdash; The minimum number of pods that should be available at any given point in time. This is used to configure a PodDisruptionBudget for the service, allowing you to achieve a graceful rollout. See https://blog.gruntwork.io/avoiding-outages-in-your-kubernetes-cluster-using-poddisruptionbudgets-ef6a4baa5085 for an introduction to PodDisruptionBudgets.
+An object defining the policy to attach to `iam_role_name` if the IAM role is going to be created. Accepts a map of objects, where the map keys are sids for IAM policy statements, and the object fields are the resources, actions, and the effect ('Allow' or 'Deny') of the statement. Ignored if `iam_role_arn` is provided. Leave as null if you do not wish to use IAM role with Service Accounts.
 
-<a name="num_days_after_which_archive_ingress_log_data" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`num_days_after_which_archive_ingress_log_data`**](#num_days_after_which_archive_ingress_log_data) &mdash; After this number of days, Ingress log files should be transitioned from S3 to Glacier. Set to 0 to never archive logs.
+```hcl
+map(object({
+    resources = list(string)
+    actions   = list(string)
+    effect    = string
+  }))
+```
 
-<a name="num_days_after_which_delete_ingress_log_data" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`num_days_after_which_delete_ingress_log_data`**](#num_days_after_which_delete_ingress_log_data) &mdash; After this number of days, Ingress log files should be deleted from S3. Set to 0 to never delete logs.
+<HclListItem name="iam_role_exists" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="override_chart_inputs" className="snap-top"></a>
+Whether or not the IAM role passed in `iam_role_name` already exists. Set to true if it exists, or false if it needs to be created. Defaults to false.
 
-* [**`override_chart_inputs`**](#override_chart_inputs) &mdash; Override any computed chart inputs with this map. This map is shallow merged to the computed chart inputs prior to passing on to the Helm Release. This is provided as a workaround while the terraform module does not support a particular input value that is exposed in the underlying chart. Please always file a GitHub issue to request exposing additional underlying input values prior to using this variable.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="readiness_probe_grace_period_seconds" className="snap-top"></a>
+<HclListItem name="iam_role_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`readiness_probe_grace_period_seconds`**](#readiness_probe_grace_period_seconds) &mdash; Seconds to wait after Pod creation before liveness probe has any effect. Any failures during this period are ignored.
+The name of an IAM role that will be used by the pod to access the AWS API. If `iam_role_exists` is set to false, this role will be created. Leave as an empty string if you do not wish to use IAM role with Service Accounts.
 
-<a name="readiness_probe_interval_seconds" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
 
-* [**`readiness_probe_interval_seconds`**](#readiness_probe_interval_seconds) &mdash; The approximate amount of time, in seconds, between liveness checks of an individual Target.
+<HclListItem name="ingress_access_logs_s3_bucket_already_exists" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="readiness_probe_path" className="snap-top"></a>
+Set to true if the S3 bucket to store the Ingress access logs is managed external to this module.
 
-* [**`readiness_probe_path`**](#readiness_probe_path) &mdash; URL path for the endpoint that the readiness probe should ping.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="readiness_probe_port" className="snap-top"></a>
+<HclListItem name="ingress_access_logs_s3_bucket_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`readiness_probe_port`**](#readiness_probe_port) &mdash; Port that the readiness probe should use to connect to the application container.
+The name to use for the S3 bucket where the Ingress access logs will be stored. If you leave this blank, a name will be generated automatically based on <a href="#application_name"><code>application_name</code></a>.
 
-<a name="readiness_probe_protocol" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
 
-* [**`readiness_probe_protocol`**](#readiness_probe_protocol) &mdash; Protocol (HTTP or HTTPS) that the readiness probe should use to connect to the application container.
+<HclListItem name="ingress_access_logs_s3_prefix" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="scratch_paths" className="snap-top"></a>
+The prefix to use for ingress access logs associated with the ALB. All logs will be stored in a key with this prefix. If null, the application name will be used.
 
-* [**`scratch_paths`**](#scratch_paths) &mdash; Paths that should be allocated as tmpfs volumes in the Deployment container. Each entry in the map is a key value pair where the key is an arbitrary name to bind to the volume, and the value is the path in the container to mount the tmpfs volume.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="secrets_as_env_vars" className="snap-top"></a>
+<HclListItem name="ingress_annotations" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`secrets_as_env_vars`**](#secrets_as_env_vars) &mdash; Kubernetes Secrets to be injected into the container. Each entry in the map represents a Secret to be injected, with the key representing the name of the Secret. The value is also a map, with each entry corresponding to an entry in the Secret, with the key corresponding to the Secret entry key and the value corresponding to the environment variable name.
+A list of custom ingress annotations, such as health checks and TLS certificates, to add to the Helm chart. See: https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/
 
-<a name="secrets_as_volumes" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`secrets_as_volumes`**](#secrets_as_volumes) &mdash; Kubernetes Secrets to be injected into the container as volume mounts. Each entry in the map represents a Secret to be mounted, with the key representing the name of the Secret and the value representing a file path on the container to mount the Secret to.
+```hcl
+map(string)
+```
 
-<a name="service_account_exists" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`service_account_exists`**](#service_account_exists) &mdash; When true, and [`service_account_name`](#service_account_name) is not blank, lookup and assign an existing ServiceAccount in the Namespace to the Pods.
+<HclListItem name="ingress_backend_protocol" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="service_account_name" className="snap-top"></a>
+The protocol used by the Ingress ALB resource to communicate with the Service. Must be one of HTTP or HTTPS.
 
-* [**`service_account_name`**](#service_account_name) &mdash; The name of a service account to create for use with the Pods. This service account will be mapped to the IAM role defined in [``var.iam_role_name`](#`var.iam_role_name)` to give the pod permissions to access the AWS API. Must be unique in this namespace. Leave as an empty string if you do not wish to assign a Service Account to the Pods.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="HTTP"/>
+</HclListItem>
 
-<a name="service_port" className="snap-top"></a>
+<HclListItem name="ingress_configure_ssl_redirect" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`service_port`**](#service_port) &mdash; The port to expose on the Service. This is most useful when addressing the Service internally to the cluster, as it is ignored when connecting from the Ingress resource.
+When true, HTTP requests will automatically be redirected to use SSL (HTTPS). Used only when expose_type is either external or internal.
 
-<a name="sidecar_containers" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`sidecar_containers`**](#sidecar_containers) &mdash; Map of keys to container definitions that allow you to manage additional side car containers that should be included in the Pod. Note that the values are injected directly into the container list for the Pod Spec.
+<HclListItem name="ingress_group" requirement="optional" type="object">
+<HclListItemDescription>
 
-<a name="termination_grace_period_seconds" className="snap-top"></a>
+Assign the ingress resource to an IngressGroup. All Ingress rules of the group will be collapsed to a single ALB. The rules will be collapsed in priority order, with lower numbers being evaluated first.
 
-* [**`termination_grace_period_seconds`**](#termination_grace_period_seconds) &mdash; Grace period in seconds that Kubernetes will wait before terminating the pod. The timeout happens in parallel to preStop hook and the SIGTERM signal, Kubernetes does not wait for preStop to finish before beginning the grace period.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="use_managed_iam_policies" className="snap-top"></a>
+```hcl
+object({
+    # Ingress group to assign to.
+    name = string
+    # The priority of the rules in this Ingress. Smaller numbers have higher priority.
+    priority = number
+  })
+```
 
-* [**`use_managed_iam_policies`**](#use_managed_iam_policies) &mdash; When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="values_file_path" className="snap-top"></a>
+<HclListItem name="ingress_listener_protocol_ports" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`values_file_path`**](#values_file_path) &mdash; A local file path where the helm chart values will be emitted. Use to debug issues with the helm chart values. Set to null to prevent creation of the file.
+A list of maps of protocols and ports that the ALB should listen on.
 
-<a name="wait" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`wait`**](#wait) &mdash; When true, wait until Pods are up and healthy or [`wait_timeout`](#wait_timeout) seconds before exiting terraform.
+```hcl
+list(object({
+    protocol = string
+    port     = number
+  }))
+```
 
-<a name="wait_timeout" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-* [**`wait_timeout`**](#wait_timeout) &mdash; Number of seconds to wait for Pods to become healthy before marking the deployment as a failure.
+```hcl
+[
+  {
+    port = 80,
+    protocol = "HTTP"
+  },
+  {
+    port = 443,
+    protocol = "HTTPS"
+  }
+]
+```
+
+</HclListItemDefaultValue>
+</HclListItem>
+
+<HclListItem name="ingress_path" requirement="optional" type="string">
+<HclListItemDescription>
+
+Path prefix that should be matched to route to the service. For Kubernetes Versions &lt;1.19, Use /* to match all paths. For Kubernetes Versions >=1.19, use / with ingress_path_type set to Prefix to match all paths.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="/"/>
+</HclListItem>
+
+<HclListItem name="ingress_path_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+The path type to use for the ingress rule. Refer to https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types for more information.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="Prefix"/>
+</HclListItem>
+
+<HclListItem name="ingress_ssl_redirect_rule_already_exists" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true if the Ingress SSL redirect rule is managed externally. This is useful when configuring Ingress grouping and you only want one service to be managing the SSL redirect rules. Only used if ingress_configure_ssl_redirect is true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="ingress_ssl_redirect_rule_requires_path_type" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Whether or not the redirect rule requires setting path type. Set to true when deploying to Kubernetes clusters with version >=1.19. Only used if ingress_configure_ssl_redirect is true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="ingress_target_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+Controls how the ALB routes traffic to the Pods. Supports 'instance' mode (route traffic to NodePort and load balance across all worker nodes, relying on Kubernetes Service networking to route to the pods), or 'ip' mode (route traffic directly to the pod IP - only works with AWS VPC CNI). Must be set to 'ip' if using Fargate. Only used if expose_type is not cluster-internal.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="instance"/>
+</HclListItem>
+
+<HclListItem name="liveness_probe_grace_period_seconds" requirement="optional" type="number">
+<HclListItemDescription>
+
+Seconds to wait after Pod creation before liveness probe has any effect. Any failures during this period are ignored.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="15"/>
+</HclListItem>
+
+<HclListItem name="liveness_probe_interval_seconds" requirement="optional" type="number">
+<HclListItemDescription>
+
+The approximate amount of time, in seconds, between liveness checks of an individual Target.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="30"/>
+</HclListItem>
+
+<HclListItem name="liveness_probe_path" requirement="optional" type="string">
+<HclListItemDescription>
+
+URL path for the endpoint that the liveness probe should ping.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="/"/>
+</HclListItem>
+
+<HclListItem name="liveness_probe_port" requirement="optional" type="number">
+<HclListItemDescription>
+
+Port that the liveness probe should use to connect to the application container.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="80"/>
+</HclListItem>
+
+<HclListItem name="liveness_probe_protocol" requirement="optional" type="string">
+<HclListItemDescription>
+
+Protocol (HTTP or HTTPS) that the liveness probe should use to connect to the application container.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="HTTP"/>
+</HclListItem>
+
+<HclListItem name="min_number_of_pods_available" requirement="optional" type="number">
+<HclListItemDescription>
+
+The minimum number of pods that should be available at any given point in time. This is used to configure a PodDisruptionBudget for the service, allowing you to achieve a graceful rollout. See https://blog.gruntwork.io/avoiding-outages-in-your-kubernetes-cluster-using-poddisruptionbudgets-ef6a4baa5085 for an introduction to PodDisruptionBudgets.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="0"/>
+</HclListItem>
+
+<HclListItem name="num_days_after_which_archive_ingress_log_data" requirement="optional" type="number">
+<HclListItemDescription>
+
+After this number of days, Ingress log files should be transitioned from S3 to Glacier. Set to 0 to never archive logs.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="0"/>
+</HclListItem>
+
+<HclListItem name="num_days_after_which_delete_ingress_log_data" requirement="optional" type="number">
+<HclListItemDescription>
+
+After this number of days, Ingress log files should be deleted from S3. Set to 0 to never delete logs.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="0"/>
+</HclListItem>
+
+<HclListItem name="override_chart_inputs" requirement="optional" type="any">
+<HclListItemDescription>
+
+Override any computed chart inputs with this map. This map is shallow merged to the computed chart inputs prior to passing on to the Helm Release. This is provided as a workaround while the terraform module does not support a particular input value that is exposed in the underlying chart. Please always file a GitHub issue to request exposing additional underlying input values prior to using this variable.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="readiness_probe_grace_period_seconds" requirement="optional" type="number">
+<HclListItemDescription>
+
+Seconds to wait after Pod creation before liveness probe has any effect. Any failures during this period are ignored.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="15"/>
+</HclListItem>
+
+<HclListItem name="readiness_probe_interval_seconds" requirement="optional" type="number">
+<HclListItemDescription>
+
+The approximate amount of time, in seconds, between liveness checks of an individual Target.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="30"/>
+</HclListItem>
+
+<HclListItem name="readiness_probe_path" requirement="optional" type="string">
+<HclListItemDescription>
+
+URL path for the endpoint that the readiness probe should ping.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="/"/>
+</HclListItem>
+
+<HclListItem name="readiness_probe_port" requirement="optional" type="number">
+<HclListItemDescription>
+
+Port that the readiness probe should use to connect to the application container.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="80"/>
+</HclListItem>
+
+<HclListItem name="readiness_probe_protocol" requirement="optional" type="string">
+<HclListItemDescription>
+
+Protocol (HTTP or HTTPS) that the readiness probe should use to connect to the application container.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="HTTP"/>
+</HclListItem>
+
+<HclListItem name="scratch_paths" requirement="optional" type="map">
+<HclListItemDescription>
+
+Paths that should be allocated as tmpfs volumes in the Deployment container. Each entry in the map is a key value pair where the key is an arbitrary name to bind to the volume, and the value is the path in the container to mount the tmpfs volume.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="secrets_as_env_vars" requirement="optional" type="map">
+<HclListItemDescription>
+
+Kubernetes Secrets to be injected into the container. Each entry in the map represents a Secret to be injected, with the key representing the name of the Secret. The value is also a map, with each entry corresponding to an entry in the Secret, with the key corresponding to the Secret entry key and the value corresponding to the environment variable name.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(map(string))
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="secrets_as_volumes" requirement="optional" type="map">
+<HclListItemDescription>
+
+Kubernetes Secrets to be injected into the container as volume mounts. Each entry in the map represents a Secret to be mounted, with the key representing the name of the Secret and the value representing a file path on the container to mount the Secret to.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="service_account_exists" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, and service_account_name is not blank, lookup and assign an existing ServiceAccount in the Namespace to the Pods.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="service_account_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of a service account to create for use with the Pods. This service account will be mapped to the IAM role defined in `<a href="#iam_role_name"><code>iam_role_name</code></a>` to give the pod permissions to access the AWS API. Must be unique in this namespace. Leave as an empty string if you do not wish to assign a Service Account to the Pods.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="service_port" requirement="optional" type="number">
+<HclListItemDescription>
+
+The port to expose on the Service. This is most useful when addressing the Service internally to the cluster, as it is ignored when connecting from the Ingress resource.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="80"/>
+</HclListItem>
+
+<HclListItem name="sidecar_containers" requirement="optional" type="any">
+<HclListItemDescription>
+
+Map of keys to container definitions that allow you to manage additional side car containers that should be included in the Pod. Note that the values are injected directly into the container list for the Pod Spec.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="termination_grace_period_seconds" requirement="optional" type="number">
+<HclListItemDescription>
+
+Grace period in seconds that Kubernetes will wait before terminating the pod. The timeout happens in parallel to preStop hook and the SIGTERM signal, Kubernetes does not wait for preStop to finish before beginning the grace period.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="use_managed_iam_policies" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="values_file_path" requirement="optional" type="string">
+<HclListItemDescription>
+
+A local file path where the helm chart values will be emitted. Use to debug issues with the helm chart values. Set to null to prevent creation of the file.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="wait" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, wait until Pods are up and healthy or wait_timeout seconds before exiting terraform.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="wait_timeout" requirement="optional" type="number">
+<HclListItemDescription>
+
+Number of seconds to wait for Pods to become healthy before marking the deployment as a failure.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="300"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
@@ -398,5 +925,5 @@ If you want to deploy this repo in production, check out the following resources
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"7dc39c9fdbeb32161e1743a7f805c5d7"}
+{"sourcePlugin":"service-catalog-api","hash":"6d7e1ee238bf4d10a59ff0a46d345aea"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/app-orchestration/lambda.md
+++ b/docs/reference/services/app-orchestration/lambda.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -94,287 +95,672 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="alarm_sns_topic_arns" className="snap-top"></a>
+<HclListItem name="alarm_sns_topic_arns" requirement="required" type="list">
+<HclListItemDescription>
 
-* [**`alarm_sns_topic_arns`**](#alarm_sns_topic_arns) &mdash; A list of SNS topic ARNs to notify when the lambda alarms change to ALARM, OK, or [`INSUFFICIENT_DATA`](#INSUFFICIENT_DATA) state
+A list of SNS topic ARNs to notify when the lambda alarms change to ALARM, OK, or INSUFFICIENT_DATA state
 
-<a name="memory_size" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`memory_size`**](#memory_size) &mdash; The maximum amount of memory, in MB, your Lambda function will be able to use at runtime. Can be set in 64MB increments from 128MB up to 1536MB. Note that the amount of CPU power given to a Lambda function is proportional to the amount of memory you request, so a Lambda function with 256MB of memory has twice as much CPU power as one with 128MB.
+```hcl
+list(string)
+```
 
-<a name="name" className="snap-top"></a>
+</HclListItemTypeDetails>
+</HclListItem>
 
-* [**`name`**](#name) &mdash; The name of the Lambda function. Used to namespace all resources created by this module.
+<HclListItem name="memory_size" requirement="required" type="number">
+<HclListItemDescription>
 
-<a name="timeout" className="snap-top"></a>
+The maximum amount of memory, in MB, your Lambda function will be able to use at runtime. Can be set in 64MB increments from 128MB up to 1536MB. Note that the amount of CPU power given to a Lambda function is proportional to the amount of memory you request, so a Lambda function with 256MB of memory has twice as much CPU power as one with 128MB.
 
-* [**`timeout`**](#timeout) &mdash; The maximum amount of time, in seconds, your Lambda function will be allowed to run. Must be between 1 and 900 seconds.
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="name" requirement="required" type="string">
+<HclListItemDescription>
+
+The name of the Lambda function. Used to namespace all resources created by this module.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="timeout" requirement="required" type="number">
+<HclListItemDescription>
+
+The maximum amount of time, in seconds, your Lambda function will be allowed to run. Must be between 1 and 900 seconds.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="assume_role_policy" className="snap-top"></a>
+<HclListItem name="assume_role_policy" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`assume_role_policy`**](#assume_role_policy) &mdash; A custom assume role policy for the IAM role for this Lambda function. If not set, the default is a policy that allows the Lambda service to assume the IAM role, which is what most users will need. However, you can use this variable to override the policy for special cases, such as using a Lambda function to rotate AWS Secrets Manager secrets.
+A custom assume role policy for the IAM role for this Lambda function. If not set, the default is a policy that allows the Lambda service to assume the IAM role, which is what most users will need. However, you can use this variable to override the policy for special cases, such as using a Lambda function to rotate AWS Secrets Manager secrets.
 
-<a name="cloudwatch_log_group_kms_key_id" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`cloudwatch_log_group_kms_key_id`**](#cloudwatch_log_group_kms_key_id) &mdash; The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data.
+<HclListItem name="cloudwatch_log_group_kms_key_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="cloudwatch_log_group_retention_in_days" className="snap-top"></a>
+The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data.
 
-* [**`cloudwatch_log_group_retention_in_days`**](#cloudwatch_log_group_retention_in_days) &mdash; The number of days to retain log events in the log group. Refer to [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days) for all the valid values. When null, the log events are retained forever.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="cloudwatch_log_group_subscription_destination_arn" className="snap-top"></a>
+<HclListItem name="cloudwatch_log_group_retention_in_days" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`cloudwatch_log_group_subscription_destination_arn`**](#cloudwatch_log_group_subscription_destination_arn) &mdash; The ARN of the destination to deliver matching log events to. Kinesis stream or Lambda function ARN. Only applicable if [`should_create_cloudwatch_log_group`](#should_create_cloudwatch_log_group) is true.
+The number of days to retain log events in the log group. Refer to https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days for all the valid values. When null, the log events are retained forever.
 
-<a name="cloudwatch_log_group_subscription_distribution" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`cloudwatch_log_group_subscription_distribution`**](#cloudwatch_log_group_subscription_distribution) &mdash; The method used to distribute log data to the destination. Only applicable when [`cloudwatch_log_group_subscription_destination_arn`](#cloudwatch_log_group_subscription_destination_arn) is a kinesis stream. Valid values are `Random` and `ByLogStream`.
+<HclListItem name="cloudwatch_log_group_subscription_destination_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="cloudwatch_log_group_subscription_filter_pattern" className="snap-top"></a>
+The ARN of the destination to deliver matching log events to. Kinesis stream or Lambda function ARN. Only applicable if <a href="#should_create_cloudwatch_log_group"><code>should_create_cloudwatch_log_group</code></a> is true.
 
-* [**`cloudwatch_log_group_subscription_filter_pattern`**](#cloudwatch_log_group_subscription_filter_pattern) &mdash; A valid CloudWatch Logs filter pattern for subscribing to a filtered stream of log events.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="cloudwatch_log_group_subscription_role_arn" className="snap-top"></a>
+<HclListItem name="cloudwatch_log_group_subscription_distribution" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`cloudwatch_log_group_subscription_role_arn`**](#cloudwatch_log_group_subscription_role_arn) &mdash; ARN of an IAM role that grants Amazon CloudWatch Logs permissions to deliver ingested log events to the destination. Only applicable when [`cloudwatch_log_group_subscription_destination_arn`](#cloudwatch_log_group_subscription_destination_arn) is a kinesis stream.
+The method used to distribute log data to the destination. Only applicable when <a href="#cloudwatch_log_group_subscription_destination_arn"><code>cloudwatch_log_group_subscription_destination_arn</code></a> is a kinesis stream. Valid values are `Random` and `ByLogStream`.
 
-<a name="cloudwatch_log_group_tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`cloudwatch_log_group_tags`**](#cloudwatch_log_group_tags) &mdash; Tags to apply on the CloudWatch Log Group, encoded as a map where the keys are tag keys and values are tag values.
+<HclListItem name="cloudwatch_log_group_subscription_filter_pattern" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="command" className="snap-top"></a>
+A valid CloudWatch Logs filter pattern for subscribing to a filtered stream of log events.
 
-* [**`command`**](#command) &mdash; The CMD for the docker image. Only used if you specify a Docker image via [`image_uri`](#image_uri).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
 
-<a name="comparison_operator" className="snap-top"></a>
+<HclListItem name="cloudwatch_log_group_subscription_role_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`comparison_operator`**](#comparison_operator) &mdash; The arithmetic operation to use when comparing the specified Statistic and Threshold. The specified Statistic value is used as the first operand. Either of the following is supported: `GreaterThanOrEqualToThreshold`, `GreaterThanThreshold`, `LessThanThreshold`, `LessThanOrEqualToThreshold`. Additionally, the values `LessThanLowerOrGreaterThanUpperThreshold`, `LessThanLowerThreshold`, and `GreaterThanUpperThreshold` are used only for alarms based on anomaly detection models.
+ARN of an IAM role that grants Amazon CloudWatch Logs permissions to deliver ingested log events to the destination. Only applicable when <a href="#cloudwatch_log_group_subscription_destination_arn"><code>cloudwatch_log_group_subscription_destination_arn</code></a> is a kinesis stream.
 
-<a name="create_resources" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`create_resources`**](#create_resources) &mdash; Set to false to have this module skip creating resources. This weird parameter exists solely because Terraform does not support conditional modules. Therefore, this is a hack to allow you to conditionally decide if this module should create anything or not.
+<HclListItem name="cloudwatch_log_group_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="datapoints_to_alarm" className="snap-top"></a>
+Tags to apply on the CloudWatch Log Group, encoded as a map where the keys are tag keys and values are tag values.
 
-* [**`datapoints_to_alarm`**](#datapoints_to_alarm) &mdash; The number of datapoints that must be breaching to trigger the alarm.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="dead_letter_target_arn" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`dead_letter_target_arn`**](#dead_letter_target_arn) &mdash; The ARN of an SNS topic or an SQS queue to notify when invocation of a Lambda function fails. If this option is used, you must grant this function's IAM role (the ID is outputted as [`iam_role_id`](#iam_role_id)) access to write to the target object, which means allowing either the sns:Publish or sqs:SendMessage action on this ARN, depending on which service is targeted.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="description" className="snap-top"></a>
+<HclListItem name="command" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`description`**](#description) &mdash; A description of what the Lambda function does.
+The CMD for the docker image. Only used if you specify a Docker image via image_uri.
 
-<a name="enable_versioning" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`enable_versioning`**](#enable_versioning) &mdash; Set to true to enable versioning for this Lambda function. This allows you to use aliases to refer to execute different versions of the function in different environments. Note that an alternative way to run Lambda functions in multiple environments is to version your Terraform code.
+```hcl
+list(string)
+```
 
-<a name="entry_point" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`entry_point`**](#entry_point) &mdash; The ENTRYPOINT for the docker image. Only used if you specify a Docker image via [`image_uri`](#image_uri).
+<HclListItem name="comparison_operator" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="environment_variables" className="snap-top"></a>
+The arithmetic operation to use when comparing the specified Statistic and Threshold. The specified Statistic value is used as the first operand. Either of the following is supported: `GreaterThanOrEqualToThreshold`, `GreaterThanThreshold`, `LessThanThreshold`, `LessThanOrEqualToThreshold`. Additionally, the values `LessThanLowerOrGreaterThanUpperThreshold`, `LessThanLowerThreshold`, and `GreaterThanUpperThreshold` are used only for alarms based on anomaly detection models.
 
-* [**`environment_variables`**](#environment_variables) &mdash; A map of environment variables to pass to the Lambda function. AWS will automatically encrypt these with KMS and decrypt them when running the function.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="GreaterThanThreshold"/>
+</HclListItem>
 
-<a name="evaluation_periods" className="snap-top"></a>
+<HclListItem name="create_resources" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`evaluation_periods`**](#evaluation_periods) &mdash; The number of periods over which data is compared to the specified threshold.
+Set to false to have this module skip creating resources. This weird parameter exists solely because Terraform does not support conditional modules. Therefore, this is a hack to allow you to conditionally decide if this module should create anything or not.
 
-<a name="file_system_access_point_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`file_system_access_point_arn`**](#file_system_access_point_arn) &mdash; The ARN of an EFS access point to use to access the file system. Only used if [`mount_to_file_system`](#mount_to_file_system) is true.
+<HclListItem name="datapoints_to_alarm" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="file_system_mount_path" className="snap-top"></a>
+The number of datapoints that must be breaching to trigger the alarm.
 
-* [**`file_system_mount_path`**](#file_system_mount_path) &mdash; The mount path where the lambda can access the file system. This path must begin with /mnt/. Only used if [`mount_to_file_system`](#mount_to_file_system) is true.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1"/>
+</HclListItem>
 
-<a name="handler" className="snap-top"></a>
+<HclListItem name="dead_letter_target_arn" requirement="optional">
+<HclListItemDescription>
 
-* [**`handler`**](#handler) &mdash; The function entrypoint in your code. This is typically the name of a function or method in your code that AWS will execute when this Lambda function is triggered.
+The ARN of an SNS topic or an SQS queue to notify when invocation of a Lambda function fails. If this option is used, you must grant this function's IAM role (the ID is outputted as iam_role_id) access to write to the target object, which means allowing either the sns:Publish or sqs:SendMessage action on this ARN, depending on which service is targeted.
 
-<a name="image_uri" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`image_uri`**](#image_uri) &mdash; The ECR image URI containing the function's deployment package. Example: [`01234501234501.dkr.ecr.us-east-1.amazonaws.com/image_name:image_tag`](#01234501234501.dkr.ecr.us-east-1.amazonaws.com/image_name:image_tag)
+<HclListItem name="description" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="kms_key_arn" className="snap-top"></a>
+A description of what the Lambda function does.
 
-* [**`kms_key_arn`**](#kms_key_arn) &mdash; A custom KMS key to use to encrypt and decrypt Lambda function environment variables. Leave it blank to use the default KMS key provided in your AWS account.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="lambda_role_permissions_boundary_arn" className="snap-top"></a>
+<HclListItem name="enable_versioning" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`lambda_role_permissions_boundary_arn`**](#lambda_role_permissions_boundary_arn) &mdash; The ARN of the policy that is used to set the permissions boundary for the IAM role for the lambda
+Set to true to enable versioning for this Lambda function. This allows you to use aliases to refer to execute different versions of the function in different environments. Note that an alternative way to run Lambda functions in multiple environments is to version your Terraform code.
 
-<a name="layers" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`layers`**](#layers) &mdash; The list of Lambda Layer Version ARNs to attach to your Lambda Function. You can have a maximum of 5 Layers attached to each function.
+<HclListItem name="entry_point" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="metric_name" className="snap-top"></a>
+The ENTRYPOINT for the docker image. Only used if you specify a Docker image via image_uri.
 
-* [**`metric_name`**](#metric_name) &mdash; The name for the alarm's associated metric.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="mount_to_file_system" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`mount_to_file_system`**](#mount_to_file_system) &mdash; Set to true to mount your Lambda function on an EFS. Note that the lambda must also be deployed inside a VPC [`(run_in_vpc`](#(run_in_vpc) must be set to true) for this config to have any effect.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="namespace" className="snap-top"></a>
+<HclListItem name="environment_variables" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`namespace`**](#namespace) &mdash; The namespace to use for all resources created by this module. If not set, [`lambda_function_name`](#lambda_function_name), with '-scheduled' as a suffix, is used.
+A map of environment variables to pass to the Lambda function. AWS will automatically encrypt these with KMS and decrypt them when running the function.
 
-<a name="period" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`period`**](#period) &mdash; The period in seconds over which the specified `statistic` is applied.
+```hcl
+map(string)
+```
 
-<a name="reserved_concurrent_executions" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-* [**`reserved_concurrent_executions`**](#reserved_concurrent_executions) &mdash; The amount of reserved concurrent executions for this lambda function or -1 if unreserved.
+```hcl
+{
+  EnvVarPlaceHolder = "Placeholder"
+}
+```
 
-<a name="run_in_vpc" className="snap-top"></a>
+</HclListItemDefaultValue>
+</HclListItem>
 
-* [**`run_in_vpc`**](#run_in_vpc) &mdash; Set to true to give your Lambda function access to resources within a VPC.
+<HclListItem name="evaluation_periods" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="runtime" className="snap-top"></a>
+The number of periods over which data is compared to the specified threshold.
 
-* [**`runtime`**](#runtime) &mdash; The runtime environment for the Lambda function (e.g. nodejs, python2.7, java8). See [`https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction`](#https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction).html#SSS-CreateFunction-request-Runtime for all possible values.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1"/>
+</HclListItem>
 
-<a name="s3_bucket" className="snap-top"></a>
+<HclListItem name="file_system_access_point_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`s3_bucket`**](#s3_bucket) &mdash; An S3 bucket location containing the function's deployment package. Exactly one of [`source_path`](#source_path) or the [`s3_xxx`](#s3_xxx) variables must be specified.
+The ARN of an EFS access point to use to access the file system. Only used if <a href="#mount_to_file_system"><code>mount_to_file_system</code></a> is true.
 
-<a name="s3_key" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`s3_key`**](#s3_key) &mdash; The path within [`s3_bucket`](#s3_bucket) where the deployment package is located. Exactly one of [`source_path`](#source_path) or the [`s3_xxx`](#s3_xxx) variables must be specified.
+<HclListItem name="file_system_mount_path" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="s3_object_version" className="snap-top"></a>
+The mount path where the lambda can access the file system. This path must begin with /mnt/. Only used if <a href="#mount_to_file_system"><code>mount_to_file_system</code></a> is true.
 
-* [**`s3_object_version`**](#s3_object_version) &mdash; The version of the path in [`s3_key`](#s3_key) to use as the deployment package. Exactly one of [`source_path`](#source_path) or the [`s3_xxx`](#s3_xxx) variables must be specified.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="schedule_expression" className="snap-top"></a>
+<HclListItem name="handler" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`schedule_expression`**](#schedule_expression) &mdash; An expression that defines the schedule for this lambda job. For example, cron(0 20 * * ? *) or rate(5 minutes). For more information visit https://docs.aws.amazon.com/lambda/latest/dg/services-cloudwatchevents-expressions.html
+The function entrypoint in your code. This is typically the name of a function or method in your code that AWS will execute when this Lambda function is triggered.
 
-<a name="set_source_code_hash" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`set_source_code_hash`**](#set_source_code_hash) &mdash; If set to false, this function will no longer set the [`source_code_hash`](#source_code_hash) parameter, so this module will no longer detect and upload changes to the deployment package. This is primarily useful if you update the Lambda function from outside of this module (e.g., you have scripts that do it separately) and want to avoid a plan diff. Used only if [`source_path`](#source_path) is non-empty.
+<HclListItem name="image_uri" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="should_create_cloudwatch_log_group" className="snap-top"></a>
+The ECR image URI containing the function's deployment package. Example: 01234501234501.dkr.ecr.us-east-1.amazonaws.com/image_name:image_tag
 
-* [**`should_create_cloudwatch_log_group`**](#should_create_cloudwatch_log_group) &mdash; When true, precreate the CloudWatch Log Group to use for log aggregation from the lambda function execution. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, AWS Lambda will automatically create a basic log group to use.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="should_create_outbound_rule" className="snap-top"></a>
+<HclListItem name="kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`should_create_outbound_rule`**](#should_create_outbound_rule) &mdash; If true, create an egress rule allowing all outbound traffic from Lambda function to the entire Internet (e.g. 0.0.0.0/0).
+A custom KMS key to use to encrypt and decrypt Lambda function environment variables. Leave it blank to use the default KMS key provided in your AWS account.
 
-<a name="skip_zip" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`skip_zip`**](#skip_zip) &mdash; Set to true to skip zip archive creation and assume that [`source_path`](#source_path) points to a pregenerated zip archive.
+<HclListItem name="lambda_role_permissions_boundary_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="source_path" className="snap-top"></a>
+The ARN of the policy that is used to set the permissions boundary for the IAM role for the lambda
 
-* [**`source_path`**](#source_path) &mdash; The path to the directory that contains your Lambda function source code. This code will be zipped up and uploaded to Lambda as your deployment package. If [`skip_zip`](#skip_zip) is set to true, then this is assumed to be the path to an already-zipped file, and it will be uploaded directly to Lambda as a deployment package. Exactly one of [`source_path`](#source_path) or the [`s3_xxx`](#s3_xxx) variables must be specified.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="statistic" className="snap-top"></a>
+<HclListItem name="layers" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`statistic`**](#statistic) &mdash; The statistic to apply to the alarm's associated metric.
+The list of Lambda Layer Version ARNs to attach to your Lambda Function. You can have a maximum of 5 Layers attached to each function.
 
-<a name="subnet_ids" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`subnet_ids`**](#subnet_ids) &mdash; A list of subnet IDs the Lambda function should be able to access within your VPC. Only used if [`run_in_vpc`](#run_in_vpc) is true.
+```hcl
+list(string)
+```
 
-<a name="tags" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`tags`**](#tags) &mdash; A map of tags to apply to the Lambda function.
+<HclListItem name="metric_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="threshold" className="snap-top"></a>
+The name for the alarm's associated metric.
 
-* [**`threshold`**](#threshold) &mdash; The value against which the specified statistic is compared. This parameter is required for alarms based on static thresholds, but should not be used for alarms based on anomaly detection models.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="Errors"/>
+</HclListItem>
 
-<a name="use_managed_iam_policies" className="snap-top"></a>
+<HclListItem name="mount_to_file_system" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`use_managed_iam_policies`**](#use_managed_iam_policies) &mdash; When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+Set to true to mount your Lambda function on an EFS. Note that the lambda must also be deployed inside a VPC (run_in_vpc must be set to true) for this config to have any effect.
 
-<a name="vpc_id" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`vpc_id`**](#vpc_id) &mdash; The ID of the VPC the Lambda function should be able to access. Only used if [`run_in_vpc`](#run_in_vpc) is true.
+<HclListItem name="namespace" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="working_directory" className="snap-top"></a>
+The namespace to use for all resources created by this module. If not set, <a href="#lambda_function_name"><code>lambda_function_name</code></a>, with '-scheduled' as a suffix, is used.
 
-* [**`working_directory`**](#working_directory) &mdash; The working directory for the docker image. Only used if you specify a Docker image via [`image_uri`](#image_uri).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="zip_output_path" className="snap-top"></a>
+<HclListItem name="period" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`zip_output_path`**](#zip_output_path) &mdash; The path to store the output zip file of your source code. If empty, defaults to module path. This should be the full path to the zip file, not a directory.
+The period in seconds over which the specified `statistic` is applied.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="60"/>
+</HclListItem>
+
+<HclListItem name="reserved_concurrent_executions" requirement="optional" type="number">
+<HclListItemDescription>
+
+The amount of reserved concurrent executions for this lambda function or -1 if unreserved.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="run_in_vpc" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to give your Lambda function access to resources within a VPC.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="runtime" requirement="optional" type="string">
+<HclListItemDescription>
+
+The runtime environment for the Lambda function (e.g. nodejs, python2.7, java8). See https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime for all possible values.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="s3_bucket" requirement="optional" type="string">
+<HclListItemDescription>
+
+An S3 bucket location containing the function's deployment package. Exactly one of <a href="#source_path"><code>source_path</code></a> or the <a href="#s3_xxx"><code>s3_xxx</code></a> variables must be specified.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="s3_key" requirement="optional" type="string">
+<HclListItemDescription>
+
+The path within <a href="#s3_bucket"><code>s3_bucket</code></a> where the deployment package is located. Exactly one of <a href="#source_path"><code>source_path</code></a> or the <a href="#s3_xxx"><code>s3_xxx</code></a> variables must be specified.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="s3_object_version" requirement="optional" type="string">
+<HclListItemDescription>
+
+The version of the path in <a href="#s3_key"><code>s3_key</code></a> to use as the deployment package. Exactly one of <a href="#source_path"><code>source_path</code></a> or the <a href="#s3_xxx"><code>s3_xxx</code></a> variables must be specified.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="schedule_expression" requirement="optional" type="string">
+<HclListItemDescription>
+
+An expression that defines the schedule for this lambda job. For example, cron(0 20 * * ? *) or rate(5 minutes). For more information visit https://docs.aws.amazon.com/lambda/latest/dg/services-cloudwatchevents-expressions.html
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="set_source_code_hash" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If set to false, this function will no longer set the source_code_hash parameter, so this module will no longer detect and upload changes to the deployment package. This is primarily useful if you update the Lambda function from outside of this module (e.g., you have scripts that do it separately) and want to avoid a plan diff. Used only if <a href="#source_path"><code>source_path</code></a> is non-empty.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="should_create_cloudwatch_log_group" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, precreate the CloudWatch Log Group to use for log aggregation from the lambda function execution. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, AWS Lambda will automatically create a basic log group to use.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="should_create_outbound_rule" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If true, create an egress rule allowing all outbound traffic from Lambda function to the entire Internet (e.g. 0.0.0.0/0).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="skip_zip" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to skip zip archive creation and assume that <a href="#source_path"><code>source_path</code></a> points to a pregenerated zip archive.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="source_path" requirement="optional" type="string">
+<HclListItemDescription>
+
+The path to the directory that contains your Lambda function source code. This code will be zipped up and uploaded to Lambda as your deployment package. If <a href="#skip_zip"><code>skip_zip</code></a> is set to true, then this is assumed to be the path to an already-zipped file, and it will be uploaded directly to Lambda as a deployment package. Exactly one of <a href="#source_path"><code>source_path</code></a> or the <a href="#s3_xxx"><code>s3_xxx</code></a> variables must be specified.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="statistic" requirement="optional" type="string">
+<HclListItemDescription>
+
+The statistic to apply to the alarm's associated metric.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="Sum"/>
+</HclListItem>
+
+<HclListItem name="subnet_ids" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of subnet IDs the Lambda function should be able to access within your VPC. Only used if <a href="#run_in_vpc"><code>run_in_vpc</code></a> is true.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of tags to apply to the Lambda function.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="threshold" requirement="optional" type="number">
+<HclListItemDescription>
+
+The value against which the specified statistic is compared. This parameter is required for alarms based on static thresholds, but should not be used for alarms based on anomaly detection models.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="0"/>
+</HclListItem>
+
+<HclListItem name="use_managed_iam_policies" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="vpc_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ID of the VPC the Lambda function should be able to access. Only used if <a href="#run_in_vpc"><code>run_in_vpc</code></a> is true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="working_directory" requirement="optional" type="string">
+<HclListItemDescription>
+
+The working directory for the docker image. Only used if you specify a Docker image via image_uri.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="zip_output_path" requirement="optional" type="string">
+<HclListItemDescription>
+
+The path to store the output zip file of your source code. If empty, defaults to module path. This should be the full path to the zip file, not a directory.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="alarm_actions" className="snap-top"></a>
+<HclListItem name="alarm_actions">
+<HclListItemDescription>
 
-* [**`alarm_actions`**](#alarm_actions) &mdash; The list of actions to execute when this alarm transitions into an ALARM state from any other state
+The list of actions to execute when this alarm transitions into an ALARM state from any other state
 
-<a name="alarm_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`alarm_arn`**](#alarm_arn) &mdash; ARN of the Cloudwatch alarm
+<HclListItem name="alarm_arn">
+<HclListItemDescription>
 
-<a name="alarm_name" className="snap-top"></a>
+ARN of the Cloudwatch alarm
 
-* [**`alarm_name`**](#alarm_name) &mdash; Name of the Cloudwatch alarm
+</HclListItemDescription>
+</HclListItem>
 
-<a name="event_rule_arn" className="snap-top"></a>
+<HclListItem name="alarm_name">
+<HclListItemDescription>
 
-* [**`event_rule_arn`**](#event_rule_arn) &mdash; Cloudwatch Event Rule Arn
+Name of the Cloudwatch alarm
 
-<a name="event_rule_schedule" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`event_rule_schedule`**](#event_rule_schedule) &mdash; Cloudwatch Event Rule schedule expression
+<HclListItem name="event_rule_arn">
+<HclListItemDescription>
 
-<a name="function_arn" className="snap-top"></a>
+Cloudwatch Event Rule Arn
 
-* [**`function_arn`**](#function_arn) &mdash; Amazon Resource Name (ARN) identifying the Lambda Function
+</HclListItemDescription>
+</HclListItem>
 
-<a name="function_name" className="snap-top"></a>
+<HclListItem name="event_rule_schedule">
+<HclListItemDescription>
 
-* [**`function_name`**](#function_name) &mdash; Unique name for Lambda Function
+Cloudwatch Event Rule schedule expression
 
-<a name="iam_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`iam_role_arn`**](#iam_role_arn) &mdash; Amazon Resource Name (ARN) of the AWS IAM Role created for the Lambda Function
+<HclListItem name="function_arn">
+<HclListItemDescription>
 
-<a name="iam_role_id" className="snap-top"></a>
+Amazon Resource Name (ARN) identifying the Lambda Function
 
-* [**`iam_role_id`**](#iam_role_id) &mdash; Name of the AWS IAM Role created for the Lambda Function
+</HclListItemDescription>
+</HclListItem>
 
-<a name="insufficient_data_actions" className="snap-top"></a>
+<HclListItem name="function_name">
+<HclListItemDescription>
 
-* [**`insufficient_data_actions`**](#insufficient_data_actions) &mdash; The list of actions to execute when this alarm transitions into an [`INSUFFICIENT_DATA`](#INSUFFICIENT_DATA) state from any other state
+Unique name for Lambda Function
 
-<a name="invoke_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`invoke_arn`**](#invoke_arn) &mdash; Amazon Resource Name (ARN) to be used for invoking the Lambda Function
+<HclListItem name="iam_role_arn">
+<HclListItemDescription>
 
-<a name="ok_actions" className="snap-top"></a>
+Amazon Resource Name (ARN) of the AWS IAM Role created for the Lambda Function
 
-* [**`ok_actions`**](#ok_actions) &mdash; The list of actions to execute when this alarm transitions into an OK state from any other state
+</HclListItemDescription>
+</HclListItem>
 
-<a name="qualified_arn" className="snap-top"></a>
+<HclListItem name="iam_role_id">
+<HclListItemDescription>
 
-* [**`qualified_arn`**](#qualified_arn) &mdash; Amazon Resource Name (ARN) identifying your Lambda Function version
+Name of the AWS IAM Role created for the Lambda Function
 
-<a name="security_group_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`security_group_id`**](#security_group_id) &mdash; Security Group ID of the Security Group created for the Lambda Function
+<HclListItem name="insufficient_data_actions">
+<HclListItemDescription>
 
-<a name="version" className="snap-top"></a>
+The list of actions to execute when this alarm transitions into an INSUFFICIENT_DATA state from any other state
 
-* [**`version`**](#version) &mdash; Latest published version of your Lambda Function
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="invoke_arn">
+<HclListItemDescription>
+
+Amazon Resource Name (ARN) to be used for invoking the Lambda Function
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="ok_actions">
+<HclListItemDescription>
+
+The list of actions to execute when this alarm transitions into an OK state from any other state
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="qualified_arn">
+<HclListItemDescription>
+
+Amazon Resource Name (ARN) identifying your Lambda Function version
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="security_group_id">
+<HclListItemDescription>
+
+Security Group ID of the Security Group created for the Lambda Function
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="version">
+<HclListItemDescription>
+
+Latest published version of your Lambda Function
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"b67c4aa10351512cb984e0d87aa4e441"}
+{"sourcePlugin":"service-catalog-api","hash":"c3091f9fb46ecb27b84c21fcaf82ca0f"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/app-orchestration/public-static-website.md
+++ b/docs/reference/services/app-orchestration/public-static-website.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.83.0"/>
 
@@ -109,103 +110,227 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="acm_certificate_domain_name" className="snap-top"></a>
+<HclListItem name="acm_certificate_domain_name" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`acm_certificate_domain_name`**](#acm_certificate_domain_name) &mdash; The domain name for which an ACM cert has been issued (e.g. *.foo.com). Only used if [`create_route53_entry`](#create_route53_entry) is true. Set to blank otherwise.
+The domain name for which an ACM cert has been issued (e.g. *.foo.com). Only used if <a href="#create_route53_entry"><code>create_route53_entry</code></a> is true. Set to blank otherwise.
 
-<a name="website_domain_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`website_domain_name`**](#website_domain_name) &mdash; The name of the website and the S3 bucket to create (e.g. static.foo.com).
+<HclListItem name="website_domain_name" requirement="required" type="string">
+<HclListItemDescription>
+
+The name of the website and the S3 bucket to create (e.g. static.foo.com).
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="base_domain_name" className="snap-top"></a>
+<HclListItem name="base_domain_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`base_domain_name`**](#base_domain_name) &mdash; The domain name associated with a hosted zone in Route 53. Usually the base domain name of [`website_domain_name`](#website_domain_name) (e.g. foo.com). This is used to find the hosted zone that will be used for the CloudFront distribution. If [`create_route53_entry`](#create_route53_entry) is true, one of [`base_domain_name`](#base_domain_name) or [`hosted_zone_id`](#hosted_zone_id) must be provided.
+The domain name associated with a hosted zone in Route 53. Usually the base domain name of <a href="#website_domain_name"><code>website_domain_name</code></a> (e.g. foo.com). This is used to find the hosted zone that will be used for the CloudFront distribution. If <a href="#create_route53_entry"><code>create_route53_entry</code></a> is true, one of base_domain_name or <a href="#hosted_zone_id"><code>hosted_zone_id</code></a> must be provided.
 
-<a name="base_domain_name_tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`base_domain_name_tags`**](#base_domain_name_tags) &mdash; The tags associated with [`base_domain_name`](#base_domain_name). If there are multiple hosted zones for the same [`base_domain_name`](#base_domain_name), this will help filter the hosted zones so that the correct hosted zone is found.
+<HclListItem name="base_domain_name_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="create_route53_entry" className="snap-top"></a>
+The tags associated with <a href="#base_domain_name"><code>base_domain_name</code></a>. If there are multiple hosted zones for the same base_domain_name, this will help filter the hosted zones so that the correct hosted zone is found.
 
-* [**`create_route53_entry`**](#create_route53_entry) &mdash; If set to true, create a DNS A Record in Route 53. If [`create_route53_entry`](#create_route53_entry) is true, one of [`base_domain_name`](#base_domain_name) or [`hosted_zone_id`](#hosted_zone_id) must be provided.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="custom_tags" className="snap-top"></a>
+```hcl
+map(any)
+```
 
-* [**`custom_tags`**](#custom_tags) &mdash; A map of custom tags to apply to the S3 bucket containing the website and the CloudFront distribution created for it. The key is the tag name and the value is the tag value.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="default_ttl" className="snap-top"></a>
+<HclListItem name="create_route53_entry" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`default_ttl`**](#default_ttl) &mdash; The default amount of time, in seconds, that an object is in a CloudFront cache before CloudFront forwards another request in the absence of an 'Cache-Control max-age' or 'Expires' header.
+If set to true, create a DNS A Record in Route 53. If <a href="#create_route53_entry"><code>create_route53_entry</code></a> is true, one of base_domain_name or <a href="#hosted_zone_id"><code>hosted_zone_id</code></a> must be provided.
 
-<a name="error_document" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`error_document`**](#error_document) &mdash; The path to the error document in the S3 bucket (e.g. error.html).
+<HclListItem name="custom_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="force_destroy" className="snap-top"></a>
+A map of custom tags to apply to the S3 bucket containing the website and the CloudFront distribution created for it. The key is the tag name and the value is the tag value.
 
-* [**`force_destroy`**](#force_destroy) &mdash; If set to true, this will force the delete of the website, redirect, and access log S3 buckets when you run terraform destroy, even if there is still content in those buckets. This is only meant for testing and should not be used in production.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="geo_locations_list" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`geo_locations_list`**](#geo_locations_list) &mdash; The ISO 3166-1-alpha-2 codes for which you want CloudFront either to distribute your content (if [`geo_restriction_type`](#geo_restriction_type) is whitelist) or not distribute your content (if [`geo_restriction_type`](#geo_restriction_type) is blacklist).
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="geo_restriction_type" className="snap-top"></a>
+<HclListItem name="default_ttl" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`geo_restriction_type`**](#geo_restriction_type) &mdash; The method that you want to use to restrict distribution of your content by country: none, whitelist, or blacklist.
+The default amount of time, in seconds, that an object is in a CloudFront cache before CloudFront forwards another request in the absence of an 'Cache-Control max-age' or 'Expires' header.
 
-<a name="hosted_zone_id" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="30"/>
+</HclListItem>
 
-* [**`hosted_zone_id`**](#hosted_zone_id) &mdash; The ID of the Route 53 Hosted Zone in which to create the DNS A Records specified in [`website_domain_name`](#website_domain_name). If [`create_route53_entry`](#create_route53_entry) is true, one of [`base_domain_name`](#base_domain_name) or [`hosted_zone_id`](#hosted_zone_id) must be provided.
+<HclListItem name="error_document" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="index_document" className="snap-top"></a>
+The path to the error document in the S3 bucket (e.g. error.html).
 
-* [**`index_document`**](#index_document) &mdash; The path to the index document in the S3 bucket (e.g. index.html).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="error.html"/>
+</HclListItem>
 
-<a name="max_ttl" className="snap-top"></a>
+<HclListItem name="force_destroy" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`max_ttl`**](#max_ttl) &mdash; The maximum amount of time, in seconds, that an object is in a CloudFront cache before CloudFront forwards another request to your origin to determine whether the object has been updated. Only effective in the presence of 'Cache-Control max-age', 'Cache-Control s-maxage', and 'Expires' headers.
+If set to true, this will force the delete of the website, redirect, and access log S3 buckets when you run terraform destroy, even if there is still content in those buckets. This is only meant for testing and should not be used in production.
 
-<a name="min_ttl" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`min_ttl`**](#min_ttl) &mdash; The minimum amount of time that you want objects to stay in CloudFront caches before CloudFront queries your origin to see whether the object has been updated.
+<HclListItem name="geo_locations_list" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="routing_rules" className="snap-top"></a>
+The ISO 3166-1-alpha-2 codes for which you want CloudFront either to distribute your content (if <a href="#geo_restriction_type"><code>geo_restriction_type</code></a> is whitelist) or not distribute your content (if <a href="#geo_restriction_type"><code>geo_restriction_type</code></a> is blacklist).
 
-* [**`routing_rules`**](#routing_rules) &mdash; A json array containing routing rules describing redirect behavior and when redirects are applied. For routing rule syntax, see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html. This will only be used if [`should_redirect_all_requests`](#should_redirect_all_requests) is false
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="viewer_protocol_policy" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`viewer_protocol_policy`**](#viewer_protocol_policy) &mdash; Use this element to specify the protocol that users can use to access the files in the origin specified by TargetOriginId when a request matches the path pattern in PathPattern. One of allow-all, https-only, or redirect-to-https.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="geo_restriction_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+The method that you want to use to restrict distribution of your content by country: none, whitelist, or blacklist.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="none"/>
+</HclListItem>
+
+<HclListItem name="hosted_zone_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ID of the Route 53 Hosted Zone in which to create the DNS A Records specified in <a href="#website_domain_name"><code>website_domain_name</code></a>. If <a href="#create_route53_entry"><code>create_route53_entry</code></a> is true, one of base_domain_name or <a href="#hosted_zone_id"><code>hosted_zone_id</code></a> must be provided.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="index_document" requirement="optional" type="string">
+<HclListItemDescription>
+
+The path to the index document in the S3 bucket (e.g. index.html).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="index.html"/>
+</HclListItem>
+
+<HclListItem name="max_ttl" requirement="optional" type="number">
+<HclListItemDescription>
+
+The maximum amount of time, in seconds, that an object is in a CloudFront cache before CloudFront forwards another request to your origin to determine whether the object has been updated. Only effective in the presence of 'Cache-Control max-age', 'Cache-Control s-maxage', and 'Expires' headers.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="60"/>
+</HclListItem>
+
+<HclListItem name="min_ttl" requirement="optional" type="number">
+<HclListItemDescription>
+
+The minimum amount of time that you want objects to stay in CloudFront caches before CloudFront queries your origin to see whether the object has been updated.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="0"/>
+</HclListItem>
+
+<HclListItem name="routing_rules" requirement="optional" type="string">
+<HclListItemDescription>
+
+A json array containing routing rules describing redirect behavior and when redirects are applied. For routing rule syntax, see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html. This will only be used if <a href="#should_redirect_all_requests"><code>should_redirect_all_requests</code></a> is false
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="viewer_protocol_policy" requirement="optional" type="string">
+<HclListItemDescription>
+
+Use this element to specify the protocol that users can use to access the files in the origin specified by TargetOriginId when a request matches the path pattern in PathPattern. One of allow-all, https-only, or redirect-to-https.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="allow-all"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="cloudfront_access_logs_bucket_arn" className="snap-top"></a>
+<HclListItem name="cloudfront_access_logs_bucket_arn">
+<HclListItemDescription>
 
-* [**`cloudfront_access_logs_bucket_arn`**](#cloudfront_access_logs_bucket_arn) &mdash; The ARN of the created S3 bucket associated with the website's CloudFront access logs.
+The ARN of the created S3 bucket associated with the website's CloudFront access logs.
 
-<a name="cloudfront_domain_names" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cloudfront_domain_names`**](#cloudfront_domain_names) &mdash; The domain names created for the CloudFront Distribution. Should be the same as the input [`website_domain_name`](#website_domain_name).
+<HclListItem name="cloudfront_domain_names">
+<HclListItemDescription>
 
-<a name="cloudfront_id" className="snap-top"></a>
+The domain names created for the CloudFront Distribution. Should be the same as the input <a href="#website_domain_name"><code>website_domain_name</code></a>.
 
-* [**`cloudfront_id`**](#cloudfront_id) &mdash; The CloudFront ID of the created CloudFront Distribution.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="website_access_logs_bucket_arn" className="snap-top"></a>
+<HclListItem name="cloudfront_id">
+<HclListItemDescription>
 
-* [**`website_access_logs_bucket_arn`**](#website_access_logs_bucket_arn) &mdash; The ARN of the created S3 bucket associated with the website access logs.
+The CloudFront ID of the created CloudFront Distribution.
 
-<a name="website_s3_bucket_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`website_s3_bucket_arn`**](#website_s3_bucket_arn) &mdash; The ARN of the created S3 bucket associated with the website.
+<HclListItem name="website_access_logs_bucket_arn">
+<HclListItemDescription>
+
+The ARN of the created S3 bucket associated with the website access logs.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="website_s3_bucket_arn">
+<HclListItemDescription>
+
+The ARN of the created S3 bucket associated with the website.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"31a9cfc543f0ede3a8ff73ba6e6568fe"}
+{"sourcePlugin":"service-catalog-api","hash":"6bd75027a663f966af6140b2289c4408"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/ci-cd-pipeline/ecs-deploy-runner.md
+++ b/docs/reference/services/ci-cd-pipeline/ecs-deploy-runner.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -97,235 +98,1014 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="ami_builder_config" className="snap-top"></a>
+<HclListItem name="ami_builder_config" requirement="required" type="object">
+<HclListItemDescription>
 
-* [**`ami_builder_config`**](#ami_builder_config) &mdash; Configuration options for the ami-builder container of the ECS deploy runner stack. This container will be used for building AMIs in the CI/CD pipeline using packer. Set to `null` to disable this container.
+Configuration options for the ami-builder container of the ECS deploy runner stack. This container will be used for building AMIs in the CI/CD pipeline using packer. Set to `null` to disable this container.
 
-<a name="docker_image_builder_config" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`docker_image_builder_config`**](#docker_image_builder_config) &mdash; Configuration options for the docker-image-builder container of the ECS deploy runner stack. This container will be used for building docker images in the CI/CD pipeline. Set to `null` to disable this container.
+```hcl
+object({
+    # Docker repo and image tag to use as the container image for the ami builder. This should be based on the
+    # Dockerfile in terraform-aws-ci/modules/ecs-deploy-runner/docker/deploy-runner.
+    container_image = object({
+      docker_image = string
+      docker_tag   = string
+    })
 
-<a name="private_subnet_ids" className="snap-top"></a>
+    # An object defining the IAM policy statements to attach to the IAM role associated with the ECS task for the
+    # ami builder. Accepts a map of objects, where the map keys are sids for IAM policy statements, and the object
+    # fields are the resources, actions, and the effect (\"Allow\" or \"Deny\") of the statement.
+    # Note that you do not need to explicitly grant read access to the secrets manager entries set on the other
+    # variables (repo_access_ssh_key_secrets_manager_arn and secrets_manager_env_vars).
+    # iam_policy = {
+    #   S3Access = {
+    #     actions = ["s3:*"]
+    #     resources = ["arn:aws:s3:::mybucket"]
+    #     effect = "Allow"
+    #   },
+    #   EC2Access = {
+    #     actions = ["ec2:*"],
+    #     resources = ["*"]
+    #     effect = "Allow"
+    #   }
+    # }
+    iam_policy = map(object({
+      resources = list(string)
+      actions   = list(string)
+      effect    = string
+    }))
 
-* [**`private_subnet_ids`**](#private_subnet_ids) &mdash; List of IDs of private subnets that can be used for running the ECS task and Lambda function.
+    # List of repositories that are allowed to build docker images. These should be the SSH git URL of the repository
+    # (e.g., git@github.com:gruntwork-io/terraform-aws-ci.git).
+    allowed_repos = list(string)
 
-<a name="terraform_applier_config" className="snap-top"></a>
+    # List of repositories (matching the regex) that are allowed to build AMIs. These should be the SSH git URL of the repository
+    # (e.g., "(git@github.com:gruntwork-io/)+" ).
+    # Note that this is a list of individual regex because HCL doesn't allow bitwise operator: https://github.com/hashicorp/terraform/issues/25326
+    allowed_repos_regex = list(string)
 
-* [**`terraform_applier_config`**](#terraform_applier_config) &mdash; Configuration options for the terraform-applier container of the ECS deploy runner stack. This container will be used for running infrastructure deployment actions (including automated variable updates) in the CI/CD pipeline with Terraform / Terragrunt. Set to `null` to disable this container.
+    # The ARN of a secrets manager entry containing the raw contents of a SSH private key to use when accessing remote
+    # git repositories containing packer templates.
+    repo_access_ssh_key_secrets_manager_arn = string
 
-<a name="terraform_planner_config" className="snap-top"></a>
+    # Configurations for setting up private git repo access to https based git URLs for each supported VCS platform.
+    # The following keys are supported:
+    #
+    # - github_token_secrets_manager_arn    : The ARN of an AWS Secrets Manager entry containing contents of a GitHub
+    #                                         Personal Access Token for accessing git repos over HTTPS.
+    # - gitlab_token_secrets_manager_arn    : The ARN of an AWS Secrets Manager entry containing contents of a GitLab
+    #                                         Personal Access Token for accessing git repos over HTTPS.
+    # - bitbucket_token_secrets_manager_arn : The ARN of an AWS Secrets Manager entry containing contents of a BitBucket
+    #                                         Personal Access Token for accessing git repos over HTTPS.
+    #                                         bitbucket_username is required if this is set.
+    # - bitbucket_username                  : The username of the BitBucket user associated with the bitbucket token
+    #                                         passed in with bitbucket_token_secrets_manager_arn.
+    repo_access_https_tokens = map(string)
 
-* [**`terraform_planner_config`**](#terraform_planner_config) &mdash; Configuration options for the terraform-planner container of the ECS deploy runner stack. This container will be used for running infrastructure plan (including validate) actions in the CI/CD pipeline with Terraform / Terragrunt. Set to `null` to disable this container.
+    # ARNs of AWS Secrets Manager entries that you would like to expose to the packer process as environment
+    # variables. For example,
+    # secrets_manager_env_vars = {
+    #   GITHUB_OAUTH_TOKEN = "ARN_OF_PAT"
+    # }
+    # Will inject the secret value stored in the secrets manager entry ARN_OF_PAT as the env var `GITHUB_OAUTH_TOKEN`
+    # in the container that can then be passed through to the AMI via the `env` directive in the packer template.
+    secrets_manager_env_vars = map(string)
 
-<a name="vpc_id" className="snap-top"></a>
+    # Map of environment variable names to values share with the container during runtime.
+    # Do NOT use this for sensitive variables! Use secrets_manager_env_vars for secrets.
+    environment_vars = map(string)
+  })
+```
 
-* [**`vpc_id`**](#vpc_id) &mdash; ID of the VPC where the ECS task and Lambda function should run.
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="docker_image_builder_config" requirement="required" type="object">
+<HclListItemDescription>
+
+Configuration options for the docker-image-builder container of the ECS deploy runner stack. This container will be used for building docker images in the CI/CD pipeline. Set to `null` to disable this container.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+object({
+    # Docker repo and image tag to use as the container image for the docker image builder. This should be based on the
+    # Dockerfile in terraform-aws-ci/modules/ecs-deploy-runner/docker/kaniko.
+    container_image = object({
+      docker_image = string
+      docker_tag   = string
+    })
+
+    # An object defining the IAM policy statements to attach to the IAM role associated with the ECS task for the docker
+    # image builder. Accepts a map of objects, where the map keys are sids for IAM policy statements, and the object
+    # fields are the resources, actions, and the effect (\"Allow\" or \"Deny\") of the statement.
+    # Note that you do not need to explicitly grant read access to the secrets manager entries set on the other
+    # variables (git_config and secrets_manager_env_vars).
+    # iam_policy = {
+    #   S3Access = {
+    #     actions = ["s3:*"]
+    #     resources = ["arn:aws:s3:::mybucket"]
+    #     effect = "Allow"
+    #   },
+    #   EC2Access = {
+    #     actions = ["ec2:*"],
+    #     resources = ["*"]
+    #     effect = "Allow"
+    #   }
+    # }
+    iam_policy = map(object({
+      resources = list(string)
+      actions   = list(string)
+      effect    = string
+    }))
+
+    # List of repositories that are allowed to build docker images. These should be the https git URL of the repository
+    # (e.g., https://github.com/gruntwork-io/terraform-aws-ci.git).
+    allowed_repos = list(string)
+
+    # List of repositories (matching the regex) that are allowed to build AMIs. These should be the https git URL of the repository
+    # (e.g., "https://github.com/gruntwork-io/.+" ).
+    # Note that this is a list of individual regex because HCL doesn't allow bitwise operator: https://github.com/hashicorp/terraform/issues/25326
+    allowed_repos_regex = list(string)
+
+    # ARNs of AWS Secrets Manager entries that can be used for authenticating to HTTPS based git repos that contain the
+    # Dockerfile for building the images. The associated user is recommended to be limited to read access only.
+    #
+    # Settings for each git service provider:
+    #
+    # Github:
+    # - `username_secrets_manager_arn` should contain a valid Personal Access Token for the corresponding machine user.
+    # - `password_secrets_manager_arn` should be set to null.
+    #
+    # BitBucket:
+    # - `username_secrets_manager_arn` should contain the bitbucket username for the corresponding machine user.
+    # - `password_secrets_manager_arn` should contain a valid App password for the corresponding machine user.
+    #
+    # GitLab:
+    # - `username_secrets_manager_arn` should contain the hardcoded string "oauth2" (without the quotes).
+    # - `password_secrets_manager_arn` should contain a valid Personal Access Token for the corresponding machine user.
+    git_config = object({
+      username_secrets_manager_arn = string
+      password_secrets_manager_arn = string
+    })
+
+    # ARNs of AWS Secrets Manager entries that you would like to expose to the docker build process as environment
+    # variables that can be passed in as build args. For example,
+    # secrets_manager_env_vars = {
+    #   GITHUB_OAUTH_TOKEN = "ARN_OF_PAT"
+    # }
+    # Will inject the secret value stored in the secrets manager entry ARN_OF_PAT as the env var `GITHUB_OAUTH_TOKEN`
+    # in the container that can then be passed through to the docker build if you pass in
+    # `--build-arg GITHUB_OAUTH_TOKEN`.
+    secrets_manager_env_vars = map(string)
+
+    # Map of environment variable names to values share with the container during runtime.
+    # Do NOT use this for sensitive variables! Use secrets_manager_env_vars for secrets.
+    environment_vars = map(string)
+  })
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="private_subnet_ids" requirement="required" type="list">
+<HclListItemDescription>
+
+List of IDs of private subnets that can be used for running the ECS task and Lambda function.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="terraform_applier_config" requirement="required" type="object">
+<HclListItemDescription>
+
+Configuration options for the terraform-applier container of the ECS deploy runner stack. This container will be used for running infrastructure deployment actions (including automated variable updates) in the CI/CD pipeline with Terraform / Terragrunt. Set to `null` to disable this container.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+object({
+    # Docker repo and image tag to use as the container image for the ami builder. This should be based on the
+    # Dockerfile in terraform-aws-ci/modules/ecs-deploy-runner/docker/deploy-runner.
+    container_image = object({
+      docker_image = string
+      docker_tag   = string
+    })
+
+    # An object defining the IAM policy statements to attach to the IAM role associated with the ECS task for the
+    # terraform applier. Accepts a map of objects, where the map keys are sids for IAM policy statements, and the object
+    # fields are the resources, actions, and the effect (\"Allow\" or \"Deny\") of the statement.
+    # Note that you do not need to explicitly grant read access to the secrets manager entries set on the other
+    # variables (repo_access_ssh_key_secrets_manager_arn and secrets_manager_env_vars).
+    # iam_policy = {
+    #   S3Access = {
+    #     actions = ["s3:*"]
+    #     resources = ["arn:aws:s3:::mybucket"]
+    #     effect = "Allow"
+    #   },
+    #   EC2Access = {
+    #     actions = ["ec2:*"],
+    #     resources = ["*"]
+    #     effect = "Allow"
+    #   }
+    # }
+    iam_policy = map(object({
+      resources = list(string)
+      actions   = list(string)
+      effect    = string
+    }))
+
+    # List of Git repository containing infrastructure live configuration (top level terraform or terragrunt
+    # configuration to deploy infrastructure) that the deploy runner is allowed to deploy. These should be the SSH git
+    # URL of the repository (e.g., git@github.com:gruntwork-io/terraform-aws-ci.git).
+    # NOTE: when only a single repository is provided, this will automatically be included as a hardcoded option.
+    infrastructure_live_repositories = list(string)
+
+    # List of Git repositories (matching the regex) containing infrastructure live configuration (top level terraform or terragrunt
+    # configuration to deploy infrastructure) that the deploy runner is allowed to deploy. These should be the SSH git
+    # URL of the repository (e.g., git@github.com:gruntwork-io/terraform-aws-ci.git).
+    # Note that this is a list of individual regex because HCL doesn't allow bitwise operator: https://github.com/hashicorp/terraform/issues/25326
+    infrastructure_live_repositories_regex = list(string)
+
+    # List of variable names that are allowed to be automatically updated by the CI/CD pipeline. Recommended to set to:
+    # ["tag", "docker_tag", "ami_version_tag", "ami"]
+    allowed_update_variable_names = list(string)
+
+    # A list of Git Refs (branch or tag) that are approved for running apply on. Any git ref that does not match this
+    # list will not be allowed to run `apply` or `apply-all`. This is useful for protecting against internal threats
+    # where users have access to the CI script and bypass the approval flow by commiting a new CI flow on their branch.
+    # Set to null to allow all refs to apply.
+    allowed_apply_git_refs = list(string)
+
+    # User information to use when commiting updates to the infrastructure live configuration.
+    machine_user_git_info = object({
+      name  = string
+      email = string
+    })
+
+    # The ARN of a secrets manager entry containing the raw contents of a SSH private key to use when accessing remote
+    # repository containing the live infrastructure configuration. This SSH key should be for a machine user that has write
+    # access to the code when using with terraform-update-variable.
+    repo_access_ssh_key_secrets_manager_arn = string
+
+    # Configurations for setting up private git repo access to https based git URLs for each supported VCS platform.
+    # The following keys are supported:
+    #
+    # - github_token_secrets_manager_arn    : The ARN of an AWS Secrets Manager entry containing contents of a GitHub
+    #                                         Personal Access Token for accessing git repos over HTTPS.
+    # - gitlab_token_secrets_manager_arn    : The ARN of an AWS Secrets Manager entry containing contents of a GitLab
+    #                                         Personal Access Token for accessing git repos over HTTPS.
+    # - bitbucket_token_secrets_manager_arn : The ARN of an AWS Secrets Manager entry containing contents of a BitBucket
+    #                                         Personal Access Token for accessing git repos over HTTPS.
+    #                                         bitbucket_username is required if this is set.
+    # - bitbucket_username                  : The username of the BitBucket user associated with the bitbucket token
+    #                                         passed in with bitbucket_token_secrets_manager_arn.
+    repo_access_https_tokens = map(string)
+
+    # ARNs of AWS Secrets Manager entries that you would like to expose to the terraform/terragrunt process as
+    # environment variables. For example,
+    # secrets_manager_env_vars = {
+    #   GITHUB_OAUTH_TOKEN = "ARN_OF_PAT"
+    # }
+    # Will inject the secret value stored in the secrets manager entry ARN_OF_PAT as the env var `GITHUB_OAUTH_TOKEN`
+    # in the container that can then be accessed through terraform/terragrunt.
+    secrets_manager_env_vars = map(string)
+
+    # Map of environment variable names to values share with the container during runtime.
+    # Do NOT use this for sensitive variables! Use secrets_manager_env_vars for secrets.
+    environment_vars = map(string)
+  })
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="terraform_planner_config" requirement="required" type="object">
+<HclListItemDescription>
+
+Configuration options for the terraform-planner container of the ECS deploy runner stack. This container will be used for running infrastructure plan (including validate) actions in the CI/CD pipeline with Terraform / Terragrunt. Set to `null` to disable this container.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+object({
+    # Docker repo and image tag to use as the container image for the ami builder. This should be based on the
+    # Dockerfile in terraform-aws-ci/modules/ecs-deploy-runner/docker/deploy-runner.
+    container_image = object({
+      docker_image = string
+      docker_tag   = string
+    })
+
+    # An object defining the IAM policy statements to attach to the IAM role associated with the ECS task for the
+    # terraform planner. Accepts a map of objects, where the map keys are sids for IAM policy statements, and the object
+    # fields are the resources, actions, and the effect (\"Allow\" or \"Deny\") of the statement.
+    # Note that you do not need to explicitly grant read access to the secrets manager entries set on the other
+    # variables (repo_access_ssh_key_secrets_manager_arn and secrets_manager_env_vars).
+    # iam_policy = {
+    #   S3Access = {
+    #     actions = ["s3:*"]
+    #     resources = ["arn:aws:s3:::mybucket"]
+    #     effect = "Allow"
+    #   },
+    #   EC2Access = {
+    #     actions = ["ec2:*"],
+    #     resources = ["*"]
+    #     effect = "Allow"
+    #   }
+    # }
+    iam_policy = map(object({
+      resources = list(string)
+      actions   = list(string)
+      effect    = string
+    }))
+
+    # List of git repositories containing infrastructure live configuration (top level terraform or terragrunt
+    # configuration to deploy infrastructure) that the deploy runner is allowed to run plan on. These should be the SSH
+    # git URL of the repository (e.g., git@github.com:gruntwork-io/terraform-aws-ci.git).
+    # NOTE: when only a single repository is provided, this will automatically be included as a hardcoded option.
+    infrastructure_live_repositories = list(string)
+
+    # List of Git repositories (matching the regex) containing infrastructure live configuration (top level terraform or terragrunt
+    # configuration to deploy infrastructure) that the deploy runner is allowed to deploy. These should be the SSH git
+    # URL of the repository (e.g., git@github.com:gruntwork-io/terraform-aws-ci.git).
+    # Note that this is a list of individual regex because HCL doesn't allow bitwise operator: https://github.com/hashicorp/terraform/issues/25326
+    infrastructure_live_repositories_regex = list(string)
+
+    # The ARN of a secrets manager entry containing the raw contents of a SSH private key to use when accessing the
+    # infrastructure live repository.
+    repo_access_ssh_key_secrets_manager_arn = string
+
+    # Configurations for setting up private git repo access to https based git URLs for each supported VCS platform.
+    # The following keys are supported:
+    #
+    # - github_token_secrets_manager_arn    : The ARN of an AWS Secrets Manager entry containing contents of a GitHub
+    #                                         Personal Access Token for accessing git repos over HTTPS.
+    # - gitlab_token_secrets_manager_arn    : The ARN of an AWS Secrets Manager entry containing contents of a GitLab
+    #                                         Personal Access Token for accessing git repos over HTTPS.
+    # - bitbucket_token_secrets_manager_arn : The ARN of an AWS Secrets Manager entry containing contents of a BitBucket
+    #                                         Personal Access Token for accessing git repos over HTTPS.
+    #                                         bitbucket_username is required if this is set.
+    # - bitbucket_username                  : The username of the BitBucket user associated with the bitbucket token
+    #                                         passed in with bitbucket_token_secrets_manager_arn.
+    repo_access_https_tokens = map(string)
+
+    # ARNs of AWS Secrets Manager entries that you would like to expose to the terraform/terragrunt process as
+    # environment variables. For example,
+    # secrets_manager_env_vars = {
+    #   GITHUB_OAUTH_TOKEN = "ARN_OF_PAT"
+    # }
+    # Will inject the secret value stored in the secrets manager entry ARN_OF_PAT as the env var `GITHUB_OAUTH_TOKEN`
+    # in the container that can then be accessed through terraform/terragrunt.
+    secrets_manager_env_vars = map(string)
+
+    # Map of environment variable names to values share with the container during runtime.
+    # Do NOT use this for sensitive variables! Use secrets_manager_env_vars for secrets.
+    environment_vars = map(string)
+  })
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="vpc_id" requirement="required" type="string">
+<HclListItemDescription>
+
+ID of the VPC where the ECS task and Lambda function should run.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="additional_container_images" className="snap-top"></a>
+<HclListItem name="additional_container_images" requirement="optional" type="map">
+<HclListItemDescription>
+
+Container configurations that should be added to the ECS Deploy Runner that should be added in addition to the standard containers. This can be used to customize your deployment of the ECS Deploy Runner beyond the standard use cases.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(object({
+    # Docker container identifiers
+    docker_image = string
+    docker_tag   = string
+
+    # Map of environment variable names to secret manager arns of secrets to share with the container during runtime.
+    # Note that the container processes will not be able to directly read these secrets directly using the Secrets
+    # Manager API (they are only available implicitly through the env vars).
+    secrets_manager_env_vars = map(string)
 
-* [**`additional_container_images`**](#additional_container_images) &mdash; Container configurations that should be added to the ECS Deploy Runner that should be added in addition to the standard containers. This can be used to customize your deployment of the ECS Deploy Runner beyond the standard use cases.
+    # Map of environment variable names to values share with the container during runtime.
+    # Do NOT use this for sensitive variables! Use secrets_manager_env_vars for secrets.
+    environment_vars = map(string)
 
-<a name="cloudwatch_log_group_for_ec2_kms_key_id" className="snap-top"></a>
+    # List of additional secrets manager entries that the container should have access to, but not directly injected as
+    # environment variables. These secrets can be read by the container processes using the Secrets Manager API, unlike
+    # those shared as environment variables with `secrets_manager_env_vars`.
+    additional_secrets_manager_arns = list(string)
 
-* [**`cloudwatch_log_group_for_ec2_kms_key_id`**](#cloudwatch_log_group_for_ec2_kms_key_id) &mdash; The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data.
+    # Security configuration for each script for each container. Each entry in the map corresponds to a script in the
+    # triggers directory. If a script is not included in the map, then the default is to allow no additional args to be
+    # passed in when invoked.
+    script_config = map(object({
+      # Which options and args to always pass in alongside the ones provided by the command.
+      # This is a map of option keys to args to pass in. Each arg in the list will be passed in as a separate option.
+      # E.g., if you had {'foo': ['bar', 'baz', 'car']}, then this will be: `--foo bar --foo baz --foo car`
+      # This will be passed in first, before the args provided by the user in the event data.
+      hardcoded_options = map(list(string))
 
-<a name="cloudwatch_log_group_for_ec2_retention_in_days" className="snap-top"></a>
+      # Unlike hardcoded_options, this is used for hardcoded positional args and will always be passed in at the end of
+      # the args list.
+      hardcoded_args = list(string)
 
-* [**`cloudwatch_log_group_for_ec2_retention_in_days`**](#cloudwatch_log_group_for_ec2_retention_in_days) &mdash; The number of days to retain log events in the log group. Refer to [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days) for all the valid values. When null, the log events are retained forever.
+      # Whether or not positional args are allowed to be passed in.
+      allow_positional_args = bool
 
-<a name="cloudwatch_log_group_for_ec2_tags" className="snap-top"></a>
+      # This is a list of option keys that are explicitly allowed. When set, any option key that is not present in this
+      # list will cause an exception. Note that `null` means allow any option, as opposed to `[]` which means allow no
+      # option. Only one of `allowed_options` or `restricted_options` should be used.
+      allowed_options = list(string)
 
-* [**`cloudwatch_log_group_for_ec2_tags`**](#cloudwatch_log_group_for_ec2_tags) &mdash; Tags to apply on the CloudWatch Log Group, encoded as a map where the keys are tag keys and values are tag values.
+      # List of options without arguments
+      allowed_options_without_args = list(string)
 
-<a name="container_cpu" className="snap-top"></a>
+      # This is a list of option keys that are not allowed. When set, any option key passed in that is in this list will
+      # cause an exception. Empty list means allow any option (unless restricted by allowed_options).
+      restricted_options = list(string)
 
-* [**`container_cpu`**](#container_cpu) &mdash; The default CPU units for the instances that Fargate will spin up. The invoker allows users to override the CPU at run time, but this value will be used if the user provides no value for the CPU. Options here: [`https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate`](#https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate).html#fargate-tasks-size.
+      # This is a map of option keys to a regex for specifying what args are allowed to be passed in for that option key.
+      # There is no restriction to the option if there is no entry in this map.
+      restricted_options_regex = map(string)
+    }))
 
-<a name="container_default_launch_type" className="snap-top"></a>
+    # Whether or not the particular container is the default container for the pipeline. This container is used when no
+    # name is provided to the infrastructure deployer. Exactly one must be marked as the default. An arbitrary container
+    # will be picked amongst the list of defaults when multiple are marked as default.
+    # If no containers are marked as default, then the invoker lambda function always requires a container name to be
+    # provided.
+    default = bool
+  }))
+```
 
-* [**`container_default_launch_type`**](#container_default_launch_type) &mdash; The default launch type of the ECS deploy runner workers. This launch type will be used if it is not overridden during invocation of the lambda function. Must be FARGATE or EC2.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="container_max_cpu" className="snap-top"></a>
+<HclListItem name="cloudwatch_log_group_for_ec2_kms_key_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`container_max_cpu`**](#container_max_cpu) &mdash; The maximum CPU units that is allowed to be specified by the user when invoking the deploy runner with the Lambda function.
+The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data.
 
-<a name="container_max_memory" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`container_max_memory`**](#container_max_memory) &mdash; The maximum memory units that is allowed to be specified by the user when invoking the deploy runner with the Lambda function.
+<HclListItem name="cloudwatch_log_group_for_ec2_retention_in_days" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="container_memory" className="snap-top"></a>
+The number of days to retain log events in the log group. Refer to https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days for all the valid values. When null, the log events are retained forever.
 
-* [**`container_memory`**](#container_memory) &mdash; The default memory units for the instances that Fargate will spin up. The invoker allows users to override the memory at run time, but this value will be used if the user provides no value for memory. Options here: [`https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate`](#https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate).html#fargate-tasks-size.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="docker_image_builder_hardcoded_args" className="snap-top"></a>
+<HclListItem name="cloudwatch_log_group_for_ec2_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`docker_image_builder_hardcoded_args`**](#docker_image_builder_hardcoded_args) &mdash; Unlike [`hardcoded_options`](#hardcoded_options), this is used for hardcoded positional args and will always be passed in at the end of the args list.
+Tags to apply on the CloudWatch Log Group, encoded as a map where the keys are tag keys and values are tag values.
 
-<a name="docker_image_builder_hardcoded_options" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`docker_image_builder_hardcoded_options`**](#docker_image_builder_hardcoded_options) &mdash; Which options and args to always pass in alongside the ones provided by the command. This is a map of option keys to args to pass in. Each arg in the list will be passed in as a separate option. This will be passed in first, before the args provided by the user in the event data.
+```hcl
+map(string)
+```
 
-<a name="ec2_worker_pool_configuration" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`ec2_worker_pool_configuration`**](#ec2_worker_pool_configuration) &mdash; Worker configuration of a EC2 worker pool for the ECS cluster. An EC2 worker pool supports caching of Docker images, so your builds may run faster, whereas Fargate is serverless, so you have no persistent EC2 instances to manage and pay for. If null, no EC2 worker pool will be allocated and the deploy runner will be in Fargate only mode. Note that when this variable is set, this example module will automatically lookup and use the base ECS optimized AMI that AWS provides.
+<HclListItem name="container_cpu" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="ecs_task_cloudwatch_log_group_kms_key_id" className="snap-top"></a>
+The default CPU units for the instances that Fargate will spin up. The invoker allows users to override the CPU at run time, but this value will be used if the user provides no value for the CPU. Options here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size.
 
-* [**`ecs_task_cloudwatch_log_group_kms_key_id`**](#ecs_task_cloudwatch_log_group_kms_key_id) &mdash; The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1024"/>
+</HclListItem>
 
-<a name="ecs_task_cloudwatch_log_group_name" className="snap-top"></a>
+<HclListItem name="container_default_launch_type" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`ecs_task_cloudwatch_log_group_name`**](#ecs_task_cloudwatch_log_group_name) &mdash; A custom name to set for the CloudWatch Log Group used to stream the container logs. When null, the Log Group will default to /ecs/{var.name}.
+The default launch type of the ECS deploy runner workers. This launch type will be used if it is not overridden during invocation of the lambda function. Must be FARGATE or EC2.
 
-<a name="ecs_task_cloudwatch_log_group_retention_in_days" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="FARGATE"/>
+</HclListItem>
 
-* [**`ecs_task_cloudwatch_log_group_retention_in_days`**](#ecs_task_cloudwatch_log_group_retention_in_days) &mdash; The number of days to retain log events in the log group. Refer to [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days) for all the valid values. When null, the log events are retained forever.
+<HclListItem name="container_max_cpu" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="ecs_task_cloudwatch_log_group_subscription_destination_arn" className="snap-top"></a>
+The maximum CPU units that is allowed to be specified by the user when invoking the deploy runner with the Lambda function.
 
-* [**`ecs_task_cloudwatch_log_group_subscription_destination_arn`**](#ecs_task_cloudwatch_log_group_subscription_destination_arn) &mdash; The ARN of the destination to deliver matching log events to. Kinesis stream or Lambda function ARN. Only applicable if [`ecs_task_should_create_cloudwatch_log_group`](#ecs_task_should_create_cloudwatch_log_group) is true, and [`container_images`](#container_images) is non-empty.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="8192"/>
+</HclListItem>
 
-<a name="ecs_task_cloudwatch_log_group_subscription_distribution" className="snap-top"></a>
+<HclListItem name="container_max_memory" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`ecs_task_cloudwatch_log_group_subscription_distribution`**](#ecs_task_cloudwatch_log_group_subscription_distribution) &mdash; The method used to distribute log data to the destination. Only applicable when [`ecs_task_cloudwatch_log_group_subscription_destination_arn`](#ecs_task_cloudwatch_log_group_subscription_destination_arn) is a kinesis stream. Valid values are `Random` and `ByLogStream`.
+The maximum memory units that is allowed to be specified by the user when invoking the deploy runner with the Lambda function.
 
-<a name="ecs_task_cloudwatch_log_group_subscription_filter_pattern" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="32768"/>
+</HclListItem>
 
-* [**`ecs_task_cloudwatch_log_group_subscription_filter_pattern`**](#ecs_task_cloudwatch_log_group_subscription_filter_pattern) &mdash; A valid CloudWatch Logs filter pattern for subscribing to a filtered stream of log events.
+<HclListItem name="container_memory" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="ecs_task_cloudwatch_log_group_subscription_role_arn" className="snap-top"></a>
+The default memory units for the instances that Fargate will spin up. The invoker allows users to override the memory at run time, but this value will be used if the user provides no value for memory. Options here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size.
 
-* [**`ecs_task_cloudwatch_log_group_subscription_role_arn`**](#ecs_task_cloudwatch_log_group_subscription_role_arn) &mdash; ARN of an IAM role that grants Amazon CloudWatch Logs permissions to deliver ingested log events to the destination. Only applicable when [`ecs_task_cloudwatch_log_group_subscription_destination_arn`](#ecs_task_cloudwatch_log_group_subscription_destination_arn) is a kinesis stream.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="2048"/>
+</HclListItem>
 
-<a name="ecs_task_cloudwatch_log_group_tags" className="snap-top"></a>
+<HclListItem name="docker_image_builder_hardcoded_args" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`ecs_task_cloudwatch_log_group_tags`**](#ecs_task_cloudwatch_log_group_tags) &mdash; Tags to apply on the CloudWatch Log Group, encoded as a map where the keys are tag keys and values are tag values.
+Unlike hardcoded_options, this is used for hardcoded positional args and will always be passed in at the end of the args list.
 
-<a name="ecs_task_should_create_cloudwatch_log_group" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`ecs_task_should_create_cloudwatch_log_group`**](#ecs_task_should_create_cloudwatch_log_group) &mdash; When true, precreate the CloudWatch Log Group to use for log aggregation from the ECS Task execution. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, AWS ECS will automatically create a basic log group to use.
+```hcl
+list(string)
+```
 
-<a name="iam_groups" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[
+  '--idempotent'
+]"/>
+</HclListItem>
 
-* [**`iam_groups`**](#iam_groups) &mdash; List of AWS IAM groups that should be given access to invoke the deploy runner.
+<HclListItem name="docker_image_builder_hardcoded_options" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="iam_roles" className="snap-top"></a>
+Which options and args to always pass in alongside the ones provided by the command. This is a map of option keys to args to pass in. Each arg in the list will be passed in as a separate option. This will be passed in first, before the args provided by the user in the event data.
 
-* [**`iam_roles`**](#iam_roles) &mdash; List of AWS IAM roles that should be given access to invoke the deploy runner.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="iam_users" className="snap-top"></a>
+```hcl
+map(list(string))
+```
 
-* [**`iam_users`**](#iam_users) &mdash; List of AWS IAM usernames that should be given access to invoke the deploy runner.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="invoke_schedule" className="snap-top"></a>
+<HclListItem name="ec2_worker_pool_configuration" requirement="optional" type="any">
+<HclListItemDescription>
 
-* [**`invoke_schedule`**](#invoke_schedule) &mdash; Configurations for invoking ECS Deploy Runner on a schedule. Use this to configure any periodic background jobs that you would like run through the ECS Deploy Runner (e.g., regularly running plan on your infrastructure to detect drift). Input is a map of unique schedule name to its settings.
+Worker configuration of a EC2 worker pool for the ECS cluster. An EC2 worker pool supports caching of Docker images, so your builds may run faster, whereas Fargate is serverless, so you have no persistent EC2 instances to manage and pay for. If null, no EC2 worker pool will be allocated and the deploy runner will be in Fargate only mode. Note that when this variable is set, this example module will automatically lookup and use the base ECS optimized AMI that AWS provides.
 
-<a name="invoker_lambda_cloudwatch_log_group_kms_key_id" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`invoker_lambda_cloudwatch_log_group_kms_key_id`**](#invoker_lambda_cloudwatch_log_group_kms_key_id) &mdash; The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data for the invoker lambda function.
+<HclListItem name="ecs_task_cloudwatch_log_group_kms_key_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="invoker_lambda_cloudwatch_log_group_retention_in_days" className="snap-top"></a>
+The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data.
 
-* [**`invoker_lambda_cloudwatch_log_group_retention_in_days`**](#invoker_lambda_cloudwatch_log_group_retention_in_days) &mdash; The number of days to retain log events in the log group for the invoker lambda function. Refer to [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days) for all the valid values. When null, the log events are retained forever.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="invoker_lambda_cloudwatch_log_group_tags" className="snap-top"></a>
+<HclListItem name="ecs_task_cloudwatch_log_group_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`invoker_lambda_cloudwatch_log_group_tags`**](#invoker_lambda_cloudwatch_log_group_tags) &mdash; Tags to apply on the CloudWatch Log Group for the invoker lambda function, encoded as a map where the keys are tag keys and values are tag values.
+A custom name to set for the CloudWatch Log Group used to stream the container logs. When null, the Log Group will default to /ecs/{var.name}.
 
-<a name="invoker_lambda_should_create_cloudwatch_log_group" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`invoker_lambda_should_create_cloudwatch_log_group`**](#invoker_lambda_should_create_cloudwatch_log_group) &mdash; When true, precreate the CloudWatch Log Group to use for log aggregation from the invoker lambda function execution. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, AWS Lambda will automatically create a basic log group to use.
+<HclListItem name="ecs_task_cloudwatch_log_group_retention_in_days" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="kms_grant_opt_in_regions" className="snap-top"></a>
+The number of days to retain log events in the log group. Refer to https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days for all the valid values. When null, the log events are retained forever.
 
-* [**`kms_grant_opt_in_regions`**](#kms_grant_opt_in_regions) &mdash; Create multi-region resources in the specified regions. The best practice is to enable multi-region services in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="name" className="snap-top"></a>
+<HclListItem name="ecs_task_cloudwatch_log_group_subscription_destination_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`name`**](#name) &mdash; Name of this instance of the deploy runner stack. Used to namespace all resources.
+The ARN of the destination to deliver matching log events to. Kinesis stream or Lambda function ARN. Only applicable if <a href="#ecs_task_should_create_cloudwatch_log_group"><code>ecs_task_should_create_cloudwatch_log_group</code></a> is true, and <a href="#container_images"><code>container_images</code></a> is non-empty.
 
-<a name="outbound_security_group_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`outbound_security_group_name`**](#outbound_security_group_name) &mdash; When non-null, set the security group name of the ECS Deploy Runner ECS Task to this string. When null, a unique name will be generated by Terraform to avoid conflicts when deploying multiple instances of the ECS Deploy Runner.
+<HclListItem name="ecs_task_cloudwatch_log_group_subscription_distribution" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="shared_secrets_enabled" className="snap-top"></a>
+The method used to distribute log data to the destination. Only applicable when <a href="#ecs_task_cloudwatch_log_group_subscription_destination_arn"><code>ecs_task_cloudwatch_log_group_subscription_destination_arn</code></a> is a kinesis stream. Valid values are `Random` and `ByLogStream`.
 
-* [**`shared_secrets_enabled`**](#shared_secrets_enabled) &mdash; If true, this module will create grants for a given shared secrets KMS key. You must pass a value for [`shared_secrets_kms_cmk_arn`](#shared_secrets_kms_cmk_arn) if this is set to true. Defaults to false.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="shared_secrets_kms_cmk_arn" className="snap-top"></a>
+<HclListItem name="ecs_task_cloudwatch_log_group_subscription_filter_pattern" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`shared_secrets_kms_cmk_arn`**](#shared_secrets_kms_cmk_arn) &mdash; The ARN of the KMS CMK used for sharing AWS Secrets Manager secrets between accounts.
+A valid CloudWatch Logs filter pattern for subscribing to a filtered stream of log events.
 
-<a name="should_create_cloudwatch_log_group_for_ec2" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
 
-* [**`should_create_cloudwatch_log_group_for_ec2`**](#should_create_cloudwatch_log_group_for_ec2) &mdash; When true, precreate the CloudWatch Log Group to use for log aggregation from the EC2 instances. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, the CloudWatch agent will automatically create a basic log group to use.
+<HclListItem name="ecs_task_cloudwatch_log_group_subscription_role_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="snapshot_encryption_kms_cmk_arns" className="snap-top"></a>
+ARN of an IAM role that grants Amazon CloudWatch Logs permissions to deliver ingested log events to the destination. Only applicable when <a href="#ecs_task_cloudwatch_log_group_subscription_destination_arn"><code>ecs_task_cloudwatch_log_group_subscription_destination_arn</code></a> is a kinesis stream.
 
-* [**`snapshot_encryption_kms_cmk_arns`**](#snapshot_encryption_kms_cmk_arns) &mdash; Map of names to ARNs of KMS CMKs that are used to encrypt snapshots (including AMIs). This module will create the necessary KMS key grants to allow the respective deploy containers access to utilize the keys for managing the encrypted snapshots. The keys are arbitrary names that are used to identify the key.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="use_managed_iam_policies" className="snap-top"></a>
+<HclListItem name="ecs_task_cloudwatch_log_group_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`use_managed_iam_policies`**](#use_managed_iam_policies) &mdash; When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+Tags to apply on the CloudWatch Log Group, encoded as a map where the keys are tag keys and values are tag values.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="ecs_task_should_create_cloudwatch_log_group" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, precreate the CloudWatch Log Group to use for log aggregation from the ECS Task execution. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, AWS ECS will automatically create a basic log group to use.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="iam_groups" requirement="optional" type="list">
+<HclListItemDescription>
+
+List of AWS IAM groups that should be given access to invoke the deploy runner.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="iam_roles" requirement="optional" type="list">
+<HclListItemDescription>
+
+List of AWS IAM roles that should be given access to invoke the deploy runner.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="iam_users" requirement="optional" type="list">
+<HclListItemDescription>
+
+List of AWS IAM usernames that should be given access to invoke the deploy runner.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="invoke_schedule" requirement="optional" type="map">
+<HclListItemDescription>
+
+Configurations for invoking ECS Deploy Runner on a schedule. Use this to configure any periodic background jobs that you would like run through the ECS Deploy Runner (e.g., regularly running plan on your infrastructure to detect drift). Input is a map of unique schedule name to its settings.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(object({
+    # Name of the container in ECS Deploy Runner that should be invoked (e.g., terraform-planner).
+    container_name = string
+
+    # The script within the container that should be invoked (e.g., infrastructure-deploy-script).
+    script = string
+
+    # The args that should be passed to the script.
+    args = string
+
+    # An expression that defines the schedule. For example, cron(0 20 * * ? *) or rate(5 minutes).
+    schedule_expression = string
+  }))
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="invoker_lambda_cloudwatch_log_group_kms_key_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data for the invoker lambda function.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="invoker_lambda_cloudwatch_log_group_retention_in_days" requirement="optional" type="number">
+<HclListItemDescription>
+
+The number of days to retain log events in the log group for the invoker lambda function. Refer to https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days for all the valid values. When null, the log events are retained forever.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="invoker_lambda_cloudwatch_log_group_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+Tags to apply on the CloudWatch Log Group for the invoker lambda function, encoded as a map where the keys are tag keys and values are tag values.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="invoker_lambda_should_create_cloudwatch_log_group" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, precreate the CloudWatch Log Group to use for log aggregation from the invoker lambda function execution. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, AWS Lambda will automatically create a basic log group to use.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="kms_grant_opt_in_regions" requirement="optional" type="list">
+<HclListItemDescription>
+
+Create multi-region resources in the specified regions. The best practice is to enable multi-region services in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
+
+```hcl
+[
+  "eu-north-1",
+  "ap-south-1",
+  "eu-west-3",
+  "eu-west-2",
+  "eu-west-1",
+  "ap-northeast-2",
+  "ap-northeast-1",
+  "sa-east-1",
+  "ca-central-1",
+  "ap-southeast-1",
+  "ap-southeast-2",
+  "eu-central-1",
+  "us-east-1",
+  "us-east-2",
+  "us-west-1",
+  "us-west-2"
+]
+```
+
+</HclListItemDefaultValue>
+</HclListItem>
+
+<HclListItem name="name" requirement="optional" type="string">
+<HclListItemDescription>
+
+Name of this instance of the deploy runner stack. Used to namespace all resources.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ecs-deploy-runner"/>
+</HclListItem>
+
+<HclListItem name="outbound_security_group_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+When non-null, set the security group name of the ECS Deploy Runner ECS Task to this string. When null, a unique name will be generated by Terraform to avoid conflicts when deploying multiple instances of the ECS Deploy Runner.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="shared_secrets_enabled" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If true, this module will create grants for a given shared secrets KMS key. You must pass a value for shared_secrets_kms_cmk_arn if this is set to true. Defaults to false.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="shared_secrets_kms_cmk_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ARN of the KMS CMK used for sharing AWS Secrets Manager secrets between accounts.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="should_create_cloudwatch_log_group_for_ec2" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, precreate the CloudWatch Log Group to use for log aggregation from the EC2 instances. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, the CloudWatch agent will automatically create a basic log group to use.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="snapshot_encryption_kms_cmk_arns" requirement="optional" type="map">
+<HclListItemDescription>
+
+Map of names to ARNs of KMS CMKs that are used to encrypt snapshots (including AMIs). This module will create the necessary KMS key grants to allow the respective deploy containers access to utilize the keys for managing the encrypted snapshots. The keys are arbitrary names that are used to identify the key.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="use_managed_iam_policies" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="cloudwatch_log_group_name" className="snap-top"></a>
+<HclListItem name="cloudwatch_log_group_name">
+<HclListItemDescription>
 
-* [**`cloudwatch_log_group_name`**](#cloudwatch_log_group_name) &mdash; Name of the CloudWatch Log Group used to store the log output from the Deploy Runner ECS task.
+Name of the CloudWatch Log Group used to store the log output from the Deploy Runner ECS task.
 
-<a name="default_ecs_task_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`default_ecs_task_arn`**](#default_ecs_task_arn) &mdash; AWS ARN of the default ECS Task Definition. Can be used to trigger the ECS Task directly.
+<HclListItem name="default_ecs_task_arn">
+<HclListItemDescription>
 
-<a name="ecs_cluster_arn" className="snap-top"></a>
+AWS ARN of the default ECS Task Definition. Can be used to trigger the ECS Task directly.
 
-* [**`ecs_cluster_arn`**](#ecs_cluster_arn) &mdash; AWS ARN of the ECS Cluster that can be used to run the deploy runner task.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="ecs_task_arns" className="snap-top"></a>
+<HclListItem name="ecs_cluster_arn">
+<HclListItemDescription>
 
-* [**`ecs_task_arns`**](#ecs_task_arns) &mdash; Map of AWS ARNs of the ECS Task Definition. There are four entries, one for each container in the standard config (docker-image-builder ; ami-builder ; terraform-planner ; terraform-applier).
+AWS ARN of the ECS Cluster that can be used to run the deploy runner task.
 
-<a name="ecs_task_execution_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`ecs_task_execution_role_arn`**](#ecs_task_execution_role_arn) &mdash; ECS Task execution role ARN
+<HclListItem name="ecs_task_arns">
+<HclListItemDescription>
 
-<a name="ecs_task_families" className="snap-top"></a>
+Map of AWS ARNs of the ECS Task Definition. There are four entries, one for each container in the standard config (docker-image-builder ; ami-builder ; terraform-planner ; terraform-applier).
 
-* [**`ecs_task_families`**](#ecs_task_families) &mdash; Map of the families of the ECS Task Definition that is currently live. There are four entries, one for each container in the standard config (docker-image-builder ; ami-builder ; terraform-planner ; terraform-applier).
+</HclListItemDescription>
+</HclListItem>
 
-<a name="ecs_task_iam_roles" className="snap-top"></a>
+<HclListItem name="ecs_task_execution_role_arn">
+<HclListItemDescription>
 
-* [**`ecs_task_iam_roles`**](#ecs_task_iam_roles) &mdash; Map of AWS ARNs and names of the IAM role that will be attached to the ECS task to grant it access to AWS resources. Each container will have its own IAM role. There are four entries, one for each container in the standard config (docker-image-builder ; ami-builder ; terraform-planner ; terraform-applier).
+ECS Task execution role ARN
 
-<a name="ecs_task_revisions" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`ecs_task_revisions`**](#ecs_task_revisions) &mdash; Map of the current revision of the ECS Task Definition that is currently live. There are four entries, one for each container in the standard config (docker-image-builder ; ami-builder ; terraform-planner ; terraform-applier).
+<HclListItem name="ecs_task_families">
+<HclListItemDescription>
 
-<a name="invoke_policy_arn" className="snap-top"></a>
+Map of the families of the ECS Task Definition that is currently live. There are four entries, one for each container in the standard config (docker-image-builder ; ami-builder ; terraform-planner ; terraform-applier).
 
-* [**`invoke_policy_arn`**](#invoke_policy_arn) &mdash; The ARN of the IAM policy that allows access to the invoke the deploy runner.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="invoker_function_arn" className="snap-top"></a>
+<HclListItem name="ecs_task_iam_roles">
+<HclListItemDescription>
 
-* [**`invoker_function_arn`**](#invoker_function_arn) &mdash; AWS ARN of the invoker lambda function that can be used to invoke a deployment.
+Map of AWS ARNs and names of the IAM role that will be attached to the ECS task to grant it access to AWS resources. Each container will have its own IAM role. There are four entries, one for each container in the standard config (docker-image-builder ; ami-builder ; terraform-planner ; terraform-applier).
 
-<a name="invoker_function_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`invoker_function_name`**](#invoker_function_name) &mdash; Name of the invoker lambda function that can be used to invoke a deployment.
+<HclListItem name="ecs_task_revisions">
+<HclListItemDescription>
 
-<a name="security_group_allow_all_outbound_id" className="snap-top"></a>
+Map of the current revision of the ECS Task Definition that is currently live. There are four entries, one for each container in the standard config (docker-image-builder ; ami-builder ; terraform-planner ; terraform-applier).
 
-* [**`security_group_allow_all_outbound_id`**](#security_group_allow_all_outbound_id) &mdash; Security Group ID of the ECS task
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="invoke_policy_arn">
+<HclListItemDescription>
+
+The ARN of the IAM policy that allows access to the invoke the deploy runner.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="invoker_function_arn">
+<HclListItemDescription>
+
+AWS ARN of the invoker lambda function that can be used to invoke a deployment.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="invoker_function_name">
+<HclListItemDescription>
+
+Name of the invoker lambda function that can be used to invoke a deployment.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="security_group_allow_all_outbound_id">
+<HclListItemDescription>
+
+Security Group ID of the ECS task
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"5a8390c259102c99d9eff22d79c78a30"}
+{"sourcePlugin":"service-catalog-api","hash":"8865e555bfc21258727130ef0564a7a0"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/ci-cd-pipeline/jenkins.md
+++ b/docs/reference/services/ci-cd-pipeline/jenkins.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -91,315 +92,761 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="acm_ssl_certificate_domain" className="snap-top"></a>
+<HclListItem name="acm_ssl_certificate_domain" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`acm_ssl_certificate_domain`**](#acm_ssl_certificate_domain) &mdash; The domain name used for an SSL certificate issued by the Amazon Certificate Manager (ACM).
+The domain name used for an SSL certificate issued by the Amazon Certificate Manager (ACM).
 
-<a name="alb_subnet_ids" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`alb_subnet_ids`**](#alb_subnet_ids) &mdash; The IDs of the subnets in which to deploy the ALB that runs in front of Jenkins. Must be subnets in [`vpc_id`](#vpc_id).
+<HclListItem name="alb_subnet_ids" requirement="required" type="list">
+<HclListItemDescription>
 
-<a name="ami" className="snap-top"></a>
+The IDs of the subnets in which to deploy the ALB that runs in front of Jenkins. Must be subnets in <a href="#vpc_id"><code>vpc_id</code></a>.
 
-* [**`ami`**](#ami) &mdash; The ID of the AMI to run on the Jenkins server. This should be the AMI build from the Packer template jenkins-ubuntu.json. One of var.ami or [`ami_filters`](#ami_filters) is required. Set to null if looking up the ami with filters.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="ami_filters" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`ami_filters`**](#ami_filters) &mdash; Properties on the AMI that can be used to lookup a prebuilt AMI for use with Jenkins. You can build the AMI using the Packer template jenkins-ubuntu.json. Only used if var.ami is null. One of var.ami or [`ami_filters`](#ami_filters) is required. Set to null if passing the ami ID directly.
+</HclListItemTypeDetails>
+</HclListItem>
 
-<a name="domain_name" className="snap-top"></a>
+<HclListItem name="ami" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`domain_name`**](#domain_name) &mdash; The domain name for the DNS A record to add for Jenkins (e.g. jenkins.foo.com). Must be in the domain managed by [`hosted_zone_id`](#hosted_zone_id).
+The ID of the AMI to run on the Jenkins server. This should be the AMI build from the Packer template jenkins-ubuntu.json. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if looking up the ami with filters.
 
-<a name="hosted_zone_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`hosted_zone_id`**](#hosted_zone_id) &mdash; The ID of the Route 53 Hosted Zone in which to create a DNS A record for Jenkins.
+<HclListItem name="ami_filters" requirement="required" type="object">
+<HclListItemDescription>
 
-<a name="instance_type" className="snap-top"></a>
+Properties on the AMI that can be used to lookup a prebuilt AMI for use with Jenkins. You can build the AMI using the Packer template jenkins-ubuntu.json. Only used if var.ami is null. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if passing the ami ID directly.
 
-* [**`instance_type`**](#instance_type) &mdash; The instance type to use for the Jenkins server (e.g. t2.medium)
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="jenkins_subnet_id" className="snap-top"></a>
+```hcl
+object({
+    # List of owners to limit the search. Set to null if you do not wish to limit the search by AMI owners.
+    owners = list(string)
 
-* [**`jenkins_subnet_id`**](#jenkins_subnet_id) &mdash; The ID of the subnet in which to deploy Jenkins. Must be a subnet in [`vpc_id`](#vpc_id).
+    # Name/Value pairs to filter the AMI off of. There are several valid keys, for a full reference, check out the
+    # documentation for describe-images in the AWS CLI reference
+    # (https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html).
+    filters = list(object({
+      name   = string
+      values = list(string)
+    }))
+  })
+```
 
-<a name="memory" className="snap-top"></a>
+</HclListItemTypeDetails>
+</HclListItem>
 
-* [**`memory`**](#memory) &mdash; The amount of memory to give Jenkins (e.g., 1g or 512m). Used for the -Xms and -Xmx settings.
+<HclListItem name="domain_name" requirement="required" type="string">
+<HclListItemDescription>
 
-<a name="vpc_id" className="snap-top"></a>
+The domain name for the DNS A record to add for Jenkins (e.g. jenkins.foo.com). Must be in the domain managed by <a href="#hosted_zone_id"><code>hosted_zone_id</code></a>.
 
-* [**`vpc_id`**](#vpc_id) &mdash; The ID of the VPC in which to deploy Jenkins
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="hosted_zone_id" requirement="required" type="string">
+<HclListItemDescription>
+
+The ID of the Route 53 Hosted Zone in which to create a DNS A record for Jenkins.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="instance_type" requirement="required" type="string">
+<HclListItemDescription>
+
+The instance type to use for the Jenkins server (e.g. t2.medium)
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="jenkins_subnet_id" requirement="required" type="string">
+<HclListItemDescription>
+
+The ID of the subnet in which to deploy Jenkins. Must be a subnet in <a href="#vpc_id"><code>vpc_id</code></a>.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="memory" requirement="required" type="string">
+<HclListItemDescription>
+
+The amount of memory to give Jenkins (e.g., 1g or 512m). Used for the -Xms and -Xmx settings.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="vpc_id" requirement="required" type="string">
+<HclListItemDescription>
+
+The ID of the VPC in which to deploy Jenkins
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="alarms_sns_topic_arn" className="snap-top"></a>
+<HclListItem name="alarms_sns_topic_arn" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`alarms_sns_topic_arn`**](#alarms_sns_topic_arn) &mdash; The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications. Also used for the alarms if the Jenkins backup job fails.
+The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications. Also used for the alarms if the Jenkins backup job fails.
 
-<a name="allow_incoming_http_from_cidr_blocks" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`allow_incoming_http_from_cidr_blocks`**](#allow_incoming_http_from_cidr_blocks) &mdash; The IP address ranges in CIDR format from which to allow incoming HTTP requests to Jenkins.
+```hcl
+list(string)
+```
 
-<a name="allow_incoming_http_from_security_group_ids" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`allow_incoming_http_from_security_group_ids`**](#allow_incoming_http_from_security_group_ids) &mdash; The IDs of security groups from which to allow incoming HTTP requests to Jenkins.
+<HclListItem name="allow_incoming_http_from_cidr_blocks" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="allow_ssh_from_cidr_blocks" className="snap-top"></a>
+The IP address ranges in CIDR format from which to allow incoming HTTP requests to Jenkins.
 
-* [**`allow_ssh_from_cidr_blocks`**](#allow_ssh_from_cidr_blocks) &mdash; The IP address ranges in CIDR format from which to allow incoming SSH requests to Jenkins.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="allow_ssh_from_security_group_ids" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`allow_ssh_from_security_group_ids`**](#allow_ssh_from_security_group_ids) &mdash; The IDs of security groups from which to allow incoming SSH requests to Jenkins.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="backup_job_alarm_period" className="snap-top"></a>
+<HclListItem name="allow_incoming_http_from_security_group_ids" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`backup_job_alarm_period`**](#backup_job_alarm_period) &mdash; How often, in seconds, the backup job is expected to run. This is the same as [`backup_job_schedule_expression`](#backup_job_schedule_expression), but unfortunately, Terraform offers no way to convert rate expressions to seconds. We add a CloudWatch alarm that triggers if the value of [`backup_job_metric_name`](#backup_job_metric_name) and [`backup_job_metric_namespace`](#backup_job_metric_namespace) isn't updated within this time period, as that indicates the backup failed to run.
+The IDs of security groups from which to allow incoming HTTP requests to Jenkins.
 
-<a name="backup_job_metric_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`backup_job_metric_name`**](#backup_job_metric_name) &mdash; The name for the CloudWatch Metric the AWS lambda backup job will increment every time the job completes successfully.
+```hcl
+list(string)
+```
 
-<a name="backup_job_metric_namespace" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`backup_job_metric_namespace`**](#backup_job_metric_namespace) &mdash; The namespace for the CloudWatch Metric the AWS lambda backup job will increment every time the job completes successfully.
+<HclListItem name="allow_ssh_from_cidr_blocks" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="backup_job_schedule_expression" className="snap-top"></a>
+The IP address ranges in CIDR format from which to allow incoming SSH requests to Jenkins.
 
-* [**`backup_job_schedule_expression`**](#backup_job_schedule_expression) &mdash; A cron or rate expression that specifies how often to take a snapshot of the Jenkins server for backup purposes. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html for syntax details.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="backup_using_dlm" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`backup_using_dlm`**](#backup_using_dlm) &mdash; Set to true to backup the Jenkins Server using AWS Data Lifecycle Management Policies.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="backup_using_lambda" className="snap-top"></a>
+<HclListItem name="allow_ssh_from_security_group_ids" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`backup_using_lambda`**](#backup_using_lambda) &mdash; Set to true to backup the Jenkins Server using a Scheduled Lambda Function.
+The IDs of security groups from which to allow incoming SSH requests to Jenkins.
 
-<a name="build_permission_actions" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`build_permission_actions`**](#build_permission_actions) &mdash; The list of IAM actions this Jenkins server should be allowed to do: e.g., ec2:*, s3:*, etc. This should be the list of IAM permissions Jenkins needs in this AWS account to run builds. These permissions will be added to the server's IAM role for all resources ('*').
+```hcl
+list(string)
+```
 
-<a name="cloud_init_parts" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`cloud_init_parts`**](#cloud_init_parts) &mdash; Cloud init scripts to run on the Jenkins server when it is booting. See the part blocks in [`https://www.terraform.io/docs/providers/template/d/cloudinit_config`](#https://www.terraform.io/docs/providers/template/d/cloudinit_config).html for syntax.
+<HclListItem name="backup_job_alarm_period" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="cloudwatch_log_group_kms_key_id" className="snap-top"></a>
+How often, in seconds, the backup job is expected to run. This is the same as <a href="#backup_job_schedule_expression"><code>backup_job_schedule_expression</code></a>, but unfortunately, Terraform offers no way to convert rate expressions to seconds. We add a CloudWatch alarm that triggers if the value of <a href="#backup_job_metric_name"><code>backup_job_metric_name</code></a> and <a href="#backup_job_metric_namespace"><code>backup_job_metric_namespace</code></a> isn't updated within this time period, as that indicates the backup failed to run.
 
-* [**`cloudwatch_log_group_kms_key_id`**](#cloudwatch_log_group_kms_key_id) &mdash; The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="86400"/>
+</HclListItem>
 
-<a name="cloudwatch_log_group_retention_in_days" className="snap-top"></a>
+<HclListItem name="backup_job_metric_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`cloudwatch_log_group_retention_in_days`**](#cloudwatch_log_group_retention_in_days) &mdash; The number of days to retain log events in the log group. Refer to [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days) for all the valid values. When null, the log events are retained forever.
+The name for the CloudWatch Metric the AWS lambda backup job will increment every time the job completes successfully.
 
-<a name="cloudwatch_log_group_tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="jenkins-backup-job"/>
+</HclListItem>
 
-* [**`cloudwatch_log_group_tags`**](#cloudwatch_log_group_tags) &mdash; Tags to apply on the CloudWatch Log Group, encoded as a map where the keys are tag keys and values are tag values.
+<HclListItem name="backup_job_metric_namespace" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="custom_tags" className="snap-top"></a>
+The namespace for the CloudWatch Metric the AWS lambda backup job will increment every time the job completes successfully.
 
-* [**`custom_tags`**](#custom_tags) &mdash; A list of custom tags to apply to Jenkins and all other resources.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="Custom/Jenkins"/>
+</HclListItem>
 
-<a name="default_user" className="snap-top"></a>
+<HclListItem name="backup_job_schedule_expression" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`default_user`**](#default_user) &mdash; The default OS user for the Jenkins AMI. For AWS Ubuntu AMIs, which is what the Packer template in jenkins-ubunutu.json uses, the default OS user is 'ubuntu'.
+A cron or rate expression that specifies how often to take a snapshot of the Jenkins server for backup purposes. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html for syntax details.
 
-<a name="dlm_backup_job_schedule_interval" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="rate(1 day)"/>
+</HclListItem>
 
-* [**`dlm_backup_job_schedule_interval`**](#dlm_backup_job_schedule_interval) &mdash; How often this lifecycle policy should be evaluated, in hours.
+<HclListItem name="backup_using_dlm" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="dlm_backup_job_schedule_name" className="snap-top"></a>
+Set to true to backup the Jenkins Server using AWS Data Lifecycle Management Policies.
 
-* [**`dlm_backup_job_schedule_name`**](#dlm_backup_job_schedule_name) &mdash; The name of the data lifecyle management schedule
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="dlm_backup_job_schedule_number_of_snapshots_to_retain" className="snap-top"></a>
+<HclListItem name="backup_using_lambda" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`dlm_backup_job_schedule_number_of_snapshots_to_retain`**](#dlm_backup_job_schedule_number_of_snapshots_to_retain) &mdash; How many snapshots to keep. Must be an integer between 1 and 1000.
+Set to true to backup the Jenkins Server using a Scheduled Lambda Function.
 
-<a name="dlm_backup_job_schedule_times" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`dlm_backup_job_schedule_times`**](#dlm_backup_job_schedule_times) &mdash; A list of times in 24 hour clock format that sets when the lifecyle policy should be evaluated. Max of 1.
+<HclListItem name="build_permission_actions" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="ebs_kms_key_arn" className="snap-top"></a>
+The list of IAM actions this Jenkins server should be allowed to do: e.g., ec2:*, s3:*, etc. This should be the list of IAM permissions Jenkins needs in this AWS account to run builds. These permissions will be added to the server's IAM role for all resources ('*').
 
-* [**`ebs_kms_key_arn`**](#ebs_kms_key_arn) &mdash; The ARN of the KMS key used for encrypting the Jenkins EBS volume. The module will grant Jenkins permission to use this key.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="ebs_kms_key_arn_is_alias" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`ebs_kms_key_arn_is_alias`**](#ebs_kms_key_arn_is_alias) &mdash; Whether or not the provide EBS KMS key ARN is a key alias. If providing the key ID, leave this set to false.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="enable_cloudwatch_alarms" className="snap-top"></a>
+<HclListItem name="cloud_init_parts" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`enable_cloudwatch_alarms`**](#enable_cloudwatch_alarms) &mdash; Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using [`alarms_sns_topic_arn`](#alarms_sns_topic_arn).
+Cloud init scripts to run on the Jenkins server when it is booting. See the part blocks in https://www.terraform.io/docs/providers/template/d/cloudinit_config.html for syntax.
 
-<a name="enable_cloudwatch_log_aggregation" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`enable_cloudwatch_log_aggregation`**](#enable_cloudwatch_log_aggregation) &mdash; Set to true to add AIM permissions to send logs to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/logs/cloudwatch-log-aggregation-scripts to do log aggregation in CloudWatch.
+```hcl
+map(object({
+    filename     = string
+    content_type = string
+    content      = string
+  }))
+```
 
-<a name="enable_cloudwatch_metrics" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`enable_cloudwatch_metrics`**](#enable_cloudwatch_metrics) &mdash; Set to true to add IAM permissions to send custom metrics to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/agents/cloudwatch-agent to get memory and disk metrics in CloudWatch for your Jenkins server.
+<HclListItem name="cloudwatch_log_group_kms_key_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="enable_ip_lockdown" className="snap-top"></a>
+The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data.
 
-* [**`enable_ip_lockdown`**](#enable_ip_lockdown) &mdash; Enable ip-lockdown to block access to the instance metadata. Defaults to true.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="enable_ssh_grunt" className="snap-top"></a>
+<HclListItem name="cloudwatch_log_group_retention_in_days" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`enable_ssh_grunt`**](#enable_ssh_grunt) &mdash; Set to true to add IAM permissions for ssh-grunt (https://github.com/gruntwork-io/terraform-aws-security/tree/master/modules/ssh-grunt), which will allow you to manage SSH access via IAM groups.
+The number of days to retain log events in the log group. Refer to https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days for all the valid values. When null, the log events are retained forever.
 
-<a name="external_account_auto_deploy_iam_role_arns" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`external_account_auto_deploy_iam_role_arns`**](#external_account_auto_deploy_iam_role_arns) &mdash; A list of IAM role ARNs in other AWS accounts that Jenkins will be able to assume to do automated deployment in those accounts.
+<HclListItem name="cloudwatch_log_group_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="external_account_ssh_grunt_role_arn" className="snap-top"></a>
+Tags to apply on the CloudWatch Log Group, encoded as a map where the keys are tag keys and values are tag values.
 
-* [**`external_account_ssh_grunt_role_arn`**](#external_account_ssh_grunt_role_arn) &mdash; If you are using ssh-grunt and your IAM users / groups are defined in a separate AWS account, you can use this variable to specify the ARN of an IAM role that ssh-grunt can assume to retrieve IAM group and public SSH key info from that account. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="is_internal_alb" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`is_internal_alb`**](#is_internal_alb) &mdash; Set to true to make the Jenkins ALB an internal ALB that cannot be accessed from the public Internet. We strongly recommend setting this to true to keep Jenkins more secure.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="jenkins_device_name" className="snap-top"></a>
+<HclListItem name="custom_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`jenkins_device_name`**](#jenkins_device_name) &mdash; The OS device name where the Jenkins EBS volume should be attached
+A list of custom tags to apply to Jenkins and all other resources.
 
-<a name="jenkins_mount_point" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`jenkins_mount_point`**](#jenkins_mount_point) &mdash; The OS path where the Jenkins EBS volume should be mounted
+```hcl
+map(string)
+```
 
-<a name="jenkins_user" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`jenkins_user`**](#jenkins_user) &mdash; The OS user that should be used to run Jenkins
+<HclListItem name="default_user" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="jenkins_volume_encrypted" className="snap-top"></a>
+The default OS user for the Jenkins AMI. For AWS Ubuntu AMIs, which is what the Packer template in jenkins-ubunutu.json uses, the default OS user is 'ubuntu'.
 
-* [**`jenkins_volume_encrypted`**](#jenkins_volume_encrypted) &mdash; Set to true to encrypt the Jenkins EBS volume.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ubuntu"/>
+</HclListItem>
 
-<a name="jenkins_volume_size" className="snap-top"></a>
+<HclListItem name="dlm_backup_job_schedule_interval" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`jenkins_volume_size`**](#jenkins_volume_size) &mdash; The amount of disk space, in GB, to allocate for the EBS volume used by the Jenkins server.
+How often this lifecycle policy should be evaluated, in hours.
 
-<a name="jenkins_volume_type" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="24"/>
+</HclListItem>
 
-* [**`jenkins_volume_type`**](#jenkins_volume_type) &mdash; The type of volume to use for the EBS volume used by the Jenkins server. Must be one of: standard, gp2, io1, sc1, or st1.
+<HclListItem name="dlm_backup_job_schedule_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="keypair_name" className="snap-top"></a>
+The name of the data lifecyle management schedule
 
-* [**`keypair_name`**](#keypair_name) &mdash; The name of a Key Pair that can be used to SSH to the Jenkins server. Leave blank if you don't want to enable Key Pair auth.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="daily-last-two-weeks"/>
+</HclListItem>
 
-<a name="name" className="snap-top"></a>
+<HclListItem name="dlm_backup_job_schedule_number_of_snapshots_to_retain" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`name`**](#name) &mdash; Enter the name of the Jenkins server
+How many snapshots to keep. Must be an integer between 1 and 1000.
 
-<a name="root_block_device_volume_type" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="15"/>
+</HclListItem>
 
-* [**`root_block_device_volume_type`**](#root_block_device_volume_type) &mdash; The type of volume to use for the root disk for Jenkins. Must be one of: standard, gp2, io1, sc1, or st1.
+<HclListItem name="dlm_backup_job_schedule_times" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="root_volume_size" className="snap-top"></a>
+A list of times in 24 hour clock format that sets when the lifecyle policy should be evaluated. Max of 1.
 
-* [**`root_volume_size`**](#root_volume_size) &mdash; The amount of disk space, in GB, to allocate for the root volume of this server. Note that all of Jenkins' data is stored on a separate EBS Volume (see [`jenkins_volume_size`](#jenkins_volume_size)), so this root volume is primarily used for the OS, temp folders, apps, etc.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="should_create_cloudwatch_log_group" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`should_create_cloudwatch_log_group`**](#should_create_cloudwatch_log_group) &mdash; When true, precreate the CloudWatch Log Group to use for log aggregation from the EC2 instances. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, the CloudWatch agent will automatically create a basic log group to use.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[
+  '03:00'
+]"/>
+</HclListItem>
 
-<a name="skip_health_check" className="snap-top"></a>
+<HclListItem name="ebs_kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`skip_health_check`**](#skip_health_check) &mdash; If set to true, skip the health check, and start a rolling deployment of Jenkins without waiting for it to initially be in a healthy state. This is primarily useful if the server group is in a broken state and you want to force a deployment anyway.
+The ARN of the KMS key used for encrypting the Jenkins EBS volume. The module will grant Jenkins permission to use this key.
 
-<a name="ssh_grunt_iam_group" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`ssh_grunt_iam_group`**](#ssh_grunt_iam_group) &mdash; If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to this Jenkins server. This value is only used if [`enable_ssh_grunt`](#enable_ssh_grunt)=true.
+<HclListItem name="ebs_kms_key_arn_is_alias" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="ssh_grunt_iam_group_sudo" className="snap-top"></a>
+Whether or not the provide EBS KMS key ARN is a key alias. If providing the key ID, leave this set to false.
 
-* [**`ssh_grunt_iam_group_sudo`**](#ssh_grunt_iam_group_sudo) &mdash; If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to this Jenkins server with sudo permissions. This value is only used if [`enable_ssh_grunt`](#enable_ssh_grunt)=true.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="tenancy" className="snap-top"></a>
+<HclListItem name="enable_cloudwatch_alarms" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`tenancy`**](#tenancy) &mdash; The tenancy of this server. Must be one of: default, dedicated, or host.
+Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using <a href="#alarms_sns_topic_arn"><code>alarms_sns_topic_arn</code></a>.
 
-<a name="use_managed_iam_policies" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`use_managed_iam_policies`**](#use_managed_iam_policies) &mdash; When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+<HclListItem name="enable_cloudwatch_log_aggregation" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to add AIM permissions to send logs to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/logs/cloudwatch-log-aggregation-scripts to do log aggregation in CloudWatch.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_cloudwatch_metrics" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to add IAM permissions to send custom metrics to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/agents/cloudwatch-agent to get memory and disk metrics in CloudWatch for your Jenkins server.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_ip_lockdown" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Enable ip-lockdown to block access to the instance metadata. Defaults to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_ssh_grunt" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to add IAM permissions for ssh-grunt (https://github.com/gruntwork-io/terraform-aws-security/tree/master/modules/ssh-grunt), which will allow you to manage SSH access via IAM groups.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="external_account_auto_deploy_iam_role_arns" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of IAM role ARNs in other AWS accounts that Jenkins will be able to assume to do automated deployment in those accounts.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="external_account_ssh_grunt_role_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt and your IAM users / groups are defined in a separate AWS account, you can use this variable to specify the ARN of an IAM role that ssh-grunt can assume to retrieve IAM group and public SSH key info from that account. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="is_internal_alb" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to make the Jenkins ALB an internal ALB that cannot be accessed from the public Internet. We strongly recommend setting this to true to keep Jenkins more secure.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="jenkins_device_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The OS device name where the Jenkins EBS volume should be attached
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="xvdh"/>
+</HclListItem>
+
+<HclListItem name="jenkins_mount_point" requirement="optional" type="string">
+<HclListItemDescription>
+
+The OS path where the Jenkins EBS volume should be mounted
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="/jenkins"/>
+</HclListItem>
+
+<HclListItem name="jenkins_user" requirement="optional" type="string">
+<HclListItemDescription>
+
+The OS user that should be used to run Jenkins
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="jenkins"/>
+</HclListItem>
+
+<HclListItem name="jenkins_volume_encrypted" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to encrypt the Jenkins EBS volume.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="jenkins_volume_size" requirement="optional" type="number">
+<HclListItemDescription>
+
+The amount of disk space, in GB, to allocate for the EBS volume used by the Jenkins server.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="200"/>
+</HclListItem>
+
+<HclListItem name="jenkins_volume_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+The type of volume to use for the EBS volume used by the Jenkins server. Must be one of: standard, gp2, io1, sc1, or st1.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="gp2"/>
+</HclListItem>
+
+<HclListItem name="keypair_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of a Key Pair that can be used to SSH to the Jenkins server. Leave blank if you don't want to enable Key Pair auth.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="name" requirement="optional" type="string">
+<HclListItemDescription>
+
+Enter the name of the Jenkins server
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="jenkins"/>
+</HclListItem>
+
+<HclListItem name="root_block_device_volume_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+The type of volume to use for the root disk for Jenkins. Must be one of: standard, gp2, io1, sc1, or st1.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="gp2"/>
+</HclListItem>
+
+<HclListItem name="root_volume_size" requirement="optional" type="number">
+<HclListItemDescription>
+
+The amount of disk space, in GB, to allocate for the root volume of this server. Note that all of Jenkins' data is stored on a separate EBS Volume (see <a href="#jenkins_volume_size"><code>jenkins_volume_size</code></a>), so this root volume is primarily used for the OS, temp folders, apps, etc.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="100"/>
+</HclListItem>
+
+<HclListItem name="should_create_cloudwatch_log_group" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, precreate the CloudWatch Log Group to use for log aggregation from the EC2 instances. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, the CloudWatch agent will automatically create a basic log group to use.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="skip_health_check" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If set to true, skip the health check, and start a rolling deployment of Jenkins without waiting for it to initially be in a healthy state. This is primarily useful if the server group is in a broken state and you want to force a deployment anyway.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="ssh_grunt_iam_group" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to this Jenkins server. This value is only used if enable_ssh_grunt=true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ssh-grunt-users"/>
+</HclListItem>
+
+<HclListItem name="ssh_grunt_iam_group_sudo" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to this Jenkins server with sudo permissions. This value is only used if enable_ssh_grunt=true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ssh-grunt-sudo-users"/>
+</HclListItem>
+
+<HclListItem name="tenancy" requirement="optional" type="string">
+<HclListItemDescription>
+
+The tenancy of this server. Must be one of: default, dedicated, or host.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="default"/>
+</HclListItem>
+
+<HclListItem name="use_managed_iam_policies" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="alb_arn" className="snap-top"></a>
+<HclListItem name="alb_arn">
+<HclListItemDescription>
 
-* [**`alb_arn`**](#alb_arn) &mdash; The ARN of the ALB deployed in front of Jenkins
+The ARN of the ALB deployed in front of Jenkins
 
-<a name="alb_dns_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`alb_dns_name`**](#alb_dns_name) &mdash; The DNS name of the ALB deployed in front of Jenkins
+<HclListItem name="alb_dns_name">
+<HclListItemDescription>
 
-<a name="alb_hosted_zone_id" className="snap-top"></a>
+The DNS name of the ALB deployed in front of Jenkins
 
-* [**`alb_hosted_zone_id`**](#alb_hosted_zone_id) &mdash; The hosted zone ID of the ALB deployed in front of Jenkins
+</HclListItemDescription>
+</HclListItem>
 
-<a name="alb_http_listener_arns" className="snap-top"></a>
+<HclListItem name="alb_hosted_zone_id">
+<HclListItemDescription>
 
-* [**`alb_http_listener_arns`**](#alb_http_listener_arns) &mdash; The ARNs of just the HTTP ALB listeners of the ALB deployed in front of Jenkins
+The hosted zone ID of the ALB deployed in front of Jenkins
 
-<a name="alb_https_listener_acm_cert_arns" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`alb_https_listener_acm_cert_arns`**](#alb_https_listener_acm_cert_arns) &mdash; The ARNs of just the HTTPS ALB listeners that usse ACM certs of the ALB deployed in front of Jenkins
+<HclListItem name="alb_http_listener_arns">
+<HclListItemDescription>
 
-<a name="alb_https_listener_non_acm_cert_arns" className="snap-top"></a>
+The ARNs of just the HTTP ALB listeners of the ALB deployed in front of Jenkins
 
-* [**`alb_https_listener_non_acm_cert_arns`**](#alb_https_listener_non_acm_cert_arns) &mdash; The ARNs of just the HTTPS ALB listeners that use non-ACM certs of the ALB deployed in front of Jenkins
+</HclListItemDescription>
+</HclListItem>
 
-<a name="alb_listener_arns" className="snap-top"></a>
+<HclListItem name="alb_https_listener_acm_cert_arns">
+<HclListItemDescription>
 
-* [**`alb_listener_arns`**](#alb_listener_arns) &mdash; The ARNs of the ALB listeners of the ALB deployed in front of Jenkins
+The ARNs of just the HTTPS ALB listeners that usse ACM certs of the ALB deployed in front of Jenkins
 
-<a name="alb_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`alb_name`**](#alb_name) &mdash; The name of the ALB deployed in front of Jenkins
+<HclListItem name="alb_https_listener_non_acm_cert_arns">
+<HclListItemDescription>
 
-<a name="alb_security_group_id" className="snap-top"></a>
+The ARNs of just the HTTPS ALB listeners that use non-ACM certs of the ALB deployed in front of Jenkins
 
-* [**`alb_security_group_id`**](#alb_security_group_id) &mdash; The ID of the security group attached to the ALB deployed in front of Jenkins
+</HclListItemDescription>
+</HclListItem>
 
-<a name="backup_lambda_function_arn" className="snap-top"></a>
+<HclListItem name="alb_listener_arns">
+<HclListItemDescription>
 
-* [**`backup_lambda_function_arn`**](#backup_lambda_function_arn) &mdash; 
+The ARNs of the ALB listeners of the ALB deployed in front of Jenkins
 
-<a name="backup_lambda_function_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`backup_lambda_function_name`**](#backup_lambda_function_name) &mdash; 
+<HclListItem name="alb_name">
+<HclListItemDescription>
 
-<a name="jenkins_asg_name" className="snap-top"></a>
+The name of the ALB deployed in front of Jenkins
 
-* [**`jenkins_asg_name`**](#jenkins_asg_name) &mdash; The name of the Auto Scaling Group in which Jenkins is running
+</HclListItemDescription>
+</HclListItem>
 
-<a name="jenkins_domain_name" className="snap-top"></a>
+<HclListItem name="alb_security_group_id">
+<HclListItemDescription>
 
-* [**`jenkins_domain_name`**](#jenkins_domain_name) &mdash; The public domain name configured for Jenkins
+The ID of the security group attached to the ALB deployed in front of Jenkins
 
-<a name="jenkins_ebs_volume_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`jenkins_ebs_volume_id`**](#jenkins_ebs_volume_id) &mdash; The ID of the EBS Volume that will store the [`JENKINS_HOME`](#JENKINS_HOME) directory
+<HclListItem name="backup_lambda_function_arn">
+</HclListItem>
 
-<a name="jenkins_iam_role_arn" className="snap-top"></a>
+<HclListItem name="backup_lambda_function_name">
+</HclListItem>
 
-* [**`jenkins_iam_role_arn`**](#jenkins_iam_role_arn) &mdash; The ARN of the IAM role attached to the Jenkins EC2 Instance
+<HclListItem name="jenkins_asg_name">
+<HclListItemDescription>
 
-<a name="jenkins_iam_role_id" className="snap-top"></a>
+The name of the Auto Scaling Group in which Jenkins is running
 
-* [**`jenkins_iam_role_id`**](#jenkins_iam_role_id) &mdash; The ID of the IAM role attached to the Jenkins EC2 Instance
+</HclListItemDescription>
+</HclListItem>
 
-<a name="jenkins_security_group_id" className="snap-top"></a>
+<HclListItem name="jenkins_domain_name">
+<HclListItemDescription>
 
-* [**`jenkins_security_group_id`**](#jenkins_security_group_id) &mdash; The ID of the Security Group attached to the Jenkins EC2 Instance
+The public domain name configured for Jenkins
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="jenkins_ebs_volume_id">
+<HclListItemDescription>
+
+The ID of the EBS Volume that will store the JENKINS_HOME directory
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="jenkins_iam_role_arn">
+<HclListItemDescription>
+
+The ARN of the IAM role attached to the Jenkins EC2 Instance
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="jenkins_iam_role_id">
+<HclListItemDescription>
+
+The ID of the IAM role attached to the Jenkins EC2 Instance
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="jenkins_security_group_id">
+<HclListItemDescription>
+
+The ID of the Security Group attached to the Jenkins EC2 Instance
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"0bcc39e3793c45a6d04f5ed1eb9b8d9c"}
+{"sourcePlugin":"service-catalog-api","hash":"aa5db15404ec1af2a6d8f33bc43a2f56"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/data-storage/amazon-aurora.md
+++ b/docs/reference/services/data-storage/amazon-aurora.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -89,343 +90,974 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="aurora_subnet_ids" className="snap-top"></a>
+<HclListItem name="aurora_subnet_ids" requirement="required" type="list">
+<HclListItemDescription>
 
-* [**`aurora_subnet_ids`**](#aurora_subnet_ids) &mdash; The list of IDs of the subnets in which to deploy Aurora. The list must only contain subnets in [`vpc_id`](#vpc_id).
+The list of IDs of the subnets in which to deploy Aurora. The list must only contain subnets in <a href="#vpc_id"><code>vpc_id</code></a>.
 
-<a name="name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`name`**](#name) &mdash; The name used to namespace all the Aurora resources created by these templates, including the cluster and cluster instances (e.g. drupaldb). Must be unique in this region. Must be a lowercase string.
+```hcl
+list(string)
+```
 
-<a name="vpc_id" className="snap-top"></a>
+</HclListItemTypeDetails>
+</HclListItem>
 
-* [**`vpc_id`**](#vpc_id) &mdash; The ID of the VPC in which to deploy Aurora.
+<HclListItem name="name" requirement="required" type="string">
+<HclListItemDescription>
+
+The name used to namespace all the Aurora resources created by these templates, including the cluster and cluster instances (e.g. drupaldb). Must be unique in this region. Must be a lowercase string.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="vpc_id" requirement="required" type="string">
+<HclListItemDescription>
+
+The ID of the VPC in which to deploy Aurora.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="alarms_sns_topic_arns" className="snap-top"></a>
+<HclListItem name="alarms_sns_topic_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`alarms_sns_topic_arns`**](#alarms_sns_topic_arns) &mdash; The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications. Also used for the alarms if the share snapshot backup job fails.
+The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications. Also used for the alarms if the share snapshot backup job fails.
 
-<a name="allow_connections_from_cidr_blocks" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`allow_connections_from_cidr_blocks`**](#allow_connections_from_cidr_blocks) &mdash; The list of network CIDR blocks to allow network access to Aurora from. One of [`allow_connections_from_cidr_blocks`](#allow_connections_from_cidr_blocks) or [`allow_connections_from_security_groups`](#allow_connections_from_security_groups) must be specified for the database to be reachable.
+```hcl
+list(string)
+```
 
-<a name="allow_connections_from_security_groups" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`allow_connections_from_security_groups`**](#allow_connections_from_security_groups) &mdash; The list of IDs or Security Groups to allow network access to Aurora from. All security groups must either be in the VPC specified by [`vpc_id`](#vpc_id), or a peered VPC with the VPC specified by [`vpc_id`](#vpc_id). One of [`allow_connections_from_cidr_blocks`](#allow_connections_from_cidr_blocks) or [`allow_connections_from_security_groups`](#allow_connections_from_security_groups) must be specified for the database to be reachable.
+<HclListItem name="allow_connections_from_cidr_blocks" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="allow_major_version_upgrade" className="snap-top"></a>
+The list of network CIDR blocks to allow network access to Aurora from. One of <a href="#allow_connections_from_cidr_blocks"><code>allow_connections_from_cidr_blocks</code></a> or <a href="#allow_connections_from_security_groups"><code>allow_connections_from_security_groups</code></a> must be specified for the database to be reachable.
 
-* [**`allow_major_version_upgrade`**](#allow_major_version_upgrade) &mdash; Enable to allow major engine version upgrades when changing engine versions.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="apply_immediately" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`apply_immediately`**](#apply_immediately) &mdash; Specifies whether any cluster modifications are applied immediately, or during the next maintenance window. Note that cluster modifications may cause degraded performance or downtime.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="backup_job_alarm_period" className="snap-top"></a>
+<HclListItem name="allow_connections_from_security_groups" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`backup_job_alarm_period`**](#backup_job_alarm_period) &mdash; How often, in seconds, the backup job is expected to run. This is the same as [`schedule_expression`](#schedule_expression), but unfortunately, Terraform offers no way to convert rate expressions to seconds. We add a CloudWatch alarm that triggers if the metric in [`create_snapshot_cloudwatch_metric_namespace`](#create_snapshot_cloudwatch_metric_namespace) isn't updated within this time period, as that indicates the backup failed to run.
+The list of IDs or Security Groups to allow network access to Aurora from. All security groups must either be in the VPC specified by <a href="#vpc_id"><code>vpc_id</code></a>, or a peered VPC with the VPC specified by <a href="#vpc_id"><code>vpc_id</code></a>. One of <a href="#allow_connections_from_cidr_blocks"><code>allow_connections_from_cidr_blocks</code></a> or <a href="#allow_connections_from_security_groups"><code>allow_connections_from_security_groups</code></a> must be specified for the database to be reachable.
 
-<a name="backup_retention_period" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`backup_retention_period`**](#backup_retention_period) &mdash; How many days to keep backup snapshots around before cleaning them up. Max: 35
+```hcl
+list(string)
+```
 
-<a name="copy_tags_to_snapshot" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`copy_tags_to_snapshot`**](#copy_tags_to_snapshot) &mdash; Copy all the Aurora cluster tags to snapshots. Default is false.
+<HclListItem name="allow_major_version_upgrade" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="create_snapshot_cloudwatch_metric_namespace" className="snap-top"></a>
+Enable to allow major engine version upgrades when changing engine versions.
 
-* [**`create_snapshot_cloudwatch_metric_namespace`**](#create_snapshot_cloudwatch_metric_namespace) &mdash; The namespace to use for the CloudWatch metric we report every time a new RDS snapshot is created. We add a CloudWatch alarm on this metric to notify us if the backup job fails to run for any reason. Defaults to the cluster name.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="custom_tags" className="snap-top"></a>
+<HclListItem name="apply_immediately" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`custom_tags`**](#custom_tags) &mdash; A map of custom tags to apply to the RDS cluster and all associated resources created for it. The key is the tag name and the value is the tag value.
+Specifies whether any cluster modifications are applied immediately, or during the next maintenance window. Note that cluster modifications may cause degraded performance or downtime.
 
-<a name="dashboard_cpu_usage_widget_parameters" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`dashboard_cpu_usage_widget_parameters`**](#dashboard_cpu_usage_widget_parameters) &mdash; Parameters for the cpu usage widget to output for use in a CloudWatch dashboard.
+<HclListItem name="backup_job_alarm_period" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="dashboard_db_connections_widget_parameters" className="snap-top"></a>
+How often, in seconds, the backup job is expected to run. This is the same as <a href="#schedule_expression"><code>schedule_expression</code></a>, but unfortunately, Terraform offers no way to convert rate expressions to seconds. We add a CloudWatch alarm that triggers if the metric in <a href="#create_snapshot_cloudwatch_metric_namespace"><code>create_snapshot_cloudwatch_metric_namespace</code></a> isn't updated within this time period, as that indicates the backup failed to run.
 
-* [**`dashboard_db_connections_widget_parameters`**](#dashboard_db_connections_widget_parameters) &mdash; Parameters for the database connections widget to output for use in a CloudWatch dashboard.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="3600"/>
+</HclListItem>
 
-<a name="dashboard_disk_space_widget_parameters" className="snap-top"></a>
+<HclListItem name="backup_retention_period" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`dashboard_disk_space_widget_parameters`**](#dashboard_disk_space_widget_parameters) &mdash; Parameters for the available disk space widget to output for use in a CloudWatch dashboard.
+How many days to keep backup snapshots around before cleaning them up. Max: 35
 
-<a name="dashboard_memory_widget_parameters" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="30"/>
+</HclListItem>
 
-* [**`dashboard_memory_widget_parameters`**](#dashboard_memory_widget_parameters) &mdash; Parameters for the available memory widget to output for use in a CloudWatch dashboard.
+<HclListItem name="copy_tags_to_snapshot" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="dashboard_read_latency_widget_parameters" className="snap-top"></a>
+Copy all the Aurora cluster tags to snapshots. Default is false.
 
-* [**`dashboard_read_latency_widget_parameters`**](#dashboard_read_latency_widget_parameters) &mdash; Parameters for the read latency widget to output for use in a CloudWatch dashboard.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="dashboard_write_latency_widget_parameters" className="snap-top"></a>
+<HclListItem name="create_snapshot_cloudwatch_metric_namespace" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`dashboard_write_latency_widget_parameters`**](#dashboard_write_latency_widget_parameters) &mdash; Parameters for the read latency widget to output for use in a CloudWatch dashboard.
+The namespace to use for the CloudWatch metric we report every time a new RDS snapshot is created. We add a CloudWatch alarm on this metric to notify us if the backup job fails to run for any reason. Defaults to the cluster name.
 
-<a name="db_cluster_custom_parameter_group" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`db_cluster_custom_parameter_group`**](#db_cluster_custom_parameter_group) &mdash; Configure a custom parameter group for the RDS DB cluster. This will create a new parameter group with the given parameters. When null, the database will be launched with the default parameter group.
+<HclListItem name="custom_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="db_config_secrets_manager_id" className="snap-top"></a>
+A map of custom tags to apply to the RDS cluster and all associated resources created for it. The key is the tag name and the value is the tag value.
 
-* [**`db_config_secrets_manager_id`**](#db_config_secrets_manager_id) &mdash; The friendly name or ARN of an AWS Secrets Manager secret that contains database configuration information in the format outlined by this document: https://docs.aws.amazon.com/secretsmanager/latest/userguide/best-practices.html. The engine, username, password, dbname, and port fields must be included in the JSON. Note that even with this precaution, this information will be stored in plaintext in the Terraform state file! See the following blog post for more details: https://blog.gruntwork.io/a-comprehensive-guide-to-managing-secrets-in-your-terraform-code-1d586955ace1. If you do not wish to use Secrets Manager, leave this as null, and use the [`master_username`](#master_username), [`master_password`](#master_password), [`db_name`](#db_name), engine, and port variables.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="db_instance_custom_parameter_group" className="snap-top"></a>
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="dashboard_cpu_usage_widget_parameters" requirement="optional" type="object">
+<HclListItemDescription>
 
-* [**`db_instance_custom_parameter_group`**](#db_instance_custom_parameter_group) &mdash; Configure a custom parameter group for the RDS DB Instance. This will create a new parameter group with the given parameters. When null, the database will be launched with the default parameter group.
+Parameters for the cpu usage widget to output for use in a CloudWatch dashboard.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="db_name" className="snap-top"></a>
+```hcl
+object({
+    # The period in seconds for metrics to sample across.
+    period = number
 
-* [**`db_name`**](#db_name) &mdash; The name for your database of up to 8 alpha-numeric characters. If you do not provide a name, Amazon RDS will not create a database in the DB cluster you are creating. This can also be provided via AWS Secrets Manager. See the description of [`db_config_secrets_manager_id`](#db_config_secrets_manager_id). A value here overrides the value in [`db_config_secrets_manager_id`](#db_config_secrets_manager_id).
+    # The width and height of the widget in grid units in a 24 column grid. E.g., a value of 12 will take up half the
+    # space.
+    width  = number
+    height = number
+  })
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-<a name="enable_cloudwatch_alarms" className="snap-top"></a>
+```hcl
+{
+  height = 6,
+  period = 60,
+  width = 8
+}
+```
+
+</HclListItemDefaultValue>
+</HclListItem>
+
+<HclListItem name="dashboard_db_connections_widget_parameters" requirement="optional" type="object">
+<HclListItemDescription>
+
+Parameters for the database connections widget to output for use in a CloudWatch dashboard.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`enable_cloudwatch_alarms`**](#enable_cloudwatch_alarms) &mdash; Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using [`alarms_sns_topic_arn`](#alarms_sns_topic_arn).
+```hcl
+object({
+    # The period in seconds for metrics to sample across.
+    period = number
 
-<a name="enable_cloudwatch_metrics" className="snap-top"></a>
+    # The width and height of the widget in grid units in a 24 column grid. E.g., a value of 12 will take up half the
+    # space.
+    width  = number
+    height = number
+  })
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
+
+```hcl
+{
+  height = 6,
+  period = 60,
+  width = 8
+}
+```
+
+</HclListItemDefaultValue>
+</HclListItem>
+
+<HclListItem name="dashboard_disk_space_widget_parameters" requirement="optional" type="object">
+<HclListItemDescription>
+
+Parameters for the available disk space widget to output for use in a CloudWatch dashboard.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+object({
+    # The period in seconds for metrics to sample across.
+    period = number
+
+    # The width and height of the widget in grid units in a 24 column grid. E.g., a value of 12 will take up half the
+    # space.
+    width  = number
+    height = number
+  })
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
+
+```hcl
+{
+  height = 6,
+  period = 60,
+  width = 8
+}
+```
+
+</HclListItemDefaultValue>
+</HclListItem>
+
+<HclListItem name="dashboard_memory_widget_parameters" requirement="optional" type="object">
+<HclListItemDescription>
+
+Parameters for the available memory widget to output for use in a CloudWatch dashboard.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+object({
+    # The period in seconds for metrics to sample across.
+    period = number
+
+    # The width and height of the widget in grid units in a 24 column grid. E.g., a value of 12 will take up half the
+    # space.
+    width  = number
+    height = number
+  })
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
+
+```hcl
+{
+  height = 6,
+  period = 60,
+  width = 8
+}
+```
+
+</HclListItemDefaultValue>
+</HclListItem>
+
+<HclListItem name="dashboard_read_latency_widget_parameters" requirement="optional" type="object">
+<HclListItemDescription>
+
+Parameters for the read latency widget to output for use in a CloudWatch dashboard.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+object({
+    # The period in seconds for metrics to sample across.
+    period = number
+
+    # The width and height of the widget in grid units in a 24 column grid. E.g., a value of 12 will take up half the
+    # space.
+    width  = number
+    height = number
+  })
+```
 
-* [**`enable_cloudwatch_metrics`**](#enable_cloudwatch_metrics) &mdash; When true, enable CloudWatch metrics for the manual snapshots created for the purpose of sharing with another account.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-<a name="enable_deletion_protection" className="snap-top"></a>
+```hcl
+{
+  height = 6,
+  period = 60,
+  width = 8
+}
+```
 
-* [**`enable_deletion_protection`**](#enable_deletion_protection) &mdash; Enable deletion protection on the database instance. If this is enabled, the database cannot be deleted.
+</HclListItemDefaultValue>
+</HclListItem>
 
-<a name="enable_perf_alarms" className="snap-top"></a>
+<HclListItem name="dashboard_write_latency_widget_parameters" requirement="optional" type="object">
+<HclListItemDescription>
 
-* [**`enable_perf_alarms`**](#enable_perf_alarms) &mdash; Set to true to enable alarms related to performance, such as read and write latency alarms. Set to false to disable those alarms if you aren't sure what would be reasonable perf numbers for your RDS set up or if those numbers are too unpredictable.
+Parameters for the read latency widget to output for use in a CloudWatch dashboard.
 
-<a name="enable_share_snapshot_cloudwatch_alarms" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`enable_share_snapshot_cloudwatch_alarms`**](#enable_share_snapshot_cloudwatch_alarms) &mdash; When true, enable CloudWatch alarms for the manual snapshots created for the purpose of sharing with another account. Only used if [`share_snapshot_with_another_account`](#share_snapshot_with_another_account) is true.
+```hcl
+object({
+    # The period in seconds for metrics to sample across.
+    period = number
 
-<a name="enabled_cloudwatch_logs_exports" className="snap-top"></a>
+    # The width and height of the widget in grid units in a 24 column grid. E.g., a value of 12 will take up half the
+    # space.
+    width  = number
+    height = number
+  })
+```
 
-* [**`enabled_cloudwatch_logs_exports`**](#enabled_cloudwatch_logs_exports) &mdash; If non-empty, the Aurora cluster will export the specified logs to Cloudwatch. Must be zero or more of: audit, error, general and slowquery
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-<a name="engine" className="snap-top"></a>
+```hcl
+{
+  height = 6,
+  period = 60,
+  width = 8
+}
+```
 
-* [**`engine`**](#engine) &mdash; The name of the database engine to be used for this DB cluster. Valid Values: aurora (for MySQL 5.6-compatible Aurora), aurora-mysql (for MySQL 5.7-compatible Aurora), and aurora-postgresql. This can also be provided via AWS Secrets Manager. See the description of [`db_config_secrets_manager_id`](#db_config_secrets_manager_id). A value here overrides the value in [`db_config_secrets_manager_id`](#db_config_secrets_manager_id).
+</HclListItemDefaultValue>
+</HclListItem>
 
-<a name="engine_mode" className="snap-top"></a>
+<HclListItem name="db_cluster_custom_parameter_group" requirement="optional" type="object">
+<HclListItemDescription>
 
-* [**`engine_mode`**](#engine_mode) &mdash; The version of aurora to run - provisioned or serverless.
+Configure a custom parameter group for the RDS DB cluster. This will create a new parameter group with the given parameters. When null, the database will be launched with the default parameter group.
 
-<a name="engine_version" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`engine_version`**](#engine_version) &mdash; The Amazon Aurora DB engine version for the selected engine and [`engine_mode`](#engine_mode). Note: Starting with Aurora MySQL 2.03.2, Aurora engine versions have the following syntax [`&lt;mysql-major-version>.mysql_aurora`](#&lt;mysql-major-version>.mysql_aurora).&lt;aurora-mysql-version>. e.g. [`5.7.mysql_aurora`](#5.7.mysql_aurora).2.08.1.
+```hcl
+object({
+    # Name of the parameter group to create
+    name = string
 
-<a name="high_cpu_utilization_period" className="snap-top"></a>
+    # The family of the DB cluster parameter group.
+    family = string
 
-* [**`high_cpu_utilization_period`**](#high_cpu_utilization_period) &mdash; The period, in seconds, over which to measure the CPU utilization percentage.
+    # The parameters to configure on the created parameter group.
+    parameters = list(object({
+      # Parameter name to configure.
+      name = string
 
-<a name="high_cpu_utilization_threshold" className="snap-top"></a>
+      # Vaue to set the parameter.
+      value = string
 
-* [**`high_cpu_utilization_threshold`**](#high_cpu_utilization_threshold) &mdash; Trigger an alarm if the DB instance has a CPU utilization percentage above this threshold.
+      # When to apply the parameter. "immediate" or "pending-reboot".
+      apply_method = string
+    }))
+  })
+```
 
-<a name="high_read_latency_period" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`high_read_latency_period`**](#high_read_latency_period) &mdash; The period, in seconds, over which to measure the read latency.
+<HclListItem name="db_config_secrets_manager_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="high_read_latency_threshold" className="snap-top"></a>
+The friendly name or ARN of an AWS Secrets Manager secret that contains database configuration information in the format outlined by this document: https://docs.aws.amazon.com/secretsmanager/latest/userguide/best-practices.html. The engine, username, password, dbname, and port fields must be included in the JSON. Note that even with this precaution, this information will be stored in plaintext in the Terraform state file! See the following blog post for more details: https://blog.gruntwork.io/a-comprehensive-guide-to-managing-secrets-in-your-terraform-code-1d586955ace1. If you do not wish to use Secrets Manager, leave this as null, and use the master_username, master_password, db_name, engine, and port variables.
 
-* [**`high_read_latency_threshold`**](#high_read_latency_threshold) &mdash; Trigger an alarm if the DB instance read latency (average amount of time taken per disk I/O operation), in seconds, is above this threshold.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="high_write_latency_period" className="snap-top"></a>
+<HclListItem name="db_instance_custom_parameter_group" requirement="optional" type="object">
+<HclListItemDescription>
 
-* [**`high_write_latency_period`**](#high_write_latency_period) &mdash; The period, in seconds, over which to measure the write latency.
+Configure a custom parameter group for the RDS DB Instance. This will create a new parameter group with the given parameters. When null, the database will be launched with the default parameter group.
 
-<a name="high_write_latency_threshold" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`high_write_latency_threshold`**](#high_write_latency_threshold) &mdash; Trigger an alarm if the DB instance write latency (average amount of time taken per disk I/O operation), in seconds, is above this threshold.
+```hcl
+object({
+    # Name of the parameter group to create
+    name = string
 
-<a name="iam_database_authentication_enabled" className="snap-top"></a>
+    # The family of the DB cluster parameter group.
+    family = string
 
-* [**`iam_database_authentication_enabled`**](#iam_database_authentication_enabled) &mdash; Specifies whether mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled. Disabled by default.
+    # The parameters to configure on the created parameter group.
+    parameters = list(object({
+      # Parameter name to configure.
+      name = string
 
-<a name="instance_count" className="snap-top"></a>
+      # Vaue to set the parameter.
+      value = string
 
-* [**`instance_count`**](#instance_count) &mdash; The number of DB instances, including the primary, to run in the RDS cluster. Only used when [`engine_mode`](#engine_mode) is set to provisioned.
+      # When to apply the parameter. "immediate" or "pending-reboot".
+      apply_method = string
+    }))
+  })
+```
 
-<a name="instance_type" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`instance_type`**](#instance_type) &mdash; The instance type to use for the db (e.g. db.r3.large). Only used when [`engine_mode`](#engine_mode) is set to provisioned.
+<HclListItem name="db_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="kms_key_arn" className="snap-top"></a>
+The name for your database of up to 8 alpha-numeric characters. If you do not provide a name, Amazon RDS will not create a database in the DB cluster you are creating. This can also be provided via AWS Secrets Manager. See the description of db_config_secrets_manager_id. A value here overrides the value in db_config_secrets_manager_id.
 
-* [**`kms_key_arn`**](#kms_key_arn) &mdash; The ARN of a KMS key that should be used to encrypt data on disk. Only used if [`storage_encrypted`](#storage_encrypted) is true. If you leave this null, the default RDS KMS key for the account will be used.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="low_disk_space_available_period" className="snap-top"></a>
+<HclListItem name="enable_cloudwatch_alarms" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`low_disk_space_available_period`**](#low_disk_space_available_period) &mdash; The period, in seconds, over which to measure the available free disk space.
+Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using <a href="#alarms_sns_topic_arn"><code>alarms_sns_topic_arn</code></a>.
 
-<a name="low_disk_space_available_threshold" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`low_disk_space_available_threshold`**](#low_disk_space_available_threshold) &mdash; Trigger an alarm if the amount of disk space, in Bytes, on the DB instance drops below this threshold.
+<HclListItem name="enable_cloudwatch_metrics" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="low_memory_available_period" className="snap-top"></a>
+When true, enable CloudWatch metrics for the manual snapshots created for the purpose of sharing with another account.
 
-* [**`low_memory_available_period`**](#low_memory_available_period) &mdash; The period, in seconds, over which to measure the available free memory.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="low_memory_available_threshold" className="snap-top"></a>
+<HclListItem name="enable_deletion_protection" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`low_memory_available_threshold`**](#low_memory_available_threshold) &mdash; Trigger an alarm if the amount of free memory, in Bytes, on the DB instance drops below this threshold.
+Enable deletion protection on the database instance. If this is enabled, the database cannot be deleted.
 
-<a name="master_password" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`master_password`**](#master_password) &mdash; The value to use for the master password of the database. This can also be provided via AWS Secrets Manager. See the description of [`db_config_secrets_manager_id`](#db_config_secrets_manager_id). A value here overrides the value in [`db_config_secrets_manager_id`](#db_config_secrets_manager_id).
+<HclListItem name="enable_perf_alarms" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="master_username" className="snap-top"></a>
+Set to true to enable alarms related to performance, such as read and write latency alarms. Set to false to disable those alarms if you aren't sure what would be reasonable perf numbers for your RDS set up or if those numbers are too unpredictable.
 
-* [**`master_username`**](#master_username) &mdash; The value to use for the master username of the database. This can also be provided via AWS Secrets Manager. See the description of [`db_config_secrets_manager_id`](#db_config_secrets_manager_id). A value here overrides the value in [`db_config_secrets_manager_id`](#db_config_secrets_manager_id).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="port" className="snap-top"></a>
+<HclListItem name="enable_share_snapshot_cloudwatch_alarms" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`port`**](#port) &mdash; The port the DB will listen on (e.g. 3306). This can also be provided via AWS Secrets Manager. See the description of [`db_config_secrets_manager_id`](#db_config_secrets_manager_id). A value here overrides the value in [`db_config_secrets_manager_id`](#db_config_secrets_manager_id).
+When true, enable CloudWatch alarms for the manual snapshots created for the purpose of sharing with another account. Only used if <a href="#share_snapshot_with_another_account"><code>share_snapshot_with_another_account</code></a> is true.
 
-<a name="publicly_accessible" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`publicly_accessible`**](#publicly_accessible) &mdash; If you wish to make your database accessible from the public Internet, set this flag to true (WARNING: NOT RECOMMENDED FOR REGULAR USAGE!!). The default is false, which means the database is only accessible from within the VPC, which is much more secure. This flag MUST be false for serverless mode.
+<HclListItem name="enabled_cloudwatch_logs_exports" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="restore_source_cluster_identifier" className="snap-top"></a>
+If non-empty, the Aurora cluster will export the specified logs to Cloudwatch. Must be zero or more of: audit, error, general and slowquery
 
-* [**`restore_source_cluster_identifier`**](#restore_source_cluster_identifier) &mdash; If non-empty, the Aurora cluster will be restored from the given source cluster using the latest restorable time. Can only be used if [`snapshot_identifier`](#snapshot_identifier) is null. For more information see [`https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_PIT`](#https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_PIT).html
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="restore_type" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`restore_type`**](#restore_type) &mdash; Only used if [`'restore_source_cluster_identifier`](#'restore_source_cluster_identifier)' is non-empty. Type of restore to be performed. Valid options are 'full-copy' and 'copy-on-write'. https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Managing.Clone.html
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="scaling_configuration_auto_pause" className="snap-top"></a>
+<HclListItem name="engine" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`scaling_configuration_auto_pause`**](#scaling_configuration_auto_pause) &mdash; Whether to enable automatic pause. A DB cluster can be paused only when it's idle (it has no connections). If a DB cluster is paused for more than seven days, the DB cluster might be backed up with a snapshot. In this case, the DB cluster is restored when there is a request to connect to it. Only used when [`engine_mode`](#engine_mode) is set to serverless.
+The name of the database engine to be used for this DB cluster. Valid Values: aurora (for MySQL 5.6-compatible Aurora), aurora-mysql (for MySQL 5.7-compatible Aurora), and aurora-postgresql. This can also be provided via AWS Secrets Manager. See the description of db_config_secrets_manager_id. A value here overrides the value in db_config_secrets_manager_id.
 
-<a name="scaling_configuration_max_capacity" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`scaling_configuration_max_capacity`**](#scaling_configuration_max_capacity) &mdash; The maximum capacity. The maximum capacity must be greater than or equal to the minimum capacity. Valid capacity values are 2, 4, 8, 16, 32, 64, 128, and 256. Only used when [`engine_mode`](#engine_mode) is set to serverless.
+<HclListItem name="engine_mode" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="scaling_configuration_min_capacity" className="snap-top"></a>
+The version of aurora to run - provisioned or serverless.
 
-* [**`scaling_configuration_min_capacity`**](#scaling_configuration_min_capacity) &mdash; The minimum capacity. The minimum capacity must be lesser than or equal to the maximum capacity. Valid capacity values are 2, 4, 8, 16, 32, 64, 128, and 256. Only used when [`engine_mode`](#engine_mode) is set to serverless.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="provisioned"/>
+</HclListItem>
 
-<a name="scaling_configuration_seconds_until_auto_pause" className="snap-top"></a>
+<HclListItem name="engine_version" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`scaling_configuration_seconds_until_auto_pause`**](#scaling_configuration_seconds_until_auto_pause) &mdash; The time, in seconds, before an Aurora DB cluster in serverless mode is paused. Valid values are 300 through 86400. Only used when [`engine_mode`](#engine_mode) is set to serverless.
+The Amazon Aurora DB engine version for the selected engine and engine_mode. Note: Starting with Aurora MySQL 2.03.2, Aurora engine versions have the following syntax &lt;mysql-major-version>.mysql_aurora.&lt;aurora-mysql-version>. e.g. 5.7.mysql_aurora.2.08.1.
 
-<a name="share_snapshot_max_snapshots" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`share_snapshot_max_snapshots`**](#share_snapshot_max_snapshots) &mdash; The maximum number of snapshots to keep around for the purpose of cross account sharing. Once this number is exceeded, a lambda function will delete the oldest snapshots. Only used if [`share_snapshot_with_another_account`](#share_snapshot_with_another_account) is true.
+<HclListItem name="high_cpu_utilization_period" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="share_snapshot_schedule_expression" className="snap-top"></a>
+The period, in seconds, over which to measure the CPU utilization percentage.
 
-* [**`share_snapshot_schedule_expression`**](#share_snapshot_schedule_expression) &mdash; An expression that defines how often to run the lambda function to take snapshots for the purpose of cross account sharing. For example, cron(0 20 * * ? *) or rate(5 minutes). Required if [`share_snapshot_with_another_account`](#share_snapshot_with_another_account) is true
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="60"/>
+</HclListItem>
 
-<a name="share_snapshot_with_account_id" className="snap-top"></a>
+<HclListItem name="high_cpu_utilization_threshold" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`share_snapshot_with_account_id`**](#share_snapshot_with_account_id) &mdash; The ID of the AWS Account that the snapshot should be shared with. Required if [`share_snapshot_with_another_account`](#share_snapshot_with_another_account) is true.
+Trigger an alarm if the DB instance has a CPU utilization percentage above this threshold.
 
-<a name="share_snapshot_with_another_account" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="90"/>
+</HclListItem>
 
-* [**`share_snapshot_with_another_account`**](#share_snapshot_with_another_account) &mdash; If set to true, take periodic snapshots of the Aurora DB that should be shared with another account.
+<HclListItem name="high_read_latency_period" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="skip_final_snapshot" className="snap-top"></a>
+The period, in seconds, over which to measure the read latency.
 
-* [**`skip_final_snapshot`**](#skip_final_snapshot) &mdash; Determines whether a final DB snapshot is created before the DB instance is deleted. Be very careful setting this to true; if you do, and you delete this DB instance, you will not have any backups of the data! You almost never want to set this to true, unless you are doing automated or manual testing.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="60"/>
+</HclListItem>
 
-<a name="snapshot_identifier" className="snap-top"></a>
+<HclListItem name="high_read_latency_threshold" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`snapshot_identifier`**](#snapshot_identifier) &mdash; If non-null, the RDS Instance will be restored from the given Snapshot ID. This is the Snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05.
+Trigger an alarm if the DB instance read latency (average amount of time taken per disk I/O operation), in seconds, is above this threshold.
 
-<a name="storage_encrypted" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="5"/>
+</HclListItem>
 
-* [**`storage_encrypted`**](#storage_encrypted) &mdash; Specifies whether the DB cluster uses encryption for data at rest in the underlying storage for the DB, its automated backups, Read Replicas, and snapshots. Uses the default aws/rds key in KMS.
+<HclListItem name="high_write_latency_period" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="too_many_db_connections_threshold" className="snap-top"></a>
+The period, in seconds, over which to measure the write latency.
 
-* [**`too_many_db_connections_threshold`**](#too_many_db_connections_threshold) &mdash; Trigger an alarm if the number of connections to the DB instance goes above this threshold.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="60"/>
+</HclListItem>
+
+<HclListItem name="high_write_latency_threshold" requirement="optional" type="number">
+<HclListItemDescription>
+
+Trigger an alarm if the DB instance write latency (average amount of time taken per disk I/O operation), in seconds, is above this threshold.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="5"/>
+</HclListItem>
+
+<HclListItem name="iam_database_authentication_enabled" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Specifies whether mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled. Disabled by default.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="instance_count" requirement="optional" type="number">
+<HclListItemDescription>
+
+The number of DB instances, including the primary, to run in the RDS cluster. Only used when <a href="#engine_mode"><code>engine_mode</code></a> is set to provisioned.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1"/>
+</HclListItem>
+
+<HclListItem name="instance_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+The instance type to use for the db (e.g. db.r3.large). Only used when <a href="#engine_mode"><code>engine_mode</code></a> is set to provisioned.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="db.t3.small"/>
+</HclListItem>
+
+<HclListItem name="kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ARN of a KMS key that should be used to encrypt data on disk. Only used if <a href="#storage_encrypted"><code>storage_encrypted</code></a> is true. If you leave this null, the default RDS KMS key for the account will be used.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="low_disk_space_available_period" requirement="optional" type="number">
+<HclListItemDescription>
+
+The period, in seconds, over which to measure the available free disk space.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="60"/>
+</HclListItem>
+
+<HclListItem name="low_disk_space_available_threshold" requirement="optional" type="number">
+<HclListItemDescription>
+
+Trigger an alarm if the amount of disk space, in Bytes, on the DB instance drops below this threshold.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1000000000"/>
+</HclListItem>
+
+<HclListItem name="low_memory_available_period" requirement="optional" type="number">
+<HclListItemDescription>
+
+The period, in seconds, over which to measure the available free memory.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="60"/>
+</HclListItem>
+
+<HclListItem name="low_memory_available_threshold" requirement="optional" type="number">
+<HclListItemDescription>
+
+Trigger an alarm if the amount of free memory, in Bytes, on the DB instance drops below this threshold.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="100000000"/>
+</HclListItem>
+
+<HclListItem name="master_password" requirement="optional" type="string">
+<HclListItemDescription>
+
+The value to use for the master password of the database. This can also be provided via AWS Secrets Manager. See the description of db_config_secrets_manager_id. A value here overrides the value in db_config_secrets_manager_id.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="master_username" requirement="optional" type="string">
+<HclListItemDescription>
+
+The value to use for the master username of the database. This can also be provided via AWS Secrets Manager. See the description of db_config_secrets_manager_id. A value here overrides the value in db_config_secrets_manager_id.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="port" requirement="optional" type="number">
+<HclListItemDescription>
+
+The port the DB will listen on (e.g. 3306). This can also be provided via AWS Secrets Manager. See the description of db_config_secrets_manager_id. A value here overrides the value in db_config_secrets_manager_id.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="publicly_accessible" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If you wish to make your database accessible from the public Internet, set this flag to true (WARNING: NOT RECOMMENDED FOR REGULAR USAGE!!). The default is false, which means the database is only accessible from within the VPC, which is much more secure. This flag MUST be false for serverless mode.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="restore_source_cluster_identifier" requirement="optional" type="string">
+<HclListItemDescription>
+
+If non-empty, the Aurora cluster will be restored from the given source cluster using the latest restorable time. Can only be used if snapshot_identifier is null. For more information see https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_PIT.html
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="restore_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+Only used if 'restore_source_cluster_identifier' is non-empty. Type of restore to be performed. Valid options are 'full-copy' and 'copy-on-write'. https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Managing.Clone.html
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="scaling_configuration_auto_pause" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Whether to enable automatic pause. A DB cluster can be paused only when it's idle (it has no connections). If a DB cluster is paused for more than seven days, the DB cluster might be backed up with a snapshot. In this case, the DB cluster is restored when there is a request to connect to it. Only used when <a href="#engine_mode"><code>engine_mode</code></a> is set to serverless.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="scaling_configuration_max_capacity" requirement="optional" type="number">
+<HclListItemDescription>
+
+The maximum capacity. The maximum capacity must be greater than or equal to the minimum capacity. Valid capacity values are 2, 4, 8, 16, 32, 64, 128, and 256. Only used when <a href="#engine_mode"><code>engine_mode</code></a> is set to serverless.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="256"/>
+</HclListItem>
+
+<HclListItem name="scaling_configuration_min_capacity" requirement="optional" type="number">
+<HclListItemDescription>
+
+The minimum capacity. The minimum capacity must be lesser than or equal to the maximum capacity. Valid capacity values are 2, 4, 8, 16, 32, 64, 128, and 256. Only used when <a href="#engine_mode"><code>engine_mode</code></a> is set to serverless.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="2"/>
+</HclListItem>
+
+<HclListItem name="scaling_configuration_seconds_until_auto_pause" requirement="optional" type="number">
+<HclListItemDescription>
+
+The time, in seconds, before an Aurora DB cluster in serverless mode is paused. Valid values are 300 through 86400. Only used when <a href="#engine_mode"><code>engine_mode</code></a> is set to serverless.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="300"/>
+</HclListItem>
+
+<HclListItem name="share_snapshot_max_snapshots" requirement="optional" type="number">
+<HclListItemDescription>
+
+The maximum number of snapshots to keep around for the purpose of cross account sharing. Once this number is exceeded, a lambda function will delete the oldest snapshots. Only used if <a href="#share_snapshot_with_another_account"><code>share_snapshot_with_another_account</code></a> is true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="30"/>
+</HclListItem>
+
+<HclListItem name="share_snapshot_schedule_expression" requirement="optional" type="string">
+<HclListItemDescription>
+
+An expression that defines how often to run the lambda function to take snapshots for the purpose of cross account sharing. For example, cron(0 20 * * ? *) or rate(5 minutes). Required if <a href="#share_snapshot_with_another_account"><code>share_snapshot_with_another_account</code></a> is true
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="share_snapshot_with_account_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ID of the AWS Account that the snapshot should be shared with. Required if <a href="#share_snapshot_with_another_account"><code>share_snapshot_with_another_account</code></a> is true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="share_snapshot_with_another_account" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If set to true, take periodic snapshots of the Aurora DB that should be shared with another account.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="skip_final_snapshot" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Determines whether a final DB snapshot is created before the DB instance is deleted. Be very careful setting this to true; if you do, and you delete this DB instance, you will not have any backups of the data! You almost never want to set this to true, unless you are doing automated or manual testing.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="snapshot_identifier" requirement="optional" type="string">
+<HclListItemDescription>
+
+If non-null, the RDS Instance will be restored from the given Snapshot ID. This is the Snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="storage_encrypted" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Specifies whether the DB cluster uses encryption for data at rest in the underlying storage for the DB, its automated backups, Read Replicas, and snapshots. Uses the default aws/rds key in KMS.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="too_many_db_connections_threshold" requirement="optional" type="number">
+<HclListItemDescription>
+
+Trigger an alarm if the number of connections to the DB instance goes above this threshold.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="all_metric_widgets" className="snap-top"></a>
+<HclListItem name="all_metric_widgets">
+<HclListItemDescription>
 
-* [**`all_metric_widgets`**](#all_metric_widgets) &mdash; A list of all the CloudWatch Dashboard metric widgets available in this module.
+A list of all the CloudWatch Dashboard metric widgets available in this module.
 
-<a name="cleanup_snapshots_lambda_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cleanup_snapshots_lambda_arn`**](#cleanup_snapshots_lambda_arn) &mdash; The ARN of the AWS Lambda Function used for cleaning up manual snapshots taken for sharing with secondary accounts.
+<HclListItem name="cleanup_snapshots_lambda_arn">
+<HclListItemDescription>
 
-<a name="cluster_arn" className="snap-top"></a>
+The ARN of the AWS Lambda Function used for cleaning up manual snapshots taken for sharing with secondary accounts.
 
-* [**`cluster_arn`**](#cluster_arn) &mdash; The ARN of the RDS Aurora cluster.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="cluster_id" className="snap-top"></a>
+<HclListItem name="cluster_arn">
+<HclListItemDescription>
 
-* [**`cluster_id`**](#cluster_id) &mdash; The ID of the RDS Aurora cluster (e.g TODO).
+The ARN of the RDS Aurora cluster.
 
-<a name="cluster_resource_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cluster_resource_id`**](#cluster_resource_id) &mdash; The unique resource ID assigned to the cluster e.g. cluster-POBCBQUFQC56EBAAWXGFJ77GRU. This is useful for allowing database authentication via IAM.
+<HclListItem name="cluster_id">
+<HclListItemDescription>
 
-<a name="create_snapshot_lambda_arn" className="snap-top"></a>
+The ID of the RDS Aurora cluster (e.g TODO).
 
-* [**`create_snapshot_lambda_arn`**](#create_snapshot_lambda_arn) &mdash; The ARN of the AWS Lambda Function used for periodically taking snapshots to share with secondary accounts.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="instance_endpoints" className="snap-top"></a>
+<HclListItem name="cluster_resource_id">
+<HclListItemDescription>
 
-* [**`instance_endpoints`**](#instance_endpoints) &mdash; A list of endpoints of the RDS instances that you can use to make requests to.
+The unique resource ID assigned to the cluster e.g. cluster-POBCBQUFQC56EBAAWXGFJ77GRU. This is useful for allowing database authentication via IAM.
 
-<a name="metric_widget_aurora_cpu_usage" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`metric_widget_aurora_cpu_usage`**](#metric_widget_aurora_cpu_usage) &mdash; A CloudWatch Dashboard widget that graphs CPU usage (percentage) of the Aurora cluster.
+<HclListItem name="create_snapshot_lambda_arn">
+<HclListItemDescription>
 
-<a name="metric_widget_aurora_db_connections" className="snap-top"></a>
+The ARN of the AWS Lambda Function used for periodically taking snapshots to share with secondary accounts.
 
-* [**`metric_widget_aurora_db_connections`**](#metric_widget_aurora_db_connections) &mdash; A CloudWatch Dashboard widget that graphs the number of active database connections of the Aurora cluster.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="metric_widget_aurora_disk_space" className="snap-top"></a>
+<HclListItem name="instance_endpoints">
+<HclListItemDescription>
 
-* [**`metric_widget_aurora_disk_space`**](#metric_widget_aurora_disk_space) &mdash; A CloudWatch Dashboard widget that graphs available disk space (in bytes) on the Aurora cluster.
+A list of endpoints of the RDS instances that you can use to make requests to.
 
-<a name="metric_widget_aurora_memory" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`metric_widget_aurora_memory`**](#metric_widget_aurora_memory) &mdash; A CloudWatch Dashboard widget that graphs available memory (in bytes) on the Aurora cluster.
+<HclListItem name="metric_widget_aurora_cpu_usage">
+<HclListItemDescription>
 
-<a name="metric_widget_aurora_read_latency" className="snap-top"></a>
+A CloudWatch Dashboard widget that graphs CPU usage (percentage) of the Aurora cluster.
 
-* [**`metric_widget_aurora_read_latency`**](#metric_widget_aurora_read_latency) &mdash; A CloudWatch Dashboard widget that graphs the average amount of time taken per disk I/O operation on reads.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="metric_widget_aurora_write_latency" className="snap-top"></a>
+<HclListItem name="metric_widget_aurora_db_connections">
+<HclListItemDescription>
 
-* [**`metric_widget_aurora_write_latency`**](#metric_widget_aurora_write_latency) &mdash; A CloudWatch Dashboard widget that graphs the average amount of time taken per disk I/O operation on writes.
+A CloudWatch Dashboard widget that graphs the number of active database connections of the Aurora cluster.
 
-<a name="port" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`port`**](#port) &mdash; The port used by the RDS Aurora cluster for handling database connections.
+<HclListItem name="metric_widget_aurora_disk_space">
+<HclListItemDescription>
 
-<a name="primary_endpoint" className="snap-top"></a>
+A CloudWatch Dashboard widget that graphs available disk space (in bytes) on the Aurora cluster.
 
-* [**`primary_endpoint`**](#primary_endpoint) &mdash; The primary endpoint of the RDS Aurora cluster that you can use to make requests to.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="primary_host" className="snap-top"></a>
+<HclListItem name="metric_widget_aurora_memory">
+<HclListItemDescription>
 
-* [**`primary_host`**](#primary_host) &mdash; The host portion of the Aurora endpoint. [`primary_endpoint`](#primary_endpoint) is in the form '&lt;host>:&lt;port>', and this output returns just the host part.
+A CloudWatch Dashboard widget that graphs available memory (in bytes) on the Aurora cluster.
 
-<a name="reader_endpoint" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`reader_endpoint`**](#reader_endpoint) &mdash; A read-only endpoint for the Aurora cluster, automatically load-balanced across replicas.
+<HclListItem name="metric_widget_aurora_read_latency">
+<HclListItemDescription>
 
-<a name="share_snapshot_lambda_arn" className="snap-top"></a>
+A CloudWatch Dashboard widget that graphs the average amount of time taken per disk I/O operation on reads.
 
-* [**`share_snapshot_lambda_arn`**](#share_snapshot_lambda_arn) &mdash; The ARN of the AWS Lambda Function used for sharing manual snapshots with secondary accounts.
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="metric_widget_aurora_write_latency">
+<HclListItemDescription>
+
+A CloudWatch Dashboard widget that graphs the average amount of time taken per disk I/O operation on writes.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="port">
+<HclListItemDescription>
+
+The port used by the RDS Aurora cluster for handling database connections.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="primary_endpoint">
+<HclListItemDescription>
+
+The primary endpoint of the RDS Aurora cluster that you can use to make requests to.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="primary_host">
+<HclListItemDescription>
+
+The host portion of the Aurora endpoint. primary_endpoint is in the form '&lt;host>:&lt;port>', and this output returns just the host part.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="reader_endpoint">
+<HclListItemDescription>
+
+A read-only endpoint for the Aurora cluster, automatically load-balanced across replicas.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="share_snapshot_lambda_arn">
+<HclListItemDescription>
+
+The ARN of the AWS Lambda Function used for sharing manual snapshots with secondary accounts.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"f5c0d2ebbed681c2ab8858138b24bd85"}
+{"sourcePlugin":"service-catalog-api","hash":"161908d41c4aa19eaf96827706de0fb4"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/data-storage/amazon-ecr-repositories.md
+++ b/docs/reference/services/data-storage/amazon-ecr-repositories.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.68.3"/>
 
@@ -79,67 +80,177 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="repositories" className="snap-top"></a>
+<HclListItem name="repositories" requirement="required" type="any">
+<HclListItemDescription>
 
-* [**`repositories`**](#repositories) &mdash; A map of repo names to configurations for that repository.
+A map of repo names to configurations for that repository.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="default_automatic_image_scanning" className="snap-top"></a>
+<HclListItem name="default_automatic_image_scanning" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`default_automatic_image_scanning`**](#default_automatic_image_scanning) &mdash; Whether or not to enable image scanning on all the repos. Can be overridden on a per repo basis by the [`enable_automatic_image_scanning`](#enable_automatic_image_scanning) property in the repositories map.
+Whether or not to enable image scanning on all the repos. Can be overridden on a per repo basis by the enable_automatic_image_scanning property in the repositories map.
 
-<a name="default_encryption_config" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`default_encryption_config`**](#default_encryption_config) &mdash; The default encryption configuration to apply to the created ECR repository. When null, the images in the ECR repo will not be encrypted at rest. Can be overridden on a per repo basis by the [`encryption_config`](#encryption_config) property in the repositories map.
+<HclListItem name="default_encryption_config" requirement="optional" type="object">
+<HclListItemDescription>
 
-<a name="default_external_account_ids_with_read_access" className="snap-top"></a>
+The default encryption configuration to apply to the created ECR repository. When null, the images in the ECR repo will not be encrypted at rest. Can be overridden on a per repo basis by the encryption_config property in the repositories map.
 
-* [**`default_external_account_ids_with_read_access`**](#default_external_account_ids_with_read_access) &mdash; The default list of AWS account IDs for external AWS accounts that should be able to pull images from these ECR repos. Can be overridden on a per repo basis by the [`external_account_ids_with_read_access`](#external_account_ids_with_read_access) property in the repositories map.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="default_external_account_ids_with_write_access" className="snap-top"></a>
+```hcl
+object({
+    # The encryption type to use for the repository. Must be AES256 or KMS.
+    encryption_type = string
+    # The KMS key to use for encrypting the images. Only used when encryption_type is KMS. If not specified, defaults to
+    # the default AWS managed key for ECR.
+    kms_key = string
+  })
+```
 
-* [**`default_external_account_ids_with_write_access`**](#default_external_account_ids_with_write_access) &mdash; The default list of AWS account IDs for external AWS accounts that should be able to pull and push images to these ECR repos. Can be overridden on a per repo basis by the [`external_account_ids_with_write_access`](#external_account_ids_with_write_access) property in the repositories map.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-<a name="default_image_tag_mutability" className="snap-top"></a>
+```hcl
+{
+  encryption_type = "AES256",
+  kms_key = null
+}
+```
 
-* [**`default_image_tag_mutability`**](#default_image_tag_mutability) &mdash; The tag mutability setting for all the repos. Must be one of: MUTABLE or IMMUTABLE. Can be overridden on a per repo basis by the [`image_tag_mutability`](#image_tag_mutability) property in the repositories map.
+</HclListItemDefaultValue>
+</HclListItem>
 
-<a name="default_lifecycle_policy_rules" className="snap-top"></a>
+<HclListItem name="default_external_account_ids_with_read_access" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`default_lifecycle_policy_rules`**](#default_lifecycle_policy_rules) &mdash; Add lifecycle policy to ECR repo.
+The default list of AWS account IDs for external AWS accounts that should be able to pull images from these ECR repos. Can be overridden on a per repo basis by the external_account_ids_with_read_access property in the repositories map.
 
-<a name="global_tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`global_tags`**](#global_tags) &mdash; A map of tags (where the key and value correspond to tag keys and values) that should be assigned to all ECR repositories.
+```hcl
+list(string)
+```
 
-<a name="replication_regions" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`replication_regions`**](#replication_regions) &mdash; List of regions (e.g., us-east-1) to replicate the ECR repository to.
+<HclListItem name="default_external_account_ids_with_write_access" requirement="optional" type="list">
+<HclListItemDescription>
+
+The default list of AWS account IDs for external AWS accounts that should be able to pull and push images to these ECR repos. Can be overridden on a per repo basis by the external_account_ids_with_write_access property in the repositories map.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="default_image_tag_mutability" requirement="optional" type="string">
+<HclListItemDescription>
+
+The tag mutability setting for all the repos. Must be one of: MUTABLE or IMMUTABLE. Can be overridden on a per repo basis by the image_tag_mutability property in the repositories map.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="MUTABLE"/>
+</HclListItem>
+
+<HclListItem name="default_lifecycle_policy_rules" requirement="optional" type="any">
+<HclListItemDescription>
+
+Add lifecycle policy to ECR repo.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="global_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of tags (where the key and value correspond to tag keys and values) that should be assigned to all ECR repositories.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="replication_regions" requirement="optional" type="list">
+<HclListItemDescription>
+
+List of regions (e.g., us-east-1) to replicate the ECR repository to.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="ecr_read_policy_actions" className="snap-top"></a>
+<HclListItem name="ecr_read_policy_actions">
+<HclListItemDescription>
 
-* [**`ecr_read_policy_actions`**](#ecr_read_policy_actions) &mdash; A list of IAM policy actions necessary for ECR read access.
+A list of IAM policy actions necessary for ECR read access.
 
-<a name="ecr_repo_arns" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`ecr_repo_arns`**](#ecr_repo_arns) &mdash; A map of repository name to its ECR ARN.
+<HclListItem name="ecr_repo_arns">
+<HclListItemDescription>
 
-<a name="ecr_repo_urls" className="snap-top"></a>
+A map of repository name to its ECR ARN.
 
-* [**`ecr_repo_urls`**](#ecr_repo_urls) &mdash; A map of repository name to its URL.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="ecr_write_policy_actions" className="snap-top"></a>
+<HclListItem name="ecr_repo_urls">
+<HclListItemDescription>
 
-* [**`ecr_write_policy_actions`**](#ecr_write_policy_actions) &mdash; A list of IAM policy actions necessary for ECR write access.
+A map of repository name to its URL.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="ecr_write_policy_actions">
+<HclListItemDescription>
+
+A list of IAM policy actions necessary for ECR write access.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"b95ec45644e4ac48d54d49ad86b64a03"}
+{"sourcePlugin":"service-catalog-api","hash":"dea900e55d8be9e6806e7f35ce2ccdc7"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/data-storage/amazon-elasti-cache-for-memcached.md
+++ b/docs/reference/services/data-storage/amazon-elasti-cache-for-memcached.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -84,91 +85,203 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="az_mode" className="snap-top"></a>
+<HclListItem name="az_mode" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`az_mode`**](#az_mode) &mdash; Specifies whether the nodes in this Memcached node group are created in a single Availability Zone or created across multiple Availability Zones in the cluster's region. Valid values for this parameter are single-az or cross-az. If you want to choose cross-az, [`num_cache_nodes`](#num_cache_nodes) must be greater than 1.
+Specifies whether the nodes in this Memcached node group are created in a single Availability Zone or created across multiple Availability Zones in the cluster's region. Valid values for this parameter are single-az or cross-az. If you want to choose cross-az, num_cache_nodes must be greater than 1.
 
-<a name="instance_type" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`instance_type`**](#instance_type) &mdash; The compute and memory capacity of the nodes (e.g. cache.m4.large).
+<HclListItem name="instance_type" requirement="required" type="string">
+<HclListItemDescription>
 
-<a name="name" className="snap-top"></a>
+The compute and memory capacity of the nodes (e.g. cache.m4.large).
 
-* [**`name`**](#name) &mdash; The name used to namespace all resources created by these templates, including the ElastiCache cluster itself. Must be unique in this region. Must be a lowercase string.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="num_cache_nodes" className="snap-top"></a>
+<HclListItem name="name" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`num_cache_nodes`**](#num_cache_nodes) &mdash; The initial number of cache nodes that the cache cluster will have. Must be between 1 and 20.
+The name used to namespace all resources created by these templates, including the ElastiCache cluster itself. Must be unique in this region. Must be a lowercase string.
 
-<a name="subnet_ids" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`subnet_ids`**](#subnet_ids) &mdash; The list of IDs of the subnets in which to deploy the ElasticCache instances. The list must only contain subnets in [`vpc_id`](#vpc_id).
+<HclListItem name="num_cache_nodes" requirement="required" type="number">
+<HclListItemDescription>
 
-<a name="vpc_id" className="snap-top"></a>
+The initial number of cache nodes that the cache cluster will have. Must be between 1 and 20.
 
-* [**`vpc_id`**](#vpc_id) &mdash; The ID of the VPC in which to deploy RDS.
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="subnet_ids" requirement="required" type="list">
+<HclListItemDescription>
+
+The list of IDs of the subnets in which to deploy the ElasticCache instances. The list must only contain subnets in <a href="#vpc_id"><code>vpc_id</code></a>.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="vpc_id" requirement="required" type="string">
+<HclListItemDescription>
+
+The ID of the VPC in which to deploy RDS.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="alarms_sns_topic_arns" className="snap-top"></a>
+<HclListItem name="alarms_sns_topic_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`alarms_sns_topic_arns`**](#alarms_sns_topic_arns) &mdash; The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications.
+The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications.
 
-<a name="allow_connections_from_cidr_blocks" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`allow_connections_from_cidr_blocks`**](#allow_connections_from_cidr_blocks) &mdash; The list of network CIDR blocks to allow network access to ElastiCache from. One of [`allow_connections_from_cidr_blocks`](#allow_connections_from_cidr_blocks) or [`allow_connections_from_security_groups`](#allow_connections_from_security_groups) must be specified for the ElastiCache instances to be reachable.
+```hcl
+list(string)
+```
 
-<a name="allow_connections_from_security_groups" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`allow_connections_from_security_groups`**](#allow_connections_from_security_groups) &mdash; The list of IDs or Security Groups to allow network access to ElastiCache from. All security groups must either be in the VPC specified by [`vpc_id`](#vpc_id), or a peered VPC with the VPC specified by [`vpc_id`](#vpc_id). One of [`allow_connections_from_cidr_blocks`](#allow_connections_from_cidr_blocks) or [`allow_connections_from_security_groups`](#allow_connections_from_security_groups) must be specified for the ElastiCache instances to be reachable.
+<HclListItem name="allow_connections_from_cidr_blocks" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="apply_immediately" className="snap-top"></a>
+The list of network CIDR blocks to allow network access to ElastiCache from. One of <a href="#allow_connections_from_cidr_blocks"><code>allow_connections_from_cidr_blocks</code></a> or <a href="#allow_connections_from_security_groups"><code>allow_connections_from_security_groups</code></a> must be specified for the ElastiCache instances to be reachable.
 
-* [**`apply_immediately`**](#apply_immediately) &mdash; Specifies whether any database modifications are applied immediately, or during the next maintenance window.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="enable_cloudwatch_alarms" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`enable_cloudwatch_alarms`**](#enable_cloudwatch_alarms) &mdash; Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using [`alarms_sns_topic_arn`](#alarms_sns_topic_arn).
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="maintenance_window" className="snap-top"></a>
+<HclListItem name="allow_connections_from_security_groups" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`maintenance_window`**](#maintenance_window) &mdash; Specifies the weekly time range for when maintenance on the cache cluster is performed (e.g. sun:05:00-sun:09:00). The format is ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.
+The list of IDs or Security Groups to allow network access to ElastiCache from. All security groups must either be in the VPC specified by <a href="#vpc_id"><code>vpc_id</code></a>, or a peered VPC with the VPC specified by <a href="#vpc_id"><code>vpc_id</code></a>. One of <a href="#allow_connections_from_cidr_blocks"><code>allow_connections_from_cidr_blocks</code></a> or <a href="#allow_connections_from_security_groups"><code>allow_connections_from_security_groups</code></a> must be specified for the ElastiCache instances to be reachable.
 
-<a name="memcached_version" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`memcached_version`**](#memcached_version) &mdash; Version number of memcached to use (e.g. 1.5.16).
+```hcl
+list(string)
+```
 
-<a name="port" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`port`**](#port) &mdash; The port number on which each of the cache nodes will accept connections (e.g. 11211).
+<HclListItem name="apply_immediately" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Specifies whether any database modifications are applied immediately, or during the next maintenance window.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="enable_cloudwatch_alarms" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using <a href="#alarms_sns_topic_arn"><code>alarms_sns_topic_arn</code></a>.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="maintenance_window" requirement="optional" type="string">
+<HclListItemDescription>
+
+Specifies the weekly time range for when maintenance on the cache cluster is performed (e.g. sun:05:00-sun:09:00). The format is ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="sat:07:00-sat:08:00"/>
+</HclListItem>
+
+<HclListItem name="memcached_version" requirement="optional" type="string">
+<HclListItemDescription>
+
+Version number of memcached to use (e.g. 1.5.16).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1.5.16"/>
+</HclListItem>
+
+<HclListItem name="port" requirement="optional" type="number">
+<HclListItemDescription>
+
+The port number on which each of the cache nodes will accept connections (e.g. 11211).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="11211"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="cache_addresses" className="snap-top"></a>
+<HclListItem name="cache_addresses">
+<HclListItemDescription>
 
-* [**`cache_addresses`**](#cache_addresses) &mdash; The list of addresses of the Memcached nodes without the port appended.
+The list of addresses of the Memcached nodes without the port appended.
 
-<a name="cache_cluster_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cache_cluster_id`**](#cache_cluster_id) &mdash; The id of the ElastiCache Memcached cluster.
+<HclListItem name="cache_cluster_id">
+<HclListItemDescription>
 
-<a name="cache_node_ids" className="snap-top"></a>
+The id of the ElastiCache Memcached cluster.
 
-* [**`cache_node_ids`**](#cache_node_ids) &mdash; The list of the AWS cache cluster node ids where each one represents a Memcached node.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="cache_port" className="snap-top"></a>
+<HclListItem name="cache_node_ids">
+<HclListItemDescription>
 
-* [**`cache_port`**](#cache_port) &mdash; The port number on which each of the cache nodes will accept connections (e.g. 11211).
+The list of the AWS cache cluster node ids where each one represents a Memcached node.
 
-<a name="configuration_endpoint" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`configuration_endpoint`**](#configuration_endpoint) &mdash; The configuration endpoint to allow host discovery.
+<HclListItem name="cache_port">
+<HclListItemDescription>
+
+The port number on which each of the cache nodes will accept connections (e.g. 11211).
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="configuration_endpoint">
+<HclListItemDescription>
+
+The configuration endpoint to allow host discovery.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"406ff8847a0204698f21bb80403a1697"}
+{"sourcePlugin":"service-catalog-api","hash":"95f37c3eb2dd14f3ea383551ad5ce7b7"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/data-storage/amazon-elasti-cache-for-redis.md
+++ b/docs/reference/services/data-storage/amazon-elasti-cache-for-redis.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -87,143 +88,335 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="enable_automatic_failover" className="snap-top"></a>
+<HclListItem name="enable_automatic_failover" requirement="required" type="bool">
+<HclListItemDescription>
 
-* [**`enable_automatic_failover`**](#enable_automatic_failover) &mdash; Indicates whether Multi-AZ is enabled. When Multi-AZ is enabled, a read-only replica is automatically promoted to a read-write primary cluster if the existing primary cluster fails. If you specify true, you must specify a value greater than 1 for [`replication_group_size`](#replication_group_size).
+Indicates whether Multi-AZ is enabled. When Multi-AZ is enabled, a read-only replica is automatically promoted to a read-write primary cluster if the existing primary cluster fails. If you specify true, you must specify a value greater than 1 for replication_group_size.
 
-<a name="enable_multi_az" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`enable_multi_az`**](#enable_multi_az) &mdash; Indicates whether Multi-AZ is enabled. When Multi-AZ is enabled, a read-only replica is automatically promoted to a read-write primary cluster if the existing primary cluster fails. If you specify true, you must specify a value greater than 1 for [`replication_group_size`](#replication_group_size).
+<HclListItem name="enable_multi_az" requirement="required" type="bool">
+<HclListItemDescription>
 
-<a name="instance_type" className="snap-top"></a>
+Indicates whether Multi-AZ is enabled. When Multi-AZ is enabled, a read-only replica is automatically promoted to a read-write primary cluster if the existing primary cluster fails. If you specify true, you must specify a value greater than 1 for replication_group_size.
 
-* [**`instance_type`**](#instance_type) &mdash; The compute and memory capacity of the nodes (e.g. cache.m4.large).
+</HclListItemDescription>
+</HclListItem>
 
-<a name="name" className="snap-top"></a>
+<HclListItem name="instance_type" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`name`**](#name) &mdash; The name used to namespace all resources created by these templates, including the ElastiCache cluster itself (e.g. rediscache). Must be unique in this region. Must be a lowercase string.
+The compute and memory capacity of the nodes (e.g. cache.m4.large).
 
-<a name="replication_group_size" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`replication_group_size`**](#replication_group_size) &mdash; The total number of nodes in the Redis Replication Group. E.g. 1 represents just the primary node, 2 represents the primary plus a single Read Replica.
+<HclListItem name="name" requirement="required" type="string">
+<HclListItemDescription>
 
-<a name="subnet_ids" className="snap-top"></a>
+The name used to namespace all resources created by these templates, including the ElastiCache cluster itself (e.g. rediscache). Must be unique in this region. Must be a lowercase string.
 
-* [**`subnet_ids`**](#subnet_ids) &mdash; The list of IDs of the subnets in which to deploy the ElasticCache instances. The list must only contain subnets in [`vpc_id`](#vpc_id).
+</HclListItemDescription>
+</HclListItem>
 
-<a name="vpc_id" className="snap-top"></a>
+<HclListItem name="replication_group_size" requirement="required" type="number">
+<HclListItemDescription>
 
-* [**`vpc_id`**](#vpc_id) &mdash; The ID of the VPC in which to deploy RDS.
+The total number of nodes in the Redis Replication Group. E.g. 1 represents just the primary node, 2 represents the primary plus a single Read Replica.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="subnet_ids" requirement="required" type="list">
+<HclListItemDescription>
+
+The list of IDs of the subnets in which to deploy the ElasticCache instances. The list must only contain subnets in <a href="#vpc_id"><code>vpc_id</code></a>.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="vpc_id" requirement="required" type="string">
+<HclListItemDescription>
+
+The ID of the VPC in which to deploy RDS.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="alarms_sns_topic_arns" className="snap-top"></a>
+<HclListItem name="alarms_sns_topic_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`alarms_sns_topic_arns`**](#alarms_sns_topic_arns) &mdash; The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications.
+The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications.
 
-<a name="allow_connections_from_cidr_blocks" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`allow_connections_from_cidr_blocks`**](#allow_connections_from_cidr_blocks) &mdash; The list of network CIDR blocks to allow network access to ElastiCache from. One of [`allow_connections_from_cidr_blocks`](#allow_connections_from_cidr_blocks) or [`allow_connections_from_security_groups`](#allow_connections_from_security_groups) must be specified for the ElastiCache instances to be reachable.
+```hcl
+list(string)
+```
 
-<a name="allow_connections_from_security_groups" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`allow_connections_from_security_groups`**](#allow_connections_from_security_groups) &mdash; The list of IDs or Security Groups to allow network access to ElastiCache from. All security groups must either be in the VPC specified by [`vpc_id`](#vpc_id), or a peered VPC with the VPC specified by [`vpc_id`](#vpc_id). One of [`allow_connections_from_cidr_blocks`](#allow_connections_from_cidr_blocks) or [`allow_connections_from_security_groups`](#allow_connections_from_security_groups) must be specified for the ElastiCache instances to be reachable.
+<HclListItem name="allow_connections_from_cidr_blocks" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="apply_immediately" className="snap-top"></a>
+The list of network CIDR blocks to allow network access to ElastiCache from. One of <a href="#allow_connections_from_cidr_blocks"><code>allow_connections_from_cidr_blocks</code></a> or <a href="#allow_connections_from_security_groups"><code>allow_connections_from_security_groups</code></a> must be specified for the ElastiCache instances to be reachable.
 
-* [**`apply_immediately`**](#apply_immediately) &mdash; Specifies whether any modifications are applied immediately, or during the next maintenance window.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="auth_token" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`auth_token`**](#auth_token) &mdash; The password used to access a password protected server. Can be specified only if [`transit_encryption_enabled`](#transit_encryption_enabled) = true. Must contain from 16 to 128 alphanumeric characters or symbols (excluding @, &lt;double-quotes>, and /)
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="cluster_mode" className="snap-top"></a>
+<HclListItem name="allow_connections_from_security_groups" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`cluster_mode`**](#cluster_mode) &mdash; Specifies the number of shards and replicas per shard in the cluster. The list should contain a single map with keys [`'num_node_groups`](#'num_node_groups)' and [`'replicas_per_node_group`](#'replicas_per_node_group)' set to desired integer values.
+The list of IDs or Security Groups to allow network access to ElastiCache from. All security groups must either be in the VPC specified by <a href="#vpc_id"><code>vpc_id</code></a>, or a peered VPC with the VPC specified by <a href="#vpc_id"><code>vpc_id</code></a>. One of <a href="#allow_connections_from_cidr_blocks"><code>allow_connections_from_cidr_blocks</code></a> or <a href="#allow_connections_from_security_groups"><code>allow_connections_from_security_groups</code></a> must be specified for the ElastiCache instances to be reachable.
 
-<a name="enable_at_rest_encryption" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`enable_at_rest_encryption`**](#enable_at_rest_encryption) &mdash; Whether to enable encryption at rest.
+```hcl
+list(string)
+```
 
-<a name="enable_cloudwatch_alarms" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`enable_cloudwatch_alarms`**](#enable_cloudwatch_alarms) &mdash; Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using [`alarms_sns_topic_arn`](#alarms_sns_topic_arn).
+<HclListItem name="apply_immediately" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="enable_transit_encryption" className="snap-top"></a>
+Specifies whether any modifications are applied immediately, or during the next maintenance window.
 
-* [**`enable_transit_encryption`**](#enable_transit_encryption) &mdash; Whether to enable encryption in transit.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="maintenance_window" className="snap-top"></a>
+<HclListItem name="auth_token" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`maintenance_window`**](#maintenance_window) &mdash; Specifies the weekly time range for when maintenance on the cache cluster is performed (e.g. sun:05:00-sun:09:00). The format is ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.
+The password used to access a password protected server. Can be specified only if transit_encryption_enabled = true. Must contain from 16 to 128 alphanumeric characters or symbols (excluding @, &lt;double-quotes>, and /)
 
-<a name="parameter_group_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`parameter_group_name`**](#parameter_group_name) &mdash; Name of the parameter group to associate with this cache cluster. This can be used to configure custom settings for the cluster.
+<HclListItem name="cluster_mode" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="port" className="snap-top"></a>
+Specifies the number of shards and replicas per shard in the cluster. The list should contain a single map with keys 'num_node_groups' and 'replicas_per_node_group' set to desired integer values.
 
-* [**`port`**](#port) &mdash; The port number on which each of the cache nodes will accept connections (e.g. 6379).
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="redis_version" className="snap-top"></a>
+```hcl
+list(object({
+    num_node_groups         = number
+    replicas_per_node_group = number
+  }))
+```
 
-* [**`redis_version`**](#redis_version) &mdash; Version number of redis to use (e.g. 5.0.6).
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="snapshot_arn" className="snap-top"></a>
+<HclListItem name="enable_at_rest_encryption" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`snapshot_arn`**](#snapshot_arn) &mdash; The Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. You can use this parameter to restore from an externally created snapshot. If you have an ElastiCache snapshot, use [`snapshot_name`](#snapshot_name).
+Whether to enable encryption at rest.
 
-<a name="snapshot_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`snapshot_name`**](#snapshot_name) &mdash; The name of a snapshot from which to restore the Redis cluster. You can use this to restore from an ElastiCache snapshot. If you have an externally created snapshot, use [`snapshot_arn`](#snapshot_arn).
+<HclListItem name="enable_cloudwatch_alarms" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="snapshot_retention_limit" className="snap-top"></a>
+Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using <a href="#alarms_sns_topic_arn"><code>alarms_sns_topic_arn</code></a>.
 
-* [**`snapshot_retention_limit`**](#snapshot_retention_limit) &mdash; The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. Set to 0 to disable snapshots.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="snapshot_window" className="snap-top"></a>
+<HclListItem name="enable_transit_encryption" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`snapshot_window`**](#snapshot_window) &mdash; The daily time range during which automated backups are created (e.g. 04:00-09:00). Time zone is UTC. Performance may be degraded while a backup runs. Set to empty string to disable snapshots.
+Whether to enable encryption in transit.
 
-<a name="sns_topic_for_notifications" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`sns_topic_for_notifications`**](#sns_topic_for_notifications) &mdash; The ARN of the SNS Topic to which notifications will be sent when a Replication Group event happens, such as an automatic failover (e.g. [`arn:aws:sns:*:123456789012:my_sns_topic`](#arn:aws:sns:*:123456789012:my_sns_topic)). An empty string is a valid value if you do not wish to receive notifications via SNS.
+<HclListItem name="maintenance_window" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="tags" className="snap-top"></a>
+Specifies the weekly time range for when maintenance on the cache cluster is performed (e.g. sun:05:00-sun:09:00). The format is ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period.
 
-* [**`tags`**](#tags) &mdash; A set of tags to set for the ElastiCache Replication Group.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="sat:07:00-sat:08:00"/>
+</HclListItem>
+
+<HclListItem name="parameter_group_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+Name of the parameter group to associate with this cache cluster. This can be used to configure custom settings for the cluster.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="port" requirement="optional" type="number">
+<HclListItemDescription>
+
+The port number on which each of the cache nodes will accept connections (e.g. 6379).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="6379"/>
+</HclListItem>
+
+<HclListItem name="redis_version" requirement="optional" type="string">
+<HclListItemDescription>
+
+Version number of redis to use (e.g. 5.0.6).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="5.0.6"/>
+</HclListItem>
+
+<HclListItem name="snapshot_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+The Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. You can use this parameter to restore from an externally created snapshot. If you have an ElastiCache snapshot, use snapshot_name.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="snapshot_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of a snapshot from which to restore the Redis cluster. You can use this to restore from an ElastiCache snapshot. If you have an externally created snapshot, use snapshot_arn.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="snapshot_retention_limit" requirement="optional" type="number">
+<HclListItemDescription>
+
+The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. Set to 0 to disable snapshots.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="15"/>
+</HclListItem>
+
+<HclListItem name="snapshot_window" requirement="optional" type="string">
+<HclListItemDescription>
+
+The daily time range during which automated backups are created (e.g. 04:00-09:00). Time zone is UTC. Performance may be degraded while a backup runs. Set to empty string to disable snapshots.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="06:00-07:00"/>
+</HclListItem>
+
+<HclListItem name="sns_topic_for_notifications" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ARN of the SNS Topic to which notifications will be sent when a Replication Group event happens, such as an automatic failover (e.g. arn:aws:sns:*:123456789012:my_sns_topic). An empty string is a valid value if you do not wish to receive notifications via SNS.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A set of tags to set for the ElastiCache Replication Group.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="cache_cluster_ids" className="snap-top"></a>
+<HclListItem name="cache_cluster_ids">
+<HclListItemDescription>
 
-* [**`cache_cluster_ids`**](#cache_cluster_ids) &mdash; The list of AWS cache cluster ids where each one represents a Redis node.
+The list of AWS cache cluster ids where each one represents a Redis node.
 
-<a name="cache_node_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cache_node_id`**](#cache_node_id) &mdash; The id of the ElastiCache node. Note: Each Redis cache cluster has only one node and its id is always 0001.
+<HclListItem name="cache_node_id">
+<HclListItemDescription>
 
-<a name="cache_port" className="snap-top"></a>
+The id of the ElastiCache node. Note: Each Redis cache cluster has only one node and its id is always 0001.
 
-* [**`cache_port`**](#cache_port) &mdash; The port number on which each of the cache nodes will accept connections (e.g. 6379).
+</HclListItemDescription>
+</HclListItem>
 
-<a name="configuration_endpoint" className="snap-top"></a>
+<HclListItem name="cache_port">
+<HclListItemDescription>
 
-* [**`configuration_endpoint`**](#configuration_endpoint) &mdash; When cluster mode is enabled, use this endpoint for all operations. Redis will automatically determine which of the cluster's node to access.
+The port number on which each of the cache nodes will accept connections (e.g. 6379).
 
-<a name="primary_endpoint" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`primary_endpoint`**](#primary_endpoint) &mdash; The primary endpoint is a DNS name that always resolves to the primary node in the Redis cluster.
+<HclListItem name="configuration_endpoint">
+<HclListItemDescription>
 
-<a name="reader_endpoint" className="snap-top"></a>
+When cluster mode is enabled, use this endpoint for all operations. Redis will automatically determine which of the cluster's node to access.
 
-* [**`reader_endpoint`**](#reader_endpoint) &mdash; When cluster mode is disabled, use this endpoint for all read operations.
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="primary_endpoint">
+<HclListItemDescription>
+
+The primary endpoint is a DNS name that always resolves to the primary node in the Redis cluster.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="reader_endpoint">
+<HclListItemDescription>
+
+When cluster mode is disabled, use this endpoint for all read operations.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"f964117ac8af85aacacdc157916ed0d6"}
+{"sourcePlugin":"service-catalog-api","hash":"ddfa297a5f9a53507d651f9258f929b4"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/data-storage/amazon-elasticsearch.md
+++ b/docs/reference/services/data-storage/amazon-elasticsearch.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -89,191 +90,436 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="domain_name" className="snap-top"></a>
+<HclListItem name="domain_name" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`domain_name`**](#domain_name) &mdash; The name of the Elasticsearch cluster. It must be unique to your account and region, start with a lowercase letter, contain between 3 and 28 characters, and contain only lowercase letters a-z, the numbers 0-9, and the hyphen (-).
+The name of the Elasticsearch cluster. It must be unique to your account and region, start with a lowercase letter, contain between 3 and 28 characters, and contain only lowercase letters a-z, the numbers 0-9, and the hyphen (-).
 
-<a name="instance_count" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`instance_count`**](#instance_count) &mdash; The number of instances to deploy in the Elasticsearch cluster. This must be an even number if [`zone_awareness_enabled`](#zone_awareness_enabled) is true.
+<HclListItem name="instance_count" requirement="required" type="number">
+<HclListItemDescription>
 
-<a name="instance_type" className="snap-top"></a>
+The number of instances to deploy in the Elasticsearch cluster. This must be an even number if zone_awareness_enabled is true.
 
-* [**`instance_type`**](#instance_type) &mdash; The instance type to use for Elasticsearch data nodes (e.g., t2.small.elasticsearch, or m4.large.elasticsearch). For supported instance types see https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-supported-instance-types.html.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="volume_size" className="snap-top"></a>
+<HclListItem name="instance_type" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`volume_size`**](#volume_size) &mdash; The size in GiB of the EBS volume for each node in the cluster (e.g. 10, or 512). For volume size limits see https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-limits.html.
+The instance type to use for Elasticsearch data nodes (e.g., t2.small.elasticsearch, or m4.large.elasticsearch). For supported instance types see https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-supported-instance-types.html.
 
-<a name="volume_type" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`volume_type`**](#volume_type) &mdash; The type of EBS volumes to use in the cluster. Must be one of: standard, gp2, io1, sc1, or st1. For a comparison of EBS volume types, see https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ebs-volume-types.html.
+<HclListItem name="volume_size" requirement="required" type="number">
+<HclListItemDescription>
 
-<a name="zone_awareness_enabled" className="snap-top"></a>
+The size in GiB of the EBS volume for each node in the cluster (e.g. 10, or 512). For volume size limits see https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-limits.html.
 
-* [**`zone_awareness_enabled`**](#zone_awareness_enabled) &mdash; Whether to deploy the Elasticsearch nodes across two Availability Zones instead of one. Note that if you enable this, the [`instance_count`](#instance_count) MUST be an even number.
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="volume_type" requirement="required" type="string">
+<HclListItemDescription>
+
+The type of EBS volumes to use in the cluster. Must be one of: standard, gp2, io1, sc1, or st1. For a comparison of EBS volume types, see https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ebs-volume-types.html.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="zone_awareness_enabled" requirement="required" type="bool">
+<HclListItemDescription>
+
+Whether to deploy the Elasticsearch nodes across two Availability Zones instead of one. Note that if you enable this, the instance_count MUST be an even number.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="advanced_options" className="snap-top"></a>
+<HclListItem name="advanced_options" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`advanced_options`**](#advanced_options) &mdash; Key-value string pairs to specify advanced configuration options. Note that the values for these configuration options must be strings (wrapped in quotes).
+Key-value string pairs to specify advanced configuration options. Note that the values for these configuration options must be strings (wrapped in quotes).
 
-<a name="advanced_security_options" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`advanced_security_options`**](#advanced_security_options) &mdash; Enable fine grain access control
+```hcl
+map(any)
+```
 
-<a name="alarm_sns_topic_arns" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`alarm_sns_topic_arns`**](#alarm_sns_topic_arns) &mdash; ARNs of the SNS topics associated with the CloudWatch alarms for the Elasticsearch cluster.
+<HclListItem name="advanced_security_options" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="allow_connections_from_cidr_blocks" className="snap-top"></a>
+Enable fine grain access control
 
-* [**`allow_connections_from_cidr_blocks`**](#allow_connections_from_cidr_blocks) &mdash; The list of network CIDR blocks to allow network access to Aurora from. One of [`allow_connections_from_cidr_blocks`](#allow_connections_from_cidr_blocks) or [`allow_connections_from_security_groups`](#allow_connections_from_security_groups) must be specified for the database to be reachable.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="allow_connections_from_security_groups" className="snap-top"></a>
+<HclListItem name="alarm_sns_topic_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`allow_connections_from_security_groups`**](#allow_connections_from_security_groups) &mdash; The list of IDs or Security Groups to allow network access to Aurora from. All security groups must either be in the VPC specified by [`vpc_id`](#vpc_id), or a peered VPC with the VPC specified by [`vpc_id`](#vpc_id). One of [`allow_connections_from_cidr_blocks`](#allow_connections_from_cidr_blocks) or [`allow_connections_from_security_groups`](#allow_connections_from_security_groups) must be specified for the database to be reachable.
+ARNs of the SNS topics associated with the CloudWatch alarms for the Elasticsearch cluster.
 
-<a name="automated_snapshot_start_hour" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`automated_snapshot_start_hour`**](#automated_snapshot_start_hour) &mdash; Hour during which the service takes an automated daily snapshot of the indices in the domain. This setting has no effect on Elasticsearch 5.3 and later.
+```hcl
+list(string)
+```
 
-<a name="availability_zone_count" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`availability_zone_count`**](#availability_zone_count) &mdash; Number of Availability Zones for the domain to use with [`zone_awareness_enabled`](#zone_awareness_enabled). Defaults to 2. Valid values: 2 or 3.
+<HclListItem name="allow_connections_from_cidr_blocks" requirement="optional" type="set">
+<HclListItemDescription>
 
-<a name="create_service_linked_role" className="snap-top"></a>
+The list of network CIDR blocks to allow network access to Aurora from. One of <a href="#allow_connections_from_cidr_blocks"><code>allow_connections_from_cidr_blocks</code></a> or <a href="#allow_connections_from_security_groups"><code>allow_connections_from_security_groups</code></a> must be specified for the database to be reachable.
 
-* [**`create_service_linked_role`**](#create_service_linked_role) &mdash; Whether or not the Service Linked Role for Elasticsearch should be created within this module. Normally the service linked role is created automatically by AWS when creating the Elasticsearch domain in the web console, but API does not implement this logic. You can either have AWS automatically manage this by creating a domain manually in the console, or manage it in terraform using the landing zone modules or this variable.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="custom_endpoint" className="snap-top"></a>
+<HclListItem name="allow_connections_from_security_groups" requirement="optional" type="set">
+<HclListItemDescription>
 
-* [**`custom_endpoint`**](#custom_endpoint) &mdash; Fully qualified domain for your custom endpoint.
+The list of IDs or Security Groups to allow network access to Aurora from. All security groups must either be in the VPC specified by <a href="#vpc_id"><code>vpc_id</code></a>, or a peered VPC with the VPC specified by <a href="#vpc_id"><code>vpc_id</code></a>. One of <a href="#allow_connections_from_cidr_blocks"><code>allow_connections_from_cidr_blocks</code></a> or <a href="#allow_connections_from_security_groups"><code>allow_connections_from_security_groups</code></a> must be specified for the database to be reachable.
 
-<a name="custom_endpoint_certificate_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`custom_endpoint_certificate_arn`**](#custom_endpoint_certificate_arn) &mdash; ACM certificate ARN for your custom endpoint.
+<HclListItem name="automated_snapshot_start_hour" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="custom_endpoint_enabled" className="snap-top"></a>
+Hour during which the service takes an automated daily snapshot of the indices in the domain. This setting has no effect on Elasticsearch 5.3 and later.
 
-* [**`custom_endpoint_enabled`**](#custom_endpoint_enabled) &mdash; Whether to enable custom endpoint for the Elasticsearch domain.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="0"/>
+</HclListItem>
 
-<a name="custom_tags" className="snap-top"></a>
+<HclListItem name="availability_zone_count" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`custom_tags`**](#custom_tags) &mdash; A map of custom tags to apply to the ElasticSearch Domain. The key is the tag name and the value is the tag value.
+Number of Availability Zones for the domain to use with <a href="#zone_awareness_enabled"><code>zone_awareness_enabled</code></a>. Defaults to 2. Valid values: 2 or 3.
 
-<a name="dedicated_master_count" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="2"/>
+</HclListItem>
 
-* [**`dedicated_master_count`**](#dedicated_master_count) &mdash; The number of dedicated master nodes to run. We recommend setting this to 3 for production deployments. Only used if [`dedicated_master_enabled`](#dedicated_master_enabled) is true.
+<HclListItem name="create_service_linked_role" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="dedicated_master_enabled" className="snap-top"></a>
+Whether or not the Service Linked Role for Elasticsearch should be created within this module. Normally the service linked role is created automatically by AWS when creating the Elasticsearch domain in the web console, but API does not implement this logic. You can either have AWS automatically manage this by creating a domain manually in the console, or manage it in terraform using the landing zone modules or this variable.
 
-* [**`dedicated_master_enabled`**](#dedicated_master_enabled) &mdash; Whether to deploy separate nodes specifically for performing cluster management tasks (e.g. tracking number of nodes, monitoring health, replicating changes). This increases the stability of large clusters and is required for clusters with more than 10 nodes.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="dedicated_master_type" className="snap-top"></a>
+<HclListItem name="custom_endpoint" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`dedicated_master_type`**](#dedicated_master_type) &mdash; The instance type for the dedicated master nodes. These nodes can use a different instance type than the rest of the cluster. Only used if [`dedicated_master_enabled`](#dedicated_master_enabled) is true.
+Fully qualified domain for your custom endpoint.
 
-<a name="ebs_enabled" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`ebs_enabled`**](#ebs_enabled) &mdash; Set to false to disable EBS volumes. This is useful for nodes that have optimized instance storage, like hosts running the i3 instance type.
+<HclListItem name="custom_endpoint_certificate_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="elasticsearch_version" className="snap-top"></a>
+ACM certificate ARN for your custom endpoint.
 
-* [**`elasticsearch_version`**](#elasticsearch_version) &mdash; The version of Elasticsearch to deploy.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="enable_cloudwatch_alarms" className="snap-top"></a>
+<HclListItem name="custom_endpoint_enabled" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`enable_cloudwatch_alarms`**](#enable_cloudwatch_alarms) &mdash; Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using [`alarms_sns_topic_arns`](#alarms_sns_topic_arns).
+Whether to enable custom endpoint for the Elasticsearch domain.
 
-<a name="enable_encryption_at_rest" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`enable_encryption_at_rest`**](#enable_encryption_at_rest) &mdash; False by default because encryption at rest is not included in the free tier. When true, the Elasticsearch domain storage will be encrypted at rest using the KMS key described with [`encryption_kms_key_id`](#encryption_kms_key_id). We strongly recommend configuring a custom KMS key instead of using the shared service key for a better security posture when configuring encryption at rest.
+<HclListItem name="custom_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="enable_node_to_node_encryption" className="snap-top"></a>
+A map of custom tags to apply to the ElasticSearch Domain. The key is the tag name and the value is the tag value.
 
-* [**`enable_node_to_node_encryption`**](#enable_node_to_node_encryption) &mdash; Whether to enable node-to-node encryption. 
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="encryption_kms_key_id" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`encryption_kms_key_id`**](#encryption_kms_key_id) &mdash; The ID of the KMS key to use to encrypt the Elasticsearch domain storage. Only used if [`enable_encryption_at_rest`](#enable_encryption_at_rest). When null, uses the aws/es service KMS key.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="iam_principal_arns" className="snap-top"></a>
+<HclListItem name="dedicated_master_count" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`iam_principal_arns`**](#iam_principal_arns) &mdash; The ARNS of the IAM users and roles to which to allow full access to the Elasticsearch cluster. Setting this to a restricted list is useful when using a public access cluster.
+The number of dedicated master nodes to run. We recommend setting this to 3 for production deployments. Only used if <a href="#dedicated_master_enabled"><code>dedicated_master_enabled</code></a> is true.
 
-<a name="internal_user_database_enabled" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`internal_user_database_enabled`**](#internal_user_database_enabled) &mdash; Whether the internal user database is enabled. Enable this to use master accounts. Only used if [`advanced_security_options`](#advanced_security_options) is set to true.
+<HclListItem name="dedicated_master_enabled" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="iops" className="snap-top"></a>
+Whether to deploy separate nodes specifically for performing cluster management tasks (e.g. tracking number of nodes, monitoring health, replicating changes). This increases the stability of large clusters and is required for clusters with more than 10 nodes.
 
-* [**`iops`**](#iops) &mdash; The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Must be between 1000 and 4000. Applicable only if [`volume_type`](#volume_type) is io1.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="is_public" className="snap-top"></a>
+<HclListItem name="dedicated_master_type" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`is_public`**](#is_public) &mdash; Whether the cluster is publicly accessible.
+The instance type for the dedicated master nodes. These nodes can use a different instance type than the rest of the cluster. Only used if <a href="#dedicated_master_enabled"><code>dedicated_master_enabled</code></a> is true.
 
-<a name="master_user_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`master_user_arn`**](#master_user_arn) &mdash; ARN of the master user. Only used if [`advanced_security_options`](#advanced_security_options) and [`internal_user_database_enabled`](#internal_user_database_enabled) are set to true.
+<HclListItem name="ebs_enabled" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="master_user_name" className="snap-top"></a>
+Set to false to disable EBS volumes. This is useful for nodes that have optimized instance storage, like hosts running the i3 instance type.
 
-* [**`master_user_name`**](#master_user_name) &mdash; Master account user name. Only used if [`advanced_security_options`](#advanced_security_options) and [`internal_user_database_enabled`](#internal_user_database_enabled) are set to true.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="master_user_password" className="snap-top"></a>
+<HclListItem name="elasticsearch_version" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`master_user_password`**](#master_user_password) &mdash; Master account user password. Only used if [`advanced_security_options`](#advanced_security_options) and [`internal_user_database_enabled`](#internal_user_database_enabled) are set to true. WARNING: this password will be stored in Terraform state.
+The version of Elasticsearch to deploy.
 
-<a name="subnet_ids" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="7.7"/>
+</HclListItem>
 
-* [**`subnet_ids`**](#subnet_ids) &mdash;  List of VPC Subnet IDs for the Elasticsearch domain endpoints to be created in. If [`zone_awareness_enabled`](#zone_awareness_enabled) is true, the first 2 or 3 provided subnet ids are used, depending on [`availability_zone_count`](#availability_zone_count). Otherwise only the first one is used.
+<HclListItem name="enable_cloudwatch_alarms" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="tls_security_policy" className="snap-top"></a>
+Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using <a href="#alarms_sns_topic_arns"><code>alarms_sns_topic_arns</code></a>.
 
-* [**`tls_security_policy`**](#tls_security_policy) &mdash; The name of the TLS security policy that needs to be applied to the HTTPS endpoint. Valid values are Policy-Min-TLS-1-0-2019-07 and Policy-Min-TLS-1-2-2019-07. Terraform performs drift detection if this is configured.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="update_timeout" className="snap-top"></a>
+<HclListItem name="enable_encryption_at_rest" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`update_timeout`**](#update_timeout) &mdash; How long to wait for updates to the ES cluster before timing out and reporting an error.
+False by default because encryption at rest is not included in the free tier. When true, the Elasticsearch domain storage will be encrypted at rest using the KMS key described with <a href="#encryption_kms_key_id"><code>encryption_kms_key_id</code></a>. We strongly recommend configuring a custom KMS key instead of using the shared service key for a better security posture when configuring encryption at rest.
 
-<a name="vpc_id" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`vpc_id`**](#vpc_id) &mdash; The id of the VPC to deploy into. It must be in the same region as the Elasticsearch domain and its tenancy must be set to Default. If [`zone_awareness_enabled`](#zone_awareness_enabled) is false, the Elasticsearch cluster will have an endpoint in one subnet of the VPC; otherwise it will have endpoints in two subnets.
+<HclListItem name="enable_node_to_node_encryption" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Whether to enable node-to-node encryption. 
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="encryption_kms_key_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ID of the KMS key to use to encrypt the Elasticsearch domain storage. Only used if enable_encryption_at_rest. When null, uses the aws/es service KMS key.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="iam_principal_arns" requirement="optional" type="list">
+<HclListItemDescription>
+
+The ARNS of the IAM users and roles to which to allow full access to the Elasticsearch cluster. Setting this to a restricted list is useful when using a public access cluster.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[
+  '*'
+]"/>
+</HclListItem>
+
+<HclListItem name="internal_user_database_enabled" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Whether the internal user database is enabled. Enable this to use master accounts. Only used if advanced_security_options is set to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="iops" requirement="optional" type="number">
+<HclListItemDescription>
+
+The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Must be between 1000 and 4000. Applicable only if <a href="#volume_type"><code>volume_type</code></a> is io1.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="is_public" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Whether the cluster is publicly accessible.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="master_user_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+ARN of the master user. Only used if advanced_security_options and internal_user_database_enabled are set to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="master_user_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+Master account user name. Only used if advanced_security_options and internal_user_database_enabled are set to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="master_user_password" requirement="optional" type="string">
+<HclListItemDescription>
+
+Master account user password. Only used if advanced_security_options and internal_user_database_enabled are set to true. WARNING: this password will be stored in Terraform state.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="subnet_ids" requirement="optional" type="list">
+<HclListItemDescription>
+
+ List of VPC Subnet IDs for the Elasticsearch domain endpoints to be created in. If <a href="#zone_awareness_enabled"><code>zone_awareness_enabled</code></a> is true, the first 2 or 3 provided subnet ids are used, depending on <a href="#availability_zone_count"><code>availability_zone_count</code></a>. Otherwise only the first one is used.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="tls_security_policy" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of the TLS security policy that needs to be applied to the HTTPS endpoint. Valid values are Policy-Min-TLS-1-0-2019-07 and Policy-Min-TLS-1-2-2019-07. Terraform performs drift detection if this is configured.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="Policy-Min-TLS-1-2-2019-07"/>
+</HclListItem>
+
+<HclListItem name="update_timeout" requirement="optional" type="string">
+<HclListItemDescription>
+
+How long to wait for updates to the ES cluster before timing out and reporting an error.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="90m"/>
+</HclListItem>
+
+<HclListItem name="vpc_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+The id of the VPC to deploy into. It must be in the same region as the Elasticsearch domain and its tenancy must be set to Default. If zone_awareness_enabled is false, the Elasticsearch cluster will have an endpoint in one subnet of the VPC; otherwise it will have endpoints in two subnets.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="cluster_arn" className="snap-top"></a>
+<HclListItem name="cluster_arn">
+<HclListItemDescription>
 
-* [**`cluster_arn`**](#cluster_arn) &mdash; The ARN of the Elasticsearch cluster created by this module.
+The ARN of the Elasticsearch cluster created by this module.
 
-<a name="cluster_domain_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cluster_domain_id`**](#cluster_domain_id) &mdash; The domain ID of the Elasticsearch cluster created by this module.
+<HclListItem name="cluster_domain_id">
+<HclListItemDescription>
 
-<a name="cluster_domain_name" className="snap-top"></a>
+The domain ID of the Elasticsearch cluster created by this module.
 
-* [**`cluster_domain_name`**](#cluster_domain_name) &mdash; The name of the Elasticsearch domain.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="cluster_endpoint" className="snap-top"></a>
+<HclListItem name="cluster_domain_name">
+<HclListItemDescription>
 
-* [**`cluster_endpoint`**](#cluster_endpoint) &mdash; The endpoint of the Elasticsearch cluster created by this module.
+The name of the Elasticsearch domain.
 
-<a name="cluster_security_group_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cluster_security_group_id`**](#cluster_security_group_id) &mdash; If the domain was created inside a VPC, the ID of the security group created by this module for securing the Elasticsearch cluster.
+<HclListItem name="cluster_endpoint">
+<HclListItemDescription>
 
-<a name="kibana_endpoint" className="snap-top"></a>
+The endpoint of the Elasticsearch cluster created by this module.
 
-* [**`kibana_endpoint`**](#kibana_endpoint) &mdash; Domain-specific endpoint for Kibana without https scheme.
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="cluster_security_group_id">
+<HclListItemDescription>
+
+If the domain was created inside a VPC, the ID of the security group created by this module for securing the Elasticsearch cluster.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="kibana_endpoint">
+<HclListItemDescription>
+
+Domain-specific endpoint for Kibana without https scheme.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"168a4d86a686827b07df052993eab5b5"}
+{"sourcePlugin":"service-catalog-api","hash":"5f7b80df5e6af6a75de318e85eb43500"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/data-storage/amazon-rds.md
+++ b/docs/reference/services/data-storage/amazon-rds.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -91,359 +92,1010 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="allocated_storage" className="snap-top"></a>
+<HclListItem name="allocated_storage" requirement="required" type="number">
+<HclListItemDescription>
 
-* [**`allocated_storage`**](#allocated_storage) &mdash; The amount of storage space the DB should use, in GB.
+The amount of storage space the DB should use, in GB.
 
-<a name="engine_version" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`engine_version`**](#engine_version) &mdash; The version of var.engine to use (e.g. 8.0.17 for mysql).
+<HclListItem name="engine_version" requirement="required" type="string">
+<HclListItemDescription>
 
-<a name="name" className="snap-top"></a>
+The version of var.engine to use (e.g. 8.0.17 for mysql).
 
-* [**`name`**](#name) &mdash; The name used to namespace all the RDS resources created by these templates, including the cluster and cluster instances (e.g. mysql-stage). Must be unique in this region. Must be a lowercase string.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="subnet_ids" className="snap-top"></a>
+<HclListItem name="name" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`subnet_ids`**](#subnet_ids) &mdash; The list of IDs of the subnets in which to deploy RDS. The list must only contain subnets in [`vpc_id`](#vpc_id).
+The name used to namespace all the RDS resources created by these templates, including the cluster and cluster instances (e.g. mysql-stage). Must be unique in this region. Must be a lowercase string.
 
-<a name="vpc_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`vpc_id`**](#vpc_id) &mdash; The ID of the VPC in which to deploy RDS.
+<HclListItem name="subnet_ids" requirement="required" type="list">
+<HclListItemDescription>
+
+The list of IDs of the subnets in which to deploy RDS. The list must only contain subnets in <a href="#vpc_id"><code>vpc_id</code></a>.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="vpc_id" requirement="required" type="string">
+<HclListItemDescription>
+
+The ID of the VPC in which to deploy RDS.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="alarms_sns_topic_arns" className="snap-top"></a>
+<HclListItem name="alarms_sns_topic_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`alarms_sns_topic_arns`**](#alarms_sns_topic_arns) &mdash; The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications. Also used for the alarms if the share snapshot backup job fails.
+The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications. Also used for the alarms if the share snapshot backup job fails.
 
-<a name="allow_connections_from_cidr_blocks" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`allow_connections_from_cidr_blocks`**](#allow_connections_from_cidr_blocks) &mdash; The list of network CIDR blocks to allow network access to RDS from. One of [`allow_connections_from_cidr_blocks`](#allow_connections_from_cidr_blocks) or [`allow_connections_from_security_groups`](#allow_connections_from_security_groups) must be specified for the database to be reachable.
+```hcl
+list(string)
+```
 
-<a name="allow_connections_from_security_groups" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`allow_connections_from_security_groups`**](#allow_connections_from_security_groups) &mdash; The list of IDs or Security Groups to allow network access to RDS from. All security groups must either be in the VPC specified by [`vpc_id`](#vpc_id), or a peered VPC with the VPC specified by [`vpc_id`](#vpc_id). One of [`allow_connections_from_cidr_blocks`](#allow_connections_from_cidr_blocks) or [`allow_connections_from_security_groups`](#allow_connections_from_security_groups) must be specified for the database to be reachable.
+<HclListItem name="allow_connections_from_cidr_blocks" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="allow_manage_key_permissions_with_iam" className="snap-top"></a>
+The list of network CIDR blocks to allow network access to RDS from. One of <a href="#allow_connections_from_cidr_blocks"><code>allow_connections_from_cidr_blocks</code></a> or <a href="#allow_connections_from_security_groups"><code>allow_connections_from_security_groups</code></a> must be specified for the database to be reachable.
 
-* [**`allow_manage_key_permissions_with_iam`**](#allow_manage_key_permissions_with_iam) &mdash; If true, both the CMK's Key Policy and IAM Policies (permissions) can be used to grant permissions on the CMK. If false, only the CMK's Key Policy can be used to grant permissions on the CMK. False is more secure (and generally preferred), but true is more flexible and convenient.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="apply_immediately" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`apply_immediately`**](#apply_immediately) &mdash; Specifies whether any cluster modifications are applied immediately, or during the next maintenance window. Note that cluster modifications may cause degraded performance or downtime.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="backup_job_alarm_period" className="snap-top"></a>
+<HclListItem name="allow_connections_from_security_groups" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`backup_job_alarm_period`**](#backup_job_alarm_period) &mdash; How often, in seconds, the backup job is expected to run. This is the same as [`schedule_expression`](#schedule_expression), but unfortunately, Terraform offers no way to convert rate expressions to seconds. We add a CloudWatch alarm that triggers if the metric in [`create_snapshot_cloudwatch_metric_namespace`](#create_snapshot_cloudwatch_metric_namespace) isn't updated within this time period, as that indicates the backup failed to run.
+The list of IDs or Security Groups to allow network access to RDS from. All security groups must either be in the VPC specified by <a href="#vpc_id"><code>vpc_id</code></a>, or a peered VPC with the VPC specified by <a href="#vpc_id"><code>vpc_id</code></a>. One of <a href="#allow_connections_from_cidr_blocks"><code>allow_connections_from_cidr_blocks</code></a> or <a href="#allow_connections_from_security_groups"><code>allow_connections_from_security_groups</code></a> must be specified for the database to be reachable.
 
-<a name="backup_retention_period" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`backup_retention_period`**](#backup_retention_period) &mdash; How many days to keep backup snapshots around before cleaning them up. Must be 1 or greater to support read replicas.
+```hcl
+list(string)
+```
 
-<a name="backup_window" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`backup_window`**](#backup_window) &mdash; The daily time range during which automated backups are created (e.g. 04:00-09:00). Time zone is UTC. Performance may be degraded while a backup runs.
+<HclListItem name="allow_manage_key_permissions_with_iam" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="cmk_administrator_iam_arns" className="snap-top"></a>
+If true, both the CMK's Key Policy and IAM Policies (permissions) can be used to grant permissions on the CMK. If false, only the CMK's Key Policy can be used to grant permissions on the CMK. False is more secure (and generally preferred), but true is more flexible and convenient.
 
-* [**`cmk_administrator_iam_arns`**](#cmk_administrator_iam_arns) &mdash; A list of IAM ARNs for users who should be given administrator access to this CMK (e.g. arn:aws:iam::&lt;aws-account-id>:user/&lt;iam-user-arn>). If this list is empty, and [`kms_key_arn`](#kms_key_arn) is null, the ARN of the current user will be used.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="cmk_external_user_iam_arns" className="snap-top"></a>
+<HclListItem name="apply_immediately" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`cmk_external_user_iam_arns`**](#cmk_external_user_iam_arns) &mdash; A list of IAM ARNs for users from external AWS accounts who should be given permissions to use this CMK (e.g. arn:aws:iam::&lt;aws-account-id>:root).
+Specifies whether any cluster modifications are applied immediately, or during the next maintenance window. Note that cluster modifications may cause degraded performance or downtime.
 
-<a name="cmk_user_iam_arns" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`cmk_user_iam_arns`**](#cmk_user_iam_arns) &mdash; A list of IAM ARNs for users who should be given permissions to use this CMK (e.g.  arn:aws:iam::&lt;aws-account-id>:user/&lt;iam-user-arn>). If this list is empty, and [`kms_key_arn`](#kms_key_arn) is null, the ARN of the current user will be used.
+<HclListItem name="backup_job_alarm_period" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="create_custom_kms_key" className="snap-top"></a>
+How often, in seconds, the backup job is expected to run. This is the same as <a href="#schedule_expression"><code>schedule_expression</code></a>, but unfortunately, Terraform offers no way to convert rate expressions to seconds. We add a CloudWatch alarm that triggers if the metric in <a href="#create_snapshot_cloudwatch_metric_namespace"><code>create_snapshot_cloudwatch_metric_namespace</code></a> isn't updated within this time period, as that indicates the backup failed to run.
 
-* [**`create_custom_kms_key`**](#create_custom_kms_key) &mdash; If set to true, create a KMS CMK and use it to encrypt data on disk in the database. The permissions for this CMK will be assigned by the following variables: [`cmk_administrator_iam_arns`](#cmk_administrator_iam_arns), [`cmk_user_iam_arns`](#cmk_user_iam_arns), [`cmk_external_user_iam_arns`](#cmk_external_user_iam_arns), [`allow_manage_key_permissions`](#allow_manage_key_permissions).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="3600"/>
+</HclListItem>
 
-<a name="create_snapshot_cloudwatch_metric_namespace" className="snap-top"></a>
+<HclListItem name="backup_retention_period" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`create_snapshot_cloudwatch_metric_namespace`**](#create_snapshot_cloudwatch_metric_namespace) &mdash; The namespace to use for the CloudWatch metric we report every time a new RDS snapshot is created. We add a CloudWatch alarm on this metric to notify us if the backup job fails to run for any reason. Defaults to the cluster name.
+How many days to keep backup snapshots around before cleaning them up. Must be 1 or greater to support read replicas.
 
-<a name="custom_parameter_group" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="30"/>
+</HclListItem>
 
-* [**`custom_parameter_group`**](#custom_parameter_group) &mdash; Configure a custom parameter group for the RDS DB. This will create a new parameter group with the given parameters. When null, the database will be launched with the default parameter group.
+<HclListItem name="backup_window" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="custom_tags" className="snap-top"></a>
+The daily time range during which automated backups are created (e.g. 04:00-09:00). Time zone is UTC. Performance may be degraded while a backup runs.
 
-* [**`custom_tags`**](#custom_tags) &mdash; A map of custom tags to apply to the RDS Instance and the Security Group created for it. The key is the tag name and the value is the tag value.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="06:00-07:00"/>
+</HclListItem>
 
-<a name="dashboard_cpu_usage_widget_parameters" className="snap-top"></a>
+<HclListItem name="cmk_administrator_iam_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`dashboard_cpu_usage_widget_parameters`**](#dashboard_cpu_usage_widget_parameters) &mdash; Parameters for the cpu usage widget to output for use in a CloudWatch dashboard.
+A list of IAM ARNs for users who should be given administrator access to this CMK (e.g. arn:aws:iam::&lt;aws-account-id>:user/&lt;iam-user-arn>). If this list is empty, and <a href="#kms_key_arn"><code>kms_key_arn</code></a> is null, the ARN of the current user will be used.
 
-<a name="dashboard_db_connections_widget_parameters" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`dashboard_db_connections_widget_parameters`**](#dashboard_db_connections_widget_parameters) &mdash; Parameters for the database connections widget to output for use in a CloudWatch dashboard.
+```hcl
+list(string)
+```
 
-<a name="dashboard_disk_space_widget_parameters" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`dashboard_disk_space_widget_parameters`**](#dashboard_disk_space_widget_parameters) &mdash; Parameters for the available disk space widget to output for use in a CloudWatch dashboard.
+<HclListItem name="cmk_external_user_iam_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="dashboard_memory_widget_parameters" className="snap-top"></a>
+A list of IAM ARNs for users from external AWS accounts who should be given permissions to use this CMK (e.g. arn:aws:iam::&lt;aws-account-id>:root).
 
-* [**`dashboard_memory_widget_parameters`**](#dashboard_memory_widget_parameters) &mdash; Parameters for the available memory widget to output for use in a CloudWatch dashboard.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="dashboard_read_latency_widget_parameters" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`dashboard_read_latency_widget_parameters`**](#dashboard_read_latency_widget_parameters) &mdash; Parameters for the read latency widget to output for use in a CloudWatch dashboard.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="dashboard_write_latency_widget_parameters" className="snap-top"></a>
+<HclListItem name="cmk_user_iam_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`dashboard_write_latency_widget_parameters`**](#dashboard_write_latency_widget_parameters) &mdash; Parameters for the read latency widget to output for use in a CloudWatch dashboard.
+A list of IAM ARNs for users who should be given permissions to use this CMK (e.g.  arn:aws:iam::&lt;aws-account-id>:user/&lt;iam-user-arn>). If this list is empty, and <a href="#kms_key_arn"><code>kms_key_arn</code></a> is null, the ARN of the current user will be used.
 
-<a name="db_config_secrets_manager_id" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`db_config_secrets_manager_id`**](#db_config_secrets_manager_id) &mdash; The friendly name or ARN of an AWS Secrets Manager secret that contains database configuration information in the format outlined by this document: https://docs.aws.amazon.com/secretsmanager/latest/userguide/best-practices.html. The engine, username, password, dbname, and port fields must be included in the JSON. Note that even with this precaution, this information will be stored in plaintext in the Terraform state file! See the following blog post for more details: https://blog.gruntwork.io/a-comprehensive-guide-to-managing-secrets-in-your-terraform-code-1d586955ace1. If you do not wish to use Secrets Manager, leave this as null, and use the [`master_username`](#master_username), [`master_password`](#master_password), [`db_name`](#db_name), engine, and port variables.
+```hcl
+list(object({
+    name = list(string)
+    conditions = list(object({
+      test     = string
+      variable = string
+      values   = list(string)
+    }))
+  }))
+```
 
-<a name="db_name" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`db_name`**](#db_name) &mdash; The name for your database of up to 8 alpha-numeric characters. If you do not provide a name, Amazon RDS will not create an empty database on the RDS instance. This can also be provided via AWS Secrets Manager. See the description of [`db_config_secrets_manager_id`](#db_config_secrets_manager_id).
+<HclListItem name="create_custom_kms_key" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="delete_automated_backups" className="snap-top"></a>
+If set to true, create a KMS CMK and use it to encrypt data on disk in the database. The permissions for this CMK will be assigned by the following variables: cmk_administrator_iam_arns, cmk_user_iam_arns, cmk_external_user_iam_arns, allow_manage_key_permissions.
 
-* [**`delete_automated_backups`**](#delete_automated_backups) &mdash; Specifies whether to remove automated backups immediately after the DB instance is deleted
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="enable_cloudwatch_alarms" className="snap-top"></a>
+<HclListItem name="create_snapshot_cloudwatch_metric_namespace" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`enable_cloudwatch_alarms`**](#enable_cloudwatch_alarms) &mdash; Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using [`alarms_sns_topic_arn`](#alarms_sns_topic_arn).
+The namespace to use for the CloudWatch metric we report every time a new RDS snapshot is created. We add a CloudWatch alarm on this metric to notify us if the backup job fails to run for any reason. Defaults to the cluster name.
 
-<a name="enable_cloudwatch_metrics" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`enable_cloudwatch_metrics`**](#enable_cloudwatch_metrics) &mdash; When true, enable CloudWatch metrics for the manual snapshots created for the purpose of sharing with another account.
+<HclListItem name="custom_parameter_group" requirement="optional" type="object">
+<HclListItemDescription>
 
-<a name="enable_deletion_protection" className="snap-top"></a>
+Configure a custom parameter group for the RDS DB. This will create a new parameter group with the given parameters. When null, the database will be launched with the default parameter group.
 
-* [**`enable_deletion_protection`**](#enable_deletion_protection) &mdash; Enable deletion protection on the RDS instance. If this is enabled, the database cannot be deleted prior to disabling
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="enable_perf_alarms" className="snap-top"></a>
+```hcl
+object({
+    # Name of the parameter group to create
+    name = string
 
-* [**`enable_perf_alarms`**](#enable_perf_alarms) &mdash; Set to true to enable alarms related to performance, such as read and write latency alarms. Set to false to disable those alarms if you aren't sure what would be reasonable perf numbers for your RDS set up or if those numbers are too unpredictable.
+    # The family of the DB parameter group.
+    family = string
 
-<a name="enable_share_snapshot_cloudwatch_alarms" className="snap-top"></a>
+    # The parameters to configure on the created parameter group.
+    parameters = list(object({
+      # Parameter name to configure.
+      name = string
 
-* [**`enable_share_snapshot_cloudwatch_alarms`**](#enable_share_snapshot_cloudwatch_alarms) &mdash; When true, enable CloudWatch alarms for the manual snapshots created for the purpose of sharing with another account. Only used if [`share_snapshot_with_another_account`](#share_snapshot_with_another_account) is true.
+      # Vaue to set the parameter.
+      value = string
 
-<a name="enabled_cloudwatch_logs_exports" className="snap-top"></a>
+      # When to apply the parameter. "immediate" or "pending-reboot".
+      apply_method = string
+    }))
+  })
+```
 
-* [**`enabled_cloudwatch_logs_exports`**](#enabled_cloudwatch_logs_exports) &mdash; List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL) and upgrade (PostgreSQL).
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="engine" className="snap-top"></a>
+<HclListItem name="custom_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`engine`**](#engine) &mdash; The DB engine to use (e.g. mysql). This can also be provided via AWS Secrets Manager. See the description of [`db_config_secrets_manager_id`](#db_config_secrets_manager_id).
+A map of custom tags to apply to the RDS Instance and the Security Group created for it. The key is the tag name and the value is the tag value.
 
-<a name="high_cpu_utilization_period" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`high_cpu_utilization_period`**](#high_cpu_utilization_period) &mdash; The period, in seconds, over which to measure the CPU utilization percentage.
+```hcl
+map(string)
+```
 
-<a name="high_cpu_utilization_threshold" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`high_cpu_utilization_threshold`**](#high_cpu_utilization_threshold) &mdash; Trigger an alarm if the DB instance has a CPU utilization percentage above this threshold.
+<HclListItem name="dashboard_cpu_usage_widget_parameters" requirement="optional" type="object">
+<HclListItemDescription>
 
-<a name="high_read_latency_period" className="snap-top"></a>
+Parameters for the cpu usage widget to output for use in a CloudWatch dashboard.
 
-* [**`high_read_latency_period`**](#high_read_latency_period) &mdash; The period, in seconds, over which to measure the read latency.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="high_read_latency_threshold" className="snap-top"></a>
+```hcl
+object({
+    # The period in seconds for metrics to sample across.
+    period = number
 
-* [**`high_read_latency_threshold`**](#high_read_latency_threshold) &mdash; Trigger an alarm if the DB instance read latency (average amount of time taken per disk I/O operation), in seconds, is above this threshold.
+    # The width and height of the widget in grid units in a 24 column grid. E.g., a value of 12 will take up half the
+    # space.
+    width  = number
+    height = number
+  })
+```
 
-<a name="high_write_latency_period" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-* [**`high_write_latency_period`**](#high_write_latency_period) &mdash; The period, in seconds, over which to measure the write latency.
+```hcl
+{
+  height = 6,
+  period = 60,
+  width = 8
+}
+```
 
-<a name="high_write_latency_threshold" className="snap-top"></a>
+</HclListItemDefaultValue>
+</HclListItem>
 
-* [**`high_write_latency_threshold`**](#high_write_latency_threshold) &mdash; Trigger an alarm if the DB instance write latency (average amount of time taken per disk I/O operation), in seconds, is above this threshold.
+<HclListItem name="dashboard_db_connections_widget_parameters" requirement="optional" type="object">
+<HclListItemDescription>
 
-<a name="iam_database_authentication_enabled" className="snap-top"></a>
+Parameters for the database connections widget to output for use in a CloudWatch dashboard.
 
-* [**`iam_database_authentication_enabled`**](#iam_database_authentication_enabled) &mdash; Specifies whether mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled. Disabled by default.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="instance_type" className="snap-top"></a>
+```hcl
+object({
+    # The period in seconds for metrics to sample across.
+    period = number
 
-* [**`instance_type`**](#instance_type) &mdash; The instance type to use for the db (e.g. db.t3.micro)
+    # The width and height of the widget in grid units in a 24 column grid. E.g., a value of 12 will take up half the
+    # space.
+    width  = number
+    height = number
+  })
+```
 
-<a name="kms_key_arn" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-* [**`kms_key_arn`**](#kms_key_arn) &mdash; The Amazon Resource Name (ARN) of an existing KMS customer master key (CMK) that will be used to encrypt/decrypt backup files. If you leave this blank, the default RDS KMS key for the account will be used. If you set [`create_custom_kms_key`](#create_custom_kms_key) to true, this value will be ignored and a custom key will be created and used instead.
+```hcl
+{
+  height = 6,
+  period = 60,
+  width = 8
+}
+```
 
-<a name="license_model" className="snap-top"></a>
+</HclListItemDefaultValue>
+</HclListItem>
 
-* [**`license_model`**](#license_model) &mdash; The license model to use for this DB. Check the docs for your RDS DB for available license models. Set to an empty string to use the default.
+<HclListItem name="dashboard_disk_space_widget_parameters" requirement="optional" type="object">
+<HclListItemDescription>
 
-<a name="low_disk_space_available_period" className="snap-top"></a>
+Parameters for the available disk space widget to output for use in a CloudWatch dashboard.
 
-* [**`low_disk_space_available_period`**](#low_disk_space_available_period) &mdash; The period, in seconds, over which to measure the available free disk space.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="low_disk_space_available_threshold" className="snap-top"></a>
+```hcl
+object({
+    # The period in seconds for metrics to sample across.
+    period = number
 
-* [**`low_disk_space_available_threshold`**](#low_disk_space_available_threshold) &mdash; Trigger an alarm if the amount of disk space, in Bytes, on the DB instance drops below this threshold.
+    # The width and height of the widget in grid units in a 24 column grid. E.g., a value of 12 will take up half the
+    # space.
+    width  = number
+    height = number
+  })
+```
 
-<a name="low_memory_available_period" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-* [**`low_memory_available_period`**](#low_memory_available_period) &mdash; The period, in seconds, over which to measure the available free memory.
+```hcl
+{
+  height = 6,
+  period = 60,
+  width = 8
+}
+```
 
-<a name="low_memory_available_threshold" className="snap-top"></a>
+</HclListItemDefaultValue>
+</HclListItem>
 
-* [**`low_memory_available_threshold`**](#low_memory_available_threshold) &mdash; Trigger an alarm if the amount of free memory, in Bytes, on the DB instance drops below this threshold.
+<HclListItem name="dashboard_memory_widget_parameters" requirement="optional" type="object">
+<HclListItemDescription>
 
-<a name="master_password" className="snap-top"></a>
+Parameters for the available memory widget to output for use in a CloudWatch dashboard.
 
-* [**`master_password`**](#master_password) &mdash; The value to use for the master password of the database. This can also be provided via AWS Secrets Manager. See the description of [`db_config_secrets_manager_id`](#db_config_secrets_manager_id).
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="master_username" className="snap-top"></a>
+```hcl
+object({
+    # The period in seconds for metrics to sample across.
+    period = number
 
-* [**`master_username`**](#master_username) &mdash; The value to use for the master username of the database. This can also be provided via AWS Secrets Manager. See the description of [`db_config_secrets_manager_id`](#db_config_secrets_manager_id).
+    # The width and height of the widget in grid units in a 24 column grid. E.g., a value of 12 will take up half the
+    # space.
+    width  = number
+    height = number
+  })
+```
 
-<a name="max_allocated_storage" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-* [**`max_allocated_storage`**](#max_allocated_storage) &mdash; When configured, the upper limit to which Amazon RDS can automatically scale the storage of the DB instance. Configuring this will automatically ignore differences to [`allocated_storage`](#allocated_storage). Must be greater than or equal to [`allocated_storage`](#allocated_storage) or 0 to disable Storage Autoscaling.
+```hcl
+{
+  height = 6,
+  period = 60,
+  width = 8
+}
+```
 
-<a name="multi_az" className="snap-top"></a>
+</HclListItemDefaultValue>
+</HclListItem>
 
-* [**`multi_az`**](#multi_az) &mdash; Specifies if a standby instance should be deployed in another availability zone. If the primary fails, this instance will automatically take over.
+<HclListItem name="dashboard_read_latency_widget_parameters" requirement="optional" type="object">
+<HclListItemDescription>
 
-<a name="num_read_replicas" className="snap-top"></a>
+Parameters for the read latency widget to output for use in a CloudWatch dashboard.
 
-* [**`num_read_replicas`**](#num_read_replicas) &mdash; The number of read replicas to deploy
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="performance_insights_enabled" className="snap-top"></a>
+```hcl
+object({
+    # The period in seconds for metrics to sample across.
+    period = number
 
-* [**`performance_insights_enabled`**](#performance_insights_enabled) &mdash; Specifies whether Performance Insights are enabled. Performance Insights can be enabled for specific versions of database engines. See https://aws.amazon.com/rds/performance-insights/ for more details.
+    # The width and height of the widget in grid units in a 24 column grid. E.g., a value of 12 will take up half the
+    # space.
+    width  = number
+    height = number
+  })
+```
 
-<a name="port" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-* [**`port`**](#port) &mdash; The port the DB will listen on (e.g. 3306). Alternatively, this can be provided via AWS Secrets Manager. See the description of [`db_config_secrets_manager_id`](#db_config_secrets_manager_id).
+```hcl
+{
+  height = 6,
+  period = 60,
+  width = 8
+}
+```
 
-<a name="publicly_accessible" className="snap-top"></a>
+</HclListItemDefaultValue>
+</HclListItem>
 
-* [**`publicly_accessible`**](#publicly_accessible) &mdash; If you wish to make your database accessible from the public Internet, set this flag to true (WARNING: NOT RECOMMENDED FOR REGULAR USAGE!!). The default is false, which means the database is only accessible from within the VPC, which is much more secure. This flag MUST be false for serverless mode.
+<HclListItem name="dashboard_write_latency_widget_parameters" requirement="optional" type="object">
+<HclListItemDescription>
 
-<a name="replica_backup_retention_period" className="snap-top"></a>
+Parameters for the read latency widget to output for use in a CloudWatch dashboard.
 
-* [**`replica_backup_retention_period`**](#replica_backup_retention_period) &mdash; How many days to keep backup snapshots around before cleaning them up on the read replicas. Must be 1 or greater to support read replicas. 0 means disable automated backups.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="share_snapshot_max_snapshots" className="snap-top"></a>
+```hcl
+object({
+    # The period in seconds for metrics to sample across.
+    period = number
 
-* [**`share_snapshot_max_snapshots`**](#share_snapshot_max_snapshots) &mdash; The maximum number of snapshots to keep around for the purpose of cross account sharing. Once this number is exceeded, a lambda function will delete the oldest snapshots. Only used if [`share_snapshot_with_another_account`](#share_snapshot_with_another_account) is true.
+    # The width and height of the widget in grid units in a 24 column grid. E.g., a value of 12 will take up half the
+    # space.
+    width  = number
+    height = number
+  })
+```
 
-<a name="share_snapshot_schedule_expression" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-* [**`share_snapshot_schedule_expression`**](#share_snapshot_schedule_expression) &mdash; An expression that defines how often to run the lambda function to take snapshots for the purpose of cross account sharing. For example, cron(0 20 * * ? *) or rate(5 minutes). Required if [`share_snapshot_with_another_account`](#share_snapshot_with_another_account) is true
+```hcl
+{
+  height = 6,
+  period = 60,
+  width = 8
+}
+```
 
-<a name="share_snapshot_with_account_id" className="snap-top"></a>
+</HclListItemDefaultValue>
+</HclListItem>
 
-* [**`share_snapshot_with_account_id`**](#share_snapshot_with_account_id) &mdash; The ID of the AWS Account that the snapshot should be shared with. Required if [`share_snapshot_with_another_account`](#share_snapshot_with_another_account) is true.
+<HclListItem name="db_config_secrets_manager_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="share_snapshot_with_another_account" className="snap-top"></a>
+The friendly name or ARN of an AWS Secrets Manager secret that contains database configuration information in the format outlined by this document: https://docs.aws.amazon.com/secretsmanager/latest/userguide/best-practices.html. The engine, username, password, dbname, and port fields must be included in the JSON. Note that even with this precaution, this information will be stored in plaintext in the Terraform state file! See the following blog post for more details: https://blog.gruntwork.io/a-comprehensive-guide-to-managing-secrets-in-your-terraform-code-1d586955ace1. If you do not wish to use Secrets Manager, leave this as null, and use the master_username, master_password, db_name, engine, and port variables.
 
-* [**`share_snapshot_with_another_account`**](#share_snapshot_with_another_account) &mdash; If set to true, take periodic snapshots of the RDS DB that should be shared with another account.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="skip_final_snapshot" className="snap-top"></a>
+<HclListItem name="db_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`skip_final_snapshot`**](#skip_final_snapshot) &mdash; Determines whether a final DB snapshot is created before the DB instance is deleted. Be very careful setting this to true; if you do, and you delete this DB instance, you will not have any backups of the data! You almost never want to set this to true, unless you are doing automated or manual testing.
+The name for your database of up to 8 alpha-numeric characters. If you do not provide a name, Amazon RDS will not create an empty database on the RDS instance. This can also be provided via AWS Secrets Manager. See the description of db_config_secrets_manager_id.
 
-<a name="snapshot_identifier" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`snapshot_identifier`**](#snapshot_identifier) &mdash; If non-null, the RDS Instance will be restored from the given Snapshot ID. This is the Snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05.
+<HclListItem name="delete_automated_backups" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="storage_encrypted" className="snap-top"></a>
+Specifies whether to remove automated backups immediately after the DB instance is deleted
 
-* [**`storage_encrypted`**](#storage_encrypted) &mdash; Specifies whether the DB instance is encrypted.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="too_many_db_connections_threshold" className="snap-top"></a>
+<HclListItem name="enable_cloudwatch_alarms" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`too_many_db_connections_threshold`**](#too_many_db_connections_threshold) &mdash; Trigger an alarm if the number of connections to the DB instance goes above this threshold.
+Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using <a href="#alarms_sns_topic_arn"><code>alarms_sns_topic_arn</code></a>.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_cloudwatch_metrics" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, enable CloudWatch metrics for the manual snapshots created for the purpose of sharing with another account.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_deletion_protection" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Enable deletion protection on the RDS instance. If this is enabled, the database cannot be deleted prior to disabling
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="enable_perf_alarms" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to enable alarms related to performance, such as read and write latency alarms. Set to false to disable those alarms if you aren't sure what would be reasonable perf numbers for your RDS set up or if those numbers are too unpredictable.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_share_snapshot_cloudwatch_alarms" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, enable CloudWatch alarms for the manual snapshots created for the purpose of sharing with another account. Only used if <a href="#share_snapshot_with_another_account"><code>share_snapshot_with_another_account</code></a> is true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enabled_cloudwatch_logs_exports" requirement="optional" type="list">
+<HclListItemDescription>
+
+List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL) and upgrade (PostgreSQL).
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="engine" requirement="optional" type="string">
+<HclListItemDescription>
+
+The DB engine to use (e.g. mysql). This can also be provided via AWS Secrets Manager. See the description of db_config_secrets_manager_id.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="high_cpu_utilization_period" requirement="optional" type="number">
+<HclListItemDescription>
+
+The period, in seconds, over which to measure the CPU utilization percentage.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="60"/>
+</HclListItem>
+
+<HclListItem name="high_cpu_utilization_threshold" requirement="optional" type="number">
+<HclListItemDescription>
+
+Trigger an alarm if the DB instance has a CPU utilization percentage above this threshold.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="90"/>
+</HclListItem>
+
+<HclListItem name="high_read_latency_period" requirement="optional" type="number">
+<HclListItemDescription>
+
+The period, in seconds, over which to measure the read latency.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="60"/>
+</HclListItem>
+
+<HclListItem name="high_read_latency_threshold" requirement="optional" type="number">
+<HclListItemDescription>
+
+Trigger an alarm if the DB instance read latency (average amount of time taken per disk I/O operation), in seconds, is above this threshold.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="5"/>
+</HclListItem>
+
+<HclListItem name="high_write_latency_period" requirement="optional" type="number">
+<HclListItemDescription>
+
+The period, in seconds, over which to measure the write latency.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="60"/>
+</HclListItem>
+
+<HclListItem name="high_write_latency_threshold" requirement="optional" type="number">
+<HclListItemDescription>
+
+Trigger an alarm if the DB instance write latency (average amount of time taken per disk I/O operation), in seconds, is above this threshold.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="5"/>
+</HclListItem>
+
+<HclListItem name="iam_database_authentication_enabled" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Specifies whether mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled. Disabled by default.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="instance_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+The instance type to use for the db (e.g. db.t3.micro)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="db.t3.micro"/>
+</HclListItem>
+
+<HclListItem name="kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+The Amazon Resource Name (ARN) of an existing KMS customer master key (CMK) that will be used to encrypt/decrypt backup files. If you leave this blank, the default RDS KMS key for the account will be used. If you set <a href="#create_custom_kms_key"><code>create_custom_kms_key</code></a> to true, this value will be ignored and a custom key will be created and used instead.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="license_model" requirement="optional" type="string">
+<HclListItemDescription>
+
+The license model to use for this DB. Check the docs for your RDS DB for available license models. Set to an empty string to use the default.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="low_disk_space_available_period" requirement="optional" type="number">
+<HclListItemDescription>
+
+The period, in seconds, over which to measure the available free disk space.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="60"/>
+</HclListItem>
+
+<HclListItem name="low_disk_space_available_threshold" requirement="optional" type="number">
+<HclListItemDescription>
+
+Trigger an alarm if the amount of disk space, in Bytes, on the DB instance drops below this threshold.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1000000000"/>
+</HclListItem>
+
+<HclListItem name="low_memory_available_period" requirement="optional" type="number">
+<HclListItemDescription>
+
+The period, in seconds, over which to measure the available free memory.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="60"/>
+</HclListItem>
+
+<HclListItem name="low_memory_available_threshold" requirement="optional" type="number">
+<HclListItemDescription>
+
+Trigger an alarm if the amount of free memory, in Bytes, on the DB instance drops below this threshold.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="100000000"/>
+</HclListItem>
+
+<HclListItem name="master_password" requirement="optional" type="string">
+<HclListItemDescription>
+
+The value to use for the master password of the database. This can also be provided via AWS Secrets Manager. See the description of db_config_secrets_manager_id.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="master_username" requirement="optional" type="string">
+<HclListItemDescription>
+
+The value to use for the master username of the database. This can also be provided via AWS Secrets Manager. See the description of db_config_secrets_manager_id.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="max_allocated_storage" requirement="optional" type="number">
+<HclListItemDescription>
+
+When configured, the upper limit to which Amazon RDS can automatically scale the storage of the DB instance. Configuring this will automatically ignore differences to allocated_storage. Must be greater than or equal to allocated_storage or 0 to disable Storage Autoscaling.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="0"/>
+</HclListItem>
+
+<HclListItem name="multi_az" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Specifies if a standby instance should be deployed in another availability zone. If the primary fails, this instance will automatically take over.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="num_read_replicas" requirement="optional" type="number">
+<HclListItemDescription>
+
+The number of read replicas to deploy
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="0"/>
+</HclListItem>
+
+<HclListItem name="performance_insights_enabled" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Specifies whether Performance Insights are enabled. Performance Insights can be enabled for specific versions of database engines. See https://aws.amazon.com/rds/performance-insights/ for more details.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="port" requirement="optional" type="number">
+<HclListItemDescription>
+
+The port the DB will listen on (e.g. 3306). Alternatively, this can be provided via AWS Secrets Manager. See the description of db_config_secrets_manager_id.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="publicly_accessible" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If you wish to make your database accessible from the public Internet, set this flag to true (WARNING: NOT RECOMMENDED FOR REGULAR USAGE!!). The default is false, which means the database is only accessible from within the VPC, which is much more secure. This flag MUST be false for serverless mode.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="replica_backup_retention_period" requirement="optional" type="number">
+<HclListItemDescription>
+
+How many days to keep backup snapshots around before cleaning them up on the read replicas. Must be 1 or greater to support read replicas. 0 means disable automated backups.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="0"/>
+</HclListItem>
+
+<HclListItem name="share_snapshot_max_snapshots" requirement="optional" type="number">
+<HclListItemDescription>
+
+The maximum number of snapshots to keep around for the purpose of cross account sharing. Once this number is exceeded, a lambda function will delete the oldest snapshots. Only used if <a href="#share_snapshot_with_another_account"><code>share_snapshot_with_another_account</code></a> is true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="30"/>
+</HclListItem>
+
+<HclListItem name="share_snapshot_schedule_expression" requirement="optional" type="string">
+<HclListItemDescription>
+
+An expression that defines how often to run the lambda function to take snapshots for the purpose of cross account sharing. For example, cron(0 20 * * ? *) or rate(5 minutes). Required if <a href="#share_snapshot_with_another_account"><code>share_snapshot_with_another_account</code></a> is true
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="share_snapshot_with_account_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ID of the AWS Account that the snapshot should be shared with. Required if <a href="#share_snapshot_with_another_account"><code>share_snapshot_with_another_account</code></a> is true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="share_snapshot_with_another_account" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If set to true, take periodic snapshots of the RDS DB that should be shared with another account.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="skip_final_snapshot" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Determines whether a final DB snapshot is created before the DB instance is deleted. Be very careful setting this to true; if you do, and you delete this DB instance, you will not have any backups of the data! You almost never want to set this to true, unless you are doing automated or manual testing.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="snapshot_identifier" requirement="optional" type="string">
+<HclListItemDescription>
+
+If non-null, the RDS Instance will be restored from the given Snapshot ID. This is the Snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="storage_encrypted" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Specifies whether the DB instance is encrypted.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="too_many_db_connections_threshold" requirement="optional" type="number">
+<HclListItemDescription>
+
+Trigger an alarm if the number of connections to the DB instance goes above this threshold.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="all_metric_widgets" className="snap-top"></a>
+<HclListItem name="all_metric_widgets">
+<HclListItemDescription>
 
-* [**`all_metric_widgets`**](#all_metric_widgets) &mdash; A list of all the CloudWatch Dashboard metric widgets available in this module.
+A list of all the CloudWatch Dashboard metric widgets available in this module.
 
-<a name="db_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`db_name`**](#db_name) &mdash; The name of the empty database created on this RDS DB instance.
+<HclListItem name="db_name">
+<HclListItemDescription>
 
-<a name="metric_widget_rds_cpu_usage" className="snap-top"></a>
+The name of the empty database created on this RDS DB instance.
 
-* [**`metric_widget_rds_cpu_usage`**](#metric_widget_rds_cpu_usage) &mdash; A CloudWatch Dashboard widget that graphs CPU usage (percentage) on the RDS DB instance.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="metric_widget_rds_db_connections" className="snap-top"></a>
+<HclListItem name="metric_widget_rds_cpu_usage">
+<HclListItemDescription>
 
-* [**`metric_widget_rds_db_connections`**](#metric_widget_rds_db_connections) &mdash; A CloudWatch Dashboard widget that graphs the number of active database connections on the RDS DB Instance.
+A CloudWatch Dashboard widget that graphs CPU usage (percentage) on the RDS DB instance.
 
-<a name="metric_widget_rds_disk_space" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`metric_widget_rds_disk_space`**](#metric_widget_rds_disk_space) &mdash; A CloudWatch Dashboard widget that graphs available disk space (in bytes) on the RDS DB instance.
+<HclListItem name="metric_widget_rds_db_connections">
+<HclListItemDescription>
 
-<a name="metric_widget_rds_memory" className="snap-top"></a>
+A CloudWatch Dashboard widget that graphs the number of active database connections on the RDS DB Instance.
 
-* [**`metric_widget_rds_memory`**](#metric_widget_rds_memory) &mdash; A CloudWatch Dashboard widget that graphs available memory (in bytes) on the RDS DB instance.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="metric_widget_rds_read_latency" className="snap-top"></a>
+<HclListItem name="metric_widget_rds_disk_space">
+<HclListItemDescription>
 
-* [**`metric_widget_rds_read_latency`**](#metric_widget_rds_read_latency) &mdash; A CloudWatch Dashboard widget that graphs the average amount of time taken per disk I/O operation on reads.
+A CloudWatch Dashboard widget that graphs available disk space (in bytes) on the RDS DB instance.
 
-<a name="metric_widget_rds_write_latency" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`metric_widget_rds_write_latency`**](#metric_widget_rds_write_latency) &mdash; A CloudWatch Dashboard widget that graphs the average amount of time taken per disk I/O operation on writes.
+<HclListItem name="metric_widget_rds_memory">
+<HclListItemDescription>
 
-<a name="name" className="snap-top"></a>
+A CloudWatch Dashboard widget that graphs available memory (in bytes) on the RDS DB instance.
 
-* [**`name`**](#name) &mdash; The name of the RDS DB instance.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="num_read_replicas" className="snap-top"></a>
+<HclListItem name="metric_widget_rds_read_latency">
+<HclListItemDescription>
 
-* [**`num_read_replicas`**](#num_read_replicas) &mdash; The number of read replicas for the RDS DB instance.
+A CloudWatch Dashboard widget that graphs the average amount of time taken per disk I/O operation on reads.
 
-<a name="port" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`port`**](#port) &mdash; The port of the RDS DB instance.
+<HclListItem name="metric_widget_rds_write_latency">
+<HclListItemDescription>
 
-<a name="primary_arn" className="snap-top"></a>
+A CloudWatch Dashboard widget that graphs the average amount of time taken per disk I/O operation on writes.
 
-* [**`primary_arn`**](#primary_arn) &mdash; The ARN of the RDS DB instance.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="primary_endpoint" className="snap-top"></a>
+<HclListItem name="name">
+<HclListItemDescription>
 
-* [**`primary_endpoint`**](#primary_endpoint) &mdash; The endpoint of the RDS DB instance that you can make requests to.
+The name of the RDS DB instance.
 
-<a name="primary_host" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`primary_host`**](#primary_host) &mdash; The host portion of the RDS DB instance endpoint. [`primary_endpoint`](#primary_endpoint) is in the form '&lt;host>:&lt;port>', and this output returns just the host part.
+<HclListItem name="num_read_replicas">
+<HclListItemDescription>
 
-<a name="primary_id" className="snap-top"></a>
+The number of read replicas for the RDS DB instance.
 
-* [**`primary_id`**](#primary_id) &mdash; The ID of the RDS DB instance.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="read_replica_arns" className="snap-top"></a>
+<HclListItem name="port">
+<HclListItemDescription>
 
-* [**`read_replica_arns`**](#read_replica_arns) &mdash; A list of ARNs of the RDS DB instance's read replicas.
+The port of the RDS DB instance.
 
-<a name="read_replica_endpoints" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`read_replica_endpoints`**](#read_replica_endpoints) &mdash; A list of endpoints of the RDS DB instance's read replicas.
+<HclListItem name="primary_arn">
+<HclListItemDescription>
 
-<a name="read_replica_ids" className="snap-top"></a>
+The ARN of the RDS DB instance.
 
-* [**`read_replica_ids`**](#read_replica_ids) &mdash; A list of IDs of the RDS DB instance's read replicas.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="security_group_id" className="snap-top"></a>
+<HclListItem name="primary_endpoint">
+<HclListItemDescription>
 
-* [**`security_group_id`**](#security_group_id) &mdash; The ID of the Security Group that controls access to the RDS DB instance.
+The endpoint of the RDS DB instance that you can make requests to.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="primary_host">
+<HclListItemDescription>
+
+The host portion of the RDS DB instance endpoint. primary_endpoint is in the form '&lt;host>:&lt;port>', and this output returns just the host part.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="primary_id">
+<HclListItemDescription>
+
+The ID of the RDS DB instance.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="read_replica_arns">
+<HclListItemDescription>
+
+A list of ARNs of the RDS DB instance's read replicas.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="read_replica_endpoints">
+<HclListItemDescription>
+
+A list of endpoints of the RDS DB instance's read replicas.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="read_replica_ids">
+<HclListItemDescription>
+
+A list of IDs of the RDS DB instance's read replicas.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="security_group_id">
+<HclListItemDescription>
+
+The ID of the Security Group that controls access to the RDS DB instance.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"229bf5de4be1ff70876c4e9facab0597"}
+{"sourcePlugin":"service-catalog-api","hash":"3870b3a6e627ef54245e01bc569fe331"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/data-storage/s-3-bucket.md
+++ b/docs/reference/services/data-storage/s-3-bucket.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.78.0"/>
 
@@ -81,159 +82,338 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="primary_bucket" className="snap-top"></a>
+<HclListItem name="primary_bucket" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`primary_bucket`**](#primary_bucket) &mdash; What to name the S3 bucket. Note that S3 bucket names must be globally unique across all AWS users!
+What to name the S3 bucket. Note that S3 bucket names must be globally unique across all AWS users!
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="access_logging_bucket" className="snap-top"></a>
+<HclListItem name="access_logging_bucket" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`access_logging_bucket`**](#access_logging_bucket) &mdash; The S3 bucket where access logs for this bucket should be stored. Set to null to disable access logging.
+The S3 bucket where access logs for this bucket should be stored. Set to null to disable access logging.
 
-<a name="access_logging_bucket_lifecycle_rules" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`access_logging_bucket_lifecycle_rules`**](#access_logging_bucket_lifecycle_rules) &mdash; The lifecycle rules for the access logs bucket. See [`lifecycle_rules`](#lifecycle_rules) for details.
+<HclListItem name="access_logging_bucket_lifecycle_rules" requirement="optional" type="any">
+<HclListItemDescription>
 
-<a name="access_logging_bucket_ownership" className="snap-top"></a>
+The lifecycle rules for the access logs bucket. See <a href="#lifecycle_rules"><code>lifecycle_rules</code></a> for details.
 
-* [**`access_logging_bucket_ownership`**](#access_logging_bucket_ownership) &mdash; Configure who will be the default owner of objects uploaded to the access logs S3 bucket: must be one of BucketOwnerPreferred (the bucket owner owns objects), ObjectWriter (the writer of each object owns that object), or null (don't configure this feature). Note that this setting only takes effect if the object is uploaded with the bucket-owner-full-control canned ACL. See https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html for more info.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="access_logging_bucket_policy_statements" className="snap-top"></a>
+<HclListItem name="access_logging_bucket_ownership" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`access_logging_bucket_policy_statements`**](#access_logging_bucket_policy_statements) &mdash; The IAM policy to apply to the S3 bucket used to store access logs. You can use this to grant read/write access. This should be a map, where each key is a unique statement ID (SID), and each value is an object that contains the parameters defined in the comment above.
+Configure who will be the default owner of objects uploaded to the access logs S3 bucket: must be one of BucketOwnerPreferred (the bucket owner owns objects), ObjectWriter (the writer of each object owns that object), or null (don't configure this feature). Note that this setting only takes effect if the object is uploaded with the bucket-owner-full-control canned ACL. See https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html for more info.
 
-<a name="access_logging_prefix" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`access_logging_prefix`**](#access_logging_prefix) &mdash; A prefix (i.e., folder path) to use for all access logs stored in [`access_logging_bucket`](#access_logging_bucket). Only used if [`access_logging_bucket`](#access_logging_bucket) is specified.
+<HclListItem name="access_logging_bucket_policy_statements" requirement="optional" type="any">
+<HclListItemDescription>
 
-<a name="bucket_kms_key_arn" className="snap-top"></a>
+The IAM policy to apply to the S3 bucket used to store access logs. You can use this to grant read/write access. This should be a map, where each key is a unique statement ID (SID), and each value is an object that contains the parameters defined in the comment above.
 
-* [**`bucket_kms_key_arn`**](#bucket_kms_key_arn) &mdash; Optional KMS key to use for encrypting data in the S3 bucket. If null, data in S3 will be encrypted using the default aws/s3 key. If provided, the key policy of the provided key must allow whoever is writing to this bucket to use that key.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="bucket_ownership" className="snap-top"></a>
+<HclListItem name="access_logging_prefix" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`bucket_ownership`**](#bucket_ownership) &mdash; Configure who will be the default owner of objects uploaded to this S3 bucket: must be one of BucketOwnerPreferred (the bucket owner owns objects), ObjectWriter (the writer of each object owns that object), or null (don't configure this feature). Note that this setting only takes effect if the object is uploaded with the bucket-owner-full-control canned ACL. See https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html for more info.
+A prefix (i.e., folder path) to use for all access logs stored in access_logging_bucket. Only used if access_logging_bucket is specified.
 
-<a name="bucket_policy_statements" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`bucket_policy_statements`**](#bucket_policy_statements) &mdash; The IAM policy to apply to this S3 bucket. You can use this to grant read/write access. This should be a map, where each key is a unique statement ID (SID), and each value is an object that contains the parameters defined in the comment above.
+<HclListItem name="bucket_kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="bucket_sse_algorithm" className="snap-top"></a>
+Optional KMS key to use for encrypting data in the S3 bucket. If null, data in S3 will be encrypted using the default aws/s3 key. If provided, the key policy of the provided key must allow whoever is writing to this bucket to use that key.
 
-* [**`bucket_sse_algorithm`**](#bucket_sse_algorithm) &mdash; The server-side encryption algorithm to use on the bucket. Valid values are AES256 and aws:kms. To disable server-side encryption, set [`enable_sse`](#enable_sse) to false.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="cors_rules" className="snap-top"></a>
+<HclListItem name="bucket_ownership" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`cors_rules`**](#cors_rules) &mdash; CORS rules to set on this S3 bucket
+Configure who will be the default owner of objects uploaded to this S3 bucket: must be one of BucketOwnerPreferred (the bucket owner owns objects), ObjectWriter (the writer of each object owns that object), or null (don't configure this feature). Note that this setting only takes effect if the object is uploaded with the bucket-owner-full-control canned ACL. See https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html for more info.
 
-<a name="enable_sse" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`enable_sse`**](#enable_sse) &mdash; Set to true to enable server-side encryption for this bucket. You can control the algorithm using [`sse_algorithm`](#sse_algorithm).
+<HclListItem name="bucket_policy_statements" requirement="optional" type="any">
+<HclListItemDescription>
 
-<a name="enable_versioning" className="snap-top"></a>
+The IAM policy to apply to this S3 bucket. You can use this to grant read/write access. This should be a map, where each key is a unique statement ID (SID), and each value is an object that contains the parameters defined in the comment above.
 
-* [**`enable_versioning`**](#enable_versioning) &mdash; Set to true to enable versioning for this bucket. If enabled, instead of overriding objects, the S3 bucket will always create a new version of each object, so all the old values are retained.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="force_destroy_logs" className="snap-top"></a>
+<HclListItem name="bucket_sse_algorithm" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`force_destroy_logs`**](#force_destroy_logs) &mdash; If set to true, when you run 'terraform destroy', delete all objects from the logs bucket so that the bucket can be destroyed without error. Warning: these objects are not recoverable so only use this if you're absolutely sure you want to permanently delete everything!
+The server-side encryption algorithm to use on the bucket. Valid values are AES256 and aws:kms. To disable server-side encryption, set <a href="#enable_sse"><code>enable_sse</code></a> to false.
 
-<a name="force_destroy_primary" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="aws:kms"/>
+</HclListItem>
 
-* [**`force_destroy_primary`**](#force_destroy_primary) &mdash; If set to true, when you run 'terraform destroy', delete all objects from the primary bucket so that the bucket can be destroyed without error. Warning: these objects are not recoverable so only use this if you're absolutely sure you want to permanently delete everything!
+<HclListItem name="cors_rules" requirement="optional" type="any">
+<HclListItemDescription>
 
-<a name="force_destroy_replica" className="snap-top"></a>
+CORS rules to set on this S3 bucket
 
-* [**`force_destroy_replica`**](#force_destroy_replica) &mdash; If set to true, when you run 'terraform destroy', delete all objects from the replica bucket so that the bucket can be destroyed without error. Warning: these objects are not recoverable so only use this if you're absolutely sure you want to permanently delete everything!
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="lifecycle_rules" className="snap-top"></a>
+<HclListItem name="enable_sse" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`lifecycle_rules`**](#lifecycle_rules) &mdash; The lifecycle rules for this S3 bucket. These can be used to change storage types or delete objects based on customizable rules. This should be a map, where each key is a unique ID for the lifecycle rule, and each value is an object that contains the parameters defined in the comment above.
+Set to true to enable server-side encryption for this bucket. You can control the algorithm using <a href="#sse_algorithm"><code>sse_algorithm</code></a>.
 
-<a name="mfa_delete" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`mfa_delete`**](#mfa_delete) &mdash; Enable MFA delete for either 'Change the versioning state of your bucket' or 'Permanently delete an object version'. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS. Only used if [`enable_versioning`](#enable_versioning) is true. For instructions on how to enable MFA Delete, check out the README from the terraform-aws-security/private-s3-bucket module.
+<HclListItem name="enable_versioning" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="replica_bucket" className="snap-top"></a>
+Set to true to enable versioning for this bucket. If enabled, instead of overriding objects, the S3 bucket will always create a new version of each object, so all the old values are retained.
 
-* [**`replica_bucket`**](#replica_bucket) &mdash; The S3 bucket that will be the replica of this bucket. Set to null to disable replication.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="replica_bucket_already_exists" className="snap-top"></a>
+<HclListItem name="force_destroy_logs" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`replica_bucket_already_exists`**](#replica_bucket_already_exists) &mdash; If set to true, replica bucket will be expected to already exist.
+If set to true, when you run 'terraform destroy', delete all objects from the logs bucket so that the bucket can be destroyed without error. Warning: these objects are not recoverable so only use this if you're absolutely sure you want to permanently delete everything!
 
-<a name="replica_bucket_lifecycle_rules" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`replica_bucket_lifecycle_rules`**](#replica_bucket_lifecycle_rules) &mdash; The lifecycle rules for the replica bucket. See [`lifecycle_rules`](#lifecycle_rules) for details.
+<HclListItem name="force_destroy_primary" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="replica_bucket_ownership" className="snap-top"></a>
+If set to true, when you run 'terraform destroy', delete all objects from the primary bucket so that the bucket can be destroyed without error. Warning: these objects are not recoverable so only use this if you're absolutely sure you want to permanently delete everything!
 
-* [**`replica_bucket_ownership`**](#replica_bucket_ownership) &mdash; Configure who will be the default owner of objects uploaded to the replica S3 bucket: must be one of BucketOwnerPreferred (the bucket owner owns objects), ObjectWriter (the writer of each object owns that object), or null (don't configure this feature). Note that this setting only takes effect if the object is uploaded with the bucket-owner-full-control canned ACL. See https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html for more info.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="replica_bucket_policy_statements" className="snap-top"></a>
+<HclListItem name="force_destroy_replica" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`replica_bucket_policy_statements`**](#replica_bucket_policy_statements) &mdash; The IAM policy to apply to the replica S3 bucket. You can use this to grant read/write access. This should be a map, where each key is a unique statement ID (SID), and each value is an object that contains the parameters defined in the comment above.
+If set to true, when you run 'terraform destroy', delete all objects from the replica bucket so that the bucket can be destroyed without error. Warning: these objects are not recoverable so only use this if you're absolutely sure you want to permanently delete everything!
 
-<a name="replica_enable_sse" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`replica_enable_sse`**](#replica_enable_sse) &mdash; Set to true to enable server-side encryption for the replica bucket. You can control the algorithm using [`replica_sse_algorithm`](#replica_sse_algorithm).
+<HclListItem name="lifecycle_rules" requirement="optional" type="any">
+<HclListItemDescription>
 
-<a name="replica_region" className="snap-top"></a>
+The lifecycle rules for this S3 bucket. These can be used to change storage types or delete objects based on customizable rules. This should be a map, where each key is a unique ID for the lifecycle rule, and each value is an object that contains the parameters defined in the comment above.
 
-* [**`replica_region`**](#replica_region) &mdash; The AWS region for the replica bucket.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="replica_sse_algorithm" className="snap-top"></a>
+<HclListItem name="mfa_delete" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`replica_sse_algorithm`**](#replica_sse_algorithm) &mdash; The server-side encryption algorithm to use on the replica bucket. Valid values are AES256 and aws:kms. To disable server-side encryption, set [`replica_enable_sse`](#replica_enable_sse) to false.
+Enable MFA delete for either 'Change the versioning state of your bucket' or 'Permanently delete an object version'. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS. Only used if enable_versioning is true. For instructions on how to enable MFA Delete, check out the README from the terraform-aws-security/private-s3-bucket module.
 
-<a name="replication_role" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`replication_role`**](#replication_role) &mdash; The ARN of the IAM role for Amazon S3 to assume when replicating objects. Only used if [`replication_bucket`](#replication_bucket) is specified.
+<HclListItem name="replica_bucket" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="replication_rules" className="snap-top"></a>
+The S3 bucket that will be the replica of this bucket. Set to null to disable replication.
 
-* [**`replication_rules`**](#replication_rules) &mdash; The rules for managing replication. Only used if [`replication_bucket`](#replication_bucket) is specified. This should be a map, where the key is a unique ID for each replication rule and the value is an object of the form explained in a comment above.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="tags" className="snap-top"></a>
+<HclListItem name="replica_bucket_already_exists" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`tags`**](#tags) &mdash; A map of tags to apply to the S3 Bucket. These tags will also be applied to the access logging and replica buckets (if any). The key is the tag name and the value is the tag value.
+If set to true, replica bucket will be expected to already exist.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="replica_bucket_lifecycle_rules" requirement="optional" type="any">
+<HclListItemDescription>
+
+The lifecycle rules for the replica bucket. See <a href="#lifecycle_rules"><code>lifecycle_rules</code></a> for details.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="replica_bucket_ownership" requirement="optional" type="string">
+<HclListItemDescription>
+
+Configure who will be the default owner of objects uploaded to the replica S3 bucket: must be one of BucketOwnerPreferred (the bucket owner owns objects), ObjectWriter (the writer of each object owns that object), or null (don't configure this feature). Note that this setting only takes effect if the object is uploaded with the bucket-owner-full-control canned ACL. See https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html for more info.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="replica_bucket_policy_statements" requirement="optional" type="any">
+<HclListItemDescription>
+
+The IAM policy to apply to the replica S3 bucket. You can use this to grant read/write access. This should be a map, where each key is a unique statement ID (SID), and each value is an object that contains the parameters defined in the comment above.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="replica_enable_sse" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to enable server-side encryption for the replica bucket. You can control the algorithm using <a href="#replica_sse_algorithm"><code>replica_sse_algorithm</code></a>.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="replica_region" requirement="optional" type="string">
+<HclListItemDescription>
+
+The AWS region for the replica bucket.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="replica_sse_algorithm" requirement="optional" type="string">
+<HclListItemDescription>
+
+The server-side encryption algorithm to use on the replica bucket. Valid values are AES256 and aws:kms. To disable server-side encryption, set <a href="#replica_enable_sse"><code>replica_enable_sse</code></a> to false.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="aws:kms"/>
+</HclListItem>
+
+<HclListItem name="replication_role" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ARN of the IAM role for Amazon S3 to assume when replicating objects. Only used if replication_bucket is specified.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="replication_rules" requirement="optional" type="any">
+<HclListItemDescription>
+
+The rules for managing replication. Only used if replication_bucket is specified. This should be a map, where the key is a unique ID for each replication rule and the value is an object of the form explained in a comment above.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of tags to apply to the S3 Bucket. These tags will also be applied to the access logging and replica buckets (if any). The key is the tag name and the value is the tag value.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="access_logging_bucket_name" className="snap-top"></a>
+<HclListItem name="access_logging_bucket_name">
+<HclListItemDescription>
 
-* [**`access_logging_bucket_name`**](#access_logging_bucket_name) &mdash; The name of the access logging S3 bucket.
+The name of the access logging S3 bucket.
 
-<a name="hosted_zone_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`hosted_zone_id`**](#hosted_zone_id) &mdash; The Route 53 Hosted Zone ID for this bucket's region.
+<HclListItem name="hosted_zone_id">
+<HclListItemDescription>
 
-<a name="primary_bucket_arn" className="snap-top"></a>
+The Route 53 Hosted Zone ID for this bucket's region.
 
-* [**`primary_bucket_arn`**](#primary_bucket_arn) &mdash; The ARN of the S3 bucket.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="primary_bucket_domain_name" className="snap-top"></a>
+<HclListItem name="primary_bucket_arn">
+<HclListItemDescription>
 
-* [**`primary_bucket_domain_name`**](#primary_bucket_domain_name) &mdash; The bucket domain name. Will be of format bucketname.s3.amazonaws.com.
+The ARN of the S3 bucket.
 
-<a name="primary_bucket_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`primary_bucket_name`**](#primary_bucket_name) &mdash; The name of the primary S3 bucket.
+<HclListItem name="primary_bucket_domain_name">
+<HclListItemDescription>
 
-<a name="primary_bucket_regional_domain_name" className="snap-top"></a>
+The bucket domain name. Will be of format bucketname.s3.amazonaws.com.
 
-* [**`primary_bucket_regional_domain_name`**](#primary_bucket_regional_domain_name) &mdash; The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="replica_bucket_name" className="snap-top"></a>
+<HclListItem name="primary_bucket_name">
+<HclListItemDescription>
 
-* [**`replica_bucket_name`**](#replica_bucket_name) &mdash; The name of the replica S3 bucket.
+The name of the primary S3 bucket.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="primary_bucket_regional_domain_name">
+<HclListItemDescription>
+
+The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="replica_bucket_name">
+<HclListItemDescription>
+
+The name of the replica S3 bucket.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"46c08e7b82b0aa404aba455fdc5faa13"}
+{"sourcePlugin":"service-catalog-api","hash":"1f1d485f80ce2fbc02dcd2406251ac51"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/landing-zone/aws-app-account-baseline-wrapper.md
+++ b/docs/reference/services/landing-zone/aws-app-account-baseline-wrapper.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -93,671 +94,1522 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="aws_account_id" className="snap-top"></a>
+<HclListItem name="aws_account_id" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`aws_account_id`**](#aws_account_id) &mdash; The AWS Account ID the template should be operated on. This avoids misconfiguration errors caused by environment variables.
+The AWS Account ID the template should be operated on. This avoids misconfiguration errors caused by environment variables.
 
-<a name="aws_region" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`aws_region`**](#aws_region) &mdash; The AWS Region to use as the global config recorder and seed region for GuardDuty.
+<HclListItem name="aws_region" requirement="required" type="string">
+<HclListItemDescription>
 
-<a name="config_opt_in_regions" className="snap-top"></a>
+The AWS Region to use as the global config recorder and seed region for GuardDuty.
 
-* [**`config_opt_in_regions`**](#config_opt_in_regions) &mdash; Creates resources in the specified regions. The best practice is to enable AWS Config in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="ebs_opt_in_regions" className="snap-top"></a>
+<HclListItem name="config_opt_in_regions" requirement="required" type="list">
+<HclListItemDescription>
 
-* [**`ebs_opt_in_regions`**](#ebs_opt_in_regions) &mdash; Creates resources in the specified regions. The best practice is to enable EBS Encryption in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for [`global_recorder_region`](#global_recorder_region) must be in this list.
+Creates resources in the specified regions. The best practice is to enable AWS Config in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions.
 
-<a name="guardduty_opt_in_regions" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`guardduty_opt_in_regions`**](#guardduty_opt_in_regions) &mdash; Creates resources in the specified regions. The best practice is to enable GuardDuty in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for [`global_recorder_region`](#global_recorder_region) must be in this list.
+```hcl
+list(string)
+```
 
-<a name="iam_access_analyzer_opt_in_regions" className="snap-top"></a>
+</HclListItemTypeDetails>
+</HclListItem>
 
-* [**`iam_access_analyzer_opt_in_regions`**](#iam_access_analyzer_opt_in_regions) &mdash; Creates resources in the specified regions. The best practice is to enable IAM Access Analyzer in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for [`global_recorder_region`](#global_recorder_region) must be in this list.
+<HclListItem name="ebs_opt_in_regions" requirement="required" type="list">
+<HclListItemDescription>
 
-<a name="kms_cmk_opt_in_regions" className="snap-top"></a>
+Creates resources in the specified regions. The best practice is to enable EBS Encryption in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for global_recorder_region must be in this list.
 
-* [**`kms_cmk_opt_in_regions`**](#kms_cmk_opt_in_regions) &mdash; Creates resources in the specified regions. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for [`global_recorder_region`](#global_recorder_region) must be in this list.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="name_prefix" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`name_prefix`**](#name_prefix) &mdash; The name used to prefix AWS Config and Cloudtrail resources, including the S3 bucket names and SNS topics used for each.
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="guardduty_opt_in_regions" requirement="required" type="list">
+<HclListItemDescription>
+
+Creates resources in the specified regions. The best practice is to enable GuardDuty in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for global_recorder_region must be in this list.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="iam_access_analyzer_opt_in_regions" requirement="required" type="list">
+<HclListItemDescription>
+
+Creates resources in the specified regions. The best practice is to enable IAM Access Analyzer in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for global_recorder_region must be in this list.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="kms_cmk_opt_in_regions" requirement="required" type="list">
+<HclListItemDescription>
+
+Creates resources in the specified regions. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for global_recorder_region must be in this list.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="name_prefix" requirement="required" type="string">
+<HclListItemDescription>
+
+The name used to prefix AWS Config and Cloudtrail resources, including the S3 bucket names and SNS topics used for each.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="additional_config_rules" className="snap-top"></a>
+<HclListItem name="additional_config_rules" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`additional_config_rules`**](#additional_config_rules) &mdash; Map of additional managed rules to add. The key is the name of the rule (e.g. ´acm-certificate-expiration-check´) and the value is an object specifying the rule details
+Map of additional managed rules to add. The key is the name of the rule (e.g. ´acm-certificate-expiration-check´) and the value is an object specifying the rule details
 
-<a name="allow_auto_deploy_from_github_actions_for_sources" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`allow_auto_deploy_from_github_actions_for_sources`**](#allow_auto_deploy_from_github_actions_for_sources) &mdash; Map of github repositories to the list of branches that are allowed to assume the IAM role. The repository should be encoded as org/repo-name (e.g., gruntwork-io/terrraform-aws-ci). Allows GitHub Actions to assume the auto deploy IAM role using an OpenID Connect Provider for the given repositories. Refer to the docs for github-actions-iam-role for more information. Note that this is mutually exclusive with [`allow_auto_deploy_from_other_account_arns`](#allow_auto_deploy_from_other_account_arns). Only used if [`enable_github_actions_access`](#enable_github_actions_access) is true. 
+```hcl
+map(object({
+    # Description of the rule
+    description : string
+    # Identifier of an available AWS Config Managed Rule to call.
+    identifier : string
+    # Trigger type of the rule, must be one of ´CONFIG_CHANGE´ or ´PERIODIC´.
+    trigger_type : string
+    # A map of input parameters for the rule. If you don't have parameters, pass in an empty map ´{}´.
+    input_parameters : map(string)
+    # Whether or not this applies to global (non-regional) resources like IAM roles. When true, these rules are disabled
+    # if var.enable_global_resource_rules is false.
+    applies_to_global_resources = bool
+  }))
+```
 
-<a name="allow_auto_deploy_from_other_account_arns" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`allow_auto_deploy_from_other_account_arns`**](#allow_auto_deploy_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed to assume the auto deploy IAM role that has the permissions in [`auto_deploy_permissions`](#auto_deploy_permissions).
+<HclListItem name="allow_auto_deploy_from_github_actions_for_sources" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="allow_billing_access_from_other_account_arns" className="snap-top"></a>
+Map of github repositories to the list of branches that are allowed to assume the IAM role. The repository should be encoded as org/repo-name (e.g., gruntwork-io/terrraform-aws-ci). Allows GitHub Actions to assume the auto deploy IAM role using an OpenID Connect Provider for the given repositories. Refer to the docs for github-actions-iam-role for more information. Note that this is mutually exclusive with <a href="#allow_auto_deploy_from_other_account_arns"><code>allow_auto_deploy_from_other_account_arns</code></a>. Only used if <a href="#enable_github_actions_access"><code>enable_github_actions_access</code></a> is true. 
 
-* [**`allow_billing_access_from_other_account_arns`**](#allow_billing_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to the billing info for this account.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="allow_cloudtrail_access_with_iam" className="snap-top"></a>
+```hcl
+map(list(string))
+```
 
-* [**`allow_cloudtrail_access_with_iam`**](#allow_cloudtrail_access_with_iam) &mdash; If true, an IAM Policy that grants access to CloudTrail will be honored. If false, only the ARNs listed in [`kms_key_user_iam_arns`](#kms_key_user_iam_arns) will have access to CloudTrail and any IAM Policy grants will be ignored. (true or false)
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="allow_dev_access_from_other_account_arns" className="snap-top"></a>
+<HclListItem name="allow_auto_deploy_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`allow_dev_access_from_other_account_arns`**](#allow_dev_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to the services in this account specified in [`dev_permitted_services`](#dev_permitted_services).
+A list of IAM ARNs from other AWS accounts that will be allowed to assume the auto deploy IAM role that has the permissions in <a href="#auto_deploy_permissions"><code>auto_deploy_permissions</code></a>.
 
-<a name="allow_full_access_from_other_account_arns" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`allow_full_access_from_other_account_arns`**](#allow_full_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to this account.
+```hcl
+list(string)
+```
 
-<a name="allow_logs_access_from_other_account_arns" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`allow_logs_access_from_other_account_arns`**](#allow_logs_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed read access to the logs in CloudTrail, AWS Config, and CloudWatch for this account. If [`cloudtrail_kms_key_arn`](#cloudtrail_kms_key_arn) is specified, will also be given permissions to decrypt with the KMS CMK that is used to encrypt CloudTrail logs.
+<HclListItem name="allow_billing_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="allow_read_only_access_from_other_account_arns" className="snap-top"></a>
+A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to the billing info for this account.
 
-* [**`allow_read_only_access_from_other_account_arns`**](#allow_read_only_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed read-only access to this account.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="allow_ssh_grunt_access_from_other_account_arns" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`allow_ssh_grunt_access_from_other_account_arns`**](#allow_ssh_grunt_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed read access to IAM groups and publish SSH keys. This is used for ssh-grunt.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="allow_support_access_from_other_account_arns" className="snap-top"></a>
+<HclListItem name="allow_cloudtrail_access_with_iam" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`allow_support_access_from_other_account_arns`**](#allow_support_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed access to AWS support for this account.
+If true, an IAM Policy that grants access to CloudTrail will be honored. If false, only the ARNs listed in <a href="#kms_key_user_iam_arns"><code>kms_key_user_iam_arns</code></a> will have access to CloudTrail and any IAM Policy grants will be ignored. (true or false)
 
-<a name="auto_deploy_permissions" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`auto_deploy_permissions`**](#auto_deploy_permissions) &mdash; A list of IAM permissions (e.g. ec2:*) that will be added to an IAM Group for doing automated deployments. NOTE: If [`should_create_iam_group_auto_deploy`](#should_create_iam_group_auto_deploy) is true, the list must have at least one element (e.g. '*').
+<HclListItem name="allow_dev_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="cloudtrail_allow_kms_describe_key_to_external_aws_accounts" className="snap-top"></a>
+A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to the services in this account specified in <a href="#dev_permitted_services"><code>dev_permitted_services</code></a>.
 
-* [**`cloudtrail_allow_kms_describe_key_to_external_aws_accounts`**](#cloudtrail_allow_kms_describe_key_to_external_aws_accounts) &mdash; Whether or not to allow kms:DescribeKey to external AWS accounts with write access to the CloudTrail bucket. This is useful during deployment so that you don't have to pass around the KMS key ARN.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="cloudtrail_cloudwatch_logs_group_name" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`cloudtrail_cloudwatch_logs_group_name`**](#cloudtrail_cloudwatch_logs_group_name) &mdash; Specify the name of the CloudWatch Logs group to publish the CloudTrail logs to. This log group exists in the current account. Set this value to `null` to avoid publishing the trail logs to the logs group. The recommended configuration for CloudTrail is (a) for each child account to aggregate its logs in an S3 bucket in a single central account, such as a logs account and (b) to also store 14 days work of logs in CloudWatch in the child account itself for local debugging.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="cloudtrail_data_logging_enabled" className="snap-top"></a>
+<HclListItem name="allow_full_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`cloudtrail_data_logging_enabled`**](#cloudtrail_data_logging_enabled) &mdash; If true, logging of data events will be enabled.
+A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to this account.
 
-<a name="cloudtrail_data_logging_include_management_events" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`cloudtrail_data_logging_include_management_events`**](#cloudtrail_data_logging_include_management_events) &mdash; Specify if you want your event selector to include management events for your trail.
+```hcl
+list(string)
+```
 
-<a name="cloudtrail_data_logging_read_write_type" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`cloudtrail_data_logging_read_write_type`**](#cloudtrail_data_logging_read_write_type) &mdash; Specify if you want your trail to log read-only events, write-only events, or all. Possible values are: ReadOnly, WriteOnly, All.
+<HclListItem name="allow_logs_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="cloudtrail_data_logging_resources" className="snap-top"></a>
+A list of IAM ARNs from other AWS accounts that will be allowed read access to the logs in CloudTrail, AWS Config, and CloudWatch for this account. If <a href="#cloudtrail_kms_key_arn"><code>cloudtrail_kms_key_arn</code></a> is specified, will also be given permissions to decrypt with the KMS CMK that is used to encrypt CloudTrail logs.
 
-* [**`cloudtrail_data_logging_resources`**](#cloudtrail_data_logging_resources) &mdash; Data resources for which to log data events. This should be a map, where each key is a data resource type, and each value is a list of data resource values. Possible values for data resource types are: AWS::S3::Object, AWS::Lambda::Function and AWS::DynamoDB::Table. See the [`'data_resource`](#'data_resource)' block within the [`'event_selector`](#'event_selector)' block of the [`'aws_cloudtrail`](#'aws_cloudtrail)' resource for context: [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail#data_resource`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail#data_resource).
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="cloudtrail_external_aws_account_ids_with_write_access" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`cloudtrail_external_aws_account_ids_with_write_access`**](#cloudtrail_external_aws_account_ids_with_write_access) &mdash; Provide a list of AWS account IDs that will be allowed to send CloudTrail logs to this account. This is only required if you are aggregating CloudTrail logs in this account (e.g., this is the logs account) from other accounts.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="cloudtrail_force_destroy" className="snap-top"></a>
+<HclListItem name="allow_read_only_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`cloudtrail_force_destroy`**](#cloudtrail_force_destroy) &mdash; If set to true, when you run 'terraform destroy', delete all objects from the bucket so that the bucket can be destroyed without error. Warning: these objects are not recoverable so only use this if you're absolutely sure you want to permanently delete everything!
+A list of IAM ARNs from other AWS accounts that will be allowed read-only access to this account.
 
-<a name="cloudtrail_kms_key_administrator_iam_arns" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`cloudtrail_kms_key_administrator_iam_arns`**](#cloudtrail_kms_key_administrator_iam_arns) &mdash; All CloudTrail Logs will be encrypted with a KMS CMK (Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. If you are aggregating CloudTrail logs and creating the CMK in this account (e.g., if this is the logs account), you MUST specify at least one IAM user (or other IAM ARN) that will be given administrator permissions for CMK, including the ability to change who can access this CMK and the extended log data it protects. If you are aggregating CloudTrail logs in another AWS account and the CMK already exists (e.g., if this is the stage or prod account), set this parameter to an empty list.
+```hcl
+list(string)
+```
 
-<a name="cloudtrail_kms_key_arn" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`cloudtrail_kms_key_arn`**](#cloudtrail_kms_key_arn) &mdash; All CloudTrail Logs will be encrypted with a KMS CMK (Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. If that CMK already exists (e.g., if this is the stage or prod account and you want to use a CMK that already exists in the logs account), set this to the ARN of that CMK. Otherwise (e.g., if this is the logs account), set this to null, and a new CMK will be created.
+<HclListItem name="allow_ssh_grunt_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="cloudtrail_kms_key_arn_is_alias" className="snap-top"></a>
+A list of IAM ARNs from other AWS accounts that will be allowed read access to IAM groups and publish SSH keys. This is used for ssh-grunt.
 
-* [**`cloudtrail_kms_key_arn_is_alias`**](#cloudtrail_kms_key_arn_is_alias) &mdash; If the [`kms_key_arn`](#kms_key_arn) provided is an alias or alias ARN, then this must be set to true so that the module will exchange the alias for a CMK ARN. Setting this to true and using aliases requires [`cloudtrail_allow_kms_describe_key_to_external_aws_accounts`](#cloudtrail_allow_kms_describe_key_to_external_aws_accounts) to also be true for multi-account scenarios.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="cloudtrail_kms_key_user_iam_arns" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`cloudtrail_kms_key_user_iam_arns`**](#cloudtrail_kms_key_user_iam_arns) &mdash; All CloudTrail Logs will be encrypted with a KMS CMK (Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. If you are aggregating CloudTrail logs and creating the CMK in this account (e.g., this is the logs account), you MUST specify at least one IAM user (or other IAM ARN) that will be given user access to this CMK, which will allow this user to read CloudTrail Logs. If you are aggregating CloudTrail logs in another AWS account and the CMK already exists, set this parameter to an empty list (e.g., if this is the stage or prod account).
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="cloudtrail_num_days_after_which_archive_log_data" className="snap-top"></a>
+<HclListItem name="allow_support_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`cloudtrail_num_days_after_which_archive_log_data`**](#cloudtrail_num_days_after_which_archive_log_data) &mdash; After this number of days, log files should be transitioned from S3 to Glacier. Enter 0 to never archive log data.
+A list of IAM ARNs from other AWS accounts that will be allowed access to AWS support for this account.
 
-<a name="cloudtrail_num_days_after_which_delete_log_data" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`cloudtrail_num_days_after_which_delete_log_data`**](#cloudtrail_num_days_after_which_delete_log_data) &mdash; After this number of days, log files should be deleted from S3. Enter 0 to never delete log data.
+```hcl
+list(string)
+```
 
-<a name="cloudtrail_num_days_to_retain_cloudwatch_logs" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`cloudtrail_num_days_to_retain_cloudwatch_logs`**](#cloudtrail_num_days_to_retain_cloudwatch_logs) &mdash; After this number of days, logs stored in CloudWatch will be deleted. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0 (default). When set to 0, logs will be retained indefinitely.
+<HclListItem name="auto_deploy_permissions" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="cloudtrail_s3_bucket_already_exists" className="snap-top"></a>
+A list of IAM permissions (e.g. ec2:*) that will be added to an IAM Group for doing automated deployments. NOTE: If <a href="#should_create_iam_group_auto_deploy"><code>should_create_iam_group_auto_deploy</code></a> is true, the list must have at least one element (e.g. '*').
 
-* [**`cloudtrail_s3_bucket_already_exists`**](#cloudtrail_s3_bucket_already_exists) &mdash; Set to false to create an S3 bucket of name [`cloudtrail_s3_bucket_name`](#cloudtrail_s3_bucket_name) in this account for storing CloudTrail logs (e.g., if this is the logs account). Set to true to assume the bucket specified in [`cloudtrail_s3_bucket_name`](#cloudtrail_s3_bucket_name) already exists in another AWS account (e.g., if this is the stage or prod account and [`cloudtrail_s3_bucket_name`](#cloudtrail_s3_bucket_name) is the name of a bucket in the logs account).
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="cloudtrail_s3_bucket_name" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`cloudtrail_s3_bucket_name`**](#cloudtrail_s3_bucket_name) &mdash; The name of the S3 Bucket where CloudTrail logs will be stored. This could be a bucket in this AWS account (e.g., if this is the logs account) or the name of a bucket in another AWS account where logs should be sent (e.g., if this is the stage or prod account and you're specifying the name of a bucket in the logs account).
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="cloudtrail_s3_mfa_delete" className="snap-top"></a>
+<HclListItem name="cloudtrail_allow_kms_describe_key_to_external_aws_accounts" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`cloudtrail_s3_mfa_delete`**](#cloudtrail_s3_mfa_delete) &mdash; Enable MFA delete for either 'Change the versioning state of your bucket' or 'Permanently delete an object version'. This setting only applies to the bucket used to storage Cloudtrail data. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS. For instructions on how to enable MFA Delete, check out the README from the terraform-aws-security/private-s3-bucket module.
+Whether or not to allow kms:DescribeKey to external AWS accounts with write access to the CloudTrail bucket. This is useful during deployment so that you don't have to pass around the KMS key ARN.
 
-<a name="cloudtrail_tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`cloudtrail_tags`**](#cloudtrail_tags) &mdash; Tags to apply to the CloudTrail resources.
+<HclListItem name="cloudtrail_cloudwatch_logs_group_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="config_aggregate_config_data_in_external_account" className="snap-top"></a>
+Specify the name of the CloudWatch Logs group to publish the CloudTrail logs to. This log group exists in the current account. Set this value to `null` to avoid publishing the trail logs to the logs group. The recommended configuration for CloudTrail is (a) for each child account to aggregate its logs in an S3 bucket in a single central account, such as a logs account and (b) to also store 14 days work of logs in CloudWatch in the child account itself for local debugging.
 
-* [**`config_aggregate_config_data_in_external_account`**](#config_aggregate_config_data_in_external_account) &mdash; Set to true to send the AWS Config data to another account (e.g., a logs account) for aggregation purposes. You must set the ID of that other account via the [`config_central_account_id`](#config_central_account_id) variable. This redundant variable has to exist because Terraform does not allow computed data in count and [`for_each`](#for_each) parameters and [`config_central_account_id`](#config_central_account_id) may be computed if its the ID of a newly-created AWS account.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="cloudtrail-logs"/>
+</HclListItem>
 
-<a name="config_central_account_id" className="snap-top"></a>
+<HclListItem name="cloudtrail_data_logging_enabled" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`config_central_account_id`**](#config_central_account_id) &mdash; If the S3 bucket and SNS topics used for AWS Config live in a different AWS account, set this variable to the ID of that account (e.g., if this is the stage or prod account, set this to the ID of the logs account). If the S3 bucket and SNS topics live in this account (e.g., this is the logs account), set this variable to null. Only used if [`config_aggregate_config_data_in_external_account`](#config_aggregate_config_data_in_external_account) is true.
+If true, logging of data events will be enabled.
 
-<a name="config_create_account_rules" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`config_create_account_rules`**](#config_create_account_rules) &mdash; Set to true to create AWS Config rules directly in this account. Set false to not create any Config rules in this account (i.e., if you created the rules at the organization level already). We recommend setting this to true to use account-level rules because org-level rules create a chicken-and-egg problem with creating new accounts.
+<HclListItem name="cloudtrail_data_logging_include_management_events" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="config_delivery_channel_kms_key_arn" className="snap-top"></a>
+Specify if you want your event selector to include management events for your trail.
 
-* [**`config_delivery_channel_kms_key_arn`**](#config_delivery_channel_kms_key_arn) &mdash; Optional KMS key to use for encrypting S3 objects on the AWS Config delivery channel for an externally managed S3 bucket. This must belong to the same region as the destination S3 bucket. If null, AWS Config will default to encrypting the delivered data with AES-256 encryption. Only used if [`should_create_s3_bucket`](#should_create_s3_bucket) is false - otherwise, [`config_s3_bucket_kms_key_arn`](#config_s3_bucket_kms_key_arn) is used.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="config_delivery_channel_kms_key_by_name" className="snap-top"></a>
+<HclListItem name="cloudtrail_data_logging_read_write_type" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`config_delivery_channel_kms_key_by_name`**](#config_delivery_channel_kms_key_by_name) &mdash; Same as [`config_delivery_channel_kms_key_arn`](#config_delivery_channel_kms_key_arn), except the value is a name of a KMS key configured with [`kms_customer_master_keys`](#kms_customer_master_keys). The module created KMS key for the delivery region (indexed by the name) will be used. Note that if both [`config_delivery_channel_kms_key_arn`](#config_delivery_channel_kms_key_arn) and [`config_delivery_channel_kms_key_by_name`](#config_delivery_channel_kms_key_by_name) are configured, the key in [`config_delivery_channel_kms_key_arn`](#config_delivery_channel_kms_key_arn) will always be used.
+Specify if you want your trail to log read-only events, write-only events, or all. Possible values are: ReadOnly, WriteOnly, All.
 
-<a name="config_force_destroy" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="All"/>
+</HclListItem>
 
-* [**`config_force_destroy`**](#config_force_destroy) &mdash; If set to true, when you run 'terraform destroy', delete all objects from the bucket so that the bucket can be destroyed without error. Warning: these objects are not recoverable so only use this if you're absolutely sure you want to permanently delete everything!
+<HclListItem name="cloudtrail_data_logging_resources" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="config_linked_accounts" className="snap-top"></a>
+Data resources for which to log data events. This should be a map, where each key is a data resource type, and each value is a list of data resource values. Possible values for data resource types are: AWS::S3::Object, AWS::Lambda::Function and AWS::DynamoDB::Table. See the 'data_resource' block within the 'event_selector' block of the 'aws_cloudtrail' resource for context: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail#data_resource.
 
-* [**`config_linked_accounts`**](#config_linked_accounts) &mdash; Provide a list of AWS account IDs that will be allowed to send AWS Config data to this account. This is only required if you are aggregating config data in this account (e.g., this is the logs account) from other accounts.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="config_num_days_after_which_archive_log_data" className="snap-top"></a>
+```hcl
+map(list(string))
+```
 
-* [**`config_num_days_after_which_archive_log_data`**](#config_num_days_after_which_archive_log_data) &mdash; After this number of days, log files should be transitioned from S3 to Glacier. Enter 0 to never archive log data.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="config_num_days_after_which_delete_log_data" className="snap-top"></a>
+<HclListItem name="cloudtrail_external_aws_account_ids_with_write_access" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`config_num_days_after_which_delete_log_data`**](#config_num_days_after_which_delete_log_data) &mdash; After this number of days, log files should be deleted from S3. Enter 0 to never delete log data.
+Provide a list of AWS account IDs that will be allowed to send CloudTrail logs to this account. This is only required if you are aggregating CloudTrail logs in this account (e.g., this is the logs account) from other accounts.
 
-<a name="config_s3_bucket_kms_key_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`config_s3_bucket_kms_key_arn`**](#config_s3_bucket_kms_key_arn) &mdash; Optional KMS key to use for encrypting S3 objects on the AWS Config bucket, when the S3 bucket is created within this module [`(var.config_should_create_s3_bucket`](#(var.config_should_create_s3_bucket) is true). For encrypting S3 objects on delivery for an externally managed S3 bucket, refer to the [`config_delivery_channel_kms_key_arn`](#config_delivery_channel_kms_key_arn) input variable. If null, data in S3 will be encrypted using the default aws/s3 key. If provided, the key policy of the provided key must permit the IAM role used by AWS Config. See https://docs.aws.amazon.com/sns/latest/dg/sns-key-management.html. Note that the KMS key must reside in the global recorder region (as configured by [`aws_region`](#aws_region)).
+```hcl
+list(string)
+```
 
-<a name="config_s3_bucket_kms_key_by_name" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`config_s3_bucket_kms_key_by_name`**](#config_s3_bucket_kms_key_by_name) &mdash; Same as [`config_s3_bucket_kms_key_arn`](#config_s3_bucket_kms_key_arn), except the value is a name of a KMS key configured with [`kms_customer_master_keys`](#kms_customer_master_keys). The module created KMS key for the global recorder region (indexed by the name) will be used. Note that if both [`config_s3_bucket_kms_key_arn`](#config_s3_bucket_kms_key_arn) and [`config_s3_bucket_kms_key_by_name`](#config_s3_bucket_kms_key_by_name) are configured, the key in [`config_s3_bucket_kms_key_arn`](#config_s3_bucket_kms_key_arn) will always be used.
+<HclListItem name="cloudtrail_force_destroy" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="config_s3_bucket_name" className="snap-top"></a>
+If set to true, when you run 'terraform destroy', delete all objects from the bucket so that the bucket can be destroyed without error. Warning: these objects are not recoverable so only use this if you're absolutely sure you want to permanently delete everything!
 
-* [**`config_s3_bucket_name`**](#config_s3_bucket_name) &mdash; The name of the S3 Bucket where Config items will be stored. Can be in the same account or in another account.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="config_s3_mfa_delete" className="snap-top"></a>
+<HclListItem name="cloudtrail_kms_key_administrator_iam_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`config_s3_mfa_delete`**](#config_s3_mfa_delete) &mdash; Enable MFA delete for either 'Change the versioning state of your bucket' or 'Permanently delete an object version'. This setting only applies to the bucket used to storage AWS Config data. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS. For instructions on how to enable MFA Delete, check out the README from the terraform-aws-security/private-s3-bucket module.
+All CloudTrail Logs will be encrypted with a KMS CMK (Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. If you are aggregating CloudTrail logs and creating the CMK in this account (e.g., if this is the logs account), you MUST specify at least one IAM user (or other IAM ARN) that will be given administrator permissions for CMK, including the ability to change who can access this CMK and the extended log data it protects. If you are aggregating CloudTrail logs in another AWS account and the CMK already exists (e.g., if this is the stage or prod account), set this parameter to an empty list.
 
-<a name="config_should_create_s3_bucket" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`config_should_create_s3_bucket`**](#config_should_create_s3_bucket) &mdash; Set to true to create an S3 bucket of name [`config_s3_bucket_name`](#config_s3_bucket_name) in this account for storing AWS Config data (e.g., if this is the logs account). Set to false to assume the bucket specified in [`config_s3_bucket_name`](#config_s3_bucket_name) already exists in another AWS account (e.g., if this is the stage or prod account and [`config_s3_bucket_name`](#config_s3_bucket_name) is the name of a bucket in the logs account).
+```hcl
+list(string)
+```
 
-<a name="config_should_create_sns_topic" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`config_should_create_sns_topic`**](#config_should_create_sns_topic) &mdash; set to true to create an sns topic in this account for sending aws config notifications (e.g., if this is the logs account). set to false to assume the topic specified in [`config_sns_topic_name`](#config_sns_topic_name) already exists in another aws account (e.g., if this is the stage or prod account and [`config_sns_topic_name`](#config_sns_topic_name) is the name of an sns topic in the logs account).
+<HclListItem name="cloudtrail_kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="config_sns_topic_kms_key_by_name_region_map" className="snap-top"></a>
+All CloudTrail Logs will be encrypted with a KMS CMK (Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. If that CMK already exists (e.g., if this is the stage or prod account and you want to use a CMK that already exists in the logs account), set this to the ARN of that CMK. Otherwise (e.g., if this is the logs account), set this to null, and a new CMK will be created.
 
-* [**`config_sns_topic_kms_key_by_name_region_map`**](#config_sns_topic_kms_key_by_name_region_map) &mdash; Same as [`config_sns_topic_kms_key_region_map`](#config_sns_topic_kms_key_region_map), except the value is a name of a KMS key configured with [`kms_customer_master_keys`](#kms_customer_master_keys). The module created KMS key for each region (indexed by the name) will be used. Note that if an entry exists for a region in both [`config_sns_topic_kms_key_region_map`](#config_sns_topic_kms_key_region_map) and [`config_sns_topic_kms_key_by_name_region_map`](#config_sns_topic_kms_key_by_name_region_map), then the key in [`config_sns_topic_kms_key_region_map`](#config_sns_topic_kms_key_region_map) will always be used.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="config_sns_topic_kms_key_region_map" className="snap-top"></a>
+<HclListItem name="cloudtrail_kms_key_arn_is_alias" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`config_sns_topic_kms_key_region_map`**](#config_sns_topic_kms_key_region_map) &mdash; Optional KMS key to use for each region for configuring default encryption for the SNS topic (encoded as a map from region - e.g. us-east-1 - to ARN of KMS key). If null or the region key is missing, encryption will not be configured for the SNS topic in that region.
+If the kms_key_arn provided is an alias or alias ARN, then this must be set to true so that the module will exchange the alias for a CMK ARN. Setting this to true and using aliases requires <a href="#cloudtrail_allow_kms_describe_key_to_external_aws_accounts"><code>cloudtrail_allow_kms_describe_key_to_external_aws_accounts</code></a> to also be true for multi-account scenarios.
 
-<a name="config_sns_topic_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`config_sns_topic_name`**](#config_sns_topic_name) &mdash; the name of the sns topic in where aws config notifications will be sent. can be in the same account or in another account.
+<HclListItem name="cloudtrail_kms_key_user_iam_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="config_tags" className="snap-top"></a>
+All CloudTrail Logs will be encrypted with a KMS CMK (Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. If you are aggregating CloudTrail logs and creating the CMK in this account (e.g., this is the logs account), you MUST specify at least one IAM user (or other IAM ARN) that will be given user access to this CMK, which will allow this user to read CloudTrail Logs. If you are aggregating CloudTrail logs in another AWS account and the CMK already exists, set this parameter to an empty list (e.g., if this is the stage or prod account).
 
-* [**`config_tags`**](#config_tags) &mdash; A map of tags to apply to the S3 Bucket. The key is the tag name and the value is the tag value.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="configrules_maximum_execution_frequency" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`configrules_maximum_execution_frequency`**](#configrules_maximum_execution_frequency) &mdash; The maximum frequency with which AWS Config runs evaluations for the ´PERIODIC´ rules. See [`https://www.terraform.io/docs/providers/aws/r/config_organization_managed_rule.html#maximum_execution_frequency`](#https://www.terraform.io/docs/providers/aws/r/config_organization_managed_rule.html#maximum_execution_frequency)
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="custom_cloudtrail_trail_name" className="snap-top"></a>
+<HclListItem name="cloudtrail_num_days_after_which_archive_log_data" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`custom_cloudtrail_trail_name`**](#custom_cloudtrail_trail_name) &mdash; A custom name to use for the Cloudtrail Trail. If null, defaults to the [`name_prefix`](#name_prefix) input variable.
+After this number of days, log files should be transitioned from S3 to Glacier. Enter 0 to never archive log data.
 
-<a name="dev_permitted_services" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="30"/>
+</HclListItem>
 
-* [**`dev_permitted_services`**](#dev_permitted_services) &mdash; A list of AWS services for which the developers from the accounts in [`allow_dev_access_from_other_account_arns`](#allow_dev_access_from_other_account_arns) will receive full permissions. See https://goo.gl/ZyoHlz to find the IAM Service name. For example, to grant developers access only to EC2 and Amazon Machine Learning, use the value ["ec2","machinelearning"]. Do NOT add iam to the list of services, or that will grant Developers de facto admin access.
+<HclListItem name="cloudtrail_num_days_after_which_delete_log_data" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="ebs_enable_encryption" className="snap-top"></a>
+After this number of days, log files should be deleted from S3. Enter 0 to never delete log data.
 
-* [**`ebs_enable_encryption`**](#ebs_enable_encryption) &mdash; If set to true (default), all new EBS volumes will have encryption enabled by default
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="365"/>
+</HclListItem>
 
-<a name="ebs_kms_key_name" className="snap-top"></a>
+<HclListItem name="cloudtrail_num_days_to_retain_cloudwatch_logs" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`ebs_kms_key_name`**](#ebs_kms_key_name) &mdash; The name of the KMS CMK to use by default for encrypting EBS volumes, if [`enable_encryption`](#enable_encryption) and [`use_existing_kms_keys`](#use_existing_kms_keys) are enabled. The name must match the name given the [`kms_customer_master_keys`](#kms_customer_master_keys) variable.
+After this number of days, logs stored in CloudWatch will be deleted. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0 (default). When set to 0, logs will be retained indefinitely.
 
-<a name="ebs_use_existing_kms_keys" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="0"/>
+</HclListItem>
 
-* [**`ebs_use_existing_kms_keys`**](#ebs_use_existing_kms_keys) &mdash; If set to true, the KMS Customer Managed Keys (CMK) with the name in [`ebs_kms_key_name`](#ebs_kms_key_name) will be set as the default for EBS encryption. When false (default), the AWS-managed aws/ebs key will be used.
+<HclListItem name="cloudtrail_s3_bucket_already_exists" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="enable_cloudtrail" className="snap-top"></a>
+Set to false to create an S3 bucket of name <a href="#cloudtrail_s3_bucket_name"><code>cloudtrail_s3_bucket_name</code></a> in this account for storing CloudTrail logs (e.g., if this is the logs account). Set to true to assume the bucket specified in <a href="#cloudtrail_s3_bucket_name"><code>cloudtrail_s3_bucket_name</code></a> already exists in another AWS account (e.g., if this is the stage or prod account and <a href="#cloudtrail_s3_bucket_name"><code>cloudtrail_s3_bucket_name</code></a> is the name of a bucket in the logs account).
 
-* [**`enable_cloudtrail`**](#enable_cloudtrail) &mdash; Set to true (default) to enable CloudTrail in this app account. Set to false to disable CloudTrail (note: all other CloudTrail variables will be ignored). Note that if you have enabled organization trail in the root (parent) account, you should set this to false; the organization trail will enable CloudTrail on child accounts by default.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="enable_config" className="snap-top"></a>
+<HclListItem name="cloudtrail_s3_bucket_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`enable_config`**](#enable_config) &mdash; Set to true to enable AWS Config in this app account. Set to false to disable AWS Config (note: all other AWS config variables will be ignored).
+The name of the S3 Bucket where CloudTrail logs will be stored. This could be a bucket in this AWS account (e.g., if this is the logs account) or the name of a bucket in another AWS account where logs should be sent (e.g., if this is the stage or prod account and you're specifying the name of a bucket in the logs account).
 
-<a name="enable_encrypted_volumes" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`enable_encrypted_volumes`**](#enable_encrypted_volumes) &mdash; Checks whether the EBS volumes that are in an attached state are encrypted.
+<HclListItem name="cloudtrail_s3_mfa_delete" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="enable_github_actions_access" className="snap-top"></a>
+Enable MFA delete for either 'Change the versioning state of your bucket' or 'Permanently delete an object version'. This setting only applies to the bucket used to storage Cloudtrail data. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS. For instructions on how to enable MFA Delete, check out the README from the terraform-aws-security/private-s3-bucket module.
 
-* [**`enable_github_actions_access`**](#enable_github_actions_access) &mdash; When true, create an Open ID Connect Provider that GitHub actions can use to assume IAM roles in the account. Refer to https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services for more information.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="enable_iam_access_analyzer" className="snap-top"></a>
+<HclListItem name="cloudtrail_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`enable_iam_access_analyzer`**](#enable_iam_access_analyzer) &mdash; A feature flag to enable or disable this module.
+Tags to apply to the CloudTrail resources.
 
-<a name="enable_iam_cross_account_roles" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`enable_iam_cross_account_roles`**](#enable_iam_cross_account_roles) &mdash; A feature flag to enable or disable this module.
+```hcl
+map(string)
+```
 
-<a name="enable_iam_password_policy" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`enable_iam_password_policy`**](#enable_iam_password_policy) &mdash; Checks whether the account password policy for IAM users meets the specified requirements.
+<HclListItem name="config_aggregate_config_data_in_external_account" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="enable_iam_user_password_policy" className="snap-top"></a>
+Set to true to send the AWS Config data to another account (e.g., a logs account) for aggregation purposes. You must set the ID of that other account via the config_central_account_id variable. This redundant variable has to exist because Terraform does not allow computed data in count and for_each parameters and <a href="#config_central_account_id"><code>config_central_account_id</code></a> may be computed if its the ID of a newly-created AWS account.
 
-* [**`enable_iam_user_password_policy`**](#enable_iam_user_password_policy) &mdash; Set to true (default) to enable the IAM User Password Policies in this app account. Set to false to disable the policies. (Note: all other IAM User Password Policy variables will be ignored).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="enable_insecure_sg_rules" className="snap-top"></a>
+<HclListItem name="config_central_account_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`enable_insecure_sg_rules`**](#enable_insecure_sg_rules) &mdash; Checks whether the security group with 0.0.0.0/0 of any Amazon Virtual Private Cloud (Amazon VPC) allows only specific inbound TCP or UDP traffic.
+If the S3 bucket and SNS topics used for AWS Config live in a different AWS account, set this variable to the ID of that account (e.g., if this is the stage or prod account, set this to the ID of the logs account). If the S3 bucket and SNS topics live in this account (e.g., this is the logs account), set this variable to null. Only used if <a href="#config_aggregate_config_data_in_external_account"><code>config_aggregate_config_data_in_external_account</code></a> is true.
 
-<a name="enable_rds_storage_encrypted" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`enable_rds_storage_encrypted`**](#enable_rds_storage_encrypted) &mdash; Checks whether storage encryption is enabled for your RDS DB instances.
+<HclListItem name="config_create_account_rules" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="enable_root_account_mfa" className="snap-top"></a>
+Set to true to create AWS Config rules directly in this account. Set false to not create any Config rules in this account (i.e., if you created the rules at the organization level already). We recommend setting this to true to use account-level rules because org-level rules create a chicken-and-egg problem with creating new accounts.
 
-* [**`enable_root_account_mfa`**](#enable_root_account_mfa) &mdash; Checks whether users of your AWS account require a multi-factor authentication (MFA) device to sign in with root credentials.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="enable_s3_bucket_public_read_prohibited" className="snap-top"></a>
+<HclListItem name="config_delivery_channel_kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`enable_s3_bucket_public_read_prohibited`**](#enable_s3_bucket_public_read_prohibited) &mdash; Checks that your Amazon S3 buckets do not allow public read access.
+Optional KMS key to use for encrypting S3 objects on the AWS Config delivery channel for an externally managed S3 bucket. This must belong to the same region as the destination S3 bucket. If null, AWS Config will default to encrypting the delivered data with AES-256 encryption. Only used if <a href="#should_create_s3_bucket"><code>should_create_s3_bucket</code></a> is false - otherwise, <a href="#config_s3_bucket_kms_key_arn"><code>config_s3_bucket_kms_key_arn</code></a> is used.
 
-<a name="enable_s3_bucket_public_write_prohibited" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`enable_s3_bucket_public_write_prohibited`**](#enable_s3_bucket_public_write_prohibited) &mdash; Checks that your Amazon S3 buckets do not allow public write access.
+<HclListItem name="config_delivery_channel_kms_key_by_name" requirement="optional" type="object">
+<HclListItemDescription>
 
-<a name="encrypted_volumes_kms_id" className="snap-top"></a>
+Same as <a href="#config_delivery_channel_kms_key_arn"><code>config_delivery_channel_kms_key_arn</code></a>, except the value is a name of a KMS key configured with <a href="#kms_customer_master_keys"><code>kms_customer_master_keys</code></a>. The module created KMS key for the delivery region (indexed by the name) will be used. Note that if both <a href="#config_delivery_channel_kms_key_arn"><code>config_delivery_channel_kms_key_arn</code></a> and <a href="#config_delivery_channel_kms_key_by_name"><code>config_delivery_channel_kms_key_by_name</code></a> are configured, the key in <a href="#config_delivery_channel_kms_key_arn"><code>config_delivery_channel_kms_key_arn</code></a> will always be used.
 
-* [**`encrypted_volumes_kms_id`**](#encrypted_volumes_kms_id) &mdash; ID or ARN of the KMS key that is used to encrypt the volume. Used for configuring the encrypted volumes config rule.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="github_actions_openid_connect_provider_thumbprint_list" className="snap-top"></a>
+```hcl
+object({
+    name   = string
+    region = string
+  })
+```
 
-* [**`github_actions_openid_connect_provider_thumbprint_list`**](#github_actions_openid_connect_provider_thumbprint_list) &mdash; When set, use the statically provided hardcoded list of thumbprints rather than looking it up dynamically. This is useful if you want to trade reliability of the OpenID Connect Provider across certificate renewals with a static list that is obtained using a trustworthy mechanism, to mitigate potential damage from a domain hijacking attack on GitHub domains.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="guardduty_cloudwatch_event_rule_name" className="snap-top"></a>
+<HclListItem name="config_force_destroy" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`guardduty_cloudwatch_event_rule_name`**](#guardduty_cloudwatch_event_rule_name) &mdash; Name of the Cloudwatch event rules.
+If set to true, when you run 'terraform destroy', delete all objects from the bucket so that the bucket can be destroyed without error. Warning: these objects are not recoverable so only use this if you're absolutely sure you want to permanently delete everything!
 
-<a name="guardduty_finding_publishing_frequency" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`guardduty_finding_publishing_frequency`**](#guardduty_finding_publishing_frequency) &mdash; Specifies the frequency of notifications sent for subsequent finding occurrences. If the detector is a GuardDuty member account, the value is determined by the GuardDuty master account and cannot be modified, otherwise defaults to [`SIX_HOURS`](#SIX_HOURS). For standalone and GuardDuty master accounts, it must be configured in Terraform to enable drift detection. Valid values for standalone and master accounts: [`FIFTEEN_MINUTES`](#FIFTEEN_MINUTES), [`ONE_HOUR`](#ONE_HOUR), [`SIX_HOURS`](#SIX_HOURS).
+<HclListItem name="config_linked_accounts" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="guardduty_findings_sns_topic_name" className="snap-top"></a>
+Provide a list of AWS account IDs that will be allowed to send AWS Config data to this account. This is only required if you are aggregating config data in this account (e.g., this is the logs account) from other accounts.
 
-* [**`guardduty_findings_sns_topic_name`**](#guardduty_findings_sns_topic_name) &mdash; Specifies a name for the created SNS topics where findings are published. [`publish_findings_to_sns`](#publish_findings_to_sns) must be set to true.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="guardduty_publish_findings_to_sns" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`guardduty_publish_findings_to_sns`**](#guardduty_publish_findings_to_sns) &mdash; Send GuardDuty findings to SNS topics specified by [`findings_sns_topic_name`](#findings_sns_topic_name).
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="iam_access_analyzer_name" className="snap-top"></a>
+<HclListItem name="config_num_days_after_which_archive_log_data" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`iam_access_analyzer_name`**](#iam_access_analyzer_name) &mdash; The name of the IAM Access Analyzer module
+After this number of days, log files should be transitioned from S3 to Glacier. Enter 0 to never archive log data.
 
-<a name="iam_access_analyzer_type" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="365"/>
+</HclListItem>
 
-* [**`iam_access_analyzer_type`**](#iam_access_analyzer_type) &mdash; If set to ORGANIZATION, the analyzer will be scanning the current organization and any policies that refer to linked resources such as S3, IAM, Lambda and SQS policies.
+<HclListItem name="config_num_days_after_which_delete_log_data" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="iam_password_policy_allow_users_to_change_password" className="snap-top"></a>
+After this number of days, log files should be deleted from S3. Enter 0 to never delete log data.
 
-* [**`iam_password_policy_allow_users_to_change_password`**](#iam_password_policy_allow_users_to_change_password) &mdash; Allow users to change their own password.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="730"/>
+</HclListItem>
 
-<a name="iam_password_policy_hard_expiry" className="snap-top"></a>
+<HclListItem name="config_s3_bucket_kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`iam_password_policy_hard_expiry`**](#iam_password_policy_hard_expiry) &mdash; Password expiration requires administrator reset.
+Optional KMS key to use for encrypting S3 objects on the AWS Config bucket, when the S3 bucket is created within this module (<a href="#config_should_create_s3_bucket"><code>config_should_create_s3_bucket</code></a> is true). For encrypting S3 objects on delivery for an externally managed S3 bucket, refer to the <a href="#config_delivery_channel_kms_key_arn"><code>config_delivery_channel_kms_key_arn</code></a> input variable. If null, data in S3 will be encrypted using the default aws/s3 key. If provided, the key policy of the provided key must permit the IAM role used by AWS Config. See https://docs.aws.amazon.com/sns/latest/dg/sns-key-management.html. Note that the KMS key must reside in the global recorder region (as configured by <a href="#aws_region"><code>aws_region</code></a>).
 
-<a name="iam_password_policy_max_password_age" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`iam_password_policy_max_password_age`**](#iam_password_policy_max_password_age) &mdash; Number of days before password expiration.
+<HclListItem name="config_s3_bucket_kms_key_by_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="iam_password_policy_minimum_password_length" className="snap-top"></a>
+Same as <a href="#config_s3_bucket_kms_key_arn"><code>config_s3_bucket_kms_key_arn</code></a>, except the value is a name of a KMS key configured with <a href="#kms_customer_master_keys"><code>kms_customer_master_keys</code></a>. The module created KMS key for the global recorder region (indexed by the name) will be used. Note that if both <a href="#config_s3_bucket_kms_key_arn"><code>config_s3_bucket_kms_key_arn</code></a> and <a href="#config_s3_bucket_kms_key_by_name"><code>config_s3_bucket_kms_key_by_name</code></a> are configured, the key in <a href="#config_s3_bucket_kms_key_arn"><code>config_s3_bucket_kms_key_arn</code></a> will always be used.
 
-* [**`iam_password_policy_minimum_password_length`**](#iam_password_policy_minimum_password_length) &mdash; Password minimum length.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="iam_password_policy_password_reuse_prevention" className="snap-top"></a>
+<HclListItem name="config_s3_bucket_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`iam_password_policy_password_reuse_prevention`**](#iam_password_policy_password_reuse_prevention) &mdash; Number of passwords before allowing reuse.
+The name of the S3 Bucket where Config items will be stored. Can be in the same account or in another account.
 
-<a name="iam_password_policy_require_lowercase_characters" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`iam_password_policy_require_lowercase_characters`**](#iam_password_policy_require_lowercase_characters) &mdash; Require at least one lowercase character in password.
+<HclListItem name="config_s3_mfa_delete" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="iam_password_policy_require_numbers" className="snap-top"></a>
+Enable MFA delete for either 'Change the versioning state of your bucket' or 'Permanently delete an object version'. This setting only applies to the bucket used to storage AWS Config data. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS. For instructions on how to enable MFA Delete, check out the README from the terraform-aws-security/private-s3-bucket module.
 
-* [**`iam_password_policy_require_numbers`**](#iam_password_policy_require_numbers) &mdash; Require at least one number in password.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="iam_password_policy_require_symbols" className="snap-top"></a>
+<HclListItem name="config_should_create_s3_bucket" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`iam_password_policy_require_symbols`**](#iam_password_policy_require_symbols) &mdash; Require at least one symbol in password.
+Set to true to create an S3 bucket of name <a href="#config_s3_bucket_name"><code>config_s3_bucket_name</code></a> in this account for storing AWS Config data (e.g., if this is the logs account). Set to false to assume the bucket specified in <a href="#config_s3_bucket_name"><code>config_s3_bucket_name</code></a> already exists in another AWS account (e.g., if this is the stage or prod account and <a href="#config_s3_bucket_name"><code>config_s3_bucket_name</code></a> is the name of a bucket in the logs account).
 
-<a name="iam_password_policy_require_uppercase_characters" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`iam_password_policy_require_uppercase_characters`**](#iam_password_policy_require_uppercase_characters) &mdash; Require at least one uppercase character in password.
+<HclListItem name="config_should_create_sns_topic" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="iam_role_tags" className="snap-top"></a>
+set to true to create an sns topic in this account for sending aws config notifications (e.g., if this is the logs account). set to false to assume the topic specified in <a href="#config_sns_topic_name"><code>config_sns_topic_name</code></a> already exists in another aws account (e.g., if this is the stage or prod account and <a href="#config_sns_topic_name"><code>config_sns_topic_name</code></a> is the name of an sns topic in the logs account).
 
-* [**`iam_role_tags`**](#iam_role_tags) &mdash; The tags to apply to all the IAM role resources.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="insecure_sg_rules_authorized_tcp_ports" className="snap-top"></a>
+<HclListItem name="config_sns_topic_kms_key_by_name_region_map" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`insecure_sg_rules_authorized_tcp_ports`**](#insecure_sg_rules_authorized_tcp_ports) &mdash; Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by a dash; for example, '443,1020-1025'.
+Same as <a href="#config_sns_topic_kms_key_region_map"><code>config_sns_topic_kms_key_region_map</code></a>, except the value is a name of a KMS key configured with <a href="#kms_customer_master_keys"><code>kms_customer_master_keys</code></a>. The module created KMS key for each region (indexed by the name) will be used. Note that if an entry exists for a region in both <a href="#config_sns_topic_kms_key_region_map"><code>config_sns_topic_kms_key_region_map</code></a> and <a href="#config_sns_topic_kms_key_by_name_region_map"><code>config_sns_topic_kms_key_by_name_region_map</code></a>, then the key in <a href="#config_sns_topic_kms_key_region_map"><code>config_sns_topic_kms_key_region_map</code></a> will always be used.
 
-<a name="insecure_sg_rules_authorized_udp_ports" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`insecure_sg_rules_authorized_udp_ports`**](#insecure_sg_rules_authorized_udp_ports) &mdash; Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by a dash; for example, '500,1020-1025'.
+```hcl
+map(string)
+```
 
-<a name="kms_cmk_global_tags" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`kms_cmk_global_tags`**](#kms_cmk_global_tags) &mdash; A map of tags to apply to all KMS Keys to be created. In this map variable, the key is the tag name and the value is the tag value.
+<HclListItem name="config_sns_topic_kms_key_region_map" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="kms_customer_master_keys" className="snap-top"></a>
+Optional KMS key to use for each region for configuring default encryption for the SNS topic (encoded as a map from region - e.g. us-east-1 - to ARN of KMS key). If null or the region key is missing, encryption will not be configured for the SNS topic in that region.
 
-* [**`kms_customer_master_keys`**](#kms_customer_master_keys) &mdash; You can use this variable to create account-level KMS Customer Master Keys (CMKs) for encrypting and decrypting data. This variable should be a map where the keys are the names of the CMK and the values are an object that defines the configuration for that CMK. See the comment below for the configuration options you can set for each key.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="kms_grant_regions" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`kms_grant_regions`**](#kms_grant_regions) &mdash; The map of names of KMS grants to the region where the key resides in. There should be a one to one mapping between entries in this map and the entries of the [`kms_grants`](#kms_grants) map. This is used to workaround a terraform limitation where the [`for_each`](#for_each) value can not depend on resources.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="kms_grants" className="snap-top"></a>
+<HclListItem name="config_sns_topic_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`kms_grants`**](#kms_grants) &mdash; Create the specified KMS grants to allow entities to use the KMS key without modifying the KMS policy or IAM. This is necessary to allow AWS services (e.g. ASG) to use CMKs encrypt and decrypt resources. The input is a map of grant name to grant properties. The name must be unique per account.
+the name of the sns topic in where aws config notifications will be sent. can be in the same account or in another account.
 
-<a name="max_session_duration_human_users" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ConfigTopic"/>
+</HclListItem>
 
-* [**`max_session_duration_human_users`**](#max_session_duration_human_users) &mdash; The maximum allowable session duration, in seconds, for the credentials you get when assuming the IAM roles created by this module. This variable applies to all IAM roles created by this module that are intended for people to use, such as allow-read-only-access-from-other-accounts. For IAM roles that are intended for machine users, such as allow-auto-deploy-from-other-accounts, see [`max_session_duration_machine_users`](#max_session_duration_machine_users).
+<HclListItem name="config_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="max_session_duration_machine_users" className="snap-top"></a>
+A map of tags to apply to the S3 Bucket. The key is the tag name and the value is the tag value.
 
-* [**`max_session_duration_machine_users`**](#max_session_duration_machine_users) &mdash; The maximum allowable session duration, in seconds, for the credentials you get when assuming the IAM roles created by this module. This variable  applies to all IAM roles created by this module that are intended for machine users, such as allow-auto-deploy-from-other-accounts. For IAM roles that are intended for human users, such as allow-read-only-access-from-other-accounts, see [`max_session_duration_human_users`](#max_session_duration_human_users).
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="rds_storage_encrypted_kms_id" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`rds_storage_encrypted_kms_id`**](#rds_storage_encrypted_kms_id) &mdash; KMS key ID or ARN used to encrypt the storage. Used for configuring the RDS storage encryption config rule.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="service_linked_roles" className="snap-top"></a>
+<HclListItem name="configrules_maximum_execution_frequency" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`service_linked_roles`**](#service_linked_roles) &mdash; Create service-linked roles for this set of services. You should pass in the URLs of the services, but without the protocol (e.g., http://) in front: e.g., use elasticbeanstalk.amazonaws.com for Elastic Beanstalk or es.amazonaws.com for Amazon Elasticsearch. Service-linked roles are predefined by the service, can typically only be assumed by that service, and include all the permissions that the service requires to call other AWS services on your behalf. You can typically only create one such role per AWS account, which is why this parameter exists in the account baseline. See [`https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws`](#https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws)-services-that-work-with-iam.html for the list of services that support service-linked roles.
+The maximum frequency with which AWS Config runs evaluations for the ´PERIODIC´ rules. See https://www.terraform.io/docs/providers/aws/r/config_organization_managed_rule.html#maximum_execution_frequency
 
-<a name="should_require_mfa" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="TwentyFour_Hours"/>
+</HclListItem>
 
-* [**`should_require_mfa`**](#should_require_mfa) &mdash; Should we require that all IAM Users use Multi-Factor Authentication for both AWS API calls and the AWS Web Console? (true or false)
+<HclListItem name="custom_cloudtrail_trail_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+A custom name to use for the Cloudtrail Trail. If null, defaults to the <a href="#name_prefix"><code>name_prefix</code></a> input variable.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="dev_permitted_services" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of AWS services for which the developers from the accounts in <a href="#allow_dev_access_from_other_account_arns"><code>allow_dev_access_from_other_account_arns</code></a> will receive full permissions. See https://goo.gl/ZyoHlz to find the IAM Service name. For example, to grant developers access only to EC2 and Amazon Machine Learning, use the value ['ec2','machinelearning']. Do NOT add iam to the list of services, or that will grant Developers de facto admin access.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="ebs_enable_encryption" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If set to true (default), all new EBS volumes will have encryption enabled by default
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="ebs_kms_key_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of the KMS CMK to use by default for encrypting EBS volumes, if <a href="#enable_encryption"><code>enable_encryption</code></a> and <a href="#use_existing_kms_keys"><code>use_existing_kms_keys</code></a> are enabled. The name must match the name given the <a href="#kms_customer_master_keys"><code>kms_customer_master_keys</code></a> variable.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="ebs_use_existing_kms_keys" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If set to true, the KMS Customer Managed Keys (CMK) with the name in <a href="#ebs_kms_key_name"><code>ebs_kms_key_name</code></a> will be set as the default for EBS encryption. When false (default), the AWS-managed aws/ebs key will be used.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="enable_cloudtrail" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true (default) to enable CloudTrail in this app account. Set to false to disable CloudTrail (note: all other CloudTrail variables will be ignored). Note that if you have enabled organization trail in the root (parent) account, you should set this to false; the organization trail will enable CloudTrail on child accounts by default.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_config" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to enable AWS Config in this app account. Set to false to disable AWS Config (note: all other AWS config variables will be ignored).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_encrypted_volumes" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Checks whether the EBS volumes that are in an attached state are encrypted.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_github_actions_access" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, create an Open ID Connect Provider that GitHub actions can use to assume IAM roles in the account. Refer to https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services for more information.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="enable_iam_access_analyzer" requirement="optional" type="bool">
+<HclListItemDescription>
+
+A feature flag to enable or disable this module.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="enable_iam_cross_account_roles" requirement="optional" type="bool">
+<HclListItemDescription>
+
+A feature flag to enable or disable this module.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_iam_password_policy" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Checks whether the account password policy for IAM users meets the specified requirements.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_iam_user_password_policy" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true (default) to enable the IAM User Password Policies in this app account. Set to false to disable the policies. (Note: all other IAM User Password Policy variables will be ignored).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_insecure_sg_rules" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Checks whether the security group with 0.0.0.0/0 of any Amazon Virtual Private Cloud (Amazon VPC) allows only specific inbound TCP or UDP traffic.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_rds_storage_encrypted" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Checks whether storage encryption is enabled for your RDS DB instances.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_root_account_mfa" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Checks whether users of your AWS account require a multi-factor authentication (MFA) device to sign in with root credentials.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_s3_bucket_public_read_prohibited" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Checks that your Amazon S3 buckets do not allow public read access.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_s3_bucket_public_write_prohibited" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Checks that your Amazon S3 buckets do not allow public write access.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="encrypted_volumes_kms_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+ID or ARN of the KMS key that is used to encrypt the volume. Used for configuring the encrypted volumes config rule.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="github_actions_openid_connect_provider_thumbprint_list" requirement="optional" type="list">
+<HclListItemDescription>
+
+When set, use the statically provided hardcoded list of thumbprints rather than looking it up dynamically. This is useful if you want to trade reliability of the OpenID Connect Provider across certificate renewals with a static list that is obtained using a trustworthy mechanism, to mitigate potential damage from a domain hijacking attack on GitHub domains.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="guardduty_cloudwatch_event_rule_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+Name of the Cloudwatch event rules.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="guardduty-finding-events"/>
+</HclListItem>
+
+<HclListItem name="guardduty_finding_publishing_frequency" requirement="optional" type="string">
+<HclListItemDescription>
+
+Specifies the frequency of notifications sent for subsequent finding occurrences. If the detector is a GuardDuty member account, the value is determined by the GuardDuty master account and cannot be modified, otherwise defaults to SIX_HOURS. For standalone and GuardDuty master accounts, it must be configured in Terraform to enable drift detection. Valid values for standalone and master accounts: FIFTEEN_MINUTES, ONE_HOUR, SIX_HOURS.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="guardduty_findings_sns_topic_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+Specifies a name for the created SNS topics where findings are published. publish_findings_to_sns must be set to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="guardduty-findings"/>
+</HclListItem>
+
+<HclListItem name="guardduty_publish_findings_to_sns" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Send GuardDuty findings to SNS topics specified by findings_sns_topic_name.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="iam_access_analyzer_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of the IAM Access Analyzer module
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="baseline_app-iam_access_analyzer"/>
+</HclListItem>
+
+<HclListItem name="iam_access_analyzer_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+If set to ORGANIZATION, the analyzer will be scanning the current organization and any policies that refer to linked resources such as S3, IAM, Lambda and SQS policies.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ORGANIZATION"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_allow_users_to_change_password" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Allow users to change their own password.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_hard_expiry" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Password expiration requires administrator reset.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_max_password_age" requirement="optional" type="number">
+<HclListItemDescription>
+
+Number of days before password expiration.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="30"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_minimum_password_length" requirement="optional" type="number">
+<HclListItemDescription>
+
+Password minimum length.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="16"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_password_reuse_prevention" requirement="optional" type="number">
+<HclListItemDescription>
+
+Number of passwords before allowing reuse.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="5"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_require_lowercase_characters" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Require at least one lowercase character in password.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_require_numbers" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Require at least one number in password.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_require_symbols" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Require at least one symbol in password.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_require_uppercase_characters" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Require at least one uppercase character in password.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="iam_role_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+The tags to apply to all the IAM role resources.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="insecure_sg_rules_authorized_tcp_ports" requirement="optional" type="string">
+<HclListItemDescription>
+
+Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by a dash; for example, '443,1020-1025'.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="443"/>
+</HclListItem>
+
+<HclListItem name="insecure_sg_rules_authorized_udp_ports" requirement="optional" type="string">
+<HclListItemDescription>
+
+Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by a dash; for example, '500,1020-1025'.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="kms_cmk_global_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of tags to apply to all KMS Keys to be created. In this map variable, the key is the tag name and the value is the tag value.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="kms_customer_master_keys" requirement="optional" type="any">
+<HclListItemDescription>
+
+You can use this variable to create account-level KMS Customer Master Keys (CMKs) for encrypting and decrypting data. This variable should be a map where the keys are the names of the CMK and the values are an object that defines the configuration for that CMK. See the comment below for the configuration options you can set for each key.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="kms_grant_regions" requirement="optional" type="map">
+<HclListItemDescription>
+
+The map of names of KMS grants to the region where the key resides in. There should be a one to one mapping between entries in this map and the entries of the kms_grants map. This is used to workaround a terraform limitation where the for_each value can not depend on resources.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="kms_grants" requirement="optional" type="map">
+<HclListItemDescription>
+
+Create the specified KMS grants to allow entities to use the KMS key without modifying the KMS policy or IAM. This is necessary to allow AWS services (e.g. ASG) to use CMKs encrypt and decrypt resources. The input is a map of grant name to grant properties. The name must be unique per account.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(object({
+    # ARN of the KMS CMK that the grant applies to. Note that the region is introspected based on the ARN.
+    kms_cmk_arn = string
+
+    # The principal that is given permission to perform the operations that the grant permits. This must be in ARN
+    # format. For example, the grantee principal for ASG is:
+    # arn:aws:iam::111122223333:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling
+    grantee_principal = string
+
+    # A list of operations that the grant permits. The permitted values are:
+    # Decrypt, Encrypt, GenerateDataKey, GenerateDataKeyWithoutPlaintext, ReEncryptFrom, ReEncryptTo, CreateGrant,
+    # RetireGrant, DescribeKey
+    granted_operations = list(string)
+  }))
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="max_session_duration_human_users" requirement="optional" type="number">
+<HclListItemDescription>
+
+The maximum allowable session duration, in seconds, for the credentials you get when assuming the IAM roles created by this module. This variable applies to all IAM roles created by this module that are intended for people to use, such as allow-read-only-access-from-other-accounts. For IAM roles that are intended for machine users, such as allow-auto-deploy-from-other-accounts, see <a href="#max_session_duration_machine_users"><code>max_session_duration_machine_users</code></a>.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="43200"/>
+</HclListItem>
+
+<HclListItem name="max_session_duration_machine_users" requirement="optional" type="number">
+<HclListItemDescription>
+
+The maximum allowable session duration, in seconds, for the credentials you get when assuming the IAM roles created by this module. This variable  applies to all IAM roles created by this module that are intended for machine users, such as allow-auto-deploy-from-other-accounts. For IAM roles that are intended for human users, such as allow-read-only-access-from-other-accounts, see <a href="#max_session_duration_human_users"><code>max_session_duration_human_users</code></a>.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="3600"/>
+</HclListItem>
+
+<HclListItem name="rds_storage_encrypted_kms_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+KMS key ID or ARN used to encrypt the storage. Used for configuring the RDS storage encryption config rule.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="service_linked_roles" requirement="optional" type="set">
+<HclListItemDescription>
+
+Create service-linked roles for this set of services. You should pass in the URLs of the services, but without the protocol (e.g., http://) in front: e.g., use elasticbeanstalk.amazonaws.com for Elastic Beanstalk or es.amazonaws.com for Amazon Elasticsearch. Service-linked roles are predefined by the service, can typically only be assumed by that service, and include all the permissions that the service requires to call other AWS services on your behalf. You can typically only create one such role per AWS account, which is why this parameter exists in the account baseline. See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-services-that-work-with-iam.html for the list of services that support service-linked roles.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="should_require_mfa" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we require that all IAM Users use Multi-Factor Authentication for both AWS API calls and the AWS Web Console? (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="allow_auto_deploy_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_auto_deploy_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-* [**`allow_auto_deploy_access_from_other_accounts_iam_role_arn`**](#allow_auto_deploy_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="allow_auto_deploy_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-<a name="allow_auto_deploy_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_billing_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-* [**`allow_auto_deploy_access_from_other_accounts_iam_role_id`**](#allow_auto_deploy_access_from_other_accounts_iam_role_id) &mdash; 
+<HclListItem name="allow_billing_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-<a name="allow_billing_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_billing_access_sign_in_url">
+</HclListItem>
 
-* [**`allow_billing_access_from_other_accounts_iam_role_arn`**](#allow_billing_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="allow_dev_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-<a name="allow_billing_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_dev_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-* [**`allow_billing_access_from_other_accounts_iam_role_id`**](#allow_billing_access_from_other_accounts_iam_role_id) &mdash; 
+<HclListItem name="allow_dev_access_sign_in_url">
+</HclListItem>
 
-<a name="allow_billing_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="allow_full_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-* [**`allow_billing_access_sign_in_url`**](#allow_billing_access_sign_in_url) &mdash; 
+<HclListItem name="allow_full_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-<a name="allow_dev_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_full_access_sign_in_url">
+</HclListItem>
 
-* [**`allow_dev_access_from_other_accounts_iam_role_arn`**](#allow_dev_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="allow_houston_cli_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-<a name="allow_dev_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_houston_cli_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-* [**`allow_dev_access_from_other_accounts_iam_role_id`**](#allow_dev_access_from_other_accounts_iam_role_id) &mdash; 
+<HclListItem name="allow_iam_admin_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-<a name="allow_dev_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="allow_iam_admin_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-* [**`allow_dev_access_sign_in_url`**](#allow_dev_access_sign_in_url) &mdash; 
+<HclListItem name="allow_iam_admin_access_sign_in_url">
+</HclListItem>
 
-<a name="allow_full_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_logs_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-* [**`allow_full_access_from_other_accounts_iam_role_arn`**](#allow_full_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="allow_logs_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-<a name="allow_full_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_logs_access_sign_in_url">
+</HclListItem>
 
-* [**`allow_full_access_from_other_accounts_iam_role_id`**](#allow_full_access_from_other_accounts_iam_role_id) &mdash; 
+<HclListItem name="allow_read_only_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-<a name="allow_full_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="allow_read_only_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-* [**`allow_full_access_sign_in_url`**](#allow_full_access_sign_in_url) &mdash; 
+<HclListItem name="allow_read_only_access_sign_in_url">
+</HclListItem>
 
-<a name="allow_houston_cli_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_ssh_grunt_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-* [**`allow_houston_cli_access_from_other_accounts_iam_role_arn`**](#allow_houston_cli_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="allow_ssh_grunt_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-<a name="allow_houston_cli_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_ssh_grunt_access_sign_in_url">
+</HclListItem>
 
-* [**`allow_houston_cli_access_from_other_accounts_iam_role_id`**](#allow_houston_cli_access_from_other_accounts_iam_role_id) &mdash; 
+<HclListItem name="allow_ssh_grunt_houston_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-<a name="allow_iam_admin_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_ssh_grunt_houston_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-* [**`allow_iam_admin_access_from_other_accounts_iam_role_arn`**](#allow_iam_admin_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="allow_ssh_grunt_houston_access_sign_in_url">
+</HclListItem>
 
-<a name="allow_iam_admin_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_support_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-* [**`allow_iam_admin_access_from_other_accounts_iam_role_id`**](#allow_iam_admin_access_from_other_accounts_iam_role_id) &mdash; 
+<HclListItem name="allow_support_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-<a name="allow_iam_admin_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="allow_support_access_sign_in_url">
+</HclListItem>
 
-* [**`allow_iam_admin_access_sign_in_url`**](#allow_iam_admin_access_sign_in_url) &mdash; 
+<HclListItem name="aws_ebs_encryption_by_default_enabled">
+<HclListItemDescription>
 
-<a name="allow_logs_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+A map from region to a boolean indicating whether or not EBS encryption is enabled by default for each region.
 
-* [**`allow_logs_access_from_other_accounts_iam_role_arn`**](#allow_logs_access_from_other_accounts_iam_role_arn) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="allow_logs_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="aws_ebs_encryption_default_kms_key">
+<HclListItemDescription>
 
-* [**`allow_logs_access_from_other_accounts_iam_role_id`**](#allow_logs_access_from_other_accounts_iam_role_id) &mdash; 
+A map from region to the ARN of the KMS key used for default EBS encryption for each region.
 
-<a name="allow_logs_access_sign_in_url" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`allow_logs_access_sign_in_url`**](#allow_logs_access_sign_in_url) &mdash; 
+<HclListItem name="cloudtrail_cloudwatch_group_arn">
+<HclListItemDescription>
 
-<a name="allow_read_only_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+The ARN of the cloudwatch log group.
 
-* [**`allow_read_only_access_from_other_accounts_iam_role_arn`**](#allow_read_only_access_from_other_accounts_iam_role_arn) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="allow_read_only_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="cloudtrail_cloudwatch_group_name">
+<HclListItemDescription>
 
-* [**`allow_read_only_access_from_other_accounts_iam_role_id`**](#allow_read_only_access_from_other_accounts_iam_role_id) &mdash; 
+The name of the cloudwatch log group.
 
-<a name="allow_read_only_access_sign_in_url" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`allow_read_only_access_sign_in_url`**](#allow_read_only_access_sign_in_url) &mdash; 
+<HclListItem name="cloudtrail_iam_role_arn">
+<HclListItemDescription>
 
-<a name="allow_ssh_grunt_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+The ARN of the IAM role used by the cloudwatch log group.
 
-* [**`allow_ssh_grunt_access_from_other_accounts_iam_role_arn`**](#allow_ssh_grunt_access_from_other_accounts_iam_role_arn) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="allow_ssh_grunt_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="cloudtrail_iam_role_name">
+<HclListItemDescription>
 
-* [**`allow_ssh_grunt_access_from_other_accounts_iam_role_id`**](#allow_ssh_grunt_access_from_other_accounts_iam_role_id) &mdash; 
+The name of the IAM role used by the cloudwatch log group.
 
-<a name="allow_ssh_grunt_access_sign_in_url" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`allow_ssh_grunt_access_sign_in_url`**](#allow_ssh_grunt_access_sign_in_url) &mdash; 
+<HclListItem name="cloudtrail_kms_key_alias_name">
+<HclListItemDescription>
 
-<a name="allow_ssh_grunt_houston_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+The alias of the KMS key used by the S3 bucket to encrypt cloudtrail logs.
 
-* [**`allow_ssh_grunt_houston_access_from_other_accounts_iam_role_arn`**](#allow_ssh_grunt_houston_access_from_other_accounts_iam_role_arn) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="allow_ssh_grunt_houston_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="cloudtrail_kms_key_arn">
+<HclListItemDescription>
 
-* [**`allow_ssh_grunt_houston_access_from_other_accounts_iam_role_id`**](#allow_ssh_grunt_houston_access_from_other_accounts_iam_role_id) &mdash; 
+The ARN of the KMS key used by the S3 bucket to encrypt cloudtrail logs.
 
-<a name="allow_ssh_grunt_houston_access_sign_in_url" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`allow_ssh_grunt_houston_access_sign_in_url`**](#allow_ssh_grunt_houston_access_sign_in_url) &mdash; 
+<HclListItem name="cloudtrail_s3_access_logging_bucket_name">
+<HclListItemDescription>
 
-<a name="allow_support_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+The name of the S3 bucket where server access logs are delivered.
 
-* [**`allow_support_access_from_other_accounts_iam_role_arn`**](#allow_support_access_from_other_accounts_iam_role_arn) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="allow_support_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="cloudtrail_s3_bucket_name">
+<HclListItemDescription>
 
-* [**`allow_support_access_from_other_accounts_iam_role_id`**](#allow_support_access_from_other_accounts_iam_role_id) &mdash; 
+The name of the S3 bucket where cloudtrail logs are delivered.
 
-<a name="allow_support_access_sign_in_url" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`allow_support_access_sign_in_url`**](#allow_support_access_sign_in_url) &mdash; 
+<HclListItem name="cloudtrail_trail_arn">
+<HclListItemDescription>
 
-<a name="aws_ebs_encryption_by_default_enabled" className="snap-top"></a>
+The ARN of the cloudtrail trail.
 
-* [**`aws_ebs_encryption_by_default_enabled`**](#aws_ebs_encryption_by_default_enabled) &mdash; A map from region to a boolean indicating whether or not EBS encryption is enabled by default for each region.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="aws_ebs_encryption_default_kms_key" className="snap-top"></a>
+<HclListItem name="config_iam_role_arns">
+<HclListItemDescription>
 
-* [**`aws_ebs_encryption_default_kms_key`**](#aws_ebs_encryption_default_kms_key) &mdash; A map from region to the ARN of the KMS key used for default EBS encryption for each region.
+The ARNs of the IAM role used by the config recorder.
 
-<a name="cloudtrail_cloudwatch_group_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cloudtrail_cloudwatch_group_arn`**](#cloudtrail_cloudwatch_group_arn) &mdash; The ARN of the cloudwatch log group.
+<HclListItem name="config_recorder_names">
+<HclListItemDescription>
 
-<a name="cloudtrail_cloudwatch_group_name" className="snap-top"></a>
+The names of the configuration recorder.
 
-* [**`cloudtrail_cloudwatch_group_name`**](#cloudtrail_cloudwatch_group_name) &mdash; The name of the cloudwatch log group.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="cloudtrail_iam_role_arn" className="snap-top"></a>
+<HclListItem name="config_s3_bucket_names">
+<HclListItemDescription>
 
-* [**`cloudtrail_iam_role_arn`**](#cloudtrail_iam_role_arn) &mdash; The ARN of the IAM role used by the cloudwatch log group.
+The names of the S3 bucket used by AWS Config to store configuration items.
 
-<a name="cloudtrail_iam_role_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cloudtrail_iam_role_name`**](#cloudtrail_iam_role_name) &mdash; The name of the IAM role used by the cloudwatch log group.
+<HclListItem name="config_sns_topic_arns">
+<HclListItemDescription>
 
-<a name="cloudtrail_kms_key_alias_name" className="snap-top"></a>
+The ARNs of the SNS Topic used by the config notifications.
 
-* [**`cloudtrail_kms_key_alias_name`**](#cloudtrail_kms_key_alias_name) &mdash; The alias of the KMS key used by the S3 bucket to encrypt cloudtrail logs.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="cloudtrail_kms_key_arn" className="snap-top"></a>
+<HclListItem name="github_actions_iam_openid_connect_provider_arn">
+<HclListItemDescription>
 
-* [**`cloudtrail_kms_key_arn`**](#cloudtrail_kms_key_arn) &mdash; The ARN of the KMS key used by the S3 bucket to encrypt cloudtrail logs.
+ARN of the OpenID Connect Provider that can be used to attach AWS IAM Roles to GitHub Actions.
 
-<a name="cloudtrail_s3_access_logging_bucket_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cloudtrail_s3_access_logging_bucket_name`**](#cloudtrail_s3_access_logging_bucket_name) &mdash; The name of the S3 bucket where server access logs are delivered.
+<HclListItem name="github_actions_iam_openid_connect_provider_url">
+<HclListItemDescription>
 
-<a name="cloudtrail_s3_bucket_name" className="snap-top"></a>
+URL of the OpenID Connect Provider that can be used to attach AWS IAM Roles to GitHub Actions.
 
-* [**`cloudtrail_s3_bucket_name`**](#cloudtrail_s3_bucket_name) &mdash; The name of the S3 bucket where cloudtrail logs are delivered.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="cloudtrail_trail_arn" className="snap-top"></a>
+<HclListItem name="guardduty_cloudwatch_event_rule_arns">
+<HclListItemDescription>
 
-* [**`cloudtrail_trail_arn`**](#cloudtrail_trail_arn) &mdash; The ARN of the cloudtrail trail.
+The ARNs of the cloudwatch event rules used to publish findings to sns if <a href="#publish_findings_to_sns"><code>publish_findings_to_sns</code></a> is set to true.
 
-<a name="config_iam_role_arns" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`config_iam_role_arns`**](#config_iam_role_arns) &mdash; The ARNs of the IAM role used by the config recorder.
+<HclListItem name="guardduty_cloudwatch_event_target_arns">
+<HclListItemDescription>
 
-<a name="config_recorder_names" className="snap-top"></a>
+The ARNs of the cloudwatch event targets used to publish findings to sns if <a href="#publish_findings_to_sns"><code>publish_findings_to_sns</code></a> is set to true.
 
-* [**`config_recorder_names`**](#config_recorder_names) &mdash; The names of the configuration recorder.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="config_s3_bucket_names" className="snap-top"></a>
+<HclListItem name="guardduty_detector_ids">
+<HclListItemDescription>
 
-* [**`config_s3_bucket_names`**](#config_s3_bucket_names) &mdash; The names of the S3 bucket used by AWS Config to store configuration items.
+The IDs of the GuardDuty detectors.
 
-<a name="config_sns_topic_arns" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`config_sns_topic_arns`**](#config_sns_topic_arns) &mdash; The ARNs of the SNS Topic used by the config notifications.
+<HclListItem name="guardduty_findings_sns_topic_arns">
+<HclListItemDescription>
 
-<a name="github_actions_iam_openid_connect_provider_arn" className="snap-top"></a>
+The ARNs of the SNS topics where findings are published if <a href="#publish_findings_to_sns"><code>publish_findings_to_sns</code></a> is set to true.
 
-* [**`github_actions_iam_openid_connect_provider_arn`**](#github_actions_iam_openid_connect_provider_arn) &mdash; ARN of the OpenID Connect Provider that can be used to attach AWS IAM Roles to GitHub Actions.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="github_actions_iam_openid_connect_provider_url" className="snap-top"></a>
+<HclListItem name="guardduty_findings_sns_topic_names">
+<HclListItemDescription>
 
-* [**`github_actions_iam_openid_connect_provider_url`**](#github_actions_iam_openid_connect_provider_url) &mdash; URL of the OpenID Connect Provider that can be used to attach AWS IAM Roles to GitHub Actions.
+The names of the SNS topic where findings are published if <a href="#publish_findings_to_sns"><code>publish_findings_to_sns</code></a> is set to true.
 
-<a name="guardduty_cloudwatch_event_rule_arns" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`guardduty_cloudwatch_event_rule_arns`**](#guardduty_cloudwatch_event_rule_arns) &mdash; The ARNs of the cloudwatch event rules used to publish findings to sns if [`publish_findings_to_sns`](#publish_findings_to_sns) is set to true.
+<HclListItem name="invalid_cmk_inputs">
+<HclListItemDescription>
 
-<a name="guardduty_cloudwatch_event_target_arns" className="snap-top"></a>
+Map of CMKs from the input <a href="#customer_master_keys"><code>customer_master_keys</code></a> that had an invalid region, and thus were not created. The structure of the map is the same as the input. This will only include KMS key inputs that were not created because the region attribute was invalid (either not a valid region identifier, the region is not enabled on the account, or the region is not included in the <a href="#opt_in_regions"><code>opt_in_regions</code></a> input).
 
-* [**`guardduty_cloudwatch_event_target_arns`**](#guardduty_cloudwatch_event_target_arns) &mdash; The ARNs of the cloudwatch event targets used to publish findings to sns if [`publish_findings_to_sns`](#publish_findings_to_sns) is set to true.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="guardduty_detector_ids" className="snap-top"></a>
+<HclListItem name="kms_key_aliases">
+<HclListItemDescription>
 
-* [**`guardduty_detector_ids`**](#guardduty_detector_ids) &mdash; The IDs of the GuardDuty detectors.
+A map from region to aliases of the KMS CMKs that were created. The value will also be a map mapping the keys from the <a href="#customer_master_keys"><code>customer_master_keys</code></a> input variable to the corresponding alias.
 
-<a name="guardduty_findings_sns_topic_arns" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`guardduty_findings_sns_topic_arns`**](#guardduty_findings_sns_topic_arns) &mdash; The ARNs of the SNS topics where findings are published if [`publish_findings_to_sns`](#publish_findings_to_sns) is set to true.
+<HclListItem name="kms_key_arns">
+<HclListItemDescription>
 
-<a name="guardduty_findings_sns_topic_names" className="snap-top"></a>
+A map from region to ARNs of the KMS CMKs that were created. The value will also be a map mapping the keys from the <a href="#kms_customer_master_keys"><code>kms_customer_master_keys</code></a> input variable to the corresponding ARN.
 
-* [**`guardduty_findings_sns_topic_names`**](#guardduty_findings_sns_topic_names) &mdash; The names of the SNS topic where findings are published if [`publish_findings_to_sns`](#publish_findings_to_sns) is set to true.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="invalid_cmk_inputs" className="snap-top"></a>
+<HclListItem name="kms_key_ids">
+<HclListItemDescription>
 
-* [**`invalid_cmk_inputs`**](#invalid_cmk_inputs) &mdash; Map of CMKs from the input [`customer_master_keys`](#customer_master_keys) that had an invalid region, and thus were not created. The structure of the map is the same as the input. This will only include KMS key inputs that were not created because the region attribute was invalid (either not a valid region identifier, the region is not enabled on the account, or the region is not included in the [`opt_in_regions`](#opt_in_regions) input).
+A map from region to IDs of the KMS CMKs that were created. The value will also be a map mapping the keys from the <a href="#kms_customer_master_keys"><code>kms_customer_master_keys</code></a> input variable to the corresponding ID.
 
-<a name="kms_key_aliases" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`kms_key_aliases`**](#kms_key_aliases) &mdash; A map from region to aliases of the KMS CMKs that were created. The value will also be a map mapping the keys from the [`customer_master_keys`](#customer_master_keys) input variable to the corresponding alias.
+<HclListItem name="service_linked_role_arns">
+<HclListItemDescription>
 
-<a name="kms_key_arns" className="snap-top"></a>
+A map of ARNs of the service linked roles created from <a href="#service_linked_roles"><code>service_linked_roles</code></a>.
 
-* [**`kms_key_arns`**](#kms_key_arns) &mdash; A map from region to ARNs of the KMS CMKs that were created. The value will also be a map mapping the keys from the [`kms_customer_master_keys`](#kms_customer_master_keys) input variable to the corresponding ARN.
-
-<a name="kms_key_ids" className="snap-top"></a>
-
-* [**`kms_key_ids`**](#kms_key_ids) &mdash; A map from region to IDs of the KMS CMKs that were created. The value will also be a map mapping the keys from the [`kms_customer_master_keys`](#kms_customer_master_keys) input variable to the corresponding ID.
-
-<a name="service_linked_role_arns" className="snap-top"></a>
-
-* [**`service_linked_role_arns`**](#service_linked_role_arns) &mdash; A map of ARNs of the service linked roles created from [`service_linked_roles`](#service_linked_roles).
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"2f70d7a69c3cc9de1baeb5eecbee2239"}
+{"sourcePlugin":"service-catalog-api","hash":"c185e4e4ac16c1c955e3637ad06226a8"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/landing-zone/aws-root-account-baseline-wrapper.md
+++ b/docs/reference/services/landing-zone/aws-root-account-baseline-wrapper.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -97,903 +98,1862 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="aws_account_id" className="snap-top"></a>
+<HclListItem name="aws_account_id" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`aws_account_id`**](#aws_account_id) &mdash; The AWS Account ID the template should be operated on. This avoids misconfiguration errors caused by environment variables.
+The AWS Account ID the template should be operated on. This avoids misconfiguration errors caused by environment variables.
 
-<a name="aws_region" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`aws_region`**](#aws_region) &mdash; The AWS Region to use as the global config recorder and seed region for GuardDuty.
+<HclListItem name="aws_region" requirement="required" type="string">
+<HclListItemDescription>
 
-<a name="child_accounts" className="snap-top"></a>
+The AWS Region to use as the global config recorder and seed region for GuardDuty.
 
-* [**`child_accounts`**](#child_accounts) &mdash; Map of child accounts to create. The map key is the name of the account and the value is an object containing account configuration variables. See the comments below for what keys and values this object should contain.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="config_opt_in_regions" className="snap-top"></a>
+<HclListItem name="child_accounts" requirement="required" type="any">
+<HclListItemDescription>
 
-* [**`config_opt_in_regions`**](#config_opt_in_regions) &mdash; Creates resources in the specified regions. The best practice is to enable AWS Config in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions.
+Map of child accounts to create. The map key is the name of the account and the value is an object containing account configuration variables. See the comments below for what keys and values this object should contain.
 
-<a name="ebs_opt_in_regions" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`ebs_opt_in_regions`**](#ebs_opt_in_regions) &mdash; Creates resources in the specified regions. The best practice is to enable EBS Encryption in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for [`global_recorder_region`](#global_recorder_region) must be in this list.
+<HclListItem name="config_opt_in_regions" requirement="required" type="list">
+<HclListItemDescription>
 
-<a name="guardduty_opt_in_regions" className="snap-top"></a>
+Creates resources in the specified regions. The best practice is to enable AWS Config in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions.
 
-* [**`guardduty_opt_in_regions`**](#guardduty_opt_in_regions) &mdash; Creates resources in the specified regions. The best practice is to enable GuardDuty in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for [`global_recorder_region`](#global_recorder_region) must be in this list.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="iam_access_analyzer_opt_in_regions" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`iam_access_analyzer_opt_in_regions`**](#iam_access_analyzer_opt_in_regions) &mdash; Creates resources in the specified regions. The best practice is to enable IAM Access Analyzer in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for [`global_recorder_region`](#global_recorder_region) must be in this list.
+</HclListItemTypeDetails>
+</HclListItem>
 
-<a name="name_prefix" className="snap-top"></a>
+<HclListItem name="ebs_opt_in_regions" requirement="required" type="list">
+<HclListItemDescription>
 
-* [**`name_prefix`**](#name_prefix) &mdash; The name used to prefix AWS Config and Cloudtrail resources, including the S3 bucket names and SNS topics used for each.
+Creates resources in the specified regions. The best practice is to enable EBS Encryption in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for global_recorder_region must be in this list.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="guardduty_opt_in_regions" requirement="required" type="list">
+<HclListItemDescription>
+
+Creates resources in the specified regions. The best practice is to enable GuardDuty in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for global_recorder_region must be in this list.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="iam_access_analyzer_opt_in_regions" requirement="required" type="list">
+<HclListItemDescription>
+
+Creates resources in the specified regions. The best practice is to enable IAM Access Analyzer in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for global_recorder_region must be in this list.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="name_prefix" requirement="required" type="string">
+<HclListItemDescription>
+
+The name used to prefix AWS Config and Cloudtrail resources, including the S3 bucket names and SNS topics used for each.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="additional_config_rules" className="snap-top"></a>
+<HclListItem name="additional_config_rules" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`additional_config_rules`**](#additional_config_rules) &mdash; Map of additional managed rules to add. The key is the name of the rule (e.g. ´acm-certificate-expiration-check´) and the value is an object specifying the rule details
+Map of additional managed rules to add. The key is the name of the rule (e.g. ´acm-certificate-expiration-check´) and the value is an object specifying the rule details
 
-<a name="allow_auto_deploy_from_github_actions_for_sources" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`allow_auto_deploy_from_github_actions_for_sources`**](#allow_auto_deploy_from_github_actions_for_sources) &mdash; Map of github repositories to the list of branches that are allowed to assume the IAM role. The repository should be encoded as org/repo-name (e.g., gruntwork-io/terrraform-aws-ci). Allows GitHub Actions to assume the auto deploy IAM role using an OpenID Connect Provider for the given repositories. Refer to the docs for github-actions-iam-role for more information. Note that this is mutually exclusive with [`allow_auto_deploy_from_other_account_arns`](#allow_auto_deploy_from_other_account_arns). Only used if [`enable_github_actions_access`](#enable_github_actions_access) is true. 
+```hcl
+map(object({
+    # Description of the rule
+    description : string
+    # Identifier of an available AWS Config Managed Rule to call.
+    identifier : string
+    # Trigger type of the rule, must be one of ´CONFIG_CHANGE´ or ´PERIODIC´.
+    trigger_type : string
+    # A map of input parameters for the rule. If you don't have parameters, pass in an empty map ´{}´.
+    input_parameters : map(string)
+    # Whether or not this applies to global (non-regional) resources like IAM roles. When true, these rules are disabled
+    # if var.enable_global_resource_rules is false.
+    applies_to_global_resources = bool
+  }))
+```
 
-<a name="allow_auto_deploy_from_other_account_arns" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`allow_auto_deploy_from_other_account_arns`**](#allow_auto_deploy_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed to assume the auto deploy IAM role that has the permissions in [`auto_deploy_permissions`](#auto_deploy_permissions).
+<HclListItem name="allow_auto_deploy_from_github_actions_for_sources" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="allow_billing_access_from_other_account_arns" className="snap-top"></a>
+Map of github repositories to the list of branches that are allowed to assume the IAM role. The repository should be encoded as org/repo-name (e.g., gruntwork-io/terrraform-aws-ci). Allows GitHub Actions to assume the auto deploy IAM role using an OpenID Connect Provider for the given repositories. Refer to the docs for github-actions-iam-role for more information. Note that this is mutually exclusive with <a href="#allow_auto_deploy_from_other_account_arns"><code>allow_auto_deploy_from_other_account_arns</code></a>. Only used if <a href="#enable_github_actions_access"><code>enable_github_actions_access</code></a> is true. 
 
-* [**`allow_billing_access_from_other_account_arns`**](#allow_billing_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to the billing info for this account.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="allow_cloudtrail_access_with_iam" className="snap-top"></a>
+```hcl
+map(list(string))
+```
 
-* [**`allow_cloudtrail_access_with_iam`**](#allow_cloudtrail_access_with_iam) &mdash; If true, an IAM Policy that grants access to CloudTrail will be honored. If false, only the ARNs listed in [`kms_key_user_iam_arns`](#kms_key_user_iam_arns) will have access to CloudTrail and any IAM Policy grants will be ignored. (true or false)
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="allow_dev_access_from_other_account_arns" className="snap-top"></a>
+<HclListItem name="allow_auto_deploy_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`allow_dev_access_from_other_account_arns`**](#allow_dev_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to the services in this account specified in [`dev_permitted_services`](#dev_permitted_services).
+A list of IAM ARNs from other AWS accounts that will be allowed to assume the auto deploy IAM role that has the permissions in <a href="#auto_deploy_permissions"><code>auto_deploy_permissions</code></a>.
 
-<a name="allow_full_access_from_other_account_arns" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`allow_full_access_from_other_account_arns`**](#allow_full_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to this account.
+```hcl
+list(string)
+```
 
-<a name="allow_logs_access_from_other_account_arns" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`allow_logs_access_from_other_account_arns`**](#allow_logs_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed read access to the logs in CloudTrail, AWS Config, and CloudWatch for this account. If [`cloudtrail_kms_key_arn`](#cloudtrail_kms_key_arn) is specified, will also be given permissions to decrypt with the KMS CMK that is used to encrypt CloudTrail logs.
+<HclListItem name="allow_billing_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="allow_read_only_access_from_other_account_arns" className="snap-top"></a>
+A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to the billing info for this account.
 
-* [**`allow_read_only_access_from_other_account_arns`**](#allow_read_only_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed read-only access to this account.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="allow_ssh_grunt_access_from_other_account_arns" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`allow_ssh_grunt_access_from_other_account_arns`**](#allow_ssh_grunt_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed read access to IAM groups and publish SSH keys. This is used for ssh-grunt.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="allow_support_access_from_other_account_arns" className="snap-top"></a>
+<HclListItem name="allow_cloudtrail_access_with_iam" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`allow_support_access_from_other_account_arns`**](#allow_support_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed access to AWS support for this account.
+If true, an IAM Policy that grants access to CloudTrail will be honored. If false, only the ARNs listed in <a href="#kms_key_user_iam_arns"><code>kms_key_user_iam_arns</code></a> will have access to CloudTrail and any IAM Policy grants will be ignored. (true or false)
 
-<a name="auto_deploy_permissions" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`auto_deploy_permissions`**](#auto_deploy_permissions) &mdash; A list of IAM permissions (e.g. ec2:*) that will be added to an IAM Group for doing automated deployments. NOTE: If [`should_create_iam_group_auto_deploy`](#should_create_iam_group_auto_deploy) is true, the list must have at least one element (e.g. '*').
+<HclListItem name="allow_dev_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="cloudtrail_allow_kms_describe_key_to_external_aws_accounts" className="snap-top"></a>
+A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to the services in this account specified in <a href="#dev_permitted_services"><code>dev_permitted_services</code></a>.
 
-* [**`cloudtrail_allow_kms_describe_key_to_external_aws_accounts`**](#cloudtrail_allow_kms_describe_key_to_external_aws_accounts) &mdash; Whether or not to allow kms:DescribeKey to external AWS accounts with write access to the CloudTrail bucket. This is useful during deployment so that you don't have to pass around the KMS key ARN.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="cloudtrail_cloudwatch_logs_group_name" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`cloudtrail_cloudwatch_logs_group_name`**](#cloudtrail_cloudwatch_logs_group_name) &mdash; Specify the name of the CloudWatch Logs group to publish the CloudTrail logs to. This log group exists in the current account. Set this value to `null` to avoid publishing the trail logs to the logs group. The recommended configuration for CloudTrail is (a) for each child account to aggregate its logs in an S3 bucket in a single central account, such as a logs account and (b) to also store 14 days work of logs in CloudWatch in the child account itself for local debugging.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="cloudtrail_data_logging_enabled" className="snap-top"></a>
+<HclListItem name="allow_full_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`cloudtrail_data_logging_enabled`**](#cloudtrail_data_logging_enabled) &mdash; If true, logging of data events will be enabled.
+A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to this account.
 
-<a name="cloudtrail_data_logging_include_management_events" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`cloudtrail_data_logging_include_management_events`**](#cloudtrail_data_logging_include_management_events) &mdash; Specify if you want your event selector to include management events for your trail.
+```hcl
+list(string)
+```
 
-<a name="cloudtrail_data_logging_read_write_type" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`cloudtrail_data_logging_read_write_type`**](#cloudtrail_data_logging_read_write_type) &mdash; Specify if you want your trail to log read-only events, write-only events, or all. Possible values are: ReadOnly, WriteOnly, All.
+<HclListItem name="allow_logs_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="cloudtrail_data_logging_resources" className="snap-top"></a>
+A list of IAM ARNs from other AWS accounts that will be allowed read access to the logs in CloudTrail, AWS Config, and CloudWatch for this account. If <a href="#cloudtrail_kms_key_arn"><code>cloudtrail_kms_key_arn</code></a> is specified, will also be given permissions to decrypt with the KMS CMK that is used to encrypt CloudTrail logs.
 
-* [**`cloudtrail_data_logging_resources`**](#cloudtrail_data_logging_resources) &mdash; Data resources for which to log data events. This should be a map, where each key is a data resource type, and each value is a list of data resource values. Possible values for data resource types are: AWS::S3::Object, AWS::Lambda::Function and AWS::DynamoDB::Table. See the [`'data_resource`](#'data_resource)' block within the [`'event_selector`](#'event_selector)' block of the [`'aws_cloudtrail`](#'aws_cloudtrail)' resource for context: [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail#data_resource`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail#data_resource).
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="cloudtrail_enable_key_rotation" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`cloudtrail_enable_key_rotation`**](#cloudtrail_enable_key_rotation) &mdash; Whether or not to enable automatic annual rotation of the KMS key. Defaults to true.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="cloudtrail_force_destroy" className="snap-top"></a>
+<HclListItem name="allow_read_only_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`cloudtrail_force_destroy`**](#cloudtrail_force_destroy) &mdash; If set to true, when you run 'terraform destroy', delete all objects from the bucket so that the bucket can be destroyed without error. Warning: these objects are not recoverable so only use this if you're absolutely sure you want to permanently delete everything!
+A list of IAM ARNs from other AWS accounts that will be allowed read-only access to this account.
 
-<a name="cloudtrail_is_organization_trail" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`cloudtrail_is_organization_trail`**](#cloudtrail_is_organization_trail) &mdash; Specifies whether the trail is an AWS Organizations trail. Organization trails log events for the root account and all member accounts. Can only be created in the organization root account. (true or false)
+```hcl
+list(string)
+```
 
-<a name="cloudtrail_kms_key_administrator_iam_arns" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`cloudtrail_kms_key_administrator_iam_arns`**](#cloudtrail_kms_key_administrator_iam_arns) &mdash; All CloudTrail Logs will be encrypted with a KMS Key (a Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. The IAM Users specified in this list will have rights to change who can access this extended log data. Note that if you specify a logs account (by setting [`is_logs_account`](#is_logs_account) = true on one of the accounts in [`child_accounts`](#child_accounts)), the KMS CMK will be created in that account, and the root of that account will automatically be made an admin of the CMK.
+<HclListItem name="allow_ssh_grunt_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="cloudtrail_kms_key_arn" className="snap-top"></a>
+A list of IAM ARNs from other AWS accounts that will be allowed read access to IAM groups and publish SSH keys. This is used for ssh-grunt.
 
-* [**`cloudtrail_kms_key_arn`**](#cloudtrail_kms_key_arn) &mdash; All CloudTrail Logs will be encrypted with a KMS CMK (Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. If that CMK already exists, set this to the ARN of that CMK. Otherwise, set this to null, and a new CMK will be created. If you set [`is_logs_account`](#is_logs_account) to true on one of the accounts in [`child_accounts`](#child_accounts), the KMS CMK will be created in that account (this is the recommended approach!).
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="cloudtrail_kms_key_arn_is_alias" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`cloudtrail_kms_key_arn_is_alias`**](#cloudtrail_kms_key_arn_is_alias) &mdash; If the [`kms_key_arn`](#kms_key_arn) provided is an alias or alias ARN, then this must be set to true so that the module will exchange the alias for a CMK ARN. Setting this to true and using aliases requires [`cloudtrail_allow_kms_describe_key_to_external_aws_accounts`](#cloudtrail_allow_kms_describe_key_to_external_aws_accounts) to also be true for multi-account scenarios.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="cloudtrail_kms_key_user_iam_arns" className="snap-top"></a>
+<HclListItem name="allow_support_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`cloudtrail_kms_key_user_iam_arns`**](#cloudtrail_kms_key_user_iam_arns) &mdash; All CloudTrail Logs will be encrypted with a KMS Key (a Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. The IAM Users specified in this list will have read-only access to this extended log data.
+A list of IAM ARNs from other AWS accounts that will be allowed access to AWS support for this account.
 
-<a name="cloudtrail_num_days_after_which_archive_log_data" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`cloudtrail_num_days_after_which_archive_log_data`**](#cloudtrail_num_days_after_which_archive_log_data) &mdash; After this number of days, log files should be transitioned from S3 to Glacier. Enter 0 to never archive log data.
+```hcl
+list(string)
+```
 
-<a name="cloudtrail_num_days_after_which_delete_log_data" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`cloudtrail_num_days_after_which_delete_log_data`**](#cloudtrail_num_days_after_which_delete_log_data) &mdash; After this number of days, log files should be deleted from S3. Enter 0 to never delete log data.
+<HclListItem name="auto_deploy_permissions" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="cloudtrail_num_days_to_retain_cloudwatch_logs" className="snap-top"></a>
+A list of IAM permissions (e.g. ec2:*) that will be added to an IAM Group for doing automated deployments. NOTE: If <a href="#should_create_iam_group_auto_deploy"><code>should_create_iam_group_auto_deploy</code></a> is true, the list must have at least one element (e.g. '*').
 
-* [**`cloudtrail_num_days_to_retain_cloudwatch_logs`**](#cloudtrail_num_days_to_retain_cloudwatch_logs) &mdash; After this number of days, logs stored in CloudWatch will be deleted. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0 (default). When set to 0, logs will be retained indefinitely.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="cloudtrail_organization_id" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`cloudtrail_organization_id`**](#cloudtrail_organization_id) &mdash; The ID of the organization. Required only if an organization wide CloudTrail is being setup and [``create_organization`](#`create_organization)` is set to false. The organization ID is required to ensure that the entire organization is whitelisted in the CloudTrail bucket write policy.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="cloudtrail_s3_bucket_name" className="snap-top"></a>
+<HclListItem name="cloudtrail_allow_kms_describe_key_to_external_aws_accounts" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`cloudtrail_s3_bucket_name`**](#cloudtrail_s3_bucket_name) &mdash; The name of the S3 Bucket where CloudTrail logs will be stored. This could be a bucket in this AWS account or the name of a bucket in another AWS account where CloudTrail logs should be sent. If you set [`is_logs_account`](#is_logs_account) on one of the accounts in [`child_accounts`](#child_accounts), the S3 bucket will be created in that account (this is the recommended approach!).
+Whether or not to allow kms:DescribeKey to external AWS accounts with write access to the CloudTrail bucket. This is useful during deployment so that you don't have to pass around the KMS key ARN.
 
-<a name="cloudtrail_s3_mfa_delete" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`cloudtrail_s3_mfa_delete`**](#cloudtrail_s3_mfa_delete) &mdash; Enable MFA delete for either 'Change the versioning state of your bucket' or 'Permanently delete an object version'. This setting only applies to the bucket used to storage Cloudtrail data. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS.  For instructions on how to enable MFA Delete, check out the README from the terraform-aws-security/private-s3-bucket module.
+<HclListItem name="cloudtrail_cloudwatch_logs_group_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="cloudtrail_should_create_s3_bucket" className="snap-top"></a>
+Specify the name of the CloudWatch Logs group to publish the CloudTrail logs to. This log group exists in the current account. Set this value to `null` to avoid publishing the trail logs to the logs group. The recommended configuration for CloudTrail is (a) for each child account to aggregate its logs in an S3 bucket in a single central account, such as a logs account and (b) to also store 14 days work of logs in CloudWatch in the child account itself for local debugging.
 
-* [**`cloudtrail_should_create_s3_bucket`**](#cloudtrail_should_create_s3_bucket) &mdash; If true, create an S3 bucket of name [`cloudtrail_s3_bucket_name`](#cloudtrail_s3_bucket_name) for CloudTrail logs, either in the logs account—the account in [`child_accounts`](#child_accounts) that has [`is_logs_account`](#is_logs_account) set to true (this is the recommended approach!)—or in this account if none of the child accounts are marked as a logs account. If false, assume [`cloudtrail_s3_bucket_name`](#cloudtrail_s3_bucket_name) is an S3 bucket that already exists. We recommend setting this to true and setting [`is_logs_account`](#is_logs_account) to true on one of the accounts in [`child_accounts`](#child_accounts) to use that account as a logs account where you aggregate all your CloudTrail data. In case you want to disable the CloudTrail module and the S3 bucket, you need to set both [`enable_cloudtrail`](#enable_cloudtrail) and [`cloudtrail_should_create_s3_bucket`](#cloudtrail_should_create_s3_bucket) to false.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="cloudtrail-logs"/>
+</HclListItem>
 
-<a name="cloudtrail_tags" className="snap-top"></a>
+<HclListItem name="cloudtrail_data_logging_enabled" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`cloudtrail_tags`**](#cloudtrail_tags) &mdash; Tags to apply to the CloudTrail resources.
+If true, logging of data events will be enabled.
 
-<a name="config_aggregate_config_data_in_external_account" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`config_aggregate_config_data_in_external_account`**](#config_aggregate_config_data_in_external_account) &mdash; Set to true to send the AWS Config data to another account (e.g., a logs account) for aggregation purposes. You must set the ID of that other account via the [`config_central_account_id`](#config_central_account_id) variable. Note that if one of the accounts in [`child_accounts`](#child_accounts) has [`is_logs_account`](#is_logs_account) set to true (this is the approach we recommended!), this variable will be assumed to be true, so you don't have to pass any value for it.  This redundant variable has to exist because Terraform does not allow computed data in count and [`for_each`](#for_each) parameters and [`config_central_account_id`](#config_central_account_id) may be computed if its the ID of a newly-created AWS account.
+<HclListItem name="cloudtrail_data_logging_include_management_events" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="config_central_account_id" className="snap-top"></a>
+Specify if you want your event selector to include management events for your trail.
 
-* [**`config_central_account_id`**](#config_central_account_id) &mdash; If the S3 bucket and SNS topics used for AWS Config live in a different AWS account, set this variable to the ID of that account. If the S3 bucket and SNS topics live in this account, set this variable to an empty string. Note that if one of the accounts in [`child_accounts`](#child_accounts) has [`is_logs_account`](#is_logs_account) set to true (this is the approach we recommended!), that account's ID will be used automatically, and you can leave this variable null.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="config_create_account_rules" className="snap-top"></a>
+<HclListItem name="cloudtrail_data_logging_read_write_type" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`config_create_account_rules`**](#config_create_account_rules) &mdash; Set to true to create account-level AWS Config rules directly in this account. Set false to create org-level rules that apply to this account and all child accounts. We recommend setting this to true to use account-level rules because org-level rules create a chicken-and-egg problem with creating new accounts (see this module's README for details).
+Specify if you want your trail to log read-only events, write-only events, or all. Possible values are: ReadOnly, WriteOnly, All.
 
-<a name="config_delivery_channel_kms_key_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="All"/>
+</HclListItem>
 
-* [**`config_delivery_channel_kms_key_arn`**](#config_delivery_channel_kms_key_arn) &mdash; Optional KMS key to use for encrypting S3 objects on the AWS Config delivery channel for an externally managed S3 bucket. This must belong to the same region as the destination S3 bucket. If null, AWS Config will default to encrypting the delivered data with AES-256 encryption. Only used if [`should_create_s3_bucket`](#should_create_s3_bucket) is false - otherwise, [`config_s3_bucket_kms_key_arn`](#config_s3_bucket_kms_key_arn) is used.
+<HclListItem name="cloudtrail_data_logging_resources" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="config_force_destroy" className="snap-top"></a>
+Data resources for which to log data events. This should be a map, where each key is a data resource type, and each value is a list of data resource values. Possible values for data resource types are: AWS::S3::Object, AWS::Lambda::Function and AWS::DynamoDB::Table. See the 'data_resource' block within the 'event_selector' block of the 'aws_cloudtrail' resource for context: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail#data_resource.
 
-* [**`config_force_destroy`**](#config_force_destroy) &mdash; If set to true, when you run 'terraform destroy', delete all objects from the bucket so that the bucket can be destroyed without error. Warning: these objects are not recoverable so only use this if you're absolutely sure you want to permanently delete everything!
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="config_num_days_after_which_archive_log_data" className="snap-top"></a>
+```hcl
+map(list(string))
+```
 
-* [**`config_num_days_after_which_archive_log_data`**](#config_num_days_after_which_archive_log_data) &mdash; After this number of days, log files should be transitioned from S3 to Glacier. Enter 0 to never archive log data.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="config_num_days_after_which_delete_log_data" className="snap-top"></a>
+<HclListItem name="cloudtrail_enable_key_rotation" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`config_num_days_after_which_delete_log_data`**](#config_num_days_after_which_delete_log_data) &mdash; After this number of days, log files should be deleted from S3. Enter 0 to never delete log data.
+Whether or not to enable automatic annual rotation of the KMS key. Defaults to true.
 
-<a name="config_s3_bucket_kms_key_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`config_s3_bucket_kms_key_arn`**](#config_s3_bucket_kms_key_arn) &mdash; Optional KMS key (in logs account) to use for encrypting S3 objects on the AWS Config bucket, when the S3 bucket is created within this module [`(var.config_should_create_s3_bucket`](#(var.config_should_create_s3_bucket) is true). For encrypting S3 objects on delivery for an externally managed S3 bucket, refer to the [`config_delivery_channel_kms_key_arn`](#config_delivery_channel_kms_key_arn) input variable. If null, data in S3 will be encrypted using the default aws/s3 key. If provided, the key policy of the provided key must permit the IAM role used by AWS Config. See https://docs.aws.amazon.com/sns/latest/dg/sns-key-management.html. Note that the KMS key must reside in the global recorder region (as configured by [`aws_region`](#aws_region)).
+<HclListItem name="cloudtrail_force_destroy" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="config_s3_bucket_name" className="snap-top"></a>
+If set to true, when you run 'terraform destroy', delete all objects from the bucket so that the bucket can be destroyed without error. Warning: these objects are not recoverable so only use this if you're absolutely sure you want to permanently delete everything!
 
-* [**`config_s3_bucket_name`**](#config_s3_bucket_name) &mdash; The name of the S3 Bucket where Config items will be stored. This could be a bucket in this AWS account or the name of a bucket in another AWS account where Config items should be sent. If you set [`is_logs_account`](#is_logs_account) to true on one of the accounts in [`child_accounts`](#child_accounts), the S3 bucket will be created in that account (this is the recommended approach!).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="config_s3_mfa_delete" className="snap-top"></a>
+<HclListItem name="cloudtrail_is_organization_trail" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`config_s3_mfa_delete`**](#config_s3_mfa_delete) &mdash; Enable MFA delete for either 'Change the versioning state of your bucket' or 'Permanently delete an object version'. This setting only applies to the bucket used to storage AWS Config data. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS. For instructions on how to enable MFA Delete, check out the README from the terraform-aws-security/private-s3-bucket module.
+Specifies whether the trail is an AWS Organizations trail. Organization trails log events for the root account and all member accounts. Can only be created in the organization root account. (true or false)
 
-<a name="config_should_create_s3_bucket" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`config_should_create_s3_bucket`**](#config_should_create_s3_bucket) &mdash; If true, create an S3 bucket of name [`config_s3_bucket_name`](#config_s3_bucket_name) for AWS Config data, either in the logs account—the account in [`child_accounts`](#child_accounts) that has [`is_logs_account`](#is_logs_account) set to true (this is the recommended approach!)—or in this account if none of the child accounts are marked as a logs account. If false, assume [`config_s3_bucket_name`](#config_s3_bucket_name) is an S3 bucket that already exists. We recommend setting this to true and setting [`is_logs_account`](#is_logs_account) to true on one of the accounts in [`child_accounts`](#child_accounts) to use that account as a logs account where you aggregate all your AWS Config data. In case you want to disable the AWS Config module and the S3 bucket, you need to set both [`enable_config`](#enable_config) and [`config_should_create_s3_bucket`](#config_should_create_s3_bucket) to false.
+<HclListItem name="cloudtrail_kms_key_administrator_iam_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="config_should_create_sns_topic" className="snap-top"></a>
+All CloudTrail Logs will be encrypted with a KMS Key (a Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. The IAM Users specified in this list will have rights to change who can access this extended log data. Note that if you specify a logs account (by setting is_logs_account = true on one of the accounts in <a href="#child_accounts"><code>child_accounts</code></a>), the KMS CMK will be created in that account, and the root of that account will automatically be made an admin of the CMK.
 
-* [**`config_should_create_sns_topic`**](#config_should_create_sns_topic) &mdash; Set to true to create an SNS topic in this account for sending AWS Config notifications. Set to false to assume the topic specified in [`config_sns_topic_name`](#config_sns_topic_name) already exists in another AWS account (e.g the logs account).
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="config_sns_topic_kms_key_region_map" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`config_sns_topic_kms_key_region_map`**](#config_sns_topic_kms_key_region_map) &mdash; Optional KMS key to use for each region for configuring default encryption for the SNS topic (encoded as a map from region - e.g. us-east-1 - to ARN of KMS key). If null or the region key is missing, encryption will not be configured for the SNS topic in that region.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="config_sns_topic_name" className="snap-top"></a>
+<HclListItem name="cloudtrail_kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`config_sns_topic_name`**](#config_sns_topic_name) &mdash; The name of the SNS Topic in where AWS Config notifications will be sent. Can be in the same account or in another account.
+All CloudTrail Logs will be encrypted with a KMS CMK (Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. If that CMK already exists, set this to the ARN of that CMK. Otherwise, set this to null, and a new CMK will be created. If you set is_logs_account to true on one of the accounts in <a href="#child_accounts"><code>child_accounts</code></a>, the KMS CMK will be created in that account (this is the recommended approach!).
 
-<a name="config_tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`config_tags`**](#config_tags) &mdash; A map of tags to apply to the S3 Bucket. The key is the tag name and the value is the tag value.
+<HclListItem name="cloudtrail_kms_key_arn_is_alias" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="configrules_excluded_accounts" className="snap-top"></a>
+If the kms_key_arn provided is an alias or alias ARN, then this must be set to true so that the module will exchange the alias for a CMK ARN. Setting this to true and using aliases requires <a href="#cloudtrail_allow_kms_describe_key_to_external_aws_accounts"><code>cloudtrail_allow_kms_describe_key_to_external_aws_accounts</code></a> to also be true for multi-account scenarios.
 
-* [**`configrules_excluded_accounts`**](#configrules_excluded_accounts) &mdash; List of AWS account identifiers to exclude from org-level Config rules. Only used if [`config_create_account_rules`](#config_create_account_rules) is false (not recommended).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="configrules_maximum_execution_frequency" className="snap-top"></a>
+<HclListItem name="cloudtrail_kms_key_user_iam_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`configrules_maximum_execution_frequency`**](#configrules_maximum_execution_frequency) &mdash; The maximum frequency with which AWS Config runs evaluations for the ´PERIODIC´ rules. See [`https://www.terraform.io/docs/providers/aws/r/config_organization_managed_rule.html#maximum_execution_frequency`](#https://www.terraform.io/docs/providers/aws/r/config_organization_managed_rule.html#maximum_execution_frequency)
+All CloudTrail Logs will be encrypted with a KMS Key (a Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. The IAM Users specified in this list will have read-only access to this extended log data.
 
-<a name="create_organization" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`create_organization`**](#create_organization) &mdash; Set to true to create/configure AWS Organizations for the first time in this account. If you already configured AWS Organizations in your account, set this to false; alternatively, you could set it to true and run 'terraform import' to import you existing Organization.
+```hcl
+list(string)
+```
 
-<a name="cross_account_access_all_group_name" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`cross_account_access_all_group_name`**](#cross_account_access_all_group_name) &mdash; The name of the IAM group that will grant access to all external AWS accounts in [`iam_groups_for_cross_account_access`](#iam_groups_for_cross_account_access).
+<HclListItem name="cloudtrail_num_days_after_which_archive_log_data" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="dev_permitted_services" className="snap-top"></a>
+After this number of days, log files should be transitioned from S3 to Glacier. Enter 0 to never archive log data.
 
-* [**`dev_permitted_services`**](#dev_permitted_services) &mdash; A list of AWS services for which the developers from the accounts in [`allow_dev_access_from_other_account_arns`](#allow_dev_access_from_other_account_arns) will receive full permissions. See https://goo.gl/ZyoHlz to find the IAM Service name. For example, to grant developers access only to EC2 and Amazon Machine Learning, use the value ["ec2","machinelearning"]. Do NOT add iam to the list of services, or that will grant Developers de facto admin access.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="30"/>
+</HclListItem>
 
-<a name="ebs_enable_encryption" className="snap-top"></a>
+<HclListItem name="cloudtrail_num_days_after_which_delete_log_data" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`ebs_enable_encryption`**](#ebs_enable_encryption) &mdash; If set to true (default), all new EBS volumes will have encryption enabled by default
+After this number of days, log files should be deleted from S3. Enter 0 to never delete log data.
 
-<a name="ebs_kms_key_arns" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="365"/>
+</HclListItem>
 
-* [**`ebs_kms_key_arns`**](#ebs_kms_key_arns) &mdash; Optional map of region names to KMS keys to use for EBS volume encryption when [`ebs_use_existing_kms_keys`](#ebs_use_existing_kms_keys) is enabled.
+<HclListItem name="cloudtrail_num_days_to_retain_cloudwatch_logs" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="ebs_use_existing_kms_keys" className="snap-top"></a>
+After this number of days, logs stored in CloudWatch will be deleted. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0 (default). When set to 0, logs will be retained indefinitely.
 
-* [**`ebs_use_existing_kms_keys`**](#ebs_use_existing_kms_keys) &mdash; If set to true, the KMS Customer Managed Keys (CMK) specified in [`ebs_kms_key_arns`](#ebs_kms_key_arns) will be set as the default for EBS encryption. When false (default), the AWS-managed aws/ebs key will be used.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="0"/>
+</HclListItem>
 
-<a name="enable_cloudtrail" className="snap-top"></a>
+<HclListItem name="cloudtrail_organization_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`enable_cloudtrail`**](#enable_cloudtrail) &mdash; Set to true to enable CloudTrail in the root account. Set to false to disable CloudTrail (note: all other CloudTrail variables will be ignored). In case you want to disable the CloudTrail module and the S3 bucket, you need to set both [`enable_cloudtrail`](#enable_cloudtrail) and [`cloudtrail_should_create_s3_bucket`](#cloudtrail_should_create_s3_bucket) to false.
+The ID of the organization. Required only if an organization wide CloudTrail is being setup and `create_organization` is set to false. The organization ID is required to ensure that the entire organization is whitelisted in the CloudTrail bucket write policy.
 
-<a name="enable_cloudtrail_s3_server_access_logging" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`enable_cloudtrail_s3_server_access_logging`**](#enable_cloudtrail_s3_server_access_logging) &mdash; Enables S3 server access logging which sends detailed records for the requests that are made to the bucket. Defaults to false.
+<HclListItem name="cloudtrail_s3_bucket_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="enable_config" className="snap-top"></a>
+The name of the S3 Bucket where CloudTrail logs will be stored. This could be a bucket in this AWS account or the name of a bucket in another AWS account where CloudTrail logs should be sent. If you set is_logs_account on one of the accounts in <a href="#child_accounts"><code>child_accounts</code></a>, the S3 bucket will be created in that account (this is the recommended approach!).
 
-* [**`enable_config`**](#enable_config) &mdash; Set to true to enable AWS Config in the root account. Set to false to disable AWS Config (note: all other AWS config variables will be ignored). In case you want to disable the CloudTrail module and the S3 bucket, you need to set both [`enable_cloudtrail`](#enable_cloudtrail) and [`cloudtrail_should_create_s3_bucket`](#cloudtrail_should_create_s3_bucket) to false.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="enable_encrypted_volumes" className="snap-top"></a>
+<HclListItem name="cloudtrail_s3_mfa_delete" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`enable_encrypted_volumes`**](#enable_encrypted_volumes) &mdash; Checks whether the EBS volumes that are in an attached state are encrypted.
+Enable MFA delete for either 'Change the versioning state of your bucket' or 'Permanently delete an object version'. This setting only applies to the bucket used to storage Cloudtrail data. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS.  For instructions on how to enable MFA Delete, check out the README from the terraform-aws-security/private-s3-bucket module.
 
-<a name="enable_github_actions_access" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`enable_github_actions_access`**](#enable_github_actions_access) &mdash; When true, create an Open ID Connect Provider that GitHub actions can use to assume IAM roles in the account. Refer to https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services for more information.
+<HclListItem name="cloudtrail_should_create_s3_bucket" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="enable_iam_access_analyzer" className="snap-top"></a>
+If true, create an S3 bucket of name <a href="#cloudtrail_s3_bucket_name"><code>cloudtrail_s3_bucket_name</code></a> for CloudTrail logs, either in the logs account—the account in <a href="#child_accounts"><code>child_accounts</code></a> that has is_logs_account set to true (this is the recommended approach!)—or in this account if none of the child accounts are marked as a logs account. If false, assume <a href="#cloudtrail_s3_bucket_name"><code>cloudtrail_s3_bucket_name</code></a> is an S3 bucket that already exists. We recommend setting this to true and setting is_logs_account to true on one of the accounts in <a href="#child_accounts"><code>child_accounts</code></a> to use that account as a logs account where you aggregate all your CloudTrail data. In case you want to disable the CloudTrail module and the S3 bucket, you need to set both <a href="#enable_cloudtrail"><code>enable_cloudtrail</code></a> and cloudtrail_should_create_s3_bucket to false.
 
-* [**`enable_iam_access_analyzer`**](#enable_iam_access_analyzer) &mdash; A feature flag to enable or disable this module.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="enable_iam_cross_account_roles" className="snap-top"></a>
+<HclListItem name="cloudtrail_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`enable_iam_cross_account_roles`**](#enable_iam_cross_account_roles) &mdash; A feature flag to enable or disable this module.
+Tags to apply to the CloudTrail resources.
 
-<a name="enable_iam_groups" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`enable_iam_groups`**](#enable_iam_groups) &mdash; A feature flag to enable or disable this module.
+```hcl
+map(string)
+```
 
-<a name="enable_iam_password_policy" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`enable_iam_password_policy`**](#enable_iam_password_policy) &mdash; Checks whether the account password policy for IAM users meets the specified requirements.
+<HclListItem name="config_aggregate_config_data_in_external_account" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="enable_insecure_sg_rules" className="snap-top"></a>
+Set to true to send the AWS Config data to another account (e.g., a logs account) for aggregation purposes. You must set the ID of that other account via the config_central_account_id variable. Note that if one of the accounts in <a href="#child_accounts"><code>child_accounts</code></a> has is_logs_account set to true (this is the approach we recommended!), this variable will be assumed to be true, so you don't have to pass any value for it.  This redundant variable has to exist because Terraform does not allow computed data in count and for_each parameters and <a href="#config_central_account_id"><code>config_central_account_id</code></a> may be computed if its the ID of a newly-created AWS account.
 
-* [**`enable_insecure_sg_rules`**](#enable_insecure_sg_rules) &mdash; Checks whether the security group with 0.0.0.0/0 of any Amazon Virtual Private Cloud (Amazon VPC) allows only specific inbound TCP or UDP traffic.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="enable_rds_storage_encrypted" className="snap-top"></a>
+<HclListItem name="config_central_account_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`enable_rds_storage_encrypted`**](#enable_rds_storage_encrypted) &mdash; Checks whether storage encryption is enabled for your RDS DB instances.
+If the S3 bucket and SNS topics used for AWS Config live in a different AWS account, set this variable to the ID of that account. If the S3 bucket and SNS topics live in this account, set this variable to an empty string. Note that if one of the accounts in <a href="#child_accounts"><code>child_accounts</code></a> has is_logs_account set to true (this is the approach we recommended!), that account's ID will be used automatically, and you can leave this variable null.
 
-<a name="enable_root_account_mfa" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
 
-* [**`enable_root_account_mfa`**](#enable_root_account_mfa) &mdash; Checks whether users of your AWS account require a multi-factor authentication (MFA) device to sign in with root credentials.
+<HclListItem name="config_create_account_rules" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="enable_s3_bucket_public_read_prohibited" className="snap-top"></a>
+Set to true to create account-level AWS Config rules directly in this account. Set false to create org-level rules that apply to this account and all child accounts. We recommend setting this to true to use account-level rules because org-level rules create a chicken-and-egg problem with creating new accounts (see this module's README for details).
 
-* [**`enable_s3_bucket_public_read_prohibited`**](#enable_s3_bucket_public_read_prohibited) &mdash; Checks that your Amazon S3 buckets do not allow public read access.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="enable_s3_bucket_public_write_prohibited" className="snap-top"></a>
+<HclListItem name="config_delivery_channel_kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`enable_s3_bucket_public_write_prohibited`**](#enable_s3_bucket_public_write_prohibited) &mdash; Checks that your Amazon S3 buckets do not allow public write access.
+Optional KMS key to use for encrypting S3 objects on the AWS Config delivery channel for an externally managed S3 bucket. This must belong to the same region as the destination S3 bucket. If null, AWS Config will default to encrypting the delivered data with AES-256 encryption. Only used if <a href="#should_create_s3_bucket"><code>should_create_s3_bucket</code></a> is false - otherwise, <a href="#config_s3_bucket_kms_key_arn"><code>config_s3_bucket_kms_key_arn</code></a> is used.
 
-<a name="encrypted_volumes_kms_id" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`encrypted_volumes_kms_id`**](#encrypted_volumes_kms_id) &mdash; ID or ARN of the KMS key that is used to encrypt the volume. Used for configuring the encrypted volumes config rule.
+<HclListItem name="config_force_destroy" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="force_destroy_users" className="snap-top"></a>
+If set to true, when you run 'terraform destroy', delete all objects from the bucket so that the bucket can be destroyed without error. Warning: these objects are not recoverable so only use this if you're absolutely sure you want to permanently delete everything!
 
-* [**`force_destroy_users`**](#force_destroy_users) &mdash; When destroying this user, destroy even if it has non-Terraform-managed IAM access keys, login profile, or MFA devices. Without [`force_destroy`](#force_destroy) a user with non-Terraform-managed access keys and login profile will fail to be destroyed.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="github_actions_openid_connect_provider_thumbprint_list" className="snap-top"></a>
+<HclListItem name="config_num_days_after_which_archive_log_data" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`github_actions_openid_connect_provider_thumbprint_list`**](#github_actions_openid_connect_provider_thumbprint_list) &mdash; When set, use the statically provided hardcoded list of thumbprints rather than looking it up dynamically. This is useful if you want to trade reliability of the OpenID Connect Provider across certificate renewals with a static list that is obtained using a trustworthy mechanism, to mitigate potential damage from a domain hijacking attack on GitHub domains.
+After this number of days, log files should be transitioned from S3 to Glacier. Enter 0 to never archive log data.
 
-<a name="guardduty_cloudwatch_event_rule_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="365"/>
+</HclListItem>
 
-* [**`guardduty_cloudwatch_event_rule_name`**](#guardduty_cloudwatch_event_rule_name) &mdash; Name of the Cloudwatch event rules.
+<HclListItem name="config_num_days_after_which_delete_log_data" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="guardduty_finding_publishing_frequency" className="snap-top"></a>
+After this number of days, log files should be deleted from S3. Enter 0 to never delete log data.
 
-* [**`guardduty_finding_publishing_frequency`**](#guardduty_finding_publishing_frequency) &mdash; Specifies the frequency of notifications sent for subsequent finding occurrences. If the detector is a GuardDuty member account, the value is determined by the GuardDuty master account and cannot be modified, otherwise defaults to [`SIX_HOURS`](#SIX_HOURS). For standalone and GuardDuty master accounts, it must be configured in Terraform to enable drift detection. Valid values for standalone and master accounts: [`FIFTEEN_MINUTES`](#FIFTEEN_MINUTES), [`ONE_HOUR`](#ONE_HOUR), [`SIX_HOURS`](#SIX_HOURS).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="730"/>
+</HclListItem>
 
-<a name="guardduty_findings_sns_topic_name" className="snap-top"></a>
+<HclListItem name="config_s3_bucket_kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`guardduty_findings_sns_topic_name`**](#guardduty_findings_sns_topic_name) &mdash; Specifies a name for the created SNS topics where findings are published. [`publish_findings_to_sns`](#publish_findings_to_sns) must be set to true.
+Optional KMS key (in logs account) to use for encrypting S3 objects on the AWS Config bucket, when the S3 bucket is created within this module (<a href="#config_should_create_s3_bucket"><code>config_should_create_s3_bucket</code></a> is true). For encrypting S3 objects on delivery for an externally managed S3 bucket, refer to the <a href="#config_delivery_channel_kms_key_arn"><code>config_delivery_channel_kms_key_arn</code></a> input variable. If null, data in S3 will be encrypted using the default aws/s3 key. If provided, the key policy of the provided key must permit the IAM role used by AWS Config. See https://docs.aws.amazon.com/sns/latest/dg/sns-key-management.html. Note that the KMS key must reside in the global recorder region (as configured by <a href="#aws_region"><code>aws_region</code></a>).
 
-<a name="guardduty_publish_findings_to_sns" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`guardduty_publish_findings_to_sns`**](#guardduty_publish_findings_to_sns) &mdash; Send GuardDuty findings to SNS topics specified by [`findings_sns_topic_name`](#findings_sns_topic_name).
+<HclListItem name="config_s3_bucket_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="iam_access_analyzer_name" className="snap-top"></a>
+The name of the S3 Bucket where Config items will be stored. This could be a bucket in this AWS account or the name of a bucket in another AWS account where Config items should be sent. If you set is_logs_account to true on one of the accounts in <a href="#child_accounts"><code>child_accounts</code></a>, the S3 bucket will be created in that account (this is the recommended approach!).
 
-* [**`iam_access_analyzer_name`**](#iam_access_analyzer_name) &mdash; The name of the IAM Access Analyzer module
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="iam_access_analyzer_type" className="snap-top"></a>
+<HclListItem name="config_s3_mfa_delete" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`iam_access_analyzer_type`**](#iam_access_analyzer_type) &mdash; If set to ORGANIZATION, the analyzer will be scanning the current organization and any policies that refer to linked resources such as S3, IAM, Lambda and SQS policies.
+Enable MFA delete for either 'Change the versioning state of your bucket' or 'Permanently delete an object version'. This setting only applies to the bucket used to storage AWS Config data. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS. For instructions on how to enable MFA Delete, check out the README from the terraform-aws-security/private-s3-bucket module.
 
-<a name="iam_group_developers_permitted_services" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`iam_group_developers_permitted_services`**](#iam_group_developers_permitted_services) &mdash; A list of AWS services for which the developers IAM Group will receive full permissions. See https://goo.gl/ZyoHlz to find the IAM Service name. For example, to grant developers access only to EC2 and Amazon Machine Learning, use the value ["ec2","machinelearning"]. Do NOT add iam to the list of services, or that will grant Developers de facto admin access. If you need to grant iam privileges, just grant the user Full Access.
+<HclListItem name="config_should_create_s3_bucket" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="iam_group_names_ssh_grunt_sudo_users" className="snap-top"></a>
+If true, create an S3 bucket of name <a href="#config_s3_bucket_name"><code>config_s3_bucket_name</code></a> for AWS Config data, either in the logs account—the account in <a href="#child_accounts"><code>child_accounts</code></a> that has is_logs_account set to true (this is the recommended approach!)—or in this account if none of the child accounts are marked as a logs account. If false, assume <a href="#config_s3_bucket_name"><code>config_s3_bucket_name</code></a> is an S3 bucket that already exists. We recommend setting this to true and setting is_logs_account to true on one of the accounts in <a href="#child_accounts"><code>child_accounts</code></a> to use that account as a logs account where you aggregate all your AWS Config data. In case you want to disable the AWS Config module and the S3 bucket, you need to set both <a href="#enable_config"><code>enable_config</code></a> and config_should_create_s3_bucket to false.
 
-* [**`iam_group_names_ssh_grunt_sudo_users`**](#iam_group_names_ssh_grunt_sudo_users) &mdash; The list of names to be used for the IAM Group that enables its members to SSH as a sudo user into any server configured with the ssh-grunt Gruntwork module. Pass in multiple to configure multiple different IAM groups to control different groupings of access at the server level. Pass in empty list to disable creation of the IAM groups.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="iam_group_names_ssh_grunt_users" className="snap-top"></a>
+<HclListItem name="config_should_create_sns_topic" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`iam_group_names_ssh_grunt_users`**](#iam_group_names_ssh_grunt_users) &mdash; The name to be used for the IAM Group that enables its members to SSH as a non-sudo user into any server configured with the ssh-grunt Gruntwork module. Pass in multiple to configure multiple different IAM groups to control different groupings of access at the server level. Pass in empty list to disable creation of the IAM groups.
+Set to true to create an SNS topic in this account for sending AWS Config notifications. Set to false to assume the topic specified in <a href="#config_sns_topic_name"><code>config_sns_topic_name</code></a> already exists in another AWS account (e.g the logs account).
 
-<a name="iam_groups_for_cross_account_access" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`iam_groups_for_cross_account_access`**](#iam_groups_for_cross_account_access) &mdash; This variable is used to create groups that allow IAM users to assume roles in your other AWS accounts. It should be a list of objects, where each object has the fields [`'group_name`](#'group_name)', which will be used as the name of the IAM group, and [`'iam_role_arns`](#'iam_role_arns)', which is a list of ARNs of IAM Roles that you can assume when part of that group. For each entry in the list of objects, we will create an IAM group that allows users to assume the given IAM role(s) in the other AWS account. This allows you to define all your IAM users in one account (e.g. the users account) and to grant them access to certain IAM roles in other accounts (e.g. the stage, prod, audit accounts).
+<HclListItem name="config_sns_topic_kms_key_region_map" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="iam_password_policy_allow_users_to_change_password" className="snap-top"></a>
+Optional KMS key to use for each region for configuring default encryption for the SNS topic (encoded as a map from region - e.g. us-east-1 - to ARN of KMS key). If null or the region key is missing, encryption will not be configured for the SNS topic in that region.
 
-* [**`iam_password_policy_allow_users_to_change_password`**](#iam_password_policy_allow_users_to_change_password) &mdash; Allow users to change their own password.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="iam_password_policy_hard_expiry" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`iam_password_policy_hard_expiry`**](#iam_password_policy_hard_expiry) &mdash; Password expiration requires administrator reset.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="iam_password_policy_max_password_age" className="snap-top"></a>
+<HclListItem name="config_sns_topic_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`iam_password_policy_max_password_age`**](#iam_password_policy_max_password_age) &mdash; Number of days before password expiration.
+The name of the SNS Topic in where AWS Config notifications will be sent. Can be in the same account or in another account.
 
-<a name="iam_password_policy_minimum_password_length" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ConfigTopic"/>
+</HclListItem>
 
-* [**`iam_password_policy_minimum_password_length`**](#iam_password_policy_minimum_password_length) &mdash; Password minimum length.
+<HclListItem name="config_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="iam_password_policy_password_reuse_prevention" className="snap-top"></a>
+A map of tags to apply to the S3 Bucket. The key is the tag name and the value is the tag value.
 
-* [**`iam_password_policy_password_reuse_prevention`**](#iam_password_policy_password_reuse_prevention) &mdash; Number of passwords before allowing reuse.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="iam_password_policy_require_lowercase_characters" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`iam_password_policy_require_lowercase_characters`**](#iam_password_policy_require_lowercase_characters) &mdash; Require at least one lowercase character in password.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="iam_password_policy_require_numbers" className="snap-top"></a>
+<HclListItem name="configrules_excluded_accounts" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`iam_password_policy_require_numbers`**](#iam_password_policy_require_numbers) &mdash; Require at least one number in password.
+List of AWS account identifiers to exclude from org-level Config rules. Only used if <a href="#config_create_account_rules"><code>config_create_account_rules</code></a> is false (not recommended).
 
-<a name="iam_password_policy_require_symbols" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`iam_password_policy_require_symbols`**](#iam_password_policy_require_symbols) &mdash; Require at least one symbol in password.
+```hcl
+list(string)
+```
 
-<a name="iam_password_policy_require_uppercase_characters" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`iam_password_policy_require_uppercase_characters`**](#iam_password_policy_require_uppercase_characters) &mdash; Require at least one uppercase character in password.
+<HclListItem name="configrules_maximum_execution_frequency" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="iam_role_tags" className="snap-top"></a>
+The maximum frequency with which AWS Config runs evaluations for the ´PERIODIC´ rules. See https://www.terraform.io/docs/providers/aws/r/config_organization_managed_rule.html#maximum_execution_frequency
 
-* [**`iam_role_tags`**](#iam_role_tags) &mdash; The tags to apply to all the IAM role resources.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="TwentyFour_Hours"/>
+</HclListItem>
 
-<a name="insecure_sg_rules_authorized_tcp_ports" className="snap-top"></a>
+<HclListItem name="create_organization" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`insecure_sg_rules_authorized_tcp_ports`**](#insecure_sg_rules_authorized_tcp_ports) &mdash; Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by a dash; for example, '443,1020-1025'.
+Set to true to create/configure AWS Organizations for the first time in this account. If you already configured AWS Organizations in your account, set this to false; alternatively, you could set it to true and run 'terraform import' to import you existing Organization.
 
-<a name="insecure_sg_rules_authorized_udp_ports" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`insecure_sg_rules_authorized_udp_ports`**](#insecure_sg_rules_authorized_udp_ports) &mdash; Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by a dash; for example, '500,1020-1025'.
+<HclListItem name="cross_account_access_all_group_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="is_multi_region_trail" className="snap-top"></a>
+The name of the IAM group that will grant access to all external AWS accounts in <a href="#iam_groups_for_cross_account_access"><code>iam_groups_for_cross_account_access</code></a>.
 
-* [**`is_multi_region_trail`**](#is_multi_region_trail) &mdash; Specifies whether CloudTrail will log only API calls in the current region or in all regions. (true or false)
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="_all-accounts"/>
+</HclListItem>
 
-<a name="organizations_aws_service_access_principals" className="snap-top"></a>
+<HclListItem name="dev_permitted_services" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`organizations_aws_service_access_principals`**](#organizations_aws_service_access_principals) &mdash; List of AWS service principal names for which you want to enable integration with your organization. Must have [``organizations_feature_set`](#`organizations_feature_set)` set to ALL. See [`https://docs.aws.amazon.com/organizations/latest/userguide/orgs_integrate_services`](#https://docs.aws.amazon.com/organizations/latest/userguide/orgs_integrate_services).html
+A list of AWS services for which the developers from the accounts in <a href="#allow_dev_access_from_other_account_arns"><code>allow_dev_access_from_other_account_arns</code></a> will receive full permissions. See https://goo.gl/ZyoHlz to find the IAM Service name. For example, to grant developers access only to EC2 and Amazon Machine Learning, use the value ['ec2','machinelearning']. Do NOT add iam to the list of services, or that will grant Developers de facto admin access.
 
-<a name="organizations_default_iam_user_access_to_billing" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`organizations_default_iam_user_access_to_billing`**](#organizations_default_iam_user_access_to_billing) &mdash; If set to ALLOW, the new account enables IAM users to access account billing information if they have the required permissions. If set to DENY, then only the root user of the new account can access account billing information.
+```hcl
+list(string)
+```
 
-<a name="organizations_default_role_name" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`organizations_default_role_name`**](#organizations_default_role_name) &mdash; The name of an IAM role that Organizations automatically preconfigures in the new member account. This role trusts the master account, allowing users in the master account to assume the role, as permitted by the master account administrator.
+<HclListItem name="ebs_enable_encryption" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="organizations_default_tags" className="snap-top"></a>
+If set to true (default), all new EBS volumes will have encryption enabled by default
 
-* [**`organizations_default_tags`**](#organizations_default_tags) &mdash; Default tags to add to accounts. Will be appended to [`´child_account`](#´child_account).*.tags´
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="organizations_enabled_policy_types" className="snap-top"></a>
+<HclListItem name="ebs_kms_key_arns" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`organizations_enabled_policy_types`**](#organizations_enabled_policy_types) &mdash; List of Organizations policy types to enable in the Organization Root. See [`https://docs.aws.amazon.com/organizations/latest/APIReference/API_EnablePolicyType`](#https://docs.aws.amazon.com/organizations/latest/APIReference/API_EnablePolicyType).html
+Optional map of region names to KMS keys to use for EBS volume encryption when <a href="#ebs_use_existing_kms_keys"><code>ebs_use_existing_kms_keys</code></a> is enabled.
 
-<a name="organizations_feature_set" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`organizations_feature_set`**](#organizations_feature_set) &mdash; Specify `ALL` or [``CONSOLIDATED_BILLING`](#`CONSOLIDATED_BILLING)`.
+```hcl
+map(string)
+```
 
-<a name="password_reset_required" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`password_reset_required`**](#password_reset_required) &mdash; Force the user to reset their password on initial login. Only used for users with [`create_login_profile`](#create_login_profile) set to true.
+<HclListItem name="ebs_use_existing_kms_keys" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="rds_storage_encrypted_kms_id" className="snap-top"></a>
+If set to true, the KMS Customer Managed Keys (CMK) specified in <a href="#ebs_kms_key_arns"><code>ebs_kms_key_arns</code></a> will be set as the default for EBS encryption. When false (default), the AWS-managed aws/ebs key will be used.
 
-* [**`rds_storage_encrypted_kms_id`**](#rds_storage_encrypted_kms_id) &mdash; KMS key ID or ARN used to encrypt the storage. Used for configuring the RDS storage encryption config rule.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="should_create_iam_group_auto_deploy" className="snap-top"></a>
+<HclListItem name="enable_cloudtrail" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`should_create_iam_group_auto_deploy`**](#should_create_iam_group_auto_deploy) &mdash; Should we create the IAM Group for auto-deploy? Allows automated deployment by granting the permissions specified in [`auto_deploy_permissions`](#auto_deploy_permissions). (true or false)
+Set to true to enable CloudTrail in the root account. Set to false to disable CloudTrail (note: all other CloudTrail variables will be ignored). In case you want to disable the CloudTrail module and the S3 bucket, you need to set both <a href="#enable_cloudtrail"><code>enable_cloudtrail</code></a> and cloudtrail_should_create_s3_bucket to false.
 
-<a name="should_create_iam_group_billing" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`should_create_iam_group_billing`**](#should_create_iam_group_billing) &mdash; Should we create the IAM Group for billing? Allows read-write access to billing features only. (true or false)
+<HclListItem name="enable_cloudtrail_s3_server_access_logging" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="should_create_iam_group_developers" className="snap-top"></a>
+Enables S3 server access logging which sends detailed records for the requests that are made to the bucket. Defaults to false.
 
-* [**`should_create_iam_group_developers`**](#should_create_iam_group_developers) &mdash; Should we create the IAM Group for developers? The permissions of that group are specified via [`iam_group_developers_permitted_services`](#iam_group_developers_permitted_services). (true or false)
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="should_create_iam_group_full_access" className="snap-top"></a>
+<HclListItem name="enable_config" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`should_create_iam_group_full_access`**](#should_create_iam_group_full_access) &mdash; Should we create the IAM Group for full access? Allows full access to all AWS resources. (true or false)
+Set to true to enable AWS Config in the root account. Set to false to disable AWS Config (note: all other AWS config variables will be ignored). In case you want to disable the CloudTrail module and the S3 bucket, you need to set both <a href="#enable_cloudtrail"><code>enable_cloudtrail</code></a> and cloudtrail_should_create_s3_bucket to false.
 
-<a name="should_create_iam_group_houston_cli_users" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`should_create_iam_group_houston_cli_users`**](#should_create_iam_group_houston_cli_users) &mdash; Should we create the IAM Group for houston CLI users? Allows users to use the houston CLI for managing and deploying services.
+<HclListItem name="enable_encrypted_volumes" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="should_create_iam_group_logs" className="snap-top"></a>
+Checks whether the EBS volumes that are in an attached state are encrypted.
 
-* [**`should_create_iam_group_logs`**](#should_create_iam_group_logs) &mdash; Should we create the IAM Group for logs? Allows read access to logs in CloudTrail, AWS Config, and CloudWatch. If [`cloudtrail_kms_key_arn`](#cloudtrail_kms_key_arn) is specified, will also be given permissions to decrypt with the KMS CMK that is used to encrypt CloudTrail logs. (true or false)
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="should_create_iam_group_read_only" className="snap-top"></a>
+<HclListItem name="enable_github_actions_access" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`should_create_iam_group_read_only`**](#should_create_iam_group_read_only) &mdash; Should we create the IAM Group for read-only? Allows read-only access to all AWS resources. (true or false)
+When true, create an Open ID Connect Provider that GitHub actions can use to assume IAM roles in the account. Refer to https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services for more information.
 
-<a name="should_create_iam_group_support" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`should_create_iam_group_support`**](#should_create_iam_group_support) &mdash; Should we create the IAM Group for support? Allows access to AWS support. (true or false)
+<HclListItem name="enable_iam_access_analyzer" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="should_create_iam_group_use_existing_iam_roles" className="snap-top"></a>
+A feature flag to enable or disable this module.
 
-* [**`should_create_iam_group_use_existing_iam_roles`**](#should_create_iam_group_use_existing_iam_roles) &mdash; Should we create the IAM Group for use-existing-iam-roles? Allow launching AWS resources with existing IAM Roles, but no ability to create new IAM Roles. (true or false)
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="should_create_iam_group_user_self_mgmt" className="snap-top"></a>
+<HclListItem name="enable_iam_cross_account_roles" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`should_create_iam_group_user_self_mgmt`**](#should_create_iam_group_user_self_mgmt) &mdash; Should we create the IAM Group for user self-management? Allows users to manage their own IAM user accounts, but not other IAM users. (true or false)
+A feature flag to enable or disable this module.
 
-<a name="should_require_mfa" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`should_require_mfa`**](#should_require_mfa) &mdash; Should we require that all IAM Users use Multi-Factor Authentication for both AWS API calls and the AWS Web Console? (true or false)
+<HclListItem name="enable_iam_groups" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="users" className="snap-top"></a>
+A feature flag to enable or disable this module.
 
-* [**`users`**](#users) &mdash; A map of users to create. The keys are the user names and the values are an object with the optional keys 'groups' (a list of IAM groups to add the user to), 'tags' (a map of tags to apply to the user), [`'pgp_key`](#'pgp_key)' (either a base-64 encoded PGP public key, or a keybase username in the form keybase:username, used to encrypt the user's credentials; required if [`create_login_profile`](#create_login_profile) or [`create_access_keys`](#create_access_keys) is true), [`'create_login_profile`](#'create_login_profile)' (if set to true, create a password to login to the AWS Web Console), [`'create_access_keys`](#'create_access_keys)' (if set to true, create access keys for the user), 'path' (the path), and [`'permissions_boundary`](#'permissions_boundary)' (the ARN of the policy that is used to set the permissions boundary for the user).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_iam_password_policy" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Checks whether the account password policy for IAM users meets the specified requirements.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_insecure_sg_rules" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Checks whether the security group with 0.0.0.0/0 of any Amazon Virtual Private Cloud (Amazon VPC) allows only specific inbound TCP or UDP traffic.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_rds_storage_encrypted" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Checks whether storage encryption is enabled for your RDS DB instances.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_root_account_mfa" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Checks whether users of your AWS account require a multi-factor authentication (MFA) device to sign in with root credentials.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_s3_bucket_public_read_prohibited" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Checks that your Amazon S3 buckets do not allow public read access.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_s3_bucket_public_write_prohibited" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Checks that your Amazon S3 buckets do not allow public write access.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="encrypted_volumes_kms_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+ID or ARN of the KMS key that is used to encrypt the volume. Used for configuring the encrypted volumes config rule.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="force_destroy_users" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When destroying this user, destroy even if it has non-Terraform-managed IAM access keys, login profile, or MFA devices. Without force_destroy a user with non-Terraform-managed access keys and login profile will fail to be destroyed.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="github_actions_openid_connect_provider_thumbprint_list" requirement="optional" type="list">
+<HclListItemDescription>
+
+When set, use the statically provided hardcoded list of thumbprints rather than looking it up dynamically. This is useful if you want to trade reliability of the OpenID Connect Provider across certificate renewals with a static list that is obtained using a trustworthy mechanism, to mitigate potential damage from a domain hijacking attack on GitHub domains.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="guardduty_cloudwatch_event_rule_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+Name of the Cloudwatch event rules.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="guardduty-finding-events"/>
+</HclListItem>
+
+<HclListItem name="guardduty_finding_publishing_frequency" requirement="optional" type="string">
+<HclListItemDescription>
+
+Specifies the frequency of notifications sent for subsequent finding occurrences. If the detector is a GuardDuty member account, the value is determined by the GuardDuty master account and cannot be modified, otherwise defaults to SIX_HOURS. For standalone and GuardDuty master accounts, it must be configured in Terraform to enable drift detection. Valid values for standalone and master accounts: FIFTEEN_MINUTES, ONE_HOUR, SIX_HOURS.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="guardduty_findings_sns_topic_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+Specifies a name for the created SNS topics where findings are published. publish_findings_to_sns must be set to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="guardduty-findings"/>
+</HclListItem>
+
+<HclListItem name="guardduty_publish_findings_to_sns" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Send GuardDuty findings to SNS topics specified by findings_sns_topic_name.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="iam_access_analyzer_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of the IAM Access Analyzer module
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="baseline_root-iam_access_analyzer"/>
+</HclListItem>
+
+<HclListItem name="iam_access_analyzer_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+If set to ORGANIZATION, the analyzer will be scanning the current organization and any policies that refer to linked resources such as S3, IAM, Lambda and SQS policies.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ORGANIZATION"/>
+</HclListItem>
+
+<HclListItem name="iam_group_developers_permitted_services" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of AWS services for which the developers IAM Group will receive full permissions. See https://goo.gl/ZyoHlz to find the IAM Service name. For example, to grant developers access only to EC2 and Amazon Machine Learning, use the value ['ec2','machinelearning']. Do NOT add iam to the list of services, or that will grant Developers de facto admin access. If you need to grant iam privileges, just grant the user Full Access.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="iam_group_names_ssh_grunt_sudo_users" requirement="optional" type="list">
+<HclListItemDescription>
+
+The list of names to be used for the IAM Group that enables its members to SSH as a sudo user into any server configured with the ssh-grunt Gruntwork module. Pass in multiple to configure multiple different IAM groups to control different groupings of access at the server level. Pass in empty list to disable creation of the IAM groups.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="iam_group_names_ssh_grunt_users" requirement="optional" type="list">
+<HclListItemDescription>
+
+The name to be used for the IAM Group that enables its members to SSH as a non-sudo user into any server configured with the ssh-grunt Gruntwork module. Pass in multiple to configure multiple different IAM groups to control different groupings of access at the server level. Pass in empty list to disable creation of the IAM groups.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="iam_groups_for_cross_account_access" requirement="optional" type="list">
+<HclListItemDescription>
+
+This variable is used to create groups that allow IAM users to assume roles in your other AWS accounts. It should be a list of objects, where each object has the fields 'group_name', which will be used as the name of the IAM group, and 'iam_role_arns', which is a list of ARNs of IAM Roles that you can assume when part of that group. For each entry in the list of objects, we will create an IAM group that allows users to assume the given IAM role(s) in the other AWS account. This allows you to define all your IAM users in one account (e.g. the users account) and to grant them access to certain IAM roles in other accounts (e.g. the stage, prod, audit accounts).
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(object({
+    group_name    = string
+    iam_role_arns = list(string)
+  }))
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_allow_users_to_change_password" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Allow users to change their own password.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_hard_expiry" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Password expiration requires administrator reset.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_max_password_age" requirement="optional" type="number">
+<HclListItemDescription>
+
+Number of days before password expiration.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="30"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_minimum_password_length" requirement="optional" type="number">
+<HclListItemDescription>
+
+Password minimum length.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="16"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_password_reuse_prevention" requirement="optional" type="number">
+<HclListItemDescription>
+
+Number of passwords before allowing reuse.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="5"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_require_lowercase_characters" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Require at least one lowercase character in password.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_require_numbers" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Require at least one number in password.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_require_symbols" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Require at least one symbol in password.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_require_uppercase_characters" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Require at least one uppercase character in password.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="iam_role_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+The tags to apply to all the IAM role resources.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="insecure_sg_rules_authorized_tcp_ports" requirement="optional" type="string">
+<HclListItemDescription>
+
+Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by a dash; for example, '443,1020-1025'.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="443"/>
+</HclListItem>
+
+<HclListItem name="insecure_sg_rules_authorized_udp_ports" requirement="optional" type="string">
+<HclListItemDescription>
+
+Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by a dash; for example, '500,1020-1025'.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="is_multi_region_trail" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Specifies whether CloudTrail will log only API calls in the current region or in all regions. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="organizations_aws_service_access_principals" requirement="optional" type="list">
+<HclListItemDescription>
+
+List of AWS service principal names for which you want to enable integration with your organization. Must have `organizations_feature_set` set to ALL. See https://docs.aws.amazon.com/organizations/latest/userguide/orgs_integrate_services.html
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
+
+```hcl
+[
+  "cloudtrail.amazonaws.com",
+  "config-multiaccountsetup.amazonaws.com",
+  "config.amazonaws.com",
+  "access-analyzer.amazonaws.com"
+]
+```
+
+</HclListItemDefaultValue>
+</HclListItem>
+
+<HclListItem name="organizations_default_iam_user_access_to_billing" requirement="optional" type="string">
+<HclListItemDescription>
+
+If set to ALLOW, the new account enables IAM users to access account billing information if they have the required permissions. If set to DENY, then only the root user of the new account can access account billing information.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ALLOW"/>
+</HclListItem>
+
+<HclListItem name="organizations_default_role_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of an IAM role that Organizations automatically preconfigures in the new member account. This role trusts the master account, allowing users in the master account to assume the role, as permitted by the master account administrator.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="OrganizationAccountAccessRole"/>
+</HclListItem>
+
+<HclListItem name="organizations_default_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+Default tags to add to accounts. Will be appended to ´child_account.*.tags´
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="organizations_enabled_policy_types" requirement="optional" type="list">
+<HclListItemDescription>
+
+List of Organizations policy types to enable in the Organization Root. See https://docs.aws.amazon.com/organizations/latest/APIReference/API_EnablePolicyType.html
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
+
+```hcl
+[
+  "SERVICE_CONTROL_POLICY"
+]
+```
+
+</HclListItemDefaultValue>
+</HclListItem>
+
+<HclListItem name="organizations_feature_set" requirement="optional" type="string">
+<HclListItemDescription>
+
+Specify `ALL` or `CONSOLIDATED_BILLING`.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ALL"/>
+</HclListItem>
+
+<HclListItem name="password_reset_required" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Force the user to reset their password on initial login. Only used for users with create_login_profile set to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="rds_storage_encrypted_kms_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+KMS key ID or ARN used to encrypt the storage. Used for configuring the RDS storage encryption config rule.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_auto_deploy" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for auto-deploy? Allows automated deployment by granting the permissions specified in <a href="#auto_deploy_permissions"><code>auto_deploy_permissions</code></a>. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_billing" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for billing? Allows read-write access to billing features only. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_developers" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for developers? The permissions of that group are specified via <a href="#iam_group_developers_permitted_services"><code>iam_group_developers_permitted_services</code></a>. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_full_access" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for full access? Allows full access to all AWS resources. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_houston_cli_users" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for houston CLI users? Allows users to use the houston CLI for managing and deploying services.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_logs" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for logs? Allows read access to logs in CloudTrail, AWS Config, and CloudWatch. If <a href="#cloudtrail_kms_key_arn"><code>cloudtrail_kms_key_arn</code></a> is specified, will also be given permissions to decrypt with the KMS CMK that is used to encrypt CloudTrail logs. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_read_only" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for read-only? Allows read-only access to all AWS resources. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_support" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for support? Allows access to AWS support. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_use_existing_iam_roles" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for use-existing-iam-roles? Allow launching AWS resources with existing IAM Roles, but no ability to create new IAM Roles. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_user_self_mgmt" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for user self-management? Allows users to manage their own IAM user accounts, but not other IAM users. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_require_mfa" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we require that all IAM Users use Multi-Factor Authentication for both AWS API calls and the AWS Web Console? (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="users" requirement="optional" type="any">
+<HclListItemDescription>
+
+A map of users to create. The keys are the user names and the values are an object with the optional keys 'groups' (a list of IAM groups to add the user to), 'tags' (a map of tags to apply to the user), 'pgp_key' (either a base-64 encoded PGP public key, or a keybase username in the form keybase:username, used to encrypt the user's credentials; required if create_login_profile or create_access_keys is true), 'create_login_profile' (if set to true, create a password to login to the AWS Web Console), 'create_access_keys' (if set to true, create access keys for the user), 'path' (the path), and 'permissions_boundary' (the ARN of the policy that is used to set the permissions boundary for the user).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="allow_auto_deploy_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_auto_deploy_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-* [**`allow_auto_deploy_access_from_other_accounts_iam_role_arn`**](#allow_auto_deploy_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="allow_auto_deploy_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-<a name="allow_auto_deploy_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_billing_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-* [**`allow_auto_deploy_access_from_other_accounts_iam_role_id`**](#allow_auto_deploy_access_from_other_accounts_iam_role_id) &mdash; 
+<HclListItem name="allow_billing_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-<a name="allow_billing_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_billing_access_sign_in_url">
+</HclListItem>
 
-* [**`allow_billing_access_from_other_accounts_iam_role_arn`**](#allow_billing_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="allow_dev_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-<a name="allow_billing_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_dev_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-* [**`allow_billing_access_from_other_accounts_iam_role_id`**](#allow_billing_access_from_other_accounts_iam_role_id) &mdash; 
+<HclListItem name="allow_dev_access_sign_in_url">
+</HclListItem>
 
-<a name="allow_billing_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="allow_full_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-* [**`allow_billing_access_sign_in_url`**](#allow_billing_access_sign_in_url) &mdash; 
+<HclListItem name="allow_full_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-<a name="allow_dev_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_full_access_sign_in_url">
+</HclListItem>
 
-* [**`allow_dev_access_from_other_accounts_iam_role_arn`**](#allow_dev_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="allow_houston_cli_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-<a name="allow_dev_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_houston_cli_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-* [**`allow_dev_access_from_other_accounts_iam_role_id`**](#allow_dev_access_from_other_accounts_iam_role_id) &mdash; 
+<HclListItem name="allow_iam_admin_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-<a name="allow_dev_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="allow_iam_admin_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-* [**`allow_dev_access_sign_in_url`**](#allow_dev_access_sign_in_url) &mdash; 
+<HclListItem name="allow_iam_admin_access_sign_in_url">
+</HclListItem>
 
-<a name="allow_full_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_logs_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-* [**`allow_full_access_from_other_accounts_iam_role_arn`**](#allow_full_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="allow_logs_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-<a name="allow_full_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_logs_access_sign_in_url">
+</HclListItem>
 
-* [**`allow_full_access_from_other_accounts_iam_role_id`**](#allow_full_access_from_other_accounts_iam_role_id) &mdash; 
+<HclListItem name="allow_read_only_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-<a name="allow_full_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="allow_read_only_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-* [**`allow_full_access_sign_in_url`**](#allow_full_access_sign_in_url) &mdash; 
+<HclListItem name="allow_read_only_access_sign_in_url">
+</HclListItem>
 
-<a name="allow_houston_cli_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_ssh_grunt_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-* [**`allow_houston_cli_access_from_other_accounts_iam_role_arn`**](#allow_houston_cli_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="allow_ssh_grunt_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-<a name="allow_houston_cli_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_ssh_grunt_access_sign_in_url">
+</HclListItem>
 
-* [**`allow_houston_cli_access_from_other_accounts_iam_role_id`**](#allow_houston_cli_access_from_other_accounts_iam_role_id) &mdash; 
+<HclListItem name="allow_ssh_grunt_houston_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-<a name="allow_iam_admin_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_ssh_grunt_houston_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-* [**`allow_iam_admin_access_from_other_accounts_iam_role_arn`**](#allow_iam_admin_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="allow_ssh_grunt_houston_access_sign_in_url">
+</HclListItem>
 
-<a name="allow_iam_admin_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_support_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-* [**`allow_iam_admin_access_from_other_accounts_iam_role_id`**](#allow_iam_admin_access_from_other_accounts_iam_role_id) &mdash; 
+<HclListItem name="allow_support_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-<a name="allow_iam_admin_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="allow_support_access_sign_in_url">
+</HclListItem>
 
-* [**`allow_iam_admin_access_sign_in_url`**](#allow_iam_admin_access_sign_in_url) &mdash; 
+<HclListItem name="aws_ebs_encryption_by_default_enabled">
+<HclListItemDescription>
 
-<a name="allow_logs_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+A map from region to a boolean indicating whether or not EBS encryption is enabled by default for each region.
 
-* [**`allow_logs_access_from_other_accounts_iam_role_arn`**](#allow_logs_access_from_other_accounts_iam_role_arn) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="allow_logs_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="aws_ebs_encryption_default_kms_key">
+<HclListItemDescription>
 
-* [**`allow_logs_access_from_other_accounts_iam_role_id`**](#allow_logs_access_from_other_accounts_iam_role_id) &mdash; 
+A map from region to the ARN of the KMS key used for default EBS encryption for each region.
 
-<a name="allow_logs_access_sign_in_url" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`allow_logs_access_sign_in_url`**](#allow_logs_access_sign_in_url) &mdash; 
+<HclListItem name="billing_iam_group_arn">
+</HclListItem>
 
-<a name="allow_read_only_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="billing_iam_group_name">
+</HclListItem>
 
-* [**`allow_read_only_access_from_other_accounts_iam_role_arn`**](#allow_read_only_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="child_accounts">
+<HclListItemDescription>
 
-<a name="allow_read_only_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+A map of all accounts created by this module (NOT including the root account). The keys are the names of the accounts and the values are the attributes for the account as defined in the aws_organizations_account resource.
 
-* [**`allow_read_only_access_from_other_accounts_iam_role_id`**](#allow_read_only_access_from_other_accounts_iam_role_id) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="allow_read_only_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="cloudtrail_cloudwatch_group_arn">
+<HclListItemDescription>
 
-* [**`allow_read_only_access_sign_in_url`**](#allow_read_only_access_sign_in_url) &mdash; 
+The ARN of the cloudwatch log group.
 
-<a name="allow_ssh_grunt_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`allow_ssh_grunt_access_from_other_accounts_iam_role_arn`**](#allow_ssh_grunt_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="cloudtrail_cloudwatch_group_name">
+<HclListItemDescription>
 
-<a name="allow_ssh_grunt_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+The name of the cloudwatch log group.
 
-* [**`allow_ssh_grunt_access_from_other_accounts_iam_role_id`**](#allow_ssh_grunt_access_from_other_accounts_iam_role_id) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="allow_ssh_grunt_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="cloudtrail_iam_role_arn">
+<HclListItemDescription>
 
-* [**`allow_ssh_grunt_access_sign_in_url`**](#allow_ssh_grunt_access_sign_in_url) &mdash; 
+The ARN of the IAM role used by the cloudwatch log group.
 
-<a name="allow_ssh_grunt_houston_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`allow_ssh_grunt_houston_access_from_other_accounts_iam_role_arn`**](#allow_ssh_grunt_houston_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="cloudtrail_iam_role_name">
+<HclListItemDescription>
 
-<a name="allow_ssh_grunt_houston_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+The name of the IAM role used by the cloudwatch log group.
 
-* [**`allow_ssh_grunt_houston_access_from_other_accounts_iam_role_id`**](#allow_ssh_grunt_houston_access_from_other_accounts_iam_role_id) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="allow_ssh_grunt_houston_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="cloudtrail_kms_key_alias_name">
+<HclListItemDescription>
 
-* [**`allow_ssh_grunt_houston_access_sign_in_url`**](#allow_ssh_grunt_houston_access_sign_in_url) &mdash; 
+The alias of the KMS key used by the S3 bucket to encrypt cloudtrail logs.
 
-<a name="allow_support_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`allow_support_access_from_other_accounts_iam_role_arn`**](#allow_support_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="cloudtrail_kms_key_arn">
+<HclListItemDescription>
 
-<a name="allow_support_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+The ARN of the KMS key used by the S3 bucket to encrypt cloudtrail logs.
 
-* [**`allow_support_access_from_other_accounts_iam_role_id`**](#allow_support_access_from_other_accounts_iam_role_id) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="allow_support_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="cloudtrail_kms_key_arn_with_dependency">
+<HclListItemDescription>
 
-* [**`allow_support_access_sign_in_url`**](#allow_support_access_sign_in_url) &mdash; 
+The ARN of the KMS key used by the S3 bucket to encrypt cloudtrail logs.
 
-<a name="aws_ebs_encryption_by_default_enabled" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`aws_ebs_encryption_by_default_enabled`**](#aws_ebs_encryption_by_default_enabled) &mdash; A map from region to a boolean indicating whether or not EBS encryption is enabled by default for each region.
+<HclListItem name="cloudtrail_s3_access_logging_bucket_arn">
+<HclListItemDescription>
 
-<a name="aws_ebs_encryption_default_kms_key" className="snap-top"></a>
+The ARN of the S3 bucket where access logs for the CloudTrail S3 bucket are delivered.
 
-* [**`aws_ebs_encryption_default_kms_key`**](#aws_ebs_encryption_default_kms_key) &mdash; A map from region to the ARN of the KMS key used for default EBS encryption for each region.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="billing_iam_group_arn" className="snap-top"></a>
+<HclListItem name="cloudtrail_s3_access_logging_bucket_name">
+<HclListItemDescription>
 
-* [**`billing_iam_group_arn`**](#billing_iam_group_arn) &mdash; 
+The name of the S3 bucket where access logs for the CloudTrail S3 bucket are delivered.
 
-<a name="billing_iam_group_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`billing_iam_group_name`**](#billing_iam_group_name) &mdash; 
+<HclListItem name="cloudtrail_s3_bucket_arn">
+<HclListItemDescription>
 
-<a name="child_accounts" className="snap-top"></a>
+The ARN of the S3 bucket where cloudtrail logs are delivered.
 
-* [**`child_accounts`**](#child_accounts) &mdash; A map of all accounts created by this module (NOT including the root account). The keys are the names of the accounts and the values are the attributes for the account as defined in the [`aws_organizations_account`](#aws_organizations_account) resource.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="cloudtrail_cloudwatch_group_arn" className="snap-top"></a>
+<HclListItem name="cloudtrail_s3_bucket_name">
+<HclListItemDescription>
 
-* [**`cloudtrail_cloudwatch_group_arn`**](#cloudtrail_cloudwatch_group_arn) &mdash; The ARN of the cloudwatch log group.
+The name of the S3 bucket where cloudtrail logs are delivered.
 
-<a name="cloudtrail_cloudwatch_group_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cloudtrail_cloudwatch_group_name`**](#cloudtrail_cloudwatch_group_name) &mdash; The name of the cloudwatch log group.
+<HclListItem name="cloudtrail_s3_bucket_name_with_dependency">
+<HclListItemDescription>
 
-<a name="cloudtrail_iam_role_arn" className="snap-top"></a>
+The name of the S3 bucket where cloudtrail logs are delivered. Sources from 'data'.
 
-* [**`cloudtrail_iam_role_arn`**](#cloudtrail_iam_role_arn) &mdash; The ARN of the IAM role used by the cloudwatch log group.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="cloudtrail_iam_role_name" className="snap-top"></a>
+<HclListItem name="cloudtrail_trail_arn">
+<HclListItemDescription>
 
-* [**`cloudtrail_iam_role_name`**](#cloudtrail_iam_role_name) &mdash; The name of the IAM role used by the cloudwatch log group.
+The ARN of the cloudtrail trail.
 
-<a name="cloudtrail_kms_key_alias_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cloudtrail_kms_key_alias_name`**](#cloudtrail_kms_key_alias_name) &mdash; The alias of the KMS key used by the S3 bucket to encrypt cloudtrail logs.
+<HclListItem name="config_iam_role_arns">
+<HclListItemDescription>
 
-<a name="cloudtrail_kms_key_arn" className="snap-top"></a>
+The ARNs of the IAM role used by the config recorder.
 
-* [**`cloudtrail_kms_key_arn`**](#cloudtrail_kms_key_arn) &mdash; The ARN of the KMS key used by the S3 bucket to encrypt cloudtrail logs.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="cloudtrail_kms_key_arn_with_dependency" className="snap-top"></a>
+<HclListItem name="config_recorder_names">
+<HclListItemDescription>
 
-* [**`cloudtrail_kms_key_arn_with_dependency`**](#cloudtrail_kms_key_arn_with_dependency) &mdash; The ARN of the KMS key used by the S3 bucket to encrypt cloudtrail logs.
+The names of the configuration recorder.
 
-<a name="cloudtrail_s3_access_logging_bucket_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cloudtrail_s3_access_logging_bucket_arn`**](#cloudtrail_s3_access_logging_bucket_arn) &mdash; The ARN of the S3 bucket where access logs for the CloudTrail S3 bucket are delivered.
+<HclListItem name="config_s3_bucket_arn">
+<HclListItemDescription>
 
-<a name="cloudtrail_s3_access_logging_bucket_name" className="snap-top"></a>
+The ARN of the S3 bucket used by AWS Config to store configuration items.
 
-* [**`cloudtrail_s3_access_logging_bucket_name`**](#cloudtrail_s3_access_logging_bucket_name) &mdash; The name of the S3 bucket where access logs for the CloudTrail S3 bucket are delivered.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="cloudtrail_s3_bucket_arn" className="snap-top"></a>
+<HclListItem name="config_s3_bucket_name">
+<HclListItemDescription>
 
-* [**`cloudtrail_s3_bucket_arn`**](#cloudtrail_s3_bucket_arn) &mdash; The ARN of the S3 bucket where cloudtrail logs are delivered.
+The name of the S3 bucket used by AWS Config to store configuration items.
 
-<a name="cloudtrail_s3_bucket_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cloudtrail_s3_bucket_name`**](#cloudtrail_s3_bucket_name) &mdash; The name of the S3 bucket where cloudtrail logs are delivered.
+<HclListItem name="config_s3_bucket_name_with_dependency">
+<HclListItemDescription>
 
-<a name="cloudtrail_s3_bucket_name_with_dependency" className="snap-top"></a>
+The name of the S3 bucket used by AWS Config to store configuration items, sources from 'data'.
 
-* [**`cloudtrail_s3_bucket_name_with_dependency`**](#cloudtrail_s3_bucket_name_with_dependency) &mdash; The name of the S3 bucket where cloudtrail logs are delivered. Sources from 'data'.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="cloudtrail_trail_arn" className="snap-top"></a>
+<HclListItem name="config_sns_topic_arns">
+<HclListItemDescription>
 
-* [**`cloudtrail_trail_arn`**](#cloudtrail_trail_arn) &mdash; The ARN of the cloudtrail trail.
+The ARNs of the SNS Topic used by the config notifications.
 
-<a name="config_iam_role_arns" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`config_iam_role_arns`**](#config_iam_role_arns) &mdash; The ARNs of the IAM role used by the config recorder.
+<HclListItem name="cross_account_access_all_group_arn">
+</HclListItem>
 
-<a name="config_recorder_names" className="snap-top"></a>
+<HclListItem name="cross_account_access_all_group_name">
+</HclListItem>
 
-* [**`config_recorder_names`**](#config_recorder_names) &mdash; The names of the configuration recorder.
+<HclListItem name="cross_account_access_group_arns">
+</HclListItem>
 
-<a name="config_s3_bucket_arn" className="snap-top"></a>
+<HclListItem name="cross_account_access_group_names">
+</HclListItem>
 
-* [**`config_s3_bucket_arn`**](#config_s3_bucket_arn) &mdash; The ARN of the S3 bucket used by AWS Config to store configuration items.
+<HclListItem name="developers_iam_group_arn">
+</HclListItem>
 
-<a name="config_s3_bucket_name" className="snap-top"></a>
+<HclListItem name="developers_iam_group_name">
+</HclListItem>
 
-* [**`config_s3_bucket_name`**](#config_s3_bucket_name) &mdash; The name of the S3 bucket used by AWS Config to store configuration items.
+<HclListItem name="full_access_iam_group_arn">
+</HclListItem>
 
-<a name="config_s3_bucket_name_with_dependency" className="snap-top"></a>
+<HclListItem name="full_access_iam_group_name">
+</HclListItem>
 
-* [**`config_s3_bucket_name_with_dependency`**](#config_s3_bucket_name_with_dependency) &mdash; The name of the S3 bucket used by AWS Config to store configuration items, sources from 'data'.
+<HclListItem name="guardduty_cloudwatch_event_rule_arns">
+<HclListItemDescription>
 
-<a name="config_sns_topic_arns" className="snap-top"></a>
+The ARNs of the cloudwatch event rules used to publish findings to sns if <a href="#publish_findings_to_sns"><code>publish_findings_to_sns</code></a> is set to true.
 
-* [**`config_sns_topic_arns`**](#config_sns_topic_arns) &mdash; The ARNs of the SNS Topic used by the config notifications.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="cross_account_access_all_group_arn" className="snap-top"></a>
+<HclListItem name="guardduty_cloudwatch_event_target_arns">
+<HclListItemDescription>
 
-* [**`cross_account_access_all_group_arn`**](#cross_account_access_all_group_arn) &mdash; 
+The ARNs of the cloudwatch event targets used to publish findings to sns if <a href="#publish_findings_to_sns"><code>publish_findings_to_sns</code></a> is set to true.
 
-<a name="cross_account_access_all_group_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cross_account_access_all_group_name`**](#cross_account_access_all_group_name) &mdash; 
+<HclListItem name="guardduty_detector_ids">
+<HclListItemDescription>
 
-<a name="cross_account_access_group_arns" className="snap-top"></a>
+The IDs of the GuardDuty detectors.
 
-* [**`cross_account_access_group_arns`**](#cross_account_access_group_arns) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="cross_account_access_group_names" className="snap-top"></a>
+<HclListItem name="guardduty_findings_sns_topic_arns">
+<HclListItemDescription>
 
-* [**`cross_account_access_group_names`**](#cross_account_access_group_names) &mdash; 
+The ARNs of the SNS topics where findings are published if <a href="#publish_findings_to_sns"><code>publish_findings_to_sns</code></a> is set to true.
 
-<a name="developers_iam_group_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`developers_iam_group_arn`**](#developers_iam_group_arn) &mdash; 
+<HclListItem name="guardduty_findings_sns_topic_names">
+<HclListItemDescription>
 
-<a name="developers_iam_group_name" className="snap-top"></a>
+The names of the SNS topic where findings are published if <a href="#publish_findings_to_sns"><code>publish_findings_to_sns</code></a> is set to true.
 
-* [**`developers_iam_group_name`**](#developers_iam_group_name) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="full_access_iam_group_arn" className="snap-top"></a>
+<HclListItem name="houston_cli_users_iam_group_arn">
+</HclListItem>
 
-* [**`full_access_iam_group_arn`**](#full_access_iam_group_arn) &mdash; 
+<HclListItem name="houston_cli_users_iam_group_name">
+</HclListItem>
 
-<a name="full_access_iam_group_name" className="snap-top"></a>
+<HclListItem name="iam_admin_iam_group_arn">
+</HclListItem>
 
-* [**`full_access_iam_group_name`**](#full_access_iam_group_name) &mdash; 
+<HclListItem name="iam_admin_iam_group_name">
+</HclListItem>
 
-<a name="guardduty_cloudwatch_event_rule_arns" className="snap-top"></a>
+<HclListItem name="iam_admin_iam_policy_arn">
+</HclListItem>
 
-* [**`guardduty_cloudwatch_event_rule_arns`**](#guardduty_cloudwatch_event_rule_arns) &mdash; The ARNs of the cloudwatch event rules used to publish findings to sns if [`publish_findings_to_sns`](#publish_findings_to_sns) is set to true.
+<HclListItem name="iam_self_mgmt_iam_group_arn">
+</HclListItem>
 
-<a name="guardduty_cloudwatch_event_target_arns" className="snap-top"></a>
+<HclListItem name="iam_self_mgmt_iam_group_name">
+</HclListItem>
 
-* [**`guardduty_cloudwatch_event_target_arns`**](#guardduty_cloudwatch_event_target_arns) &mdash; The ARNs of the cloudwatch event targets used to publish findings to sns if [`publish_findings_to_sns`](#publish_findings_to_sns) is set to true.
+<HclListItem name="iam_self_mgmt_iam_policy_arn">
+</HclListItem>
 
-<a name="guardduty_detector_ids" className="snap-top"></a>
+<HclListItem name="logs_iam_group_arn">
+</HclListItem>
 
-* [**`guardduty_detector_ids`**](#guardduty_detector_ids) &mdash; The IDs of the GuardDuty detectors.
+<HclListItem name="logs_iam_group_name">
+</HclListItem>
 
-<a name="guardduty_findings_sns_topic_arns" className="snap-top"></a>
+<HclListItem name="master_account_arn">
+<HclListItemDescription>
 
-* [**`guardduty_findings_sns_topic_arns`**](#guardduty_findings_sns_topic_arns) &mdash; The ARNs of the SNS topics where findings are published if [`publish_findings_to_sns`](#publish_findings_to_sns) is set to true.
+ARN of the master account.
 
-<a name="guardduty_findings_sns_topic_names" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`guardduty_findings_sns_topic_names`**](#guardduty_findings_sns_topic_names) &mdash; The names of the SNS topic where findings are published if [`publish_findings_to_sns`](#publish_findings_to_sns) is set to true.
+<HclListItem name="master_account_email">
+<HclListItemDescription>
 
-<a name="houston_cli_users_iam_group_arn" className="snap-top"></a>
+Email address of the master account.
 
-* [**`houston_cli_users_iam_group_arn`**](#houston_cli_users_iam_group_arn) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="houston_cli_users_iam_group_name" className="snap-top"></a>
+<HclListItem name="master_account_id">
+<HclListItemDescription>
 
-* [**`houston_cli_users_iam_group_name`**](#houston_cli_users_iam_group_name) &mdash; 
+Identifier of the master account.
 
-<a name="iam_admin_iam_group_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`iam_admin_iam_group_arn`**](#iam_admin_iam_group_arn) &mdash; 
+<HclListItem name="organization_arn">
+<HclListItemDescription>
 
-<a name="iam_admin_iam_group_name" className="snap-top"></a>
+ARN of the organization.
 
-* [**`iam_admin_iam_group_name`**](#iam_admin_iam_group_name) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="iam_admin_iam_policy_arn" className="snap-top"></a>
+<HclListItem name="organization_id">
+<HclListItemDescription>
 
-* [**`iam_admin_iam_policy_arn`**](#iam_admin_iam_policy_arn) &mdash; 
+Identifier of the organization.
 
-<a name="iam_self_mgmt_iam_group_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`iam_self_mgmt_iam_group_arn`**](#iam_self_mgmt_iam_group_arn) &mdash; 
+<HclListItem name="organization_root_id">
+<HclListItemDescription>
 
-<a name="iam_self_mgmt_iam_group_name" className="snap-top"></a>
+Identifier of the root of this organization.
 
-* [**`iam_self_mgmt_iam_group_name`**](#iam_self_mgmt_iam_group_name) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="iam_self_mgmt_iam_policy_arn" className="snap-top"></a>
+<HclListItem name="read_only_iam_group_arn">
+</HclListItem>
 
-* [**`iam_self_mgmt_iam_policy_arn`**](#iam_self_mgmt_iam_policy_arn) &mdash; 
+<HclListItem name="read_only_iam_group_name">
+</HclListItem>
 
-<a name="logs_iam_group_arn" className="snap-top"></a>
+<HclListItem name="require_mfa_policy">
+</HclListItem>
 
-* [**`logs_iam_group_arn`**](#logs_iam_group_arn) &mdash; 
+<HclListItem name="ssh_grunt_sudo_users_group_arns">
+</HclListItem>
 
-<a name="logs_iam_group_name" className="snap-top"></a>
+<HclListItem name="ssh_grunt_sudo_users_group_names">
+</HclListItem>
 
-* [**`logs_iam_group_name`**](#logs_iam_group_name) &mdash; 
+<HclListItem name="ssh_grunt_users_group_arns">
+</HclListItem>
 
-<a name="master_account_arn" className="snap-top"></a>
+<HclListItem name="ssh_grunt_users_group_names">
+</HclListItem>
 
-* [**`master_account_arn`**](#master_account_arn) &mdash; ARN of the master account.
+<HclListItem name="support_iam_group_arn">
+</HclListItem>
 
-<a name="master_account_email" className="snap-top"></a>
+<HclListItem name="support_iam_group_name">
+</HclListItem>
 
-* [**`master_account_email`**](#master_account_email) &mdash; Email address of the master account.
+<HclListItem name="use_existing_iam_roles_iam_group_arn">
+</HclListItem>
 
-<a name="master_account_id" className="snap-top"></a>
+<HclListItem name="use_existing_iam_roles_iam_group_name">
+</HclListItem>
 
-* [**`master_account_id`**](#master_account_id) &mdash; Identifier of the master account.
+<HclListItem name="user_access_keys">
+<HclListItemDescription>
 
-<a name="organization_arn" className="snap-top"></a>
+A map of user name to that user's access keys (a map with keys access_key_id and secret_access_key), with the secret_access_key encrypted with that user's PGP key (only shows up for users with create_access_keys = true). You can decrypt the secret_access_key on the CLI: echo &lt;secret_access_key> | base64 --decode | keybase pgp decrypt
 
-* [**`organization_arn`**](#organization_arn) &mdash; ARN of the organization.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="organization_id" className="snap-top"></a>
+<HclListItem name="user_arns">
+<HclListItemDescription>
 
-* [**`organization_id`**](#organization_id) &mdash; Identifier of the organization.
+A map of user name to the ARN for that IAM user.
 
-<a name="organization_root_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`organization_root_id`**](#organization_root_id) &mdash; Identifier of the root of this organization.
+<HclListItem name="user_passwords">
+<HclListItemDescription>
 
-<a name="read_only_iam_group_arn" className="snap-top"></a>
+A map of user name to that user's AWS Web Console password, encrypted with that user's PGP key (only shows up for users with create_login_profile = true). You can decrypt the password on the CLI: echo &lt;password> | base64 --decode | keybase pgp decrypt
 
-* [**`read_only_iam_group_arn`**](#read_only_iam_group_arn) &mdash; 
-
-<a name="read_only_iam_group_name" className="snap-top"></a>
-
-* [**`read_only_iam_group_name`**](#read_only_iam_group_name) &mdash; 
-
-<a name="require_mfa_policy" className="snap-top"></a>
-
-* [**`require_mfa_policy`**](#require_mfa_policy) &mdash; 
-
-<a name="ssh_grunt_sudo_users_group_arns" className="snap-top"></a>
-
-* [**`ssh_grunt_sudo_users_group_arns`**](#ssh_grunt_sudo_users_group_arns) &mdash; 
-
-<a name="ssh_grunt_sudo_users_group_names" className="snap-top"></a>
-
-* [**`ssh_grunt_sudo_users_group_names`**](#ssh_grunt_sudo_users_group_names) &mdash; 
-
-<a name="ssh_grunt_users_group_arns" className="snap-top"></a>
-
-* [**`ssh_grunt_users_group_arns`**](#ssh_grunt_users_group_arns) &mdash; 
-
-<a name="ssh_grunt_users_group_names" className="snap-top"></a>
-
-* [**`ssh_grunt_users_group_names`**](#ssh_grunt_users_group_names) &mdash; 
-
-<a name="support_iam_group_arn" className="snap-top"></a>
-
-* [**`support_iam_group_arn`**](#support_iam_group_arn) &mdash; 
-
-<a name="support_iam_group_name" className="snap-top"></a>
-
-* [**`support_iam_group_name`**](#support_iam_group_name) &mdash; 
-
-<a name="use_existing_iam_roles_iam_group_arn" className="snap-top"></a>
-
-* [**`use_existing_iam_roles_iam_group_arn`**](#use_existing_iam_roles_iam_group_arn) &mdash; 
-
-<a name="use_existing_iam_roles_iam_group_name" className="snap-top"></a>
-
-* [**`use_existing_iam_roles_iam_group_name`**](#use_existing_iam_roles_iam_group_name) &mdash; 
-
-<a name="user_access_keys" className="snap-top"></a>
-
-* [**`user_access_keys`**](#user_access_keys) &mdash; A map of user name to that user's access keys (a map with keys [`access_key_id`](#access_key_id) and [`secret_access_key`](#secret_access_key)), with the [`secret_access_key`](#secret_access_key) encrypted with that user's PGP key (only shows up for users with [`create_access_keys`](#create_access_keys) = true). You can decrypt the [`secret_access_key`](#secret_access_key) on the CLI: echo [`&lt;secret_access_key`](#&lt;secret_access_key)> | base64 --decode | keybase pgp decrypt
-
-<a name="user_arns" className="snap-top"></a>
-
-* [**`user_arns`**](#user_arns) &mdash; A map of user name to the ARN for that IAM user.
-
-<a name="user_passwords" className="snap-top"></a>
-
-* [**`user_passwords`**](#user_passwords) &mdash; A map of user name to that user's AWS Web Console password, encrypted with that user's PGP key (only shows up for users with [`create_login_profile`](#create_login_profile) = true). You can decrypt the password on the CLI: echo &lt;password> | base64 --decode | keybase pgp decrypt
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"1d0ebf37688856a0b8725246bf05f076"}
+{"sourcePlugin":"service-catalog-api","hash":"477a9172b13ca7c4261c4cc5bd5e6d4e"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/landing-zone/aws-security-account-baseline-wrapper.md
+++ b/docs/reference/services/landing-zone/aws-security-account-baseline-wrapper.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -94,935 +95,1974 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="aws_account_id" className="snap-top"></a>
+<HclListItem name="aws_account_id" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`aws_account_id`**](#aws_account_id) &mdash; The AWS Account ID the template should be operated on. This avoids misconfiguration errors caused by environment variables.
+The AWS Account ID the template should be operated on. This avoids misconfiguration errors caused by environment variables.
 
-<a name="aws_region" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`aws_region`**](#aws_region) &mdash; The AWS Region to use as the global config recorder and seed region for GuardDuty.
+<HclListItem name="aws_region" requirement="required" type="string">
+<HclListItemDescription>
 
-<a name="config_opt_in_regions" className="snap-top"></a>
+The AWS Region to use as the global config recorder and seed region for GuardDuty.
 
-* [**`config_opt_in_regions`**](#config_opt_in_regions) &mdash; Creates resources in the specified regions. The best practice is to enable AWS Config in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="ebs_opt_in_regions" className="snap-top"></a>
+<HclListItem name="config_opt_in_regions" requirement="required" type="list">
+<HclListItemDescription>
 
-* [**`ebs_opt_in_regions`**](#ebs_opt_in_regions) &mdash; Creates resources in the specified regions. The best practice is to enable EBS Encryption in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for [`global_recorder_region`](#global_recorder_region) must be in this list.
+Creates resources in the specified regions. The best practice is to enable AWS Config in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions.
 
-<a name="guardduty_opt_in_regions" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`guardduty_opt_in_regions`**](#guardduty_opt_in_regions) &mdash; Creates resources in the specified regions. The best practice is to enable GuardDuty in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for [`global_recorder_region`](#global_recorder_region) must be in this list.
+```hcl
+list(string)
+```
 
-<a name="iam_access_analyzer_opt_in_regions" className="snap-top"></a>
+</HclListItemTypeDetails>
+</HclListItem>
 
-* [**`iam_access_analyzer_opt_in_regions`**](#iam_access_analyzer_opt_in_regions) &mdash; Creates resources in the specified regions. The best practice is to enable IAM Access Analyzer in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for [`global_recorder_region`](#global_recorder_region) must be in this list.
+<HclListItem name="ebs_opt_in_regions" requirement="required" type="list">
+<HclListItemDescription>
 
-<a name="kms_cmk_opt_in_regions" className="snap-top"></a>
+Creates resources in the specified regions. The best practice is to enable EBS Encryption in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for global_recorder_region must be in this list.
 
-* [**`kms_cmk_opt_in_regions`**](#kms_cmk_opt_in_regions) &mdash; Creates resources in the specified regions. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for [`global_recorder_region`](#global_recorder_region) must be in this list.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="name_prefix" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`name_prefix`**](#name_prefix) &mdash; The name used to prefix AWS Config and Cloudtrail resources, including the S3 bucket names and SNS topics used for each.
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="guardduty_opt_in_regions" requirement="required" type="list">
+<HclListItemDescription>
+
+Creates resources in the specified regions. The best practice is to enable GuardDuty in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for global_recorder_region must be in this list.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="iam_access_analyzer_opt_in_regions" requirement="required" type="list">
+<HclListItemDescription>
+
+Creates resources in the specified regions. The best practice is to enable IAM Access Analyzer in all enabled regions in your AWS account. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for global_recorder_region must be in this list.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="kms_cmk_opt_in_regions" requirement="required" type="list">
+<HclListItemDescription>
+
+Creates resources in the specified regions. This variable must NOT be set to null or empty. Otherwise, we won't know which regions to use and authenticate to, and may use some not enabled in your AWS account (e.g., GovCloud, China, etc). To get the list of regions enabled in your AWS account, you can use the AWS CLI: aws ec2 describe-regions. The value provided for global_recorder_region must be in this list.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="name_prefix" requirement="required" type="string">
+<HclListItemDescription>
+
+The name used to prefix AWS Config and Cloudtrail resources, including the S3 bucket names and SNS topics used for each.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="additional_config_rules" className="snap-top"></a>
+<HclListItem name="additional_config_rules" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`additional_config_rules`**](#additional_config_rules) &mdash; Map of additional managed rules to add. The key is the name of the rule (e.g. ´acm-certificate-expiration-check´) and the value is an object specifying the rule details
+Map of additional managed rules to add. The key is the name of the rule (e.g. ´acm-certificate-expiration-check´) and the value is an object specifying the rule details
 
-<a name="allow_auto_deploy_from_github_actions_for_sources" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`allow_auto_deploy_from_github_actions_for_sources`**](#allow_auto_deploy_from_github_actions_for_sources) &mdash; Map of github repositories to the list of branches that are allowed to assume the IAM role. The repository should be encoded as org/repo-name (e.g., gruntwork-io/terrraform-aws-ci). Allows GitHub Actions to assume the auto deploy IAM role using an OpenID Connect Provider for the given repositories. Refer to the docs for github-actions-iam-role for more information. Note that this is mutually exclusive with [`allow_auto_deploy_from_other_account_arns`](#allow_auto_deploy_from_other_account_arns). Only used if [`enable_github_actions_access`](#enable_github_actions_access) is true. 
+```hcl
+map(object({
+    # Description of the rule
+    description : string
+    # Identifier of an available AWS Config Managed Rule to call.
+    identifier : string
+    # Trigger type of the rule, must be one of ´CONFIG_CHANGE´ or ´PERIODIC´.
+    trigger_type : string
+    # A map of input parameters for the rule. If you don't have parameters, pass in an empty map ´{}´.
+    input_parameters : map(string)
+    # Whether or not this applies to global (non-regional) resources like IAM roles. When true, these rules are disabled
+    # if var.enable_global_resource_rules is false.
+    applies_to_global_resources = bool
+  }))
+```
 
-<a name="allow_auto_deploy_from_other_account_arns" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`allow_auto_deploy_from_other_account_arns`**](#allow_auto_deploy_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed to assume the auto deploy IAM role that has the permissions in [`auto_deploy_permissions`](#auto_deploy_permissions).
+<HclListItem name="allow_auto_deploy_from_github_actions_for_sources" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="allow_billing_access_from_other_account_arns" className="snap-top"></a>
+Map of github repositories to the list of branches that are allowed to assume the IAM role. The repository should be encoded as org/repo-name (e.g., gruntwork-io/terrraform-aws-ci). Allows GitHub Actions to assume the auto deploy IAM role using an OpenID Connect Provider for the given repositories. Refer to the docs for github-actions-iam-role for more information. Note that this is mutually exclusive with <a href="#allow_auto_deploy_from_other_account_arns"><code>allow_auto_deploy_from_other_account_arns</code></a>. Only used if <a href="#enable_github_actions_access"><code>enable_github_actions_access</code></a> is true. 
 
-* [**`allow_billing_access_from_other_account_arns`**](#allow_billing_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to the billing info for this account.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="allow_cloudtrail_access_with_iam" className="snap-top"></a>
+```hcl
+map(list(string))
+```
 
-* [**`allow_cloudtrail_access_with_iam`**](#allow_cloudtrail_access_with_iam) &mdash; If true, an IAM Policy that grants access to CloudTrail will be honored. If false, only the ARNs listed in [`kms_key_user_iam_arns`](#kms_key_user_iam_arns) will have access to CloudTrail and any IAM Policy grants will be ignored. (true or false)
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="allow_dev_access_from_other_account_arns" className="snap-top"></a>
+<HclListItem name="allow_auto_deploy_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`allow_dev_access_from_other_account_arns`**](#allow_dev_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to the services in this account specified in [`dev_permitted_services`](#dev_permitted_services).
+A list of IAM ARNs from other AWS accounts that will be allowed to assume the auto deploy IAM role that has the permissions in <a href="#auto_deploy_permissions"><code>auto_deploy_permissions</code></a>.
 
-<a name="allow_full_access_from_other_account_arns" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`allow_full_access_from_other_account_arns`**](#allow_full_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to this account.
+```hcl
+list(string)
+```
 
-<a name="allow_logs_access_from_other_account_arns" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`allow_logs_access_from_other_account_arns`**](#allow_logs_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed access to the logs in CloudTrail, AWS Config, and CloudWatch for this account. Will also be given permissions to decrypt with the KMS CMK that is used to encrypt CloudTrail logs.
+<HclListItem name="allow_billing_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="allow_read_only_access_from_other_account_arns" className="snap-top"></a>
+A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to the billing info for this account.
 
-* [**`allow_read_only_access_from_other_account_arns`**](#allow_read_only_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed read-only access to this account.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="allow_ssh_grunt_access_from_other_account_arns" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`allow_ssh_grunt_access_from_other_account_arns`**](#allow_ssh_grunt_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed read access to IAM groups and publish SSH keys. This is used for ssh-grunt.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="allow_support_access_from_other_account_arns" className="snap-top"></a>
+<HclListItem name="allow_cloudtrail_access_with_iam" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`allow_support_access_from_other_account_arns`**](#allow_support_access_from_other_account_arns) &mdash; A list of IAM ARNs from other AWS accounts that will be allowed support access (AWSSupportAccess) to this account.
+If true, an IAM Policy that grants access to CloudTrail will be honored. If false, only the ARNs listed in <a href="#kms_key_user_iam_arns"><code>kms_key_user_iam_arns</code></a> will have access to CloudTrail and any IAM Policy grants will be ignored. (true or false)
 
-<a name="auto_deploy_permissions" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`auto_deploy_permissions`**](#auto_deploy_permissions) &mdash; A list of IAM permissions (e.g. ec2:*) that will be added to an IAM Group for doing automated deployments. NOTE: If [`should_create_iam_group_auto_deploy`](#should_create_iam_group_auto_deploy) is true, the list must have at least one element (e.g. '*').
+<HclListItem name="allow_dev_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="cloudtrail_allow_kms_describe_key_to_external_aws_accounts" className="snap-top"></a>
+A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to the services in this account specified in <a href="#dev_permitted_services"><code>dev_permitted_services</code></a>.
 
-* [**`cloudtrail_allow_kms_describe_key_to_external_aws_accounts`**](#cloudtrail_allow_kms_describe_key_to_external_aws_accounts) &mdash; Whether or not to allow kms:DescribeKey to external AWS accounts with write access to the CloudTrail bucket. This is useful during deployment so that you don't have to pass around the KMS key ARN.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="cloudtrail_cloudwatch_logs_group_name" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`cloudtrail_cloudwatch_logs_group_name`**](#cloudtrail_cloudwatch_logs_group_name) &mdash; Specify the name of the CloudWatch Logs group to publish the CloudTrail logs to. This log group exists in the current account. Set this value to `null` to avoid publishing the trail logs to the logs group. The recommended configuration for CloudTrail is (a) for each child account to aggregate its logs in an S3 bucket in a single central account, such as a logs account and (b) to also store 14 days work of logs in CloudWatch in the child account itself for local debugging.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="cloudtrail_data_logging_enabled" className="snap-top"></a>
+<HclListItem name="allow_full_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`cloudtrail_data_logging_enabled`**](#cloudtrail_data_logging_enabled) &mdash; If true, logging of data events will be enabled.
+A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to this account.
 
-<a name="cloudtrail_data_logging_include_management_events" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`cloudtrail_data_logging_include_management_events`**](#cloudtrail_data_logging_include_management_events) &mdash; Specify if you want your event selector to include management events for your trail.
+```hcl
+list(string)
+```
 
-<a name="cloudtrail_data_logging_read_write_type" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`cloudtrail_data_logging_read_write_type`**](#cloudtrail_data_logging_read_write_type) &mdash; Specify if you want your trail to log read-only events, write-only events, or all. Possible values are: ReadOnly, WriteOnly, All.
+<HclListItem name="allow_logs_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="cloudtrail_data_logging_resources" className="snap-top"></a>
+A list of IAM ARNs from other AWS accounts that will be allowed access to the logs in CloudTrail, AWS Config, and CloudWatch for this account. Will also be given permissions to decrypt with the KMS CMK that is used to encrypt CloudTrail logs.
 
-* [**`cloudtrail_data_logging_resources`**](#cloudtrail_data_logging_resources) &mdash; Data resources for which to log data events. This should be a map, where each key is a data resource type, and each value is a list of data resource values. Possible values for data resource types are: AWS::S3::Object, AWS::Lambda::Function and AWS::DynamoDB::Table. See the [`'data_resource`](#'data_resource)' block within the [`'event_selector`](#'event_selector)' block of the [`'aws_cloudtrail`](#'aws_cloudtrail)' resource for context: [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail#data_resource`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail#data_resource).
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="cloudtrail_external_aws_account_ids_with_write_access" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`cloudtrail_external_aws_account_ids_with_write_access`**](#cloudtrail_external_aws_account_ids_with_write_access) &mdash; A list of external AWS accounts that should be given write access for CloudTrail logs to this S3 bucket. This is useful when aggregating CloudTrail logs for multiple AWS accounts in one common S3 bucket.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="cloudtrail_force_destroy" className="snap-top"></a>
+<HclListItem name="allow_read_only_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`cloudtrail_force_destroy`**](#cloudtrail_force_destroy) &mdash; If set to true, when you run 'terraform destroy', delete all objects from the bucket so that the bucket can be destroyed without error. Warning: these objects are not recoverable so only use this if you're absolutely sure you want to permanently delete everything!
+A list of IAM ARNs from other AWS accounts that will be allowed read-only access to this account.
 
-<a name="cloudtrail_kms_key_administrator_iam_arns" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`cloudtrail_kms_key_administrator_iam_arns`**](#cloudtrail_kms_key_administrator_iam_arns) &mdash; All CloudTrail Logs will be encrypted with a KMS Key (a Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. The IAM Users specified in this list will have rights to change who can access this extended log data.
+```hcl
+list(string)
+```
 
-<a name="cloudtrail_kms_key_arn" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`cloudtrail_kms_key_arn`**](#cloudtrail_kms_key_arn) &mdash; All CloudTrail Logs will be encrypted with a KMS CMK (Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. If that CMK already exists, set this to the ARN of that CMK. Otherwise, set this to null, and a new CMK will be created. We recommend setting this to the ARN of a CMK that already exists in a separate logs account.
+<HclListItem name="allow_ssh_grunt_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="cloudtrail_kms_key_arn_is_alias" className="snap-top"></a>
+A list of IAM ARNs from other AWS accounts that will be allowed read access to IAM groups and publish SSH keys. This is used for ssh-grunt.
 
-* [**`cloudtrail_kms_key_arn_is_alias`**](#cloudtrail_kms_key_arn_is_alias) &mdash; If the [`kms_key_arn`](#kms_key_arn) provided is an alias or alias ARN, then this must be set to true so that the module will exchange the alias for a CMK ARN. Setting this to true and using aliases requires [`cloudtrail_allow_kms_describe_key_to_external_aws_accounts`](#cloudtrail_allow_kms_describe_key_to_external_aws_accounts) to also be true for multi-account scenarios.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="cloudtrail_kms_key_user_iam_arns" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`cloudtrail_kms_key_user_iam_arns`**](#cloudtrail_kms_key_user_iam_arns) &mdash; All CloudTrail Logs will be encrypted with a KMS Key (a Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. The IAM Users specified in this list will have read-only access to this extended log data.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="cloudtrail_num_days_after_which_archive_log_data" className="snap-top"></a>
+<HclListItem name="allow_support_access_from_other_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`cloudtrail_num_days_after_which_archive_log_data`**](#cloudtrail_num_days_after_which_archive_log_data) &mdash; After this number of days, log files should be transitioned from S3 to Glacier. Enter 0 to never archive log data.
+A list of IAM ARNs from other AWS accounts that will be allowed support access (AWSSupportAccess) to this account.
 
-<a name="cloudtrail_num_days_after_which_delete_log_data" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`cloudtrail_num_days_after_which_delete_log_data`**](#cloudtrail_num_days_after_which_delete_log_data) &mdash; After this number of days, log files should be deleted from S3. Enter 0 to never delete log data.
+```hcl
+list(string)
+```
 
-<a name="cloudtrail_num_days_to_retain_cloudwatch_logs" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`cloudtrail_num_days_to_retain_cloudwatch_logs`**](#cloudtrail_num_days_to_retain_cloudwatch_logs) &mdash; After this number of days, logs stored in CloudWatch will be deleted. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0 (default). When set to 0, logs will be retained indefinitely.
+<HclListItem name="auto_deploy_permissions" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="cloudtrail_s3_bucket_already_exists" className="snap-top"></a>
+A list of IAM permissions (e.g. ec2:*) that will be added to an IAM Group for doing automated deployments. NOTE: If <a href="#should_create_iam_group_auto_deploy"><code>should_create_iam_group_auto_deploy</code></a> is true, the list must have at least one element (e.g. '*').
 
-* [**`cloudtrail_s3_bucket_already_exists`**](#cloudtrail_s3_bucket_already_exists) &mdash; Set to false to create an S3 bucket of name [`cloudtrail_s3_bucket_name`](#cloudtrail_s3_bucket_name) in this account for storing CloudTrail logs. Set to true to assume the bucket specified in [`cloudtrail_s3_bucket_name`](#cloudtrail_s3_bucket_name) already exists in another AWS account. We recommend setting this to true and setting [`cloudtrail_s3_bucket_name`](#cloudtrail_s3_bucket_name) to the name of a bucket that already exists in a separate logs account.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="cloudtrail_s3_bucket_name" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`cloudtrail_s3_bucket_name`**](#cloudtrail_s3_bucket_name) &mdash; The name of the S3 Bucket where CloudTrail logs will be stored. If value is `null`, defaults to [``var.name_prefix`](#`var.name_prefix)`-cloudtrail
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="cloudtrail_s3_mfa_delete" className="snap-top"></a>
+<HclListItem name="cloudtrail_allow_kms_describe_key_to_external_aws_accounts" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`cloudtrail_s3_mfa_delete`**](#cloudtrail_s3_mfa_delete) &mdash; Enable MFA delete for either 'Change the versioning state of your bucket' or 'Permanently delete an object version'. This setting only applies to the bucket used to storage Cloudtrail data. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS. For instructions on how to enable MFA Delete, check out the README from the terraform-aws-security/private-s3-bucket module.
+Whether or not to allow kms:DescribeKey to external AWS accounts with write access to the CloudTrail bucket. This is useful during deployment so that you don't have to pass around the KMS key ARN.
 
-<a name="cloudtrail_tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`cloudtrail_tags`**](#cloudtrail_tags) &mdash; Tags to apply to the CloudTrail resources.
+<HclListItem name="cloudtrail_cloudwatch_logs_group_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="config_aggregate_config_data_in_external_account" className="snap-top"></a>
+Specify the name of the CloudWatch Logs group to publish the CloudTrail logs to. This log group exists in the current account. Set this value to `null` to avoid publishing the trail logs to the logs group. The recommended configuration for CloudTrail is (a) for each child account to aggregate its logs in an S3 bucket in a single central account, such as a logs account and (b) to also store 14 days work of logs in CloudWatch in the child account itself for local debugging.
 
-* [**`config_aggregate_config_data_in_external_account`**](#config_aggregate_config_data_in_external_account) &mdash; Set to true to send the AWS Config data to another account (e.g., a logs account) for aggregation purposes. You must set the ID of that other account via the [`config_central_account_id`](#config_central_account_id) variable. This redundant variable has to exist because Terraform does not allow computed data in count and [`for_each`](#for_each) parameters and [`config_central_account_id`](#config_central_account_id) may be computed if its the ID of a newly-created AWS account.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="cloudtrail-logs"/>
+</HclListItem>
 
-<a name="config_central_account_id" className="snap-top"></a>
+<HclListItem name="cloudtrail_data_logging_enabled" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`config_central_account_id`**](#config_central_account_id) &mdash; If the S3 bucket and SNS topics used for AWS Config live in a different AWS account, set this variable to the ID of that account. If the S3 bucket and SNS topics live in this account, set this variable to null. We recommend setting this to the ID of a separate logs account. Only used if [`config_aggregate_config_data_in_external_account`](#config_aggregate_config_data_in_external_account) is true.
+If true, logging of data events will be enabled.
 
-<a name="config_create_account_rules" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`config_create_account_rules`**](#config_create_account_rules) &mdash; Set to true to create AWS Config rules directly in this account. Set false to not create any Config rules in this account (i.e., if you created the rules at the organization level already). We recommend setting this to true to use account-level rules because org-level rules create a chicken-and-egg problem with creating new accounts.
+<HclListItem name="cloudtrail_data_logging_include_management_events" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="config_delivery_channel_kms_key_arn" className="snap-top"></a>
+Specify if you want your event selector to include management events for your trail.
 
-* [**`config_delivery_channel_kms_key_arn`**](#config_delivery_channel_kms_key_arn) &mdash; Optional KMS key to use for encrypting S3 objects on the AWS Config delivery channel for an externally managed S3 bucket. This must belong to the same region as the destination S3 bucket. If null, AWS Config will default to encrypting the delivered data with AES-256 encryption. Only used if [`should_create_s3_bucket`](#should_create_s3_bucket) is false - otherwise, [`kms_key_arn`](#kms_key_arn) is used.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="config_delivery_channel_kms_key_by_name" className="snap-top"></a>
+<HclListItem name="cloudtrail_data_logging_read_write_type" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`config_delivery_channel_kms_key_by_name`**](#config_delivery_channel_kms_key_by_name) &mdash; Same as [`config_delivery_channel_kms_key_arn`](#config_delivery_channel_kms_key_arn), except the value is a name of a KMS key configured with [`kms_customer_master_keys`](#kms_customer_master_keys). The module created KMS key for the delivery region (indexed by the name) will be used. Note that if both [`config_delivery_channel_kms_key_arn`](#config_delivery_channel_kms_key_arn) and [`config_delivery_channel_kms_key_by_name`](#config_delivery_channel_kms_key_by_name) are configured, the key in [`config_delivery_channel_kms_key_arn`](#config_delivery_channel_kms_key_arn) will always be used.
+Specify if you want your trail to log read-only events, write-only events, or all. Possible values are: ReadOnly, WriteOnly, All.
 
-<a name="config_force_destroy" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="All"/>
+</HclListItem>
 
-* [**`config_force_destroy`**](#config_force_destroy) &mdash; If set to true, when you run 'terraform destroy', delete all objects from the bucket so that the bucket can be destroyed without error. Warning: these objects are not recoverable so only use this if you're absolutely sure you want to permanently delete everything!
+<HclListItem name="cloudtrail_data_logging_resources" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="config_linked_accounts" className="snap-top"></a>
+Data resources for which to log data events. This should be a map, where each key is a data resource type, and each value is a list of data resource values. Possible values for data resource types are: AWS::S3::Object, AWS::Lambda::Function and AWS::DynamoDB::Table. See the 'data_resource' block within the 'event_selector' block of the 'aws_cloudtrail' resource for context: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail#data_resource.
 
-* [**`config_linked_accounts`**](#config_linked_accounts) &mdash; Provide a list of AWS account IDs that will send Config data to this account. This is useful if your aggregating config data in this account for other accounts.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="config_num_days_after_which_archive_log_data" className="snap-top"></a>
+```hcl
+map(list(string))
+```
 
-* [**`config_num_days_after_which_archive_log_data`**](#config_num_days_after_which_archive_log_data) &mdash; After this number of days, log files should be transitioned from S3 to Glacier. Enter 0 to never archive log data.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="config_num_days_after_which_delete_log_data" className="snap-top"></a>
+<HclListItem name="cloudtrail_external_aws_account_ids_with_write_access" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`config_num_days_after_which_delete_log_data`**](#config_num_days_after_which_delete_log_data) &mdash; After this number of days, log files should be deleted from S3. Enter 0 to never delete log data.
+A list of external AWS accounts that should be given write access for CloudTrail logs to this S3 bucket. This is useful when aggregating CloudTrail logs for multiple AWS accounts in one common S3 bucket.
 
-<a name="config_s3_bucket_kms_key_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`config_s3_bucket_kms_key_arn`**](#config_s3_bucket_kms_key_arn) &mdash; Optional KMS key to use for encrypting S3 objects on the AWS Config bucket, when the S3 bucket is created within this module [`(var.config_should_create_s3_bucket`](#(var.config_should_create_s3_bucket) is true). For encrypting S3 objects on delivery for an externally managed S3 bucket, refer to the [`config_delivery_channel_kms_key_arn`](#config_delivery_channel_kms_key_arn) input variable. If null, data in S3 will be encrypted using the default aws/s3 key. If provided, the key policy of the provided key must permit the IAM role used by AWS Config. See https://docs.aws.amazon.com/sns/latest/dg/sns-key-management.html. Note that the KMS key must reside in the global recorder region (as configured by [`aws_region`](#aws_region)).
+```hcl
+list(string)
+```
 
-<a name="config_s3_bucket_kms_key_by_name" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`config_s3_bucket_kms_key_by_name`**](#config_s3_bucket_kms_key_by_name) &mdash; Same as [`config_s3_bucket_kms_key_arn`](#config_s3_bucket_kms_key_arn), except the value is a name of a KMS key configured with [`kms_customer_master_keys`](#kms_customer_master_keys). The module created KMS key for the global recorder region (indexed by the name) will be used. Note that if both [`config_s3_bucket_kms_key_arn`](#config_s3_bucket_kms_key_arn) and [`config_s3_bucket_kms_key_by_name`](#config_s3_bucket_kms_key_by_name) are configured, the key in [`config_s3_bucket_kms_key_arn`](#config_s3_bucket_kms_key_arn) will always be used.
+<HclListItem name="cloudtrail_force_destroy" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="config_s3_bucket_name" className="snap-top"></a>
+If set to true, when you run 'terraform destroy', delete all objects from the bucket so that the bucket can be destroyed without error. Warning: these objects are not recoverable so only use this if you're absolutely sure you want to permanently delete everything!
 
-* [**`config_s3_bucket_name`**](#config_s3_bucket_name) &mdash; The name of the S3 Bucket where CloudTrail logs will be stored. This could be a bucket in this AWS account or the name of a bucket in another AWS account where logs should be sent. We recommend setting this to the name of a bucket in a separate logs account.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="config_s3_mfa_delete" className="snap-top"></a>
+<HclListItem name="cloudtrail_kms_key_administrator_iam_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`config_s3_mfa_delete`**](#config_s3_mfa_delete) &mdash; Enable MFA delete for either 'Change the versioning state of your bucket' or 'Permanently delete an object version'. This setting only applies to the bucket used to storage AWS Config data. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS. For instructions on how to enable MFA Delete, check out the README from the terraform-aws-security/private-s3-bucket module.
+All CloudTrail Logs will be encrypted with a KMS Key (a Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. The IAM Users specified in this list will have rights to change who can access this extended log data.
 
-<a name="config_should_create_s3_bucket" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`config_should_create_s3_bucket`**](#config_should_create_s3_bucket) &mdash; Set to true to create an S3 bucket of name [`config_s3_bucket_name`](#config_s3_bucket_name) in this account for storing AWS Config data. Set to false to assume the bucket specified in [`config_s3_bucket_name`](#config_s3_bucket_name) already exists in another AWS account. We recommend setting this to false and setting [`config_s3_bucket_name`](#config_s3_bucket_name) to the name off an S3 bucket that already exists in a separate logs account.
+```hcl
+list(string)
+```
 
-<a name="config_should_create_sns_topic" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`config_should_create_sns_topic`**](#config_should_create_sns_topic) &mdash; Set to true to create an SNS topic in this account for sending AWS Config notifications (e.g., if this is the logs account). Set to false to assume the topic specified in [`config_sns_topic_name`](#config_sns_topic_name) already exists in another AWS account (e.g., if this is the stage or prod account and [`config_sns_topic_name`](#config_sns_topic_name) is the name of an SNS topic in the logs account).
+<HclListItem name="cloudtrail_kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="config_sns_topic_kms_key_by_name_region_map" className="snap-top"></a>
+All CloudTrail Logs will be encrypted with a KMS CMK (Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. If that CMK already exists, set this to the ARN of that CMK. Otherwise, set this to null, and a new CMK will be created. We recommend setting this to the ARN of a CMK that already exists in a separate logs account.
 
-* [**`config_sns_topic_kms_key_by_name_region_map`**](#config_sns_topic_kms_key_by_name_region_map) &mdash; Same as [`config_sns_topic_kms_key_region_map`](#config_sns_topic_kms_key_region_map), except the value is a name of a KMS key configured with [`kms_customer_master_keys`](#kms_customer_master_keys). The module created KMS key for each region (indexed by the name) will be used. Note that if an entry exists for a region in both [`config_sns_topic_kms_key_region_map`](#config_sns_topic_kms_key_region_map) and [`config_sns_topic_kms_key_by_name_region_map`](#config_sns_topic_kms_key_by_name_region_map), then the key in [`config_sns_topic_kms_key_region_map`](#config_sns_topic_kms_key_region_map) will always be used.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="config_sns_topic_kms_key_region_map" className="snap-top"></a>
+<HclListItem name="cloudtrail_kms_key_arn_is_alias" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`config_sns_topic_kms_key_region_map`**](#config_sns_topic_kms_key_region_map) &mdash; Optional KMS key to use for each region for configuring default encryption for the SNS topic (encoded as a map from region - e.g. us-east-1 - to ARN of KMS key). If null or the region key is missing, encryption will not be configured for the SNS topic in that region.
+If the kms_key_arn provided is an alias or alias ARN, then this must be set to true so that the module will exchange the alias for a CMK ARN. Setting this to true and using aliases requires <a href="#cloudtrail_allow_kms_describe_key_to_external_aws_accounts"><code>cloudtrail_allow_kms_describe_key_to_external_aws_accounts</code></a> to also be true for multi-account scenarios.
 
-<a name="config_sns_topic_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`config_sns_topic_name`**](#config_sns_topic_name) &mdash; The name of the SNS Topic in where AWS Config notifications will be sent. Can be in the same account or in another account.
+<HclListItem name="cloudtrail_kms_key_user_iam_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="config_tags" className="snap-top"></a>
+All CloudTrail Logs will be encrypted with a KMS Key (a Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. The IAM Users specified in this list will have read-only access to this extended log data.
 
-* [**`config_tags`**](#config_tags) &mdash; A map of tags to apply to the S3 Bucket. The key is the tag name and the value is the tag value.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="configrules_maximum_execution_frequency" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`configrules_maximum_execution_frequency`**](#configrules_maximum_execution_frequency) &mdash; The maximum frequency with which AWS Config runs evaluations for the ´PERIODIC´ rules. See [`https://www.terraform.io/docs/providers/aws/r/config_organization_managed_rule.html#maximum_execution_frequency`](#https://www.terraform.io/docs/providers/aws/r/config_organization_managed_rule.html#maximum_execution_frequency)
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="cross_account_access_all_group_name" className="snap-top"></a>
+<HclListItem name="cloudtrail_num_days_after_which_archive_log_data" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`cross_account_access_all_group_name`**](#cross_account_access_all_group_name) &mdash; The name of the IAM group that will grant access to all external AWS accounts in [`iam_groups_for_cross_account_access`](#iam_groups_for_cross_account_access).
+After this number of days, log files should be transitioned from S3 to Glacier. Enter 0 to never archive log data.
 
-<a name="custom_cloudtrail_trail_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="30"/>
+</HclListItem>
 
-* [**`custom_cloudtrail_trail_name`**](#custom_cloudtrail_trail_name) &mdash; A custom name to use for the Cloudtrail Trail. If null, defaults to the [`name_prefix`](#name_prefix) input variable.
+<HclListItem name="cloudtrail_num_days_after_which_delete_log_data" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="dev_permitted_services" className="snap-top"></a>
+After this number of days, log files should be deleted from S3. Enter 0 to never delete log data.
 
-* [**`dev_permitted_services`**](#dev_permitted_services) &mdash; A list of AWS services for which the developers from the accounts in [`allow_dev_access_from_other_account_arns`](#allow_dev_access_from_other_account_arns) will receive full permissions. See https://goo.gl/ZyoHlz to find the IAM Service name. For example, to grant developers access only to EC2 and Amazon Machine Learning, use the value ["ec2","machinelearning"]. Do NOT add iam to the list of services, or that will grant Developers de facto admin access.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="365"/>
+</HclListItem>
 
-<a name="ebs_enable_encryption" className="snap-top"></a>
+<HclListItem name="cloudtrail_num_days_to_retain_cloudwatch_logs" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`ebs_enable_encryption`**](#ebs_enable_encryption) &mdash; If set to true (default), all new EBS volumes will have encryption enabled by default
+After this number of days, logs stored in CloudWatch will be deleted. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0 (default). When set to 0, logs will be retained indefinitely.
 
-<a name="ebs_kms_key_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="0"/>
+</HclListItem>
 
-* [**`ebs_kms_key_name`**](#ebs_kms_key_name) &mdash; The name of the KMS CMK to use by default for encrypting EBS volumes, if [`ebs_enable_encryption`](#ebs_enable_encryption) and [`ebs_use_existing_kms_keys`](#ebs_use_existing_kms_keys) are enabled. The name must match a name given the [`kms_customer_master_keys`](#kms_customer_master_keys) variable.
+<HclListItem name="cloudtrail_s3_bucket_already_exists" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="ebs_use_existing_kms_keys" className="snap-top"></a>
+Set to false to create an S3 bucket of name <a href="#cloudtrail_s3_bucket_name"><code>cloudtrail_s3_bucket_name</code></a> in this account for storing CloudTrail logs. Set to true to assume the bucket specified in <a href="#cloudtrail_s3_bucket_name"><code>cloudtrail_s3_bucket_name</code></a> already exists in another AWS account. We recommend setting this to true and setting <a href="#cloudtrail_s3_bucket_name"><code>cloudtrail_s3_bucket_name</code></a> to the name of a bucket that already exists in a separate logs account.
 
-* [**`ebs_use_existing_kms_keys`**](#ebs_use_existing_kms_keys) &mdash; If set to true, the KMS Customer Managed Keys (CMK) with the name in [`ebs_kms_key_name`](#ebs_kms_key_name) will be set as the default for EBS encryption. When false (default), the AWS-managed aws/ebs key will be used.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="enable_cloudtrail" className="snap-top"></a>
+<HclListItem name="cloudtrail_s3_bucket_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`enable_cloudtrail`**](#enable_cloudtrail) &mdash; Set to true (default) to enable CloudTrail in the security account. Set to false to disable CloudTrail (note: all other CloudTrail variables will be ignored). Note that if you have enabled organization trail in the root (parent) account, you should set this to false; the organization trail will enable CloudTrail on child accounts by default.
+The name of the S3 Bucket where CloudTrail logs will be stored. If value is `null`, defaults to `<a href="#name_prefix"><code>name_prefix</code></a>`-cloudtrail
 
-<a name="enable_config" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`enable_config`**](#enable_config) &mdash; Set to true to enable AWS Config in the security account. Set to false to disable AWS Config (note: all other AWS config variables will be ignored).
+<HclListItem name="cloudtrail_s3_mfa_delete" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="enable_encrypted_volumes" className="snap-top"></a>
+Enable MFA delete for either 'Change the versioning state of your bucket' or 'Permanently delete an object version'. This setting only applies to the bucket used to storage Cloudtrail data. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS. For instructions on how to enable MFA Delete, check out the README from the terraform-aws-security/private-s3-bucket module.
 
-* [**`enable_encrypted_volumes`**](#enable_encrypted_volumes) &mdash; Checks whether the EBS volumes that are in an attached state are encrypted.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="enable_github_actions_access" className="snap-top"></a>
+<HclListItem name="cloudtrail_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`enable_github_actions_access`**](#enable_github_actions_access) &mdash; When true, create an Open ID Connect Provider that GitHub actions can use to assume IAM roles in the account. Refer to https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services for more information.
+Tags to apply to the CloudTrail resources.
 
-<a name="enable_iam_access_analyzer" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`enable_iam_access_analyzer`**](#enable_iam_access_analyzer) &mdash; A feature flag to enable or disable this module.
+```hcl
+map(string)
+```
 
-<a name="enable_iam_cross_account_roles" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`enable_iam_cross_account_roles`**](#enable_iam_cross_account_roles) &mdash; A feature flag to enable or disable the Cross Account Iam Roles module.
+<HclListItem name="config_aggregate_config_data_in_external_account" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="enable_iam_groups" className="snap-top"></a>
+Set to true to send the AWS Config data to another account (e.g., a logs account) for aggregation purposes. You must set the ID of that other account via the config_central_account_id variable. This redundant variable has to exist because Terraform does not allow computed data in count and for_each parameters and <a href="#config_central_account_id"><code>config_central_account_id</code></a> may be computed if its the ID of a newly-created AWS account.
 
-* [**`enable_iam_groups`**](#enable_iam_groups) &mdash; A feature flag to enable or disable the IAM Groups module.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="enable_iam_password_policy" className="snap-top"></a>
+<HclListItem name="config_central_account_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`enable_iam_password_policy`**](#enable_iam_password_policy) &mdash; Checks whether the account password policy for IAM users meets the specified requirements.
+If the S3 bucket and SNS topics used for AWS Config live in a different AWS account, set this variable to the ID of that account. If the S3 bucket and SNS topics live in this account, set this variable to null. We recommend setting this to the ID of a separate logs account. Only used if <a href="#config_aggregate_config_data_in_external_account"><code>config_aggregate_config_data_in_external_account</code></a> is true.
 
-<a name="enable_insecure_sg_rules" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`enable_insecure_sg_rules`**](#enable_insecure_sg_rules) &mdash; Checks whether the security group with 0.0.0.0/0 of any Amazon Virtual Private Cloud (Amazon VPC) allows only specific inbound TCP or UDP traffic.
+<HclListItem name="config_create_account_rules" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="enable_rds_storage_encrypted" className="snap-top"></a>
+Set to true to create AWS Config rules directly in this account. Set false to not create any Config rules in this account (i.e., if you created the rules at the organization level already). We recommend setting this to true to use account-level rules because org-level rules create a chicken-and-egg problem with creating new accounts.
 
-* [**`enable_rds_storage_encrypted`**](#enable_rds_storage_encrypted) &mdash; Checks whether storage encryption is enabled for your RDS DB instances.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="enable_root_account_mfa" className="snap-top"></a>
+<HclListItem name="config_delivery_channel_kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`enable_root_account_mfa`**](#enable_root_account_mfa) &mdash; Checks whether users of your AWS account require a multi-factor authentication (MFA) device to sign in with root credentials.
+Optional KMS key to use for encrypting S3 objects on the AWS Config delivery channel for an externally managed S3 bucket. This must belong to the same region as the destination S3 bucket. If null, AWS Config will default to encrypting the delivered data with AES-256 encryption. Only used if <a href="#should_create_s3_bucket"><code>should_create_s3_bucket</code></a> is false - otherwise, <a href="#kms_key_arn"><code>kms_key_arn</code></a> is used.
 
-<a name="enable_s3_bucket_public_read_prohibited" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`enable_s3_bucket_public_read_prohibited`**](#enable_s3_bucket_public_read_prohibited) &mdash; Checks that your Amazon S3 buckets do not allow public read access.
+<HclListItem name="config_delivery_channel_kms_key_by_name" requirement="optional" type="object">
+<HclListItemDescription>
 
-<a name="enable_s3_bucket_public_write_prohibited" className="snap-top"></a>
+Same as <a href="#config_delivery_channel_kms_key_arn"><code>config_delivery_channel_kms_key_arn</code></a>, except the value is a name of a KMS key configured with <a href="#kms_customer_master_keys"><code>kms_customer_master_keys</code></a>. The module created KMS key for the delivery region (indexed by the name) will be used. Note that if both <a href="#config_delivery_channel_kms_key_arn"><code>config_delivery_channel_kms_key_arn</code></a> and <a href="#config_delivery_channel_kms_key_by_name"><code>config_delivery_channel_kms_key_by_name</code></a> are configured, the key in <a href="#config_delivery_channel_kms_key_arn"><code>config_delivery_channel_kms_key_arn</code></a> will always be used.
 
-* [**`enable_s3_bucket_public_write_prohibited`**](#enable_s3_bucket_public_write_prohibited) &mdash; Checks that your Amazon S3 buckets do not allow public write access.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="encrypted_volumes_kms_id" className="snap-top"></a>
+```hcl
+object({
+    name   = string
+    region = string
+  })
+```
 
-* [**`encrypted_volumes_kms_id`**](#encrypted_volumes_kms_id) &mdash; ID or ARN of the KMS key that is used to encrypt the volume. Used for configuring the encrypted volumes config rule.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="force_destroy_users" className="snap-top"></a>
+<HclListItem name="config_force_destroy" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`force_destroy_users`**](#force_destroy_users) &mdash; When destroying this user, destroy even if it has non-Terraform-managed IAM access keys, login profile, or MFA devices. Without [`force_destroy`](#force_destroy) a user with non-Terraform-managed access keys and login profile will fail to be destroyed.
+If set to true, when you run 'terraform destroy', delete all objects from the bucket so that the bucket can be destroyed without error. Warning: these objects are not recoverable so only use this if you're absolutely sure you want to permanently delete everything!
 
-<a name="github_actions_openid_connect_provider_thumbprint_list" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`github_actions_openid_connect_provider_thumbprint_list`**](#github_actions_openid_connect_provider_thumbprint_list) &mdash; When set, use the statically provided hardcoded list of thumbprints rather than looking it up dynamically. This is useful if you want to trade reliability of the OpenID Connect Provider across certificate renewals with a static list that is obtained using a trustworthy mechanism, to mitigate potential damage from a domain hijacking attack on GitHub domains.
+<HclListItem name="config_linked_accounts" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="guardduty_cloudwatch_event_rule_name" className="snap-top"></a>
+Provide a list of AWS account IDs that will send Config data to this account. This is useful if your aggregating config data in this account for other accounts.
 
-* [**`guardduty_cloudwatch_event_rule_name`**](#guardduty_cloudwatch_event_rule_name) &mdash; Name of the Cloudwatch event rules.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="guardduty_finding_publishing_frequency" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`guardduty_finding_publishing_frequency`**](#guardduty_finding_publishing_frequency) &mdash; Specifies the frequency of notifications sent for subsequent finding occurrences. If the detector is a GuardDuty member account, the value is determined by the GuardDuty master account and cannot be modified, otherwise defaults to [`SIX_HOURS`](#SIX_HOURS). For standalone and GuardDuty master accounts, it must be configured in Terraform to enable drift detection. Valid values for standalone and master accounts: [`FIFTEEN_MINUTES`](#FIFTEEN_MINUTES), [`ONE_HOUR`](#ONE_HOUR), [`SIX_HOURS`](#SIX_HOURS).
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="guardduty_findings_sns_topic_name" className="snap-top"></a>
+<HclListItem name="config_num_days_after_which_archive_log_data" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`guardduty_findings_sns_topic_name`**](#guardduty_findings_sns_topic_name) &mdash; Specifies a name for the created SNS topics where findings are published. [`publish_findings_to_sns`](#publish_findings_to_sns) must be set to true.
+After this number of days, log files should be transitioned from S3 to Glacier. Enter 0 to never archive log data.
 
-<a name="guardduty_publish_findings_to_sns" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="365"/>
+</HclListItem>
 
-* [**`guardduty_publish_findings_to_sns`**](#guardduty_publish_findings_to_sns) &mdash; Send GuardDuty findings to SNS topics specified by [`findings_sns_topic_name`](#findings_sns_topic_name).
+<HclListItem name="config_num_days_after_which_delete_log_data" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="iam_access_analyzer_name" className="snap-top"></a>
+After this number of days, log files should be deleted from S3. Enter 0 to never delete log data.
 
-* [**`iam_access_analyzer_name`**](#iam_access_analyzer_name) &mdash; The name of the IAM Access Analyzer module
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="730"/>
+</HclListItem>
 
-<a name="iam_access_analyzer_type" className="snap-top"></a>
+<HclListItem name="config_s3_bucket_kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`iam_access_analyzer_type`**](#iam_access_analyzer_type) &mdash; If set to ACCOUNT, the analyzer will only be scanning the current AWS account it's in. If set to ORGANIZATION - will scan the organization AWS account and the child accounts.
+Optional KMS key to use for encrypting S3 objects on the AWS Config bucket, when the S3 bucket is created within this module (<a href="#config_should_create_s3_bucket"><code>config_should_create_s3_bucket</code></a> is true). For encrypting S3 objects on delivery for an externally managed S3 bucket, refer to the <a href="#config_delivery_channel_kms_key_arn"><code>config_delivery_channel_kms_key_arn</code></a> input variable. If null, data in S3 will be encrypted using the default aws/s3 key. If provided, the key policy of the provided key must permit the IAM role used by AWS Config. See https://docs.aws.amazon.com/sns/latest/dg/sns-key-management.html. Note that the KMS key must reside in the global recorder region (as configured by <a href="#aws_region"><code>aws_region</code></a>).
 
-<a name="iam_group_developers_permitted_services" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`iam_group_developers_permitted_services`**](#iam_group_developers_permitted_services) &mdash; A list of AWS services for which the developers IAM Group will receive full permissions. See https://goo.gl/ZyoHlz to find the IAM Service name. For example, to grant developers access only to EC2 and Amazon Machine Learning, use the value ["ec2","machinelearning"]. Do NOT add iam to the list of services, or that will grant Developers de facto admin access. If you need to grant iam privileges, just grant the user Full Access.
+<HclListItem name="config_s3_bucket_kms_key_by_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="iam_group_name_auto_deploy" className="snap-top"></a>
+Same as <a href="#config_s3_bucket_kms_key_arn"><code>config_s3_bucket_kms_key_arn</code></a>, except the value is a name of a KMS key configured with <a href="#kms_customer_master_keys"><code>kms_customer_master_keys</code></a>. The module created KMS key for the global recorder region (indexed by the name) will be used. Note that if both <a href="#config_s3_bucket_kms_key_arn"><code>config_s3_bucket_kms_key_arn</code></a> and <a href="#config_s3_bucket_kms_key_by_name"><code>config_s3_bucket_kms_key_by_name</code></a> are configured, the key in <a href="#config_s3_bucket_kms_key_arn"><code>config_s3_bucket_kms_key_arn</code></a> will always be used.
 
-* [**`iam_group_name_auto_deploy`**](#iam_group_name_auto_deploy) &mdash; The name of the IAM Group that allows automated deployment by graning the permissions specified in [`auto_deploy_permissions`](#auto_deploy_permissions).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="iam_group_name_billing" className="snap-top"></a>
+<HclListItem name="config_s3_bucket_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`iam_group_name_billing`**](#iam_group_name_billing) &mdash; The name to be used for the IAM Group that grants read/write access to all billing features in AWS.
+The name of the S3 Bucket where CloudTrail logs will be stored. This could be a bucket in this AWS account or the name of a bucket in another AWS account where logs should be sent. We recommend setting this to the name of a bucket in a separate logs account.
 
-<a name="iam_group_name_developers" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`iam_group_name_developers`**](#iam_group_name_developers) &mdash; The name to be used for the IAM Group that grants IAM Users a reasonable set of permissions for developers.
+<HclListItem name="config_s3_mfa_delete" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="iam_group_name_full_access" className="snap-top"></a>
+Enable MFA delete for either 'Change the versioning state of your bucket' or 'Permanently delete an object version'. This setting only applies to the bucket used to storage AWS Config data. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS. For instructions on how to enable MFA Delete, check out the README from the terraform-aws-security/private-s3-bucket module.
 
-* [**`iam_group_name_full_access`**](#iam_group_name_full_access) &mdash; The name to be used for the IAM Group that grants full access to all AWS resources.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="iam_group_name_houston_cli" className="snap-top"></a>
+<HclListItem name="config_should_create_s3_bucket" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`iam_group_name_houston_cli`**](#iam_group_name_houston_cli) &mdash; The name of the IAM Group that allows access to houston CLI.
+Set to true to create an S3 bucket of name <a href="#config_s3_bucket_name"><code>config_s3_bucket_name</code></a> in this account for storing AWS Config data. Set to false to assume the bucket specified in <a href="#config_s3_bucket_name"><code>config_s3_bucket_name</code></a> already exists in another AWS account. We recommend setting this to false and setting <a href="#config_s3_bucket_name"><code>config_s3_bucket_name</code></a> to the name off an S3 bucket that already exists in a separate logs account.
 
-<a name="iam_group_name_iam_admin" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`iam_group_name_iam_admin`**](#iam_group_name_iam_admin) &mdash; The name to be used for the IAM Group that grants IAM administrative access. Effectively grants administrator access.
+<HclListItem name="config_should_create_sns_topic" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="iam_group_name_iam_user_self_mgmt" className="snap-top"></a>
+Set to true to create an SNS topic in this account for sending AWS Config notifications (e.g., if this is the logs account). Set to false to assume the topic specified in <a href="#config_sns_topic_name"><code>config_sns_topic_name</code></a> already exists in another AWS account (e.g., if this is the stage or prod account and <a href="#config_sns_topic_name"><code>config_sns_topic_name</code></a> is the name of an SNS topic in the logs account).
 
-* [**`iam_group_name_iam_user_self_mgmt`**](#iam_group_name_iam_user_self_mgmt) &mdash; The name to be used for the IAM Group that grants IAM Users the permissions to manage their own IAM User account.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="iam_group_name_logs" className="snap-top"></a>
+<HclListItem name="config_sns_topic_kms_key_by_name_region_map" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`iam_group_name_logs`**](#iam_group_name_logs) &mdash; The name to be used for the IAM Group that grants read access to CloudTrail, AWS Config, and CloudWatch in AWS.
+Same as <a href="#config_sns_topic_kms_key_region_map"><code>config_sns_topic_kms_key_region_map</code></a>, except the value is a name of a KMS key configured with <a href="#kms_customer_master_keys"><code>kms_customer_master_keys</code></a>. The module created KMS key for each region (indexed by the name) will be used. Note that if an entry exists for a region in both <a href="#config_sns_topic_kms_key_region_map"><code>config_sns_topic_kms_key_region_map</code></a> and <a href="#config_sns_topic_kms_key_by_name_region_map"><code>config_sns_topic_kms_key_by_name_region_map</code></a>, then the key in <a href="#config_sns_topic_kms_key_region_map"><code>config_sns_topic_kms_key_region_map</code></a> will always be used.
 
-<a name="iam_group_name_read_only" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`iam_group_name_read_only`**](#iam_group_name_read_only) &mdash; The name to be used for the IAM Group that grants read-only access to all AWS resources.
+```hcl
+map(string)
+```
 
-<a name="iam_group_name_support" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`iam_group_name_support`**](#iam_group_name_support) &mdash; The name of the IAM Group that allows access to AWS Support.
+<HclListItem name="config_sns_topic_kms_key_region_map" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="iam_group_name_use_existing_iam_roles" className="snap-top"></a>
+Optional KMS key to use for each region for configuring default encryption for the SNS topic (encoded as a map from region - e.g. us-east-1 - to ARN of KMS key). If null or the region key is missing, encryption will not be configured for the SNS topic in that region.
 
-* [**`iam_group_name_use_existing_iam_roles`**](#iam_group_name_use_existing_iam_roles) &mdash; The name to be used for the IAM Group that grants IAM Users the permissions to use existing IAM Roles when launching AWS Resources. This does NOT grant the permission to create new IAM Roles.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="iam_group_names_ssh_grunt_sudo_users" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`iam_group_names_ssh_grunt_sudo_users`**](#iam_group_names_ssh_grunt_sudo_users) &mdash; The list of names to be used for the IAM Group that enables its members to SSH as a sudo user into any server configured with the ssh-grunt Gruntwork module. Pass in multiple to configure multiple different IAM groups to control different groupings of access at the server level. Pass in empty list to disable creation of the IAM groups.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="iam_group_names_ssh_grunt_users" className="snap-top"></a>
+<HclListItem name="config_sns_topic_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`iam_group_names_ssh_grunt_users`**](#iam_group_names_ssh_grunt_users) &mdash; The name to be used for the IAM Group that enables its members to SSH as a non-sudo user into any server configured with the ssh-grunt Gruntwork module. Pass in multiple to configure multiple different IAM groups to control different groupings of access at the server level. Pass in empty list to disable creation of the IAM groups.
+The name of the SNS Topic in where AWS Config notifications will be sent. Can be in the same account or in another account.
 
-<a name="iam_groups_for_cross_account_access" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ConfigTopic"/>
+</HclListItem>
 
-* [**`iam_groups_for_cross_account_access`**](#iam_groups_for_cross_account_access) &mdash; This variable is used to create groups that allow IAM users to assume roles in your other AWS accounts. It should be a list of objects, where each object has the fields [`'group_name`](#'group_name)', which will be used as the name of the IAM group, and [`'iam_role_arns`](#'iam_role_arns)', which is a list of ARNs of IAM Roles that you can assume when part of that group. For each entry in the list of objects, we will create an IAM group that allows users to assume the given IAM role(s) in the other AWS account. This allows you to define all your IAM users in one account (e.g. the users account) and to grant them access to certain IAM roles in other accounts (e.g. the stage, prod, audit accounts).
+<HclListItem name="config_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="iam_password_policy_allow_users_to_change_password" className="snap-top"></a>
+A map of tags to apply to the S3 Bucket. The key is the tag name and the value is the tag value.
 
-* [**`iam_password_policy_allow_users_to_change_password`**](#iam_password_policy_allow_users_to_change_password) &mdash; Allow users to change their own password.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="iam_password_policy_hard_expiry" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`iam_password_policy_hard_expiry`**](#iam_password_policy_hard_expiry) &mdash; Password expiration requires administrator reset.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="iam_password_policy_max_password_age" className="snap-top"></a>
+<HclListItem name="configrules_maximum_execution_frequency" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`iam_password_policy_max_password_age`**](#iam_password_policy_max_password_age) &mdash; Number of days before password expiration.
+The maximum frequency with which AWS Config runs evaluations for the ´PERIODIC´ rules. See https://www.terraform.io/docs/providers/aws/r/config_organization_managed_rule.html#maximum_execution_frequency
 
-<a name="iam_password_policy_minimum_password_length" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="TwentyFour_Hours"/>
+</HclListItem>
 
-* [**`iam_password_policy_minimum_password_length`**](#iam_password_policy_minimum_password_length) &mdash; Password minimum length.
+<HclListItem name="cross_account_access_all_group_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="iam_password_policy_password_reuse_prevention" className="snap-top"></a>
+The name of the IAM group that will grant access to all external AWS accounts in <a href="#iam_groups_for_cross_account_access"><code>iam_groups_for_cross_account_access</code></a>.
 
-* [**`iam_password_policy_password_reuse_prevention`**](#iam_password_policy_password_reuse_prevention) &mdash; Number of passwords before allowing reuse.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="_all-accounts"/>
+</HclListItem>
 
-<a name="iam_password_policy_require_lowercase_characters" className="snap-top"></a>
+<HclListItem name="custom_cloudtrail_trail_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`iam_password_policy_require_lowercase_characters`**](#iam_password_policy_require_lowercase_characters) &mdash; Require at least one lowercase character in password.
+A custom name to use for the Cloudtrail Trail. If null, defaults to the <a href="#name_prefix"><code>name_prefix</code></a> input variable.
 
-<a name="iam_password_policy_require_numbers" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`iam_password_policy_require_numbers`**](#iam_password_policy_require_numbers) &mdash; Require at least one number in password.
+<HclListItem name="dev_permitted_services" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="iam_password_policy_require_symbols" className="snap-top"></a>
+A list of AWS services for which the developers from the accounts in <a href="#allow_dev_access_from_other_account_arns"><code>allow_dev_access_from_other_account_arns</code></a> will receive full permissions. See https://goo.gl/ZyoHlz to find the IAM Service name. For example, to grant developers access only to EC2 and Amazon Machine Learning, use the value ['ec2','machinelearning']. Do NOT add iam to the list of services, or that will grant Developers de facto admin access.
 
-* [**`iam_password_policy_require_symbols`**](#iam_password_policy_require_symbols) &mdash; Require at least one symbol in password.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="iam_password_policy_require_uppercase_characters" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`iam_password_policy_require_uppercase_characters`**](#iam_password_policy_require_uppercase_characters) &mdash; Require at least one uppercase character in password.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="iam_policy_iam_user_self_mgmt" className="snap-top"></a>
+<HclListItem name="ebs_enable_encryption" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`iam_policy_iam_user_self_mgmt`**](#iam_policy_iam_user_self_mgmt) &mdash; The name to be used for the IAM Policy that grants IAM Users the permissions to manage their own IAM User account.
+If set to true (default), all new EBS volumes will have encryption enabled by default
 
-<a name="iam_role_tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`iam_role_tags`**](#iam_role_tags) &mdash; The tags to apply to all the IAM role resources.
+<HclListItem name="ebs_kms_key_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="insecure_sg_rules_authorized_tcp_ports" className="snap-top"></a>
+The name of the KMS CMK to use by default for encrypting EBS volumes, if <a href="#ebs_enable_encryption"><code>ebs_enable_encryption</code></a> and <a href="#ebs_use_existing_kms_keys"><code>ebs_use_existing_kms_keys</code></a> are enabled. The name must match a name given the <a href="#kms_customer_master_keys"><code>kms_customer_master_keys</code></a> variable.
 
-* [**`insecure_sg_rules_authorized_tcp_ports`**](#insecure_sg_rules_authorized_tcp_ports) &mdash; Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by a dash; for example, '443,1020-1025'.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
 
-<a name="insecure_sg_rules_authorized_udp_ports" className="snap-top"></a>
+<HclListItem name="ebs_use_existing_kms_keys" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`insecure_sg_rules_authorized_udp_ports`**](#insecure_sg_rules_authorized_udp_ports) &mdash; Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by a dash; for example, '500,1020-1025'.
+If set to true, the KMS Customer Managed Keys (CMK) with the name in <a href="#ebs_kms_key_name"><code>ebs_kms_key_name</code></a> will be set as the default for EBS encryption. When false (default), the AWS-managed aws/ebs key will be used.
 
-<a name="kms_cmk_global_tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`kms_cmk_global_tags`**](#kms_cmk_global_tags) &mdash; A map of tags to apply to all KMS Keys to be created. In this map variable, the key is the tag name and the value is the tag value.
+<HclListItem name="enable_cloudtrail" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="kms_customer_master_keys" className="snap-top"></a>
+Set to true (default) to enable CloudTrail in the security account. Set to false to disable CloudTrail (note: all other CloudTrail variables will be ignored). Note that if you have enabled organization trail in the root (parent) account, you should set this to false; the organization trail will enable CloudTrail on child accounts by default.
 
-* [**`kms_customer_master_keys`**](#kms_customer_master_keys) &mdash; You can use this variable to create account-level KMS Customer Master Keys (CMKs) for encrypting and decrypting data. This variable should be a map where the keys are the names of the CMK and the values are an object that defines the configuration for that CMK. See the comment below for the configuration options you can set for each key.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="kms_grant_regions" className="snap-top"></a>
+<HclListItem name="enable_config" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`kms_grant_regions`**](#kms_grant_regions) &mdash; The map of names of KMS grants to the region where the key resides in. There should be a one to one mapping between entries in this map and the entries of the [`kms_grants`](#kms_grants) map. This is used to workaround a terraform limitation where the [`for_each`](#for_each) value can not depend on resources.
+Set to true to enable AWS Config in the security account. Set to false to disable AWS Config (note: all other AWS config variables will be ignored).
 
-<a name="kms_grants" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`kms_grants`**](#kms_grants) &mdash; Create the specified KMS grants to allow entities to use the KMS key without modifying the KMS policy or IAM. This is necessary to allow AWS services (e.g. ASG) to use CMKs encrypt and decrypt resources. The input is a map of grant name to grant properties. The name must be unique per account.
+<HclListItem name="enable_encrypted_volumes" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="max_session_duration_human_users" className="snap-top"></a>
+Checks whether the EBS volumes that are in an attached state are encrypted.
 
-* [**`max_session_duration_human_users`**](#max_session_duration_human_users) &mdash; The maximum allowable session duration, in seconds, for the credentials you get when assuming the IAM roles created by this module. This variable applies to all IAM roles created by this module that are intended for people to use, such as allow-read-only-access-from-other-accounts. For IAM roles that are intended for machine users, such as allow-auto-deploy-from-other-accounts, see [`max_session_duration_machine_users`](#max_session_duration_machine_users).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="max_session_duration_machine_users" className="snap-top"></a>
+<HclListItem name="enable_github_actions_access" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`max_session_duration_machine_users`**](#max_session_duration_machine_users) &mdash; The maximum allowable session duration, in seconds, for the credentials you get when assuming the IAM roles created by this module. This variable  applies to all IAM roles created by this module that are intended for machine users, such as allow-auto-deploy-from-other-accounts. For IAM roles that are intended for human users, such as allow-read-only-access-from-other-accounts, see [`max_session_duration_human_users`](#max_session_duration_human_users).
+When true, create an Open ID Connect Provider that GitHub actions can use to assume IAM roles in the account. Refer to https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services for more information.
 
-<a name="password_reset_required" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`password_reset_required`**](#password_reset_required) &mdash; Force the user to reset their password on initial login. Only used for users with [`create_login_profile`](#create_login_profile) set to true.
+<HclListItem name="enable_iam_access_analyzer" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="rds_storage_encrypted_kms_id" className="snap-top"></a>
+A feature flag to enable or disable this module.
 
-* [**`rds_storage_encrypted_kms_id`**](#rds_storage_encrypted_kms_id) &mdash; KMS key ID or ARN used to encrypt the storage. Used for configuring the RDS storage encryption config rule.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="service_linked_roles" className="snap-top"></a>
+<HclListItem name="enable_iam_cross_account_roles" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`service_linked_roles`**](#service_linked_roles) &mdash; Create service-linked roles for this set of services. You should pass in the URLs of the services, but without the protocol (e.g., http://) in front: e.g., use elasticbeanstalk.amazonaws.com for Elastic Beanstalk or es.amazonaws.com for Amazon Elasticsearch. Service-linked roles are predefined by the service, can typically only be assumed by that service, and include all the permissions that the service requires to call other AWS services on your behalf. You can typically only create one such role per AWS account, which is why this parameter exists in the account baseline. See [`https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws`](#https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws)-services-that-work-with-iam.html for the list of services that support service-linked roles.
+A feature flag to enable or disable the Cross Account Iam Roles module.
 
-<a name="should_create_iam_group_auto_deploy" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`should_create_iam_group_auto_deploy`**](#should_create_iam_group_auto_deploy) &mdash; Should we create the IAM Group for auto-deploy? Allows automated deployment by granting the permissions specified in [`auto_deploy_permissions`](#auto_deploy_permissions). (true or false)
+<HclListItem name="enable_iam_groups" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="should_create_iam_group_billing" className="snap-top"></a>
+A feature flag to enable or disable the IAM Groups module.
 
-* [**`should_create_iam_group_billing`**](#should_create_iam_group_billing) &mdash; Should we create the IAM Group for billing? Allows read-write access to billing features only. (true or false)
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="should_create_iam_group_cross_account_access_all" className="snap-top"></a>
+<HclListItem name="enable_iam_password_policy" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`should_create_iam_group_cross_account_access_all`**](#should_create_iam_group_cross_account_access_all) &mdash; Should we create the IAM Group for access to all external AWS accounts? 
+Checks whether the account password policy for IAM users meets the specified requirements.
 
-<a name="should_create_iam_group_developers" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`should_create_iam_group_developers`**](#should_create_iam_group_developers) &mdash; Should we create the IAM Group for developers? The permissions of that group are specified via [`iam_group_developers_permitted_services`](#iam_group_developers_permitted_services). (true or false)
+<HclListItem name="enable_insecure_sg_rules" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="should_create_iam_group_full_access" className="snap-top"></a>
+Checks whether the security group with 0.0.0.0/0 of any Amazon Virtual Private Cloud (Amazon VPC) allows only specific inbound TCP or UDP traffic.
 
-* [**`should_create_iam_group_full_access`**](#should_create_iam_group_full_access) &mdash; Should we create the IAM Group for full access? Allows full access to all AWS resources. (true or false)
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="should_create_iam_group_houston_cli_users" className="snap-top"></a>
+<HclListItem name="enable_rds_storage_encrypted" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`should_create_iam_group_houston_cli_users`**](#should_create_iam_group_houston_cli_users) &mdash; Should we create the IAM Group for houston CLI users? Allows users to use the houston CLI for managing and deploying services.
+Checks whether storage encryption is enabled for your RDS DB instances.
 
-<a name="should_create_iam_group_iam_admin" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`should_create_iam_group_iam_admin`**](#should_create_iam_group_iam_admin) &mdash; Should we create the IAM Group for IAM administrator access? Allows users to manage all IAM entities, effectively granting administrator access. (true or false)
+<HclListItem name="enable_root_account_mfa" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="should_create_iam_group_logs" className="snap-top"></a>
+Checks whether users of your AWS account require a multi-factor authentication (MFA) device to sign in with root credentials.
 
-* [**`should_create_iam_group_logs`**](#should_create_iam_group_logs) &mdash; Should we create the IAM Group for logs? Allows read access to CloudTrail, AWS Config, and CloudWatch. If [`cloudtrail_kms_key_arn`](#cloudtrail_kms_key_arn) is set, will also give decrypt access to a KMS CMK. (true or false)
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="should_create_iam_group_read_only" className="snap-top"></a>
+<HclListItem name="enable_s3_bucket_public_read_prohibited" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`should_create_iam_group_read_only`**](#should_create_iam_group_read_only) &mdash; Should we create the IAM Group for read-only? Allows read-only access to all AWS resources. (true or false)
+Checks that your Amazon S3 buckets do not allow public read access.
 
-<a name="should_create_iam_group_support" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`should_create_iam_group_support`**](#should_create_iam_group_support) &mdash; Should we create the IAM Group for support? Allows support access (AWSupportAccess). (true or false)
+<HclListItem name="enable_s3_bucket_public_write_prohibited" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="should_create_iam_group_use_existing_iam_roles" className="snap-top"></a>
+Checks that your Amazon S3 buckets do not allow public write access.
 
-* [**`should_create_iam_group_use_existing_iam_roles`**](#should_create_iam_group_use_existing_iam_roles) &mdash; Should we create the IAM Group for use-existing-iam-roles? Allow launching AWS resources with existing IAM Roles, but no ability to create new IAM Roles. (true or false)
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="should_create_iam_group_user_self_mgmt" className="snap-top"></a>
+<HclListItem name="encrypted_volumes_kms_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`should_create_iam_group_user_self_mgmt`**](#should_create_iam_group_user_self_mgmt) &mdash; Should we create the IAM Group for user self-management? Allows users to manage their own IAM user accounts, but not other IAM users. (true or false)
+ID or ARN of the KMS key that is used to encrypt the volume. Used for configuring the encrypted volumes config rule.
 
-<a name="should_require_mfa" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`should_require_mfa`**](#should_require_mfa) &mdash; Should we require that all IAM Users use Multi-Factor Authentication for both AWS API calls and the AWS Web Console? (true or false)
+<HclListItem name="force_destroy_users" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="users" className="snap-top"></a>
+When destroying this user, destroy even if it has non-Terraform-managed IAM access keys, login profile, or MFA devices. Without force_destroy a user with non-Terraform-managed access keys and login profile will fail to be destroyed.
 
-* [**`users`**](#users) &mdash; A map of users to create. The keys are the user names and the values are an object with the optional keys 'groups' (a list of IAM groups to add the user to), 'tags' (a map of tags to apply to the user), [`'pgp_key`](#'pgp_key)' (either a base-64 encoded PGP public key, or a keybase username in the form keybase:username, used to encrypt the user's credentials; required if [`create_login_profile`](#create_login_profile) or [`create_access_keys`](#create_access_keys) is true), [`'create_login_profile`](#'create_login_profile)' (if set to true, create a password to login to the AWS Web Console), [`'create_access_keys`](#'create_access_keys)' (if set to true, create access keys for the user), 'path' (the path), and [`'permissions_boundary`](#'permissions_boundary)' (the ARN of the policy that is used to set the permissions boundary for the user).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="github_actions_openid_connect_provider_thumbprint_list" requirement="optional" type="list">
+<HclListItemDescription>
+
+When set, use the statically provided hardcoded list of thumbprints rather than looking it up dynamically. This is useful if you want to trade reliability of the OpenID Connect Provider across certificate renewals with a static list that is obtained using a trustworthy mechanism, to mitigate potential damage from a domain hijacking attack on GitHub domains.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="guardduty_cloudwatch_event_rule_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+Name of the Cloudwatch event rules.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="guardduty-finding-events"/>
+</HclListItem>
+
+<HclListItem name="guardduty_finding_publishing_frequency" requirement="optional" type="string">
+<HclListItemDescription>
+
+Specifies the frequency of notifications sent for subsequent finding occurrences. If the detector is a GuardDuty member account, the value is determined by the GuardDuty master account and cannot be modified, otherwise defaults to SIX_HOURS. For standalone and GuardDuty master accounts, it must be configured in Terraform to enable drift detection. Valid values for standalone and master accounts: FIFTEEN_MINUTES, ONE_HOUR, SIX_HOURS.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="guardduty_findings_sns_topic_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+Specifies a name for the created SNS topics where findings are published. publish_findings_to_sns must be set to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="guardduty-findings"/>
+</HclListItem>
+
+<HclListItem name="guardduty_publish_findings_to_sns" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Send GuardDuty findings to SNS topics specified by findings_sns_topic_name.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="iam_access_analyzer_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of the IAM Access Analyzer module
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="baseline_security-iam_access_analyzer"/>
+</HclListItem>
+
+<HclListItem name="iam_access_analyzer_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+If set to ACCOUNT, the analyzer will only be scanning the current AWS account it's in. If set to ORGANIZATION - will scan the organization AWS account and the child accounts.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ACCOUNT"/>
+</HclListItem>
+
+<HclListItem name="iam_group_developers_permitted_services" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of AWS services for which the developers IAM Group will receive full permissions. See https://goo.gl/ZyoHlz to find the IAM Service name. For example, to grant developers access only to EC2 and Amazon Machine Learning, use the value ['ec2','machinelearning']. Do NOT add iam to the list of services, or that will grant Developers de facto admin access. If you need to grant iam privileges, just grant the user Full Access.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="iam_group_name_auto_deploy" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of the IAM Group that allows automated deployment by graning the permissions specified in <a href="#auto_deploy_permissions"><code>auto_deploy_permissions</code></a>.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="_machine.ecs-auto-deploy"/>
+</HclListItem>
+
+<HclListItem name="iam_group_name_billing" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name to be used for the IAM Group that grants read/write access to all billing features in AWS.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="billing"/>
+</HclListItem>
+
+<HclListItem name="iam_group_name_developers" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name to be used for the IAM Group that grants IAM Users a reasonable set of permissions for developers.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="developers"/>
+</HclListItem>
+
+<HclListItem name="iam_group_name_full_access" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name to be used for the IAM Group that grants full access to all AWS resources.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="full-access"/>
+</HclListItem>
+
+<HclListItem name="iam_group_name_houston_cli" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of the IAM Group that allows access to houston CLI.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="houston-cli-users"/>
+</HclListItem>
+
+<HclListItem name="iam_group_name_iam_admin" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name to be used for the IAM Group that grants IAM administrative access. Effectively grants administrator access.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="iam-admin"/>
+</HclListItem>
+
+<HclListItem name="iam_group_name_iam_user_self_mgmt" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name to be used for the IAM Group that grants IAM Users the permissions to manage their own IAM User account.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="iam-user-self-mgmt"/>
+</HclListItem>
+
+<HclListItem name="iam_group_name_logs" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name to be used for the IAM Group that grants read access to CloudTrail, AWS Config, and CloudWatch in AWS.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="logs"/>
+</HclListItem>
+
+<HclListItem name="iam_group_name_read_only" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name to be used for the IAM Group that grants read-only access to all AWS resources.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="read-only"/>
+</HclListItem>
+
+<HclListItem name="iam_group_name_support" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of the IAM Group that allows access to AWS Support.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="support"/>
+</HclListItem>
+
+<HclListItem name="iam_group_name_use_existing_iam_roles" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name to be used for the IAM Group that grants IAM Users the permissions to use existing IAM Roles when launching AWS Resources. This does NOT grant the permission to create new IAM Roles.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="use-existing-iam-roles"/>
+</HclListItem>
+
+<HclListItem name="iam_group_names_ssh_grunt_sudo_users" requirement="optional" type="list">
+<HclListItemDescription>
+
+The list of names to be used for the IAM Group that enables its members to SSH as a sudo user into any server configured with the ssh-grunt Gruntwork module. Pass in multiple to configure multiple different IAM groups to control different groupings of access at the server level. Pass in empty list to disable creation of the IAM groups.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
+
+```hcl
+[
+  "ssh-grunt-sudo-users"
+]
+```
+
+</HclListItemDefaultValue>
+</HclListItem>
+
+<HclListItem name="iam_group_names_ssh_grunt_users" requirement="optional" type="list">
+<HclListItemDescription>
+
+The name to be used for the IAM Group that enables its members to SSH as a non-sudo user into any server configured with the ssh-grunt Gruntwork module. Pass in multiple to configure multiple different IAM groups to control different groupings of access at the server level. Pass in empty list to disable creation of the IAM groups.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
+
+```hcl
+[
+  "ssh-grunt-users"
+]
+```
+
+</HclListItemDefaultValue>
+</HclListItem>
+
+<HclListItem name="iam_groups_for_cross_account_access" requirement="optional" type="list">
+<HclListItemDescription>
+
+This variable is used to create groups that allow IAM users to assume roles in your other AWS accounts. It should be a list of objects, where each object has the fields 'group_name', which will be used as the name of the IAM group, and 'iam_role_arns', which is a list of ARNs of IAM Roles that you can assume when part of that group. For each entry in the list of objects, we will create an IAM group that allows users to assume the given IAM role(s) in the other AWS account. This allows you to define all your IAM users in one account (e.g. the users account) and to grant them access to certain IAM roles in other accounts (e.g. the stage, prod, audit accounts).
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(object({
+    group_name    = string
+    iam_role_arns = list(string)
+  }))
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_allow_users_to_change_password" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Allow users to change their own password.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_hard_expiry" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Password expiration requires administrator reset.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_max_password_age" requirement="optional" type="number">
+<HclListItemDescription>
+
+Number of days before password expiration.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="30"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_minimum_password_length" requirement="optional" type="number">
+<HclListItemDescription>
+
+Password minimum length.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="16"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_password_reuse_prevention" requirement="optional" type="number">
+<HclListItemDescription>
+
+Number of passwords before allowing reuse.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="5"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_require_lowercase_characters" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Require at least one lowercase character in password.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_require_numbers" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Require at least one number in password.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_require_symbols" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Require at least one symbol in password.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="iam_password_policy_require_uppercase_characters" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Require at least one uppercase character in password.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="iam_policy_iam_user_self_mgmt" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name to be used for the IAM Policy that grants IAM Users the permissions to manage their own IAM User account.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="iam-user-self-mgmt"/>
+</HclListItem>
+
+<HclListItem name="iam_role_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+The tags to apply to all the IAM role resources.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="insecure_sg_rules_authorized_tcp_ports" requirement="optional" type="string">
+<HclListItemDescription>
+
+Comma-separated list of TCP ports authorized to be open to 0.0.0.0/0. Ranges are defined by a dash; for example, '443,1020-1025'.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="443"/>
+</HclListItem>
+
+<HclListItem name="insecure_sg_rules_authorized_udp_ports" requirement="optional" type="string">
+<HclListItemDescription>
+
+Comma-separated list of UDP ports authorized to be open to 0.0.0.0/0. Ranges are defined by a dash; for example, '500,1020-1025'.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="kms_cmk_global_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of tags to apply to all KMS Keys to be created. In this map variable, the key is the tag name and the value is the tag value.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="kms_customer_master_keys" requirement="optional" type="any">
+<HclListItemDescription>
+
+You can use this variable to create account-level KMS Customer Master Keys (CMKs) for encrypting and decrypting data. This variable should be a map where the keys are the names of the CMK and the values are an object that defines the configuration for that CMK. See the comment below for the configuration options you can set for each key.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="kms_grant_regions" requirement="optional" type="map">
+<HclListItemDescription>
+
+The map of names of KMS grants to the region where the key resides in. There should be a one to one mapping between entries in this map and the entries of the kms_grants map. This is used to workaround a terraform limitation where the for_each value can not depend on resources.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="kms_grants" requirement="optional" type="map">
+<HclListItemDescription>
+
+Create the specified KMS grants to allow entities to use the KMS key without modifying the KMS policy or IAM. This is necessary to allow AWS services (e.g. ASG) to use CMKs encrypt and decrypt resources. The input is a map of grant name to grant properties. The name must be unique per account.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(object({
+    # ARN of the KMS CMK that the grant applies to. Note that the region is introspected based on the ARN.
+    kms_cmk_arn = string
+
+    # The principal that is given permission to perform the operations that the grant permits. This must be in ARN
+    # format. For example, the grantee principal for ASG is:
+    # arn:aws:iam::111122223333:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling
+    grantee_principal = string
+
+    # A list of operations that the grant permits. The permitted values are:
+    # Decrypt, Encrypt, GenerateDataKey, GenerateDataKeyWithoutPlaintext, ReEncryptFrom, ReEncryptTo, CreateGrant,
+    # RetireGrant, DescribeKey
+    granted_operations = list(string)
+  }))
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="max_session_duration_human_users" requirement="optional" type="number">
+<HclListItemDescription>
+
+The maximum allowable session duration, in seconds, for the credentials you get when assuming the IAM roles created by this module. This variable applies to all IAM roles created by this module that are intended for people to use, such as allow-read-only-access-from-other-accounts. For IAM roles that are intended for machine users, such as allow-auto-deploy-from-other-accounts, see <a href="#max_session_duration_machine_users"><code>max_session_duration_machine_users</code></a>.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="43200"/>
+</HclListItem>
+
+<HclListItem name="max_session_duration_machine_users" requirement="optional" type="number">
+<HclListItemDescription>
+
+The maximum allowable session duration, in seconds, for the credentials you get when assuming the IAM roles created by this module. This variable  applies to all IAM roles created by this module that are intended for machine users, such as allow-auto-deploy-from-other-accounts. For IAM roles that are intended for human users, such as allow-read-only-access-from-other-accounts, see <a href="#max_session_duration_human_users"><code>max_session_duration_human_users</code></a>.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="3600"/>
+</HclListItem>
+
+<HclListItem name="password_reset_required" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Force the user to reset their password on initial login. Only used for users with create_login_profile set to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="rds_storage_encrypted_kms_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+KMS key ID or ARN used to encrypt the storage. Used for configuring the RDS storage encryption config rule.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="service_linked_roles" requirement="optional" type="set">
+<HclListItemDescription>
+
+Create service-linked roles for this set of services. You should pass in the URLs of the services, but without the protocol (e.g., http://) in front: e.g., use elasticbeanstalk.amazonaws.com for Elastic Beanstalk or es.amazonaws.com for Amazon Elasticsearch. Service-linked roles are predefined by the service, can typically only be assumed by that service, and include all the permissions that the service requires to call other AWS services on your behalf. You can typically only create one such role per AWS account, which is why this parameter exists in the account baseline. See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-services-that-work-with-iam.html for the list of services that support service-linked roles.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_auto_deploy" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for auto-deploy? Allows automated deployment by granting the permissions specified in <a href="#auto_deploy_permissions"><code>auto_deploy_permissions</code></a>. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_billing" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for billing? Allows read-write access to billing features only. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_cross_account_access_all" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for access to all external AWS accounts? 
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_developers" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for developers? The permissions of that group are specified via <a href="#iam_group_developers_permitted_services"><code>iam_group_developers_permitted_services</code></a>. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_full_access" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for full access? Allows full access to all AWS resources. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_houston_cli_users" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for houston CLI users? Allows users to use the houston CLI for managing and deploying services.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_iam_admin" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for IAM administrator access? Allows users to manage all IAM entities, effectively granting administrator access. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_logs" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for logs? Allows read access to CloudTrail, AWS Config, and CloudWatch. If <a href="#cloudtrail_kms_key_arn"><code>cloudtrail_kms_key_arn</code></a> is set, will also give decrypt access to a KMS CMK. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_read_only" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for read-only? Allows read-only access to all AWS resources. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_support" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for support? Allows support access (AWSupportAccess). (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_use_existing_iam_roles" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for use-existing-iam-roles? Allow launching AWS resources with existing IAM Roles, but no ability to create new IAM Roles. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_user_self_mgmt" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for user self-management? Allows users to manage their own IAM user accounts, but not other IAM users. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="should_require_mfa" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we require that all IAM Users use Multi-Factor Authentication for both AWS API calls and the AWS Web Console? (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="users" requirement="optional" type="any">
+<HclListItemDescription>
+
+A map of users to create. The keys are the user names and the values are an object with the optional keys 'groups' (a list of IAM groups to add the user to), 'tags' (a map of tags to apply to the user), 'pgp_key' (either a base-64 encoded PGP public key, or a keybase username in the form keybase:username, used to encrypt the user's credentials; required if create_login_profile or create_access_keys is true), 'create_login_profile' (if set to true, create a password to login to the AWS Web Console), 'create_access_keys' (if set to true, create access keys for the user), 'path' (the path), and 'permissions_boundary' (the ARN of the policy that is used to set the permissions boundary for the user).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="allow_auto_deploy_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_auto_deploy_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-* [**`allow_auto_deploy_access_from_other_accounts_iam_role_arn`**](#allow_auto_deploy_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="allow_auto_deploy_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-<a name="allow_auto_deploy_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_billing_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-* [**`allow_auto_deploy_access_from_other_accounts_iam_role_id`**](#allow_auto_deploy_access_from_other_accounts_iam_role_id) &mdash; 
+<HclListItem name="allow_billing_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-<a name="allow_billing_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_billing_access_sign_in_url">
+</HclListItem>
 
-* [**`allow_billing_access_from_other_accounts_iam_role_arn`**](#allow_billing_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="allow_dev_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-<a name="allow_billing_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_dev_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-* [**`allow_billing_access_from_other_accounts_iam_role_id`**](#allow_billing_access_from_other_accounts_iam_role_id) &mdash; 
+<HclListItem name="allow_dev_access_sign_in_url">
+</HclListItem>
 
-<a name="allow_billing_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="allow_full_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-* [**`allow_billing_access_sign_in_url`**](#allow_billing_access_sign_in_url) &mdash; 
+<HclListItem name="allow_full_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-<a name="allow_dev_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_full_access_sign_in_url">
+</HclListItem>
 
-* [**`allow_dev_access_from_other_accounts_iam_role_arn`**](#allow_dev_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="allow_houston_cli_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-<a name="allow_dev_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_houston_cli_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-* [**`allow_dev_access_from_other_accounts_iam_role_id`**](#allow_dev_access_from_other_accounts_iam_role_id) &mdash; 
+<HclListItem name="allow_iam_admin_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-<a name="allow_dev_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="allow_iam_admin_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-* [**`allow_dev_access_sign_in_url`**](#allow_dev_access_sign_in_url) &mdash; 
+<HclListItem name="allow_iam_admin_access_sign_in_url">
+</HclListItem>
 
-<a name="allow_full_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_logs_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-* [**`allow_full_access_from_other_accounts_iam_role_arn`**](#allow_full_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="allow_logs_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-<a name="allow_full_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_logs_access_sign_in_url">
+</HclListItem>
 
-* [**`allow_full_access_from_other_accounts_iam_role_id`**](#allow_full_access_from_other_accounts_iam_role_id) &mdash; 
+<HclListItem name="allow_read_only_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-<a name="allow_full_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="allow_read_only_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-* [**`allow_full_access_sign_in_url`**](#allow_full_access_sign_in_url) &mdash; 
+<HclListItem name="allow_read_only_access_sign_in_url">
+</HclListItem>
 
-<a name="allow_houston_cli_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_ssh_grunt_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-* [**`allow_houston_cli_access_from_other_accounts_iam_role_arn`**](#allow_houston_cli_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="allow_ssh_grunt_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-<a name="allow_houston_cli_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_ssh_grunt_access_sign_in_url">
+</HclListItem>
 
-* [**`allow_houston_cli_access_from_other_accounts_iam_role_id`**](#allow_houston_cli_access_from_other_accounts_iam_role_id) &mdash; 
+<HclListItem name="allow_ssh_grunt_houston_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-<a name="allow_iam_admin_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_ssh_grunt_houston_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-* [**`allow_iam_admin_access_from_other_accounts_iam_role_arn`**](#allow_iam_admin_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="allow_ssh_grunt_houston_access_sign_in_url">
+</HclListItem>
 
-<a name="allow_iam_admin_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_support_access_from_other_accounts_iam_role_arn">
+</HclListItem>
 
-* [**`allow_iam_admin_access_from_other_accounts_iam_role_id`**](#allow_iam_admin_access_from_other_accounts_iam_role_id) &mdash; 
+<HclListItem name="allow_support_access_from_other_accounts_iam_role_id">
+</HclListItem>
 
-<a name="allow_iam_admin_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="allow_support_access_sign_in_url">
+</HclListItem>
 
-* [**`allow_iam_admin_access_sign_in_url`**](#allow_iam_admin_access_sign_in_url) &mdash; 
+<HclListItem name="aws_ebs_encryption_by_default_enabled">
+<HclListItemDescription>
 
-<a name="allow_logs_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+A map from region to a boolean indicating whether or not EBS encryption is enabled by default for each region.
 
-* [**`allow_logs_access_from_other_accounts_iam_role_arn`**](#allow_logs_access_from_other_accounts_iam_role_arn) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="allow_logs_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="aws_ebs_encryption_default_kms_key">
+<HclListItemDescription>
 
-* [**`allow_logs_access_from_other_accounts_iam_role_id`**](#allow_logs_access_from_other_accounts_iam_role_id) &mdash; 
+A map from region to the ARN of the KMS key used for default EBS encryption for each region.
 
-<a name="allow_logs_access_sign_in_url" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`allow_logs_access_sign_in_url`**](#allow_logs_access_sign_in_url) &mdash; 
+<HclListItem name="billing_iam_group_arn">
+</HclListItem>
 
-<a name="allow_read_only_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="billing_iam_group_name">
+</HclListItem>
 
-* [**`allow_read_only_access_from_other_accounts_iam_role_arn`**](#allow_read_only_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="cloudtrail_cloudwatch_group_arn">
+<HclListItemDescription>
 
-<a name="allow_read_only_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+The ARN of the cloudwatch log group.
 
-* [**`allow_read_only_access_from_other_accounts_iam_role_id`**](#allow_read_only_access_from_other_accounts_iam_role_id) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="allow_read_only_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="cloudtrail_cloudwatch_group_name">
+<HclListItemDescription>
 
-* [**`allow_read_only_access_sign_in_url`**](#allow_read_only_access_sign_in_url) &mdash; 
+The name of the cloudwatch log group.
 
-<a name="allow_ssh_grunt_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`allow_ssh_grunt_access_from_other_accounts_iam_role_arn`**](#allow_ssh_grunt_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="cloudtrail_iam_role_arn">
+<HclListItemDescription>
 
-<a name="allow_ssh_grunt_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+The ARN of the IAM role used by the cloudwatch log group.
 
-* [**`allow_ssh_grunt_access_from_other_accounts_iam_role_id`**](#allow_ssh_grunt_access_from_other_accounts_iam_role_id) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="allow_ssh_grunt_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="cloudtrail_iam_role_name">
+<HclListItemDescription>
 
-* [**`allow_ssh_grunt_access_sign_in_url`**](#allow_ssh_grunt_access_sign_in_url) &mdash; 
+The name of the IAM role used by the cloudwatch log group.
 
-<a name="allow_ssh_grunt_houston_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`allow_ssh_grunt_houston_access_from_other_accounts_iam_role_arn`**](#allow_ssh_grunt_houston_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="cloudtrail_kms_key_alias_name">
+<HclListItemDescription>
 
-<a name="allow_ssh_grunt_houston_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+The alias of the KMS key used by the S3 bucket to encrypt cloudtrail logs.
 
-* [**`allow_ssh_grunt_houston_access_from_other_accounts_iam_role_id`**](#allow_ssh_grunt_houston_access_from_other_accounts_iam_role_id) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="allow_ssh_grunt_houston_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="cloudtrail_kms_key_arn">
+<HclListItemDescription>
 
-* [**`allow_ssh_grunt_houston_access_sign_in_url`**](#allow_ssh_grunt_houston_access_sign_in_url) &mdash; 
+The ARN of the KMS key used by the S3 bucket to encrypt cloudtrail logs.
 
-<a name="allow_support_access_from_other_accounts_iam_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`allow_support_access_from_other_accounts_iam_role_arn`**](#allow_support_access_from_other_accounts_iam_role_arn) &mdash; 
+<HclListItem name="cloudtrail_s3_access_logging_bucket_name">
+<HclListItemDescription>
 
-<a name="allow_support_access_from_other_accounts_iam_role_id" className="snap-top"></a>
+The name of the S3 bucket where server access logs are delivered.
 
-* [**`allow_support_access_from_other_accounts_iam_role_id`**](#allow_support_access_from_other_accounts_iam_role_id) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="allow_support_access_sign_in_url" className="snap-top"></a>
+<HclListItem name="cloudtrail_s3_bucket_name">
+<HclListItemDescription>
 
-* [**`allow_support_access_sign_in_url`**](#allow_support_access_sign_in_url) &mdash; 
+The name of the S3 bucket where cloudtrail logs are delivered.
 
-<a name="aws_ebs_encryption_by_default_enabled" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`aws_ebs_encryption_by_default_enabled`**](#aws_ebs_encryption_by_default_enabled) &mdash; A map from region to a boolean indicating whether or not EBS encryption is enabled by default for each region.
+<HclListItem name="cloudtrail_trail_arn">
+<HclListItemDescription>
 
-<a name="aws_ebs_encryption_default_kms_key" className="snap-top"></a>
+The ARN of the cloudtrail trail.
 
-* [**`aws_ebs_encryption_default_kms_key`**](#aws_ebs_encryption_default_kms_key) &mdash; A map from region to the ARN of the KMS key used for default EBS encryption for each region.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="billing_iam_group_arn" className="snap-top"></a>
+<HclListItem name="config_iam_role_arns">
+<HclListItemDescription>
 
-* [**`billing_iam_group_arn`**](#billing_iam_group_arn) &mdash; 
+The ARNs of the IAM role used by the config recorder.
 
-<a name="billing_iam_group_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`billing_iam_group_name`**](#billing_iam_group_name) &mdash; 
+<HclListItem name="config_recorder_names">
+<HclListItemDescription>
 
-<a name="cloudtrail_cloudwatch_group_arn" className="snap-top"></a>
+The names of the configuration recorder.
 
-* [**`cloudtrail_cloudwatch_group_arn`**](#cloudtrail_cloudwatch_group_arn) &mdash; The ARN of the cloudwatch log group.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="cloudtrail_cloudwatch_group_name" className="snap-top"></a>
+<HclListItem name="config_s3_bucket_names">
+<HclListItemDescription>
 
-* [**`cloudtrail_cloudwatch_group_name`**](#cloudtrail_cloudwatch_group_name) &mdash; The name of the cloudwatch log group.
+The names of the S3 bucket used by AWS Config to store configuration items.
 
-<a name="cloudtrail_iam_role_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cloudtrail_iam_role_arn`**](#cloudtrail_iam_role_arn) &mdash; The ARN of the IAM role used by the cloudwatch log group.
+<HclListItem name="config_sns_topic_arns">
+<HclListItemDescription>
 
-<a name="cloudtrail_iam_role_name" className="snap-top"></a>
+The ARNs of the SNS Topic used by the config notifications.
 
-* [**`cloudtrail_iam_role_name`**](#cloudtrail_iam_role_name) &mdash; The name of the IAM role used by the cloudwatch log group.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="cloudtrail_kms_key_alias_name" className="snap-top"></a>
+<HclListItem name="cross_account_access_all_group_arn">
+</HclListItem>
 
-* [**`cloudtrail_kms_key_alias_name`**](#cloudtrail_kms_key_alias_name) &mdash; The alias of the KMS key used by the S3 bucket to encrypt cloudtrail logs.
+<HclListItem name="cross_account_access_all_group_name">
+</HclListItem>
 
-<a name="cloudtrail_kms_key_arn" className="snap-top"></a>
+<HclListItem name="cross_account_access_group_arns">
+</HclListItem>
 
-* [**`cloudtrail_kms_key_arn`**](#cloudtrail_kms_key_arn) &mdash; The ARN of the KMS key used by the S3 bucket to encrypt cloudtrail logs.
+<HclListItem name="cross_account_access_group_names">
+</HclListItem>
 
-<a name="cloudtrail_s3_access_logging_bucket_name" className="snap-top"></a>
+<HclListItem name="developers_iam_group_arn">
+</HclListItem>
 
-* [**`cloudtrail_s3_access_logging_bucket_name`**](#cloudtrail_s3_access_logging_bucket_name) &mdash; The name of the S3 bucket where server access logs are delivered.
+<HclListItem name="developers_iam_group_name">
+</HclListItem>
 
-<a name="cloudtrail_s3_bucket_name" className="snap-top"></a>
+<HclListItem name="full_access_iam_group_arn">
+</HclListItem>
 
-* [**`cloudtrail_s3_bucket_name`**](#cloudtrail_s3_bucket_name) &mdash; The name of the S3 bucket where cloudtrail logs are delivered.
+<HclListItem name="full_access_iam_group_name">
+</HclListItem>
 
-<a name="cloudtrail_trail_arn" className="snap-top"></a>
+<HclListItem name="github_actions_iam_openid_connect_provider_arn">
+<HclListItemDescription>
 
-* [**`cloudtrail_trail_arn`**](#cloudtrail_trail_arn) &mdash; The ARN of the cloudtrail trail.
+ARN of the OpenID Connect Provider that can be used to attach AWS IAM Roles to GitHub Actions.
 
-<a name="config_iam_role_arns" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`config_iam_role_arns`**](#config_iam_role_arns) &mdash; The ARNs of the IAM role used by the config recorder.
+<HclListItem name="github_actions_iam_openid_connect_provider_url">
+<HclListItemDescription>
 
-<a name="config_recorder_names" className="snap-top"></a>
+URL of the OpenID Connect Provider that can be used to attach AWS IAM Roles to GitHub Actions.
 
-* [**`config_recorder_names`**](#config_recorder_names) &mdash; The names of the configuration recorder.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="config_s3_bucket_names" className="snap-top"></a>
+<HclListItem name="guardduty_cloudwatch_event_rule_arns">
+<HclListItemDescription>
 
-* [**`config_s3_bucket_names`**](#config_s3_bucket_names) &mdash; The names of the S3 bucket used by AWS Config to store configuration items.
+The ARNs of the cloudwatch event rules used to publish findings to sns if <a href="#publish_findings_to_sns"><code>publish_findings_to_sns</code></a> is set to true.
 
-<a name="config_sns_topic_arns" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`config_sns_topic_arns`**](#config_sns_topic_arns) &mdash; The ARNs of the SNS Topic used by the config notifications.
+<HclListItem name="guardduty_cloudwatch_event_target_arns">
+<HclListItemDescription>
 
-<a name="cross_account_access_all_group_arn" className="snap-top"></a>
+The ARNs of the cloudwatch event targets used to publish findings to sns if <a href="#publish_findings_to_sns"><code>publish_findings_to_sns</code></a> is set to true.
 
-* [**`cross_account_access_all_group_arn`**](#cross_account_access_all_group_arn) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="cross_account_access_all_group_name" className="snap-top"></a>
+<HclListItem name="guardduty_detector_ids">
+<HclListItemDescription>
 
-* [**`cross_account_access_all_group_name`**](#cross_account_access_all_group_name) &mdash; 
+The IDs of the GuardDuty detectors.
 
-<a name="cross_account_access_group_arns" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cross_account_access_group_arns`**](#cross_account_access_group_arns) &mdash; 
+<HclListItem name="guardduty_findings_sns_topic_arns">
+<HclListItemDescription>
 
-<a name="cross_account_access_group_names" className="snap-top"></a>
+The ARNs of the SNS topics where findings are published if <a href="#publish_findings_to_sns"><code>publish_findings_to_sns</code></a> is set to true.
 
-* [**`cross_account_access_group_names`**](#cross_account_access_group_names) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="developers_iam_group_arn" className="snap-top"></a>
+<HclListItem name="guardduty_findings_sns_topic_names">
+<HclListItemDescription>
 
-* [**`developers_iam_group_arn`**](#developers_iam_group_arn) &mdash; 
+The names of the SNS topic where findings are published if <a href="#publish_findings_to_sns"><code>publish_findings_to_sns</code></a> is set to true.
 
-<a name="developers_iam_group_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`developers_iam_group_name`**](#developers_iam_group_name) &mdash; 
+<HclListItem name="houston_cli_users_iam_group_arn">
+</HclListItem>
 
-<a name="full_access_iam_group_arn" className="snap-top"></a>
+<HclListItem name="houston_cli_users_iam_group_name">
+</HclListItem>
 
-* [**`full_access_iam_group_arn`**](#full_access_iam_group_arn) &mdash; 
+<HclListItem name="iam_admin_iam_group_arn">
+</HclListItem>
 
-<a name="full_access_iam_group_name" className="snap-top"></a>
+<HclListItem name="iam_admin_iam_group_name">
+</HclListItem>
 
-* [**`full_access_iam_group_name`**](#full_access_iam_group_name) &mdash; 
+<HclListItem name="iam_admin_iam_policy_arn">
+</HclListItem>
 
-<a name="github_actions_iam_openid_connect_provider_arn" className="snap-top"></a>
+<HclListItem name="iam_self_mgmt_iam_group_arn">
+</HclListItem>
 
-* [**`github_actions_iam_openid_connect_provider_arn`**](#github_actions_iam_openid_connect_provider_arn) &mdash; ARN of the OpenID Connect Provider that can be used to attach AWS IAM Roles to GitHub Actions.
+<HclListItem name="iam_self_mgmt_iam_group_name">
+</HclListItem>
 
-<a name="github_actions_iam_openid_connect_provider_url" className="snap-top"></a>
+<HclListItem name="iam_self_mgmt_iam_policy_arn">
+</HclListItem>
 
-* [**`github_actions_iam_openid_connect_provider_url`**](#github_actions_iam_openid_connect_provider_url) &mdash; URL of the OpenID Connect Provider that can be used to attach AWS IAM Roles to GitHub Actions.
+<HclListItem name="invalid_cmk_inputs">
+<HclListItemDescription>
 
-<a name="guardduty_cloudwatch_event_rule_arns" className="snap-top"></a>
+Map of CMKs from the input <a href="#customer_master_keys"><code>customer_master_keys</code></a> that had an invalid region, and thus were not created. The structure of the map is the same as the input. This will only include KMS key inputs that were not created because the region attribute was invalid (either not a valid region identifier, the region is not enabled on the account, or the region is not included in the <a href="#opt_in_regions"><code>opt_in_regions</code></a> input).
 
-* [**`guardduty_cloudwatch_event_rule_arns`**](#guardduty_cloudwatch_event_rule_arns) &mdash; The ARNs of the cloudwatch event rules used to publish findings to sns if [`publish_findings_to_sns`](#publish_findings_to_sns) is set to true.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="guardduty_cloudwatch_event_target_arns" className="snap-top"></a>
+<HclListItem name="kms_key_aliases">
+<HclListItemDescription>
 
-* [**`guardduty_cloudwatch_event_target_arns`**](#guardduty_cloudwatch_event_target_arns) &mdash; The ARNs of the cloudwatch event targets used to publish findings to sns if [`publish_findings_to_sns`](#publish_findings_to_sns) is set to true.
+A map from region to aliases of the KMS CMKs that were created. The value will also be a map mapping the keys from the <a href="#customer_master_keys"><code>customer_master_keys</code></a> input variable to the corresponding alias.
 
-<a name="guardduty_detector_ids" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`guardduty_detector_ids`**](#guardduty_detector_ids) &mdash; The IDs of the GuardDuty detectors.
+<HclListItem name="kms_key_arns">
+<HclListItemDescription>
 
-<a name="guardduty_findings_sns_topic_arns" className="snap-top"></a>
+A map from region to ARNs of the KMS CMKs that were created. The value will also be a map mapping the keys from the <a href="#kms_customer_master_keys"><code>kms_customer_master_keys</code></a> input variable to the corresponding ARN.
 
-* [**`guardduty_findings_sns_topic_arns`**](#guardduty_findings_sns_topic_arns) &mdash; The ARNs of the SNS topics where findings are published if [`publish_findings_to_sns`](#publish_findings_to_sns) is set to true.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="guardduty_findings_sns_topic_names" className="snap-top"></a>
+<HclListItem name="kms_key_ids">
+<HclListItemDescription>
 
-* [**`guardduty_findings_sns_topic_names`**](#guardduty_findings_sns_topic_names) &mdash; The names of the SNS topic where findings are published if [`publish_findings_to_sns`](#publish_findings_to_sns) is set to true.
+A map from region to IDs of the KMS CMKs that were created. The value will also be a map mapping the keys from the <a href="#kms_customer_master_keys"><code>kms_customer_master_keys</code></a> input variable to the corresponding ID.
 
-<a name="houston_cli_users_iam_group_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`houston_cli_users_iam_group_arn`**](#houston_cli_users_iam_group_arn) &mdash; 
+<HclListItem name="logs_iam_group_arn">
+</HclListItem>
 
-<a name="houston_cli_users_iam_group_name" className="snap-top"></a>
+<HclListItem name="logs_iam_group_name">
+</HclListItem>
 
-* [**`houston_cli_users_iam_group_name`**](#houston_cli_users_iam_group_name) &mdash; 
+<HclListItem name="read_only_iam_group_arn">
+</HclListItem>
 
-<a name="iam_admin_iam_group_arn" className="snap-top"></a>
+<HclListItem name="read_only_iam_group_name">
+</HclListItem>
 
-* [**`iam_admin_iam_group_arn`**](#iam_admin_iam_group_arn) &mdash; 
+<HclListItem name="require_mfa_policy">
+</HclListItem>
 
-<a name="iam_admin_iam_group_name" className="snap-top"></a>
+<HclListItem name="service_linked_role_arns">
+<HclListItemDescription>
 
-* [**`iam_admin_iam_group_name`**](#iam_admin_iam_group_name) &mdash; 
+A map of ARNs of the service linked roles created from <a href="#service_linked_roles"><code>service_linked_roles</code></a>.
 
-<a name="iam_admin_iam_policy_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`iam_admin_iam_policy_arn`**](#iam_admin_iam_policy_arn) &mdash; 
+<HclListItem name="ssh_grunt_sudo_users_group_arns">
+</HclListItem>
 
-<a name="iam_self_mgmt_iam_group_arn" className="snap-top"></a>
+<HclListItem name="ssh_grunt_sudo_users_group_names">
+</HclListItem>
 
-* [**`iam_self_mgmt_iam_group_arn`**](#iam_self_mgmt_iam_group_arn) &mdash; 
+<HclListItem name="ssh_grunt_users_group_arns">
+</HclListItem>
 
-<a name="iam_self_mgmt_iam_group_name" className="snap-top"></a>
+<HclListItem name="ssh_grunt_users_group_names">
+</HclListItem>
 
-* [**`iam_self_mgmt_iam_group_name`**](#iam_self_mgmt_iam_group_name) &mdash; 
+<HclListItem name="support_iam_group_arn">
+</HclListItem>
 
-<a name="iam_self_mgmt_iam_policy_arn" className="snap-top"></a>
+<HclListItem name="support_iam_group_name">
+</HclListItem>
 
-* [**`iam_self_mgmt_iam_policy_arn`**](#iam_self_mgmt_iam_policy_arn) &mdash; 
+<HclListItem name="use_existing_iam_roles_iam_group_arn">
+</HclListItem>
 
-<a name="invalid_cmk_inputs" className="snap-top"></a>
+<HclListItem name="use_existing_iam_roles_iam_group_name">
+</HclListItem>
 
-* [**`invalid_cmk_inputs`**](#invalid_cmk_inputs) &mdash; Map of CMKs from the input [`customer_master_keys`](#customer_master_keys) that had an invalid region, and thus were not created. The structure of the map is the same as the input. This will only include KMS key inputs that were not created because the region attribute was invalid (either not a valid region identifier, the region is not enabled on the account, or the region is not included in the [`opt_in_regions`](#opt_in_regions) input).
+<HclListItem name="user_access_keys">
+<HclListItemDescription>
 
-<a name="kms_key_aliases" className="snap-top"></a>
+A map of usernames to that user's access keys (a map with keys access_key_id and secret_access_key), with the secret_access_key encrypted with that user's PGP key (only shows up for users with create_access_keys = true). You can decrypt the secret_access_key on the CLI: echo &lt;secret_access_key> | base64 --decode | keybase pgp decrypt
 
-* [**`kms_key_aliases`**](#kms_key_aliases) &mdash; A map from region to aliases of the KMS CMKs that were created. The value will also be a map mapping the keys from the [`customer_master_keys`](#customer_master_keys) input variable to the corresponding alias.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="kms_key_arns" className="snap-top"></a>
+<HclListItem name="user_arns">
+<HclListItemDescription>
 
-* [**`kms_key_arns`**](#kms_key_arns) &mdash; A map from region to ARNs of the KMS CMKs that were created. The value will also be a map mapping the keys from the [`kms_customer_master_keys`](#kms_customer_master_keys) input variable to the corresponding ARN.
+A map of usernames to the ARN for that IAM user.
 
-<a name="kms_key_ids" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`kms_key_ids`**](#kms_key_ids) &mdash; A map from region to IDs of the KMS CMKs that were created. The value will also be a map mapping the keys from the [`kms_customer_master_keys`](#kms_customer_master_keys) input variable to the corresponding ID.
+<HclListItem name="user_passwords">
+<HclListItemDescription>
 
-<a name="logs_iam_group_arn" className="snap-top"></a>
+A map of usernames to that user's AWS Web Console password, encrypted with that user's PGP key (only shows up for users with create_login_profile = true). You can decrypt the password on the CLI: echo &lt;password> | base64 --decode | keybase pgp decrypt
 
-* [**`logs_iam_group_arn`**](#logs_iam_group_arn) &mdash; 
-
-<a name="logs_iam_group_name" className="snap-top"></a>
-
-* [**`logs_iam_group_name`**](#logs_iam_group_name) &mdash; 
-
-<a name="read_only_iam_group_arn" className="snap-top"></a>
-
-* [**`read_only_iam_group_arn`**](#read_only_iam_group_arn) &mdash; 
-
-<a name="read_only_iam_group_name" className="snap-top"></a>
-
-* [**`read_only_iam_group_name`**](#read_only_iam_group_name) &mdash; 
-
-<a name="require_mfa_policy" className="snap-top"></a>
-
-* [**`require_mfa_policy`**](#require_mfa_policy) &mdash; 
-
-<a name="service_linked_role_arns" className="snap-top"></a>
-
-* [**`service_linked_role_arns`**](#service_linked_role_arns) &mdash; A map of ARNs of the service linked roles created from [`service_linked_roles`](#service_linked_roles).
-
-<a name="ssh_grunt_sudo_users_group_arns" className="snap-top"></a>
-
-* [**`ssh_grunt_sudo_users_group_arns`**](#ssh_grunt_sudo_users_group_arns) &mdash; 
-
-<a name="ssh_grunt_sudo_users_group_names" className="snap-top"></a>
-
-* [**`ssh_grunt_sudo_users_group_names`**](#ssh_grunt_sudo_users_group_names) &mdash; 
-
-<a name="ssh_grunt_users_group_arns" className="snap-top"></a>
-
-* [**`ssh_grunt_users_group_arns`**](#ssh_grunt_users_group_arns) &mdash; 
-
-<a name="ssh_grunt_users_group_names" className="snap-top"></a>
-
-* [**`ssh_grunt_users_group_names`**](#ssh_grunt_users_group_names) &mdash; 
-
-<a name="support_iam_group_arn" className="snap-top"></a>
-
-* [**`support_iam_group_arn`**](#support_iam_group_arn) &mdash; 
-
-<a name="support_iam_group_name" className="snap-top"></a>
-
-* [**`support_iam_group_name`**](#support_iam_group_name) &mdash; 
-
-<a name="use_existing_iam_roles_iam_group_arn" className="snap-top"></a>
-
-* [**`use_existing_iam_roles_iam_group_arn`**](#use_existing_iam_roles_iam_group_arn) &mdash; 
-
-<a name="use_existing_iam_roles_iam_group_name" className="snap-top"></a>
-
-* [**`use_existing_iam_roles_iam_group_name`**](#use_existing_iam_roles_iam_group_name) &mdash; 
-
-<a name="user_access_keys" className="snap-top"></a>
-
-* [**`user_access_keys`**](#user_access_keys) &mdash; A map of usernames to that user's access keys (a map with keys [`access_key_id`](#access_key_id) and [`secret_access_key`](#secret_access_key)), with the [`secret_access_key`](#secret_access_key) encrypted with that user's PGP key (only shows up for users with [`create_access_keys`](#create_access_keys) = true). You can decrypt the [`secret_access_key`](#secret_access_key) on the CLI: echo [`&lt;secret_access_key`](#&lt;secret_access_key)> | base64 --decode | keybase pgp decrypt
-
-<a name="user_arns" className="snap-top"></a>
-
-* [**`user_arns`**](#user_arns) &mdash; A map of usernames to the ARN for that IAM user.
-
-<a name="user_passwords" className="snap-top"></a>
-
-* [**`user_passwords`**](#user_passwords) &mdash; A map of usernames to that user's AWS Web Console password, encrypted with that user's PGP key (only shows up for users with [`create_login_profile`](#create_login_profile) = true). You can decrypt the password on the CLI: echo &lt;password> | base64 --decode | keybase pgp decrypt
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"a61d25374932f07e658f9ca752c7273c"}
+{"sourcePlugin":"service-catalog-api","hash":"9887c8f5545a901cbe49add9fe6061b9"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/landing-zone/gruntwork-access.md
+++ b/docs/reference/services/landing-zone/gruntwork-access.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.20.0"/>
 
@@ -84,51 +85,99 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="grant_security_account_access" className="snap-top"></a>
+<HclListItem name="grant_security_account_access" requirement="required" type="bool">
+<HclListItemDescription>
 
-* [**`grant_security_account_access`**](#grant_security_account_access) &mdash; Set to true to grant your security account, with the account ID specified in [`security_account_id`](#security_account_id), access to the IAM role. This is required for deploying a Reference Architecture.
+Set to true to grant your security account, with the account ID specified in <a href="#security_account_id"><code>security_account_id</code></a>, access to the IAM role. This is required for deploying a Reference Architecture.
 
-<a name="security_account_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`security_account_id`**](#security_account_id) &mdash; The ID of your security account (where IAM users are defined). Required for deploying a Reference Architecture, as the Gruntwork team deploys an EC2 instance in the security account, and that instance assumes this IAM role to get access to all the other child accounts and bootstrap the deployment process.
+<HclListItem name="security_account_id" requirement="required" type="string">
+<HclListItemDescription>
+
+The ID of your security account (where IAM users are defined). Required for deploying a Reference Architecture, as the Gruntwork team deploys an EC2 instance in the security account, and that instance assumes this IAM role to get access to all the other child accounts and bootstrap the deployment process.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="gruntwork_aws_account_id" className="snap-top"></a>
+<HclListItem name="gruntwork_aws_account_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`gruntwork_aws_account_id`**](#gruntwork_aws_account_id) &mdash; The ID of the AWS account that will be allowed to assume the IAM role.
+The ID of the AWS account that will be allowed to assume the IAM role.
 
-<a name="iam_role_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="583800379690"/>
+</HclListItem>
 
-* [**`iam_role_name`**](#iam_role_name) &mdash; The name to use for the IAM role
+<HclListItem name="iam_role_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="managed_policy_name" className="snap-top"></a>
+The name to use for the IAM role
 
-* [**`managed_policy_name`**](#managed_policy_name) &mdash; The name of the AWS Managed Policy to attach to the IAM role. To deploy a Reference Architecture, the Gruntwork team needs AdministratorAccess, so this is the default.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="GruntworkAccountAccessRole"/>
+</HclListItem>
 
-<a name="require_mfa" className="snap-top"></a>
+<HclListItem name="managed_policy_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`require_mfa`**](#require_mfa) &mdash; If set to true, require MFA to assume the IAM role from the Gruntwork account.
+The name of the AWS Managed Policy to attach to the IAM role. To deploy a Reference Architecture, the Gruntwork team needs AdministratorAccess, so this is the default.
 
-<a name="tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="AdministratorAccess"/>
+</HclListItem>
 
-* [**`tags`**](#tags) &mdash; Tags to apply to all resources created by this module
+<HclListItem name="require_mfa" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If set to true, require MFA to assume the IAM role from the Gruntwork account.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+Tags to apply to all resources created by this module
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="iam_role_arn" className="snap-top"></a>
+<HclListItem name="iam_role_arn">
+<HclListItemDescription>
 
-* [**`iam_role_arn`**](#iam_role_arn) &mdash; The ARN of the IAM role
+The ARN of the IAM role
 
-<a name="iam_role_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`iam_role_name`**](#iam_role_name) &mdash; The name of the IAM role
+<HclListItem name="iam_role_name">
+<HclListItemDescription>
+
+The name of the IAM role
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"48de06e15a02df29884359d7c29e14e0"}
+{"sourcePlugin":"service-catalog-api","hash":"065eb90b0c1b06c0cef6779d136c64fd"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/landing-zone/iam-users-and-iam-groups.md
+++ b/docs/reference/services/landing-zone/iam-users-and-iam-groups.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.50.2"/>
 
@@ -106,315 +107,561 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="aws_account_id" className="snap-top"></a>
+<HclListItem name="aws_account_id" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`aws_account_id`**](#aws_account_id) &mdash; The AWS Account ID the template should be operated on. This avoids misconfiguration errors caused by environment variables.
+The AWS Account ID the template should be operated on. This avoids misconfiguration errors caused by environment variables.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="auto_deploy_permissions" className="snap-top"></a>
+<HclListItem name="auto_deploy_permissions" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`auto_deploy_permissions`**](#auto_deploy_permissions) &mdash; A list of IAM permissions (e.g. ec2:*) that will be added to an IAM Group for doing automated deployments. NOTE: If [`should_create_iam_group_auto_deploy`](#should_create_iam_group_auto_deploy) is true, the list must have at least one element (e.g. '*').
+A list of IAM permissions (e.g. ec2:*) that will be added to an IAM Group for doing automated deployments. NOTE: If <a href="#should_create_iam_group_auto_deploy"><code>should_create_iam_group_auto_deploy</code></a> is true, the list must have at least one element (e.g. '*').
 
-<a name="cloudtrail_kms_key_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`cloudtrail_kms_key_arn`**](#cloudtrail_kms_key_arn) &mdash; The ARN of a KMS CMK used to encrypt CloudTrail logs. If set, the logs group will include permissions to decrypt using this CMK.
+```hcl
+list(string)
+```
 
-<a name="cross_account_access_all_group_name" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`cross_account_access_all_group_name`**](#cross_account_access_all_group_name) &mdash; The name of the IAM group that will grant access to all external AWS accounts in [`iam_groups_for_cross_account_access`](#iam_groups_for_cross_account_access).
+<HclListItem name="cloudtrail_kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="enable_iam_groups" className="snap-top"></a>
+The ARN of a KMS CMK used to encrypt CloudTrail logs. If set, the logs group will include permissions to decrypt using this CMK.
 
-* [**`enable_iam_groups`**](#enable_iam_groups) &mdash; A feature flag to enable or disable the IAM Groups module.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="force_destroy_users" className="snap-top"></a>
+<HclListItem name="cross_account_access_all_group_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`force_destroy_users`**](#force_destroy_users) &mdash; When destroying this user, destroy even if it has non-Terraform-managed IAM access keys, login profile, or MFA devices. Without [`force_destroy`](#force_destroy) a user with non-Terraform-managed access keys and login profile will fail to be destroyed.
+The name of the IAM group that will grant access to all external AWS accounts in <a href="#iam_groups_for_cross_account_access"><code>iam_groups_for_cross_account_access</code></a>.
 
-<a name="iam_group_developers_permitted_services" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="_all-accounts"/>
+</HclListItem>
 
-* [**`iam_group_developers_permitted_services`**](#iam_group_developers_permitted_services) &mdash; A list of AWS services for which the developers IAM Group will receive full permissions. See https://goo.gl/ZyoHlz to find the IAM Service name. For example, to grant developers access only to EC2 and Amazon Machine Learning, use the value ["ec2","machinelearning"]. Do NOT add iam to the list of services, or that will grant Developers de facto admin access. If you need to grant iam privileges, just grant the user Full Access.
+<HclListItem name="enable_iam_groups" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="iam_group_name_auto_deploy" className="snap-top"></a>
+A feature flag to enable or disable the IAM Groups module.
 
-* [**`iam_group_name_auto_deploy`**](#iam_group_name_auto_deploy) &mdash; The name of the IAM Group that allows automated deployment by graning the permissions specified in [`auto_deploy_permissions`](#auto_deploy_permissions).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="iam_group_name_billing" className="snap-top"></a>
+<HclListItem name="force_destroy_users" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`iam_group_name_billing`**](#iam_group_name_billing) &mdash; The name to be used for the IAM Group that grants read/write access to all billing features in AWS.
+When destroying this user, destroy even if it has non-Terraform-managed IAM access keys, login profile, or MFA devices. Without force_destroy a user with non-Terraform-managed access keys and login profile will fail to be destroyed.
 
-<a name="iam_group_name_developers" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`iam_group_name_developers`**](#iam_group_name_developers) &mdash; The name to be used for the IAM Group that grants IAM Users a reasonable set of permissions for developers.
+<HclListItem name="iam_group_developers_permitted_services" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="iam_group_name_full_access" className="snap-top"></a>
+A list of AWS services for which the developers IAM Group will receive full permissions. See https://goo.gl/ZyoHlz to find the IAM Service name. For example, to grant developers access only to EC2 and Amazon Machine Learning, use the value ['ec2','machinelearning']. Do NOT add iam to the list of services, or that will grant Developers de facto admin access. If you need to grant iam privileges, just grant the user Full Access.
 
-* [**`iam_group_name_full_access`**](#iam_group_name_full_access) &mdash; The name to be used for the IAM Group that grants full access to all AWS resources.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="iam_group_name_houston_cli" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`iam_group_name_houston_cli`**](#iam_group_name_houston_cli) &mdash; The name of the IAM Group that allows access to houston CLI.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="iam_group_name_iam_admin" className="snap-top"></a>
+<HclListItem name="iam_group_name_auto_deploy" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`iam_group_name_iam_admin`**](#iam_group_name_iam_admin) &mdash; The name to be used for the IAM Group that grants IAM administrative access. Effectively grants administrator access.
+The name of the IAM Group that allows automated deployment by graning the permissions specified in <a href="#auto_deploy_permissions"><code>auto_deploy_permissions</code></a>.
 
-<a name="iam_group_name_iam_user_self_mgmt" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="_machine.ecs-auto-deploy"/>
+</HclListItem>
 
-* [**`iam_group_name_iam_user_self_mgmt`**](#iam_group_name_iam_user_self_mgmt) &mdash; The name to be used for the IAM Group that grants IAM Users the permissions to manage their own IAM User account.
+<HclListItem name="iam_group_name_billing" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="iam_group_name_logs" className="snap-top"></a>
+The name to be used for the IAM Group that grants read/write access to all billing features in AWS.
 
-* [**`iam_group_name_logs`**](#iam_group_name_logs) &mdash; The name to be used for the IAM Group that grants read access to CloudTrail, AWS Config, and CloudWatch in AWS.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="billing"/>
+</HclListItem>
 
-<a name="iam_group_name_read_only" className="snap-top"></a>
+<HclListItem name="iam_group_name_developers" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`iam_group_name_read_only`**](#iam_group_name_read_only) &mdash; The name to be used for the IAM Group that grants read-only access to all AWS resources.
+The name to be used for the IAM Group that grants IAM Users a reasonable set of permissions for developers.
 
-<a name="iam_group_name_support" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="developers"/>
+</HclListItem>
 
-* [**`iam_group_name_support`**](#iam_group_name_support) &mdash; The name of the IAM Group that allows access to AWS Support.
+<HclListItem name="iam_group_name_full_access" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="iam_group_name_use_existing_iam_roles" className="snap-top"></a>
+The name to be used for the IAM Group that grants full access to all AWS resources.
 
-* [**`iam_group_name_use_existing_iam_roles`**](#iam_group_name_use_existing_iam_roles) &mdash; The name to be used for the IAM Group that grants IAM Users the permissions to use existing IAM Roles when launching AWS Resources. This does NOT grant the permission to create new IAM Roles.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="full-access"/>
+</HclListItem>
 
-<a name="iam_group_names_ssh_grunt_sudo_users" className="snap-top"></a>
+<HclListItem name="iam_group_name_houston_cli" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`iam_group_names_ssh_grunt_sudo_users`**](#iam_group_names_ssh_grunt_sudo_users) &mdash; The list of names to be used for the IAM Group that enables its members to SSH as a sudo user into any server configured with the ssh-grunt Gruntwork module. Pass in multiple to configure multiple different IAM groups to control different groupings of access at the server level. Pass in empty list to disable creation of the IAM groups.
+The name of the IAM Group that allows access to houston CLI.
 
-<a name="iam_group_names_ssh_grunt_users" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="houston-cli-users"/>
+</HclListItem>
 
-* [**`iam_group_names_ssh_grunt_users`**](#iam_group_names_ssh_grunt_users) &mdash; The name to be used for the IAM Group that enables its members to SSH as a non-sudo user into any server configured with the ssh-grunt Gruntwork module. Pass in multiple to configure multiple different IAM groups to control different groupings of access at the server level. Pass in empty list to disable creation of the IAM groups.
+<HclListItem name="iam_group_name_iam_admin" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="iam_groups_for_cross_account_access" className="snap-top"></a>
+The name to be used for the IAM Group that grants IAM administrative access. Effectively grants administrator access.
 
-* [**`iam_groups_for_cross_account_access`**](#iam_groups_for_cross_account_access) &mdash; This variable is used to create groups that allow IAM users to assume roles in your other AWS accounts. It should be a list of objects, where each object has the fields [`'group_name`](#'group_name)', which will be used as the name of the IAM group, and [`'iam_role_arns`](#'iam_role_arns)', which is a list of ARNs of IAM Roles that you can assume when part of that group. For each entry in the list of objects, we will create an IAM group that allows users to assume the given IAM role(s) in the other AWS account. This allows you to define all your IAM users in one account (e.g. the users account) and to grant them access to certain IAM roles in other accounts (e.g. the stage, prod, audit accounts).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="iam-admin"/>
+</HclListItem>
 
-<a name="iam_policy_iam_user_self_mgmt" className="snap-top"></a>
+<HclListItem name="iam_group_name_iam_user_self_mgmt" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`iam_policy_iam_user_self_mgmt`**](#iam_policy_iam_user_self_mgmt) &mdash; The name to be used for the IAM Policy that grants IAM Users the permissions to manage their own IAM User account.
+The name to be used for the IAM Group that grants IAM Users the permissions to manage their own IAM User account.
 
-<a name="iam_role_tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="iam-user-self-mgmt"/>
+</HclListItem>
 
-* [**`iam_role_tags`**](#iam_role_tags) &mdash; The tags to apply to all the IAM role resources.
+<HclListItem name="iam_group_name_logs" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="max_session_duration_human_users" className="snap-top"></a>
+The name to be used for the IAM Group that grants read access to CloudTrail, AWS Config, and CloudWatch in AWS.
 
-* [**`max_session_duration_human_users`**](#max_session_duration_human_users) &mdash; The maximum allowable session duration, in seconds, for the credentials you get when assuming the IAM roles created by this module. This variable applies to all IAM roles created by this module that are intended for people to use, such as allow-read-only-access-from-other-accounts. For IAM roles that are intended for machine users, such as allow-auto-deploy-from-other-accounts, see [`max_session_duration_machine_users`](#max_session_duration_machine_users).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="logs"/>
+</HclListItem>
 
-<a name="max_session_duration_machine_users" className="snap-top"></a>
+<HclListItem name="iam_group_name_read_only" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`max_session_duration_machine_users`**](#max_session_duration_machine_users) &mdash; The maximum allowable session duration, in seconds, for the credentials you get when assuming the IAM roles created by this module. This variable  applies to all IAM roles created by this module that are intended for machine users, such as allow-auto-deploy-from-other-accounts. For IAM roles that are intended for human users, such as allow-read-only-access-from-other-accounts, see [`max_session_duration_human_users`](#max_session_duration_human_users).
+The name to be used for the IAM Group that grants read-only access to all AWS resources.
 
-<a name="minimum_password_length" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="read-only"/>
+</HclListItem>
 
-* [**`minimum_password_length`**](#minimum_password_length) &mdash; Password minimum length.
+<HclListItem name="iam_group_name_support" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="password_reset_required" className="snap-top"></a>
+The name of the IAM Group that allows access to AWS Support.
 
-* [**`password_reset_required`**](#password_reset_required) &mdash; Force the user to reset their password on initial login. Only used for users with [`create_login_profile`](#create_login_profile) set to true.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="support"/>
+</HclListItem>
 
-<a name="should_create_iam_group_auto_deploy" className="snap-top"></a>
+<HclListItem name="iam_group_name_use_existing_iam_roles" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`should_create_iam_group_auto_deploy`**](#should_create_iam_group_auto_deploy) &mdash; Should we create the IAM Group for auto-deploy? Allows automated deployment by granting the permissions specified in [`auto_deploy_permissions`](#auto_deploy_permissions). (true or false)
+The name to be used for the IAM Group that grants IAM Users the permissions to use existing IAM Roles when launching AWS Resources. This does NOT grant the permission to create new IAM Roles.
 
-<a name="should_create_iam_group_billing" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="use-existing-iam-roles"/>
+</HclListItem>
 
-* [**`should_create_iam_group_billing`**](#should_create_iam_group_billing) &mdash; Should we create the IAM Group for billing? Allows read-write access to billing features only. (true or false)
+<HclListItem name="iam_group_names_ssh_grunt_sudo_users" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="should_create_iam_group_cross_account_access_all" className="snap-top"></a>
+The list of names to be used for the IAM Group that enables its members to SSH as a sudo user into any server configured with the ssh-grunt Gruntwork module. Pass in multiple to configure multiple different IAM groups to control different groupings of access at the server level. Pass in empty list to disable creation of the IAM groups.
 
-* [**`should_create_iam_group_cross_account_access_all`**](#should_create_iam_group_cross_account_access_all) &mdash; Should we create the IAM Group for access to all external AWS accounts? 
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="should_create_iam_group_developers" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`should_create_iam_group_developers`**](#should_create_iam_group_developers) &mdash; Should we create the IAM Group for developers? The permissions of that group are specified via [`iam_group_developers_permitted_services`](#iam_group_developers_permitted_services). (true or false)
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-<a name="should_create_iam_group_full_access" className="snap-top"></a>
+```hcl
+[
+  "ssh-grunt-sudo-users"
+]
+```
 
-* [**`should_create_iam_group_full_access`**](#should_create_iam_group_full_access) &mdash; Should we create the IAM Group for full access? Allows full access to all AWS resources. (true or false)
+</HclListItemDefaultValue>
+</HclListItem>
 
-<a name="should_create_iam_group_houston_cli_users" className="snap-top"></a>
+<HclListItem name="iam_group_names_ssh_grunt_users" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`should_create_iam_group_houston_cli_users`**](#should_create_iam_group_houston_cli_users) &mdash; Should we create the IAM Group for houston CLI users? Allows users to use the houston CLI for managing and deploying services.
+The name to be used for the IAM Group that enables its members to SSH as a non-sudo user into any server configured with the ssh-grunt Gruntwork module. Pass in multiple to configure multiple different IAM groups to control different groupings of access at the server level. Pass in empty list to disable creation of the IAM groups.
 
-<a name="should_create_iam_group_iam_admin" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`should_create_iam_group_iam_admin`**](#should_create_iam_group_iam_admin) &mdash; Should we create the IAM Group for IAM administrator access? Allows users to manage all IAM entities, effectively granting administrator access. (true or false)
+```hcl
+list(string)
+```
 
-<a name="should_create_iam_group_logs" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-* [**`should_create_iam_group_logs`**](#should_create_iam_group_logs) &mdash; Should we create the IAM Group for logs? Allows read access to CloudTrail, AWS Config, and CloudWatch. If [`cloudtrail_kms_key_arn`](#cloudtrail_kms_key_arn) is set, will also give decrypt access to a KMS CMK. (true or false)
+```hcl
+[
+  "ssh-grunt-users"
+]
+```
 
-<a name="should_create_iam_group_read_only" className="snap-top"></a>
+</HclListItemDefaultValue>
+</HclListItem>
 
-* [**`should_create_iam_group_read_only`**](#should_create_iam_group_read_only) &mdash; Should we create the IAM Group for read-only? Allows read-only access to all AWS resources. (true or false)
+<HclListItem name="iam_groups_for_cross_account_access" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="should_create_iam_group_support" className="snap-top"></a>
+This variable is used to create groups that allow IAM users to assume roles in your other AWS accounts. It should be a list of objects, where each object has the fields 'group_name', which will be used as the name of the IAM group, and 'iam_role_arns', which is a list of ARNs of IAM Roles that you can assume when part of that group. For each entry in the list of objects, we will create an IAM group that allows users to assume the given IAM role(s) in the other AWS account. This allows you to define all your IAM users in one account (e.g. the users account) and to grant them access to certain IAM roles in other accounts (e.g. the stage, prod, audit accounts).
 
-* [**`should_create_iam_group_support`**](#should_create_iam_group_support) &mdash; Should we create the IAM Group for support? Allows support access (AWSupportAccess). (true or false)
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="should_create_iam_group_use_existing_iam_roles" className="snap-top"></a>
+```hcl
+list(object({
+    group_name    = string
+    iam_role_arns = list(string)
+  }))
+```
 
-* [**`should_create_iam_group_use_existing_iam_roles`**](#should_create_iam_group_use_existing_iam_roles) &mdash; Should we create the IAM Group for use-existing-iam-roles? Allow launching AWS resources with existing IAM Roles, but no ability to create new IAM Roles. (true or false)
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="should_create_iam_group_user_self_mgmt" className="snap-top"></a>
+<HclListItem name="iam_policy_iam_user_self_mgmt" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`should_create_iam_group_user_self_mgmt`**](#should_create_iam_group_user_self_mgmt) &mdash; Should we create the IAM Group for user self-management? Allows users to manage their own IAM user accounts, but not other IAM users. (true or false)
+The name to be used for the IAM Policy that grants IAM Users the permissions to manage their own IAM User account.
 
-<a name="should_require_mfa" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="iam-user-self-mgmt"/>
+</HclListItem>
 
-* [**`should_require_mfa`**](#should_require_mfa) &mdash; Should we require that all IAM Users use Multi-Factor Authentication for both AWS API calls and the AWS Web Console? (true or false)
+<HclListItem name="iam_role_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="users" className="snap-top"></a>
+The tags to apply to all the IAM role resources.
 
-* [**`users`**](#users) &mdash; A map of users to create. The keys are the user names and the values are an object with the optional keys 'groups' (a list of IAM groups to add the user to), 'tags' (a map of tags to apply to the user), [`'pgp_key`](#'pgp_key)' (either a base-64 encoded PGP public key, or a keybase username in the form keybase:username, used to encrypt the user's credentials; required if [`create_login_profile`](#create_login_profile) or [`create_access_keys`](#create_access_keys) is true), [`'create_login_profile`](#'create_login_profile)' (if set to true, create a password to login to the AWS Web Console), [`'create_access_keys`](#'create_access_keys)' (if set to true, create access keys for the user), 'path' (the path), and [`'permissions_boundary`](#'permissions_boundary)' (the ARN of the policy that is used to set the permissions boundary for the user).
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="max_session_duration_human_users" requirement="optional" type="number">
+<HclListItemDescription>
+
+The maximum allowable session duration, in seconds, for the credentials you get when assuming the IAM roles created by this module. This variable applies to all IAM roles created by this module that are intended for people to use, such as allow-read-only-access-from-other-accounts. For IAM roles that are intended for machine users, such as allow-auto-deploy-from-other-accounts, see <a href="#max_session_duration_machine_users"><code>max_session_duration_machine_users</code></a>.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="43200"/>
+</HclListItem>
+
+<HclListItem name="max_session_duration_machine_users" requirement="optional" type="number">
+<HclListItemDescription>
+
+The maximum allowable session duration, in seconds, for the credentials you get when assuming the IAM roles created by this module. This variable  applies to all IAM roles created by this module that are intended for machine users, such as allow-auto-deploy-from-other-accounts. For IAM roles that are intended for human users, such as allow-read-only-access-from-other-accounts, see <a href="#max_session_duration_human_users"><code>max_session_duration_human_users</code></a>.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="3600"/>
+</HclListItem>
+
+<HclListItem name="minimum_password_length" requirement="optional" type="number">
+<HclListItemDescription>
+
+Password minimum length.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="16"/>
+</HclListItem>
+
+<HclListItem name="password_reset_required" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Force the user to reset their password on initial login. Only used for users with create_login_profile set to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_auto_deploy" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for auto-deploy? Allows automated deployment by granting the permissions specified in <a href="#auto_deploy_permissions"><code>auto_deploy_permissions</code></a>. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_billing" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for billing? Allows read-write access to billing features only. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_cross_account_access_all" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for access to all external AWS accounts? 
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_developers" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for developers? The permissions of that group are specified via <a href="#iam_group_developers_permitted_services"><code>iam_group_developers_permitted_services</code></a>. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_full_access" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for full access? Allows full access to all AWS resources. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_houston_cli_users" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for houston CLI users? Allows users to use the houston CLI for managing and deploying services.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_iam_admin" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for IAM administrator access? Allows users to manage all IAM entities, effectively granting administrator access. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_logs" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for logs? Allows read access to CloudTrail, AWS Config, and CloudWatch. If <a href="#cloudtrail_kms_key_arn"><code>cloudtrail_kms_key_arn</code></a> is set, will also give decrypt access to a KMS CMK. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_read_only" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for read-only? Allows read-only access to all AWS resources. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_support" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for support? Allows support access (AWSupportAccess). (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_use_existing_iam_roles" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for use-existing-iam-roles? Allow launching AWS resources with existing IAM Roles, but no ability to create new IAM Roles. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="should_create_iam_group_user_self_mgmt" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we create the IAM Group for user self-management? Allows users to manage their own IAM user accounts, but not other IAM users. (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="should_require_mfa" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Should we require that all IAM Users use Multi-Factor Authentication for both AWS API calls and the AWS Web Console? (true or false)
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="users" requirement="optional" type="any">
+<HclListItemDescription>
+
+A map of users to create. The keys are the user names and the values are an object with the optional keys 'groups' (a list of IAM groups to add the user to), 'tags' (a map of tags to apply to the user), 'pgp_key' (either a base-64 encoded PGP public key, or a keybase username in the form keybase:username, used to encrypt the user's credentials; required if create_login_profile or create_access_keys is true), 'create_login_profile' (if set to true, create a password to login to the AWS Web Console), 'create_access_keys' (if set to true, create access keys for the user), 'path' (the path), and 'permissions_boundary' (the ARN of the policy that is used to set the permissions boundary for the user).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="billing_iam_group_arn" className="snap-top"></a>
+<HclListItem name="billing_iam_group_arn">
+</HclListItem>
 
-* [**`billing_iam_group_arn`**](#billing_iam_group_arn) &mdash; 
+<HclListItem name="billing_iam_group_name">
+</HclListItem>
 
-<a name="billing_iam_group_name" className="snap-top"></a>
+<HclListItem name="cross_account_access_all_group_arn">
+</HclListItem>
 
-* [**`billing_iam_group_name`**](#billing_iam_group_name) &mdash; 
+<HclListItem name="cross_account_access_all_group_name">
+</HclListItem>
 
-<a name="cross_account_access_all_group_arn" className="snap-top"></a>
+<HclListItem name="cross_account_access_group_arns">
+</HclListItem>
 
-* [**`cross_account_access_all_group_arn`**](#cross_account_access_all_group_arn) &mdash; 
+<HclListItem name="cross_account_access_group_names">
+</HclListItem>
 
-<a name="cross_account_access_all_group_name" className="snap-top"></a>
+<HclListItem name="developers_iam_group_arn">
+</HclListItem>
 
-* [**`cross_account_access_all_group_name`**](#cross_account_access_all_group_name) &mdash; 
+<HclListItem name="developers_iam_group_name">
+</HclListItem>
 
-<a name="cross_account_access_group_arns" className="snap-top"></a>
+<HclListItem name="full_access_iam_group_arn">
+</HclListItem>
 
-* [**`cross_account_access_group_arns`**](#cross_account_access_group_arns) &mdash; 
+<HclListItem name="full_access_iam_group_name">
+</HclListItem>
 
-<a name="cross_account_access_group_names" className="snap-top"></a>
+<HclListItem name="houston_cli_users_iam_group_arn">
+</HclListItem>
 
-* [**`cross_account_access_group_names`**](#cross_account_access_group_names) &mdash; 
+<HclListItem name="houston_cli_users_iam_group_name">
+</HclListItem>
 
-<a name="developers_iam_group_arn" className="snap-top"></a>
+<HclListItem name="iam_admin_iam_group_arn">
+</HclListItem>
 
-* [**`developers_iam_group_arn`**](#developers_iam_group_arn) &mdash; 
+<HclListItem name="iam_admin_iam_group_name">
+</HclListItem>
 
-<a name="developers_iam_group_name" className="snap-top"></a>
+<HclListItem name="iam_admin_iam_policy_arn">
+</HclListItem>
 
-* [**`developers_iam_group_name`**](#developers_iam_group_name) &mdash; 
+<HclListItem name="iam_self_mgmt_iam_group_arn">
+</HclListItem>
 
-<a name="full_access_iam_group_arn" className="snap-top"></a>
+<HclListItem name="iam_self_mgmt_iam_group_name">
+</HclListItem>
 
-* [**`full_access_iam_group_arn`**](#full_access_iam_group_arn) &mdash; 
+<HclListItem name="iam_self_mgmt_iam_policy_arn">
+</HclListItem>
 
-<a name="full_access_iam_group_name" className="snap-top"></a>
+<HclListItem name="logs_iam_group_arn">
+</HclListItem>
 
-* [**`full_access_iam_group_name`**](#full_access_iam_group_name) &mdash; 
+<HclListItem name="logs_iam_group_name">
+</HclListItem>
 
-<a name="houston_cli_users_iam_group_arn" className="snap-top"></a>
+<HclListItem name="read_only_iam_group_arn">
+</HclListItem>
 
-* [**`houston_cli_users_iam_group_arn`**](#houston_cli_users_iam_group_arn) &mdash; 
+<HclListItem name="read_only_iam_group_name">
+</HclListItem>
 
-<a name="houston_cli_users_iam_group_name" className="snap-top"></a>
+<HclListItem name="require_mfa_policy">
+</HclListItem>
 
-* [**`houston_cli_users_iam_group_name`**](#houston_cli_users_iam_group_name) &mdash; 
+<HclListItem name="ssh_grunt_sudo_users_group_arns">
+</HclListItem>
 
-<a name="iam_admin_iam_group_arn" className="snap-top"></a>
+<HclListItem name="ssh_grunt_sudo_users_group_names">
+</HclListItem>
 
-* [**`iam_admin_iam_group_arn`**](#iam_admin_iam_group_arn) &mdash; 
+<HclListItem name="ssh_grunt_users_group_arns">
+</HclListItem>
 
-<a name="iam_admin_iam_group_name" className="snap-top"></a>
+<HclListItem name="ssh_grunt_users_group_names">
+</HclListItem>
 
-* [**`iam_admin_iam_group_name`**](#iam_admin_iam_group_name) &mdash; 
+<HclListItem name="support_iam_group_arn">
+</HclListItem>
 
-<a name="iam_admin_iam_policy_arn" className="snap-top"></a>
+<HclListItem name="support_iam_group_name">
+</HclListItem>
 
-* [**`iam_admin_iam_policy_arn`**](#iam_admin_iam_policy_arn) &mdash; 
+<HclListItem name="use_existing_iam_roles_iam_group_arn">
+</HclListItem>
 
-<a name="iam_self_mgmt_iam_group_arn" className="snap-top"></a>
+<HclListItem name="use_existing_iam_roles_iam_group_name">
+</HclListItem>
 
-* [**`iam_self_mgmt_iam_group_arn`**](#iam_self_mgmt_iam_group_arn) &mdash; 
+<HclListItem name="user_access_keys">
+<HclListItemDescription>
 
-<a name="iam_self_mgmt_iam_group_name" className="snap-top"></a>
+A map of usernames to that user's access keys (a map with keys access_key_id and secret_access_key), with the secret_access_key encrypted with that user's PGP key (only shows up for users with create_access_keys = true). You can decrypt the secret_access_key on the CLI: echo &lt;secret_access_key> | base64 --decode | keybase pgp decrypt
 
-* [**`iam_self_mgmt_iam_group_name`**](#iam_self_mgmt_iam_group_name) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="iam_self_mgmt_iam_policy_arn" className="snap-top"></a>
+<HclListItem name="user_arns">
+<HclListItemDescription>
 
-* [**`iam_self_mgmt_iam_policy_arn`**](#iam_self_mgmt_iam_policy_arn) &mdash; 
+A map of usernames to the ARN for that IAM user.
 
-<a name="logs_iam_group_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`logs_iam_group_arn`**](#logs_iam_group_arn) &mdash; 
+<HclListItem name="user_passwords">
+<HclListItemDescription>
 
-<a name="logs_iam_group_name" className="snap-top"></a>
+A map of usernames to that user's AWS Web Console password, encrypted with that user's PGP key (only shows up for users with create_login_profile = true). You can decrypt the password on the CLI: echo &lt;password> | base64 --decode | keybase pgp decrypt
 
-* [**`logs_iam_group_name`**](#logs_iam_group_name) &mdash; 
-
-<a name="read_only_iam_group_arn" className="snap-top"></a>
-
-* [**`read_only_iam_group_arn`**](#read_only_iam_group_arn) &mdash; 
-
-<a name="read_only_iam_group_name" className="snap-top"></a>
-
-* [**`read_only_iam_group_name`**](#read_only_iam_group_name) &mdash; 
-
-<a name="require_mfa_policy" className="snap-top"></a>
-
-* [**`require_mfa_policy`**](#require_mfa_policy) &mdash; 
-
-<a name="ssh_grunt_sudo_users_group_arns" className="snap-top"></a>
-
-* [**`ssh_grunt_sudo_users_group_arns`**](#ssh_grunt_sudo_users_group_arns) &mdash; 
-
-<a name="ssh_grunt_sudo_users_group_names" className="snap-top"></a>
-
-* [**`ssh_grunt_sudo_users_group_names`**](#ssh_grunt_sudo_users_group_names) &mdash; 
-
-<a name="ssh_grunt_users_group_arns" className="snap-top"></a>
-
-* [**`ssh_grunt_users_group_arns`**](#ssh_grunt_users_group_arns) &mdash; 
-
-<a name="ssh_grunt_users_group_names" className="snap-top"></a>
-
-* [**`ssh_grunt_users_group_names`**](#ssh_grunt_users_group_names) &mdash; 
-
-<a name="support_iam_group_arn" className="snap-top"></a>
-
-* [**`support_iam_group_arn`**](#support_iam_group_arn) &mdash; 
-
-<a name="support_iam_group_name" className="snap-top"></a>
-
-* [**`support_iam_group_name`**](#support_iam_group_name) &mdash; 
-
-<a name="use_existing_iam_roles_iam_group_arn" className="snap-top"></a>
-
-* [**`use_existing_iam_roles_iam_group_arn`**](#use_existing_iam_roles_iam_group_arn) &mdash; 
-
-<a name="use_existing_iam_roles_iam_group_name" className="snap-top"></a>
-
-* [**`use_existing_iam_roles_iam_group_name`**](#use_existing_iam_roles_iam_group_name) &mdash; 
-
-<a name="user_access_keys" className="snap-top"></a>
-
-* [**`user_access_keys`**](#user_access_keys) &mdash; A map of usernames to that user's access keys (a map with keys [`access_key_id`](#access_key_id) and [`secret_access_key`](#secret_access_key)), with the [`secret_access_key`](#secret_access_key) encrypted with that user's PGP key (only shows up for users with [`create_access_keys`](#create_access_keys) = true). You can decrypt the [`secret_access_key`](#secret_access_key) on the CLI: echo [`&lt;secret_access_key`](#&lt;secret_access_key)> | base64 --decode | keybase pgp decrypt
-
-<a name="user_arns" className="snap-top"></a>
-
-* [**`user_arns`**](#user_arns) &mdash; A map of usernames to the ARN for that IAM user.
-
-<a name="user_passwords" className="snap-top"></a>
-
-* [**`user_passwords`**](#user_passwords) &mdash; A map of usernames to that user's AWS Web Console password, encrypted with that user's PGP key (only shows up for users with [`create_login_profile`](#create_login_profile) = true). You can decrypt the password on the CLI: echo &lt;password> | base64 --decode | keybase pgp decrypt
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"bc53972de059447f61434b12d3866bc2"}
+{"sourcePlugin":"service-catalog-api","hash":"d9eba129228397ff4904ce36bfbc806a"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/networking/elastic-load-balancer-elb.md
+++ b/docs/reference/services/networking/elastic-load-balancer-elb.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -82,171 +83,436 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="alb_name" className="snap-top"></a>
+<HclListItem name="alb_name" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`alb_name`**](#alb_name) &mdash; The name of the ALB.
+The name of the ALB.
 
-<a name="is_internal_alb" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`is_internal_alb`**](#is_internal_alb) &mdash; If the ALB should only accept traffic from within the VPC, set this to true. If it should accept traffic from the public Internet, set it to false.
+<HclListItem name="is_internal_alb" requirement="required" type="bool">
+<HclListItemDescription>
 
-<a name="num_days_after_which_archive_log_data" className="snap-top"></a>
+If the ALB should only accept traffic from within the VPC, set this to true. If it should accept traffic from the public Internet, set it to false.
 
-* [**`num_days_after_which_archive_log_data`**](#num_days_after_which_archive_log_data) &mdash; After this number of days, log files should be transitioned from S3 to Glacier. Enter 0 to never archive log data.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="num_days_after_which_delete_log_data" className="snap-top"></a>
+<HclListItem name="num_days_after_which_archive_log_data" requirement="required" type="number">
+<HclListItemDescription>
 
-* [**`num_days_after_which_delete_log_data`**](#num_days_after_which_delete_log_data) &mdash; After this number of days, log files should be deleted from S3. Enter 0 to never delete log data.
+After this number of days, log files should be transitioned from S3 to Glacier. Enter 0 to never archive log data.
 
-<a name="vpc_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`vpc_id`**](#vpc_id) &mdash; ID of the VPC where the ALB will be deployed
+<HclListItem name="num_days_after_which_delete_log_data" requirement="required" type="number">
+<HclListItemDescription>
 
-<a name="vpc_subnet_ids" className="snap-top"></a>
+After this number of days, log files should be deleted from S3. Enter 0 to never delete log data.
 
-* [**`vpc_subnet_ids`**](#vpc_subnet_ids) &mdash; The ids of the subnets that the ALB can use to source its IP
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="vpc_id" requirement="required" type="string">
+<HclListItemDescription>
+
+ID of the VPC where the ALB will be deployed
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="vpc_subnet_ids" requirement="required" type="list">
+<HclListItemDescription>
+
+The ids of the subnets that the ALB can use to source its IP
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
 
 ### Optional
 
-<a name="access_logs_s3_bucket_name" className="snap-top"></a>
+<HclListItem name="access_logs_s3_bucket_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`access_logs_s3_bucket_name`**](#access_logs_s3_bucket_name) &mdash; The name to use for the S3 bucket where the ALB access logs will be stored. If you set this to null, a name will be generated automatically based on [`alb_name`](#alb_name).
+The name to use for the S3 bucket where the ALB access logs will be stored. If you set this to null, a name will be generated automatically based on <a href="#alb_name"><code>alb_name</code></a>.
 
-<a name="acm_cert_statuses" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`acm_cert_statuses`**](#acm_cert_statuses) &mdash; When looking up the ACM certs passed in via [`https_listener_ports_and_acm_ssl_certs`](#https_listener_ports_and_acm_ssl_certs), only match certs with the given statuses. Valid values are [`PENDING_VALIDATION`](#PENDING_VALIDATION), ISSUED, INACTIVE, EXPIRED, [`VALIDATION_TIMED_OUT`](#VALIDATION_TIMED_OUT), REVOKED and FAILED.
+<HclListItem name="acm_cert_statuses" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="acm_cert_types" className="snap-top"></a>
+When looking up the ACM certs passed in via https_listener_ports_and_acm_ssl_certs, only match certs with the given statuses. Valid values are PENDING_VALIDATION, ISSUED, INACTIVE, EXPIRED, VALIDATION_TIMED_OUT, REVOKED and FAILED.
 
-* [**`acm_cert_types`**](#acm_cert_types) &mdash; When looking up the ACM certs passed in via [`https_listener_ports_and_acm_ssl_certs`](#https_listener_ports_and_acm_ssl_certs), only match certs of the given types. Valid values are [`AMAZON_ISSUED`](#AMAZON_ISSUED) and IMPORTED.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="allow_all_outbound" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`allow_all_outbound`**](#allow_all_outbound) &mdash; Set to true to enable all outbound traffic on this ALB. If set to false, the ALB will allow no outbound traffic by default. This will make the ALB unusuable, so some other code must then update the ALB Security Group to enable outbound access!
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[
+  'ISSUED'
+]"/>
+</HclListItem>
 
-<a name="allow_inbound_from_cidr_blocks" className="snap-top"></a>
+<HclListItem name="acm_cert_types" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`allow_inbound_from_cidr_blocks`**](#allow_inbound_from_cidr_blocks) &mdash; The CIDR-formatted IP Address range from which this ALB will allow incoming requests. If [`is_internal_alb`](#is_internal_alb) is false, use the default value. If [`is_internal_alb`](#is_internal_alb) is true, consider setting this to the VPC's CIDR Block, or something even more restrictive.
+When looking up the ACM certs passed in via https_listener_ports_and_acm_ssl_certs, only match certs of the given types. Valid values are AMAZON_ISSUED and IMPORTED.
 
-<a name="allow_inbound_from_security_group_ids" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`allow_inbound_from_security_group_ids`**](#allow_inbound_from_security_group_ids) &mdash; The list of IDs of security groups that should have access to the ALB
+```hcl
+list(string)
+```
 
-<a name="create_route53_entry" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
 
-* [**`create_route53_entry`**](#create_route53_entry) &mdash; Set to true to create a Route 53 DNS A record for this ALB?
+```hcl
+[
+  "AMAZON_ISSUED",
+  "IMPORTED"
+]
+```
 
-<a name="custom_tags" className="snap-top"></a>
+</HclListItemDefaultValue>
+</HclListItem>
 
-* [**`custom_tags`**](#custom_tags) &mdash; A map of custom tags to apply to the ALB and its Security Group. The key is the tag name and the value is the tag value.
+<HclListItem name="allow_all_outbound" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="default_action_body" className="snap-top"></a>
+Set to true to enable all outbound traffic on this ALB. If set to false, the ALB will allow no outbound traffic by default. This will make the ALB unusuable, so some other code must then update the ALB Security Group to enable outbound access!
 
-* [**`default_action_body`**](#default_action_body) &mdash; If a request to the load balancer does not match any of your listener rules, the default action will return a fixed response with this body.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="default_action_content_type" className="snap-top"></a>
+<HclListItem name="allow_inbound_from_cidr_blocks" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`default_action_content_type`**](#default_action_content_type) &mdash; If a request to the load balancer does not match any of your listener rules, the default action will return a fixed response with this content type.
+The CIDR-formatted IP Address range from which this ALB will allow incoming requests. If <a href="#is_internal_alb"><code>is_internal_alb</code></a> is false, use the default value. If <a href="#is_internal_alb"><code>is_internal_alb</code></a> is true, consider setting this to the VPC's CIDR Block, or something even more restrictive.
 
-<a name="default_action_status_code" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`default_action_status_code`**](#default_action_status_code) &mdash; If a request to the load balancer does not match any of your listener rules, the default action will return a fixed response with this status code.
+```hcl
+list(string)
+```
 
-<a name="domain_names" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`domain_names`**](#domain_names) &mdash; The list of domain names for the DNS A record to add for the ALB (e.g. alb.foo.com). Only used if [`create_route53_entry`](#create_route53_entry) is true.
+<HclListItem name="allow_inbound_from_security_group_ids" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="drop_invalid_header_fields" className="snap-top"></a>
+The list of IDs of security groups that should have access to the ALB
 
-* [**`drop_invalid_header_fields`**](#drop_invalid_header_fields) &mdash; If true, the ALB will drop invalid headers. Elastic Load Balancing requires that message header names contain only alphanumeric characters and hyphens.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="enable_deletion_protection" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`enable_deletion_protection`**](#enable_deletion_protection) &mdash; Enable deletion protection on the ALB instance. If this is enabled, the load balancer cannot be deleted prior to disabling
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="force_destroy" className="snap-top"></a>
+<HclListItem name="create_route53_entry" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`force_destroy`**](#force_destroy) &mdash; A boolean that indicates whether the access logs bucket should be destroyed, even if there are files in it, when you run Terraform destroy. Unless you are using this bucket only for test purposes, you'll want to leave this variable set to false.
+Set to true to create a Route 53 DNS A record for this ALB?
 
-<a name="hosted_zone_id" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`hosted_zone_id`**](#hosted_zone_id) &mdash; The ID of the hosted zone for the DNS A record to add for the ALB. Only used if [`create_route53_entry`](#create_route53_entry) is true.
+<HclListItem name="custom_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="http_listener_ports" className="snap-top"></a>
+A map of custom tags to apply to the ALB and its Security Group. The key is the tag name and the value is the tag value.
 
-* [**`http_listener_ports`**](#http_listener_ports) &mdash; A list of ports for which an HTTP Listener should be created on the ALB. Tip: When you define Listener Rules for these Listeners, be sure that, for each Listener, at least one Listener Rule  uses the '*' path to ensure that every possible request path for that Listener is handled by a Listener Rule. Otherwise some requests won't route to any Target Group.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="https_listener_ports_and_acm_ssl_certs" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`https_listener_ports_and_acm_ssl_certs`**](#https_listener_ports_and_acm_ssl_certs) &mdash; A list of the ports for which an HTTPS Listener should be created on the ALB. Each item in the list should be a map with the keys 'port', the port number to listen on, and [`'tls_domain_name`](#'tls_domain_name)', the domain name of an SSL/TLS certificate issued by the Amazon Certificate Manager (ACM) to associate with the Listener to be created. If your certificate isn't issued by ACM, specify [`https_listener_ports_and_ssl_certs`](#https_listener_ports_and_ssl_certs) instead. Tip: When you define Listener Rules for these Listeners, be sure that, for each Listener, at least one Listener Rule  uses the '*' path to ensure that every possible request path for that Listener is handled by a Listener Rule. Otherwise some requests won't route to any Target Group.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="https_listener_ports_and_ssl_certs" className="snap-top"></a>
+<HclListItem name="default_action_body" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`https_listener_ports_and_ssl_certs`**](#https_listener_ports_and_ssl_certs) &mdash; A list of the ports for which an HTTPS Listener should be created on the ALB. Each item in the list should be a map with the keys 'port', the port number to listen on, and [`'tls_arn`](#'tls_arn)', the Amazon Resource Name (ARN) of the SSL/TLS certificate to associate with the Listener to be created. If your certificate is issued by the Amazon Certificate Manager (ACM), specify [`https_listener_ports_and_acm_ssl_certs`](#https_listener_ports_and_acm_ssl_certs) instead. Tip: When you define Listener Rules for these Listeners, be sure that, for each Listener, at least one Listener Rule  uses the '*' path to ensure that every possible request path for that Listener is handled by a Listener Rule. Otherwise some requests won't route to any Target Group.
+If a request to the load balancer does not match any of your listener rules, the default action will return a fixed response with this body.
 
-<a name="idle_timeout" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`idle_timeout`**](#idle_timeout) &mdash; The time in seconds that the client TCP connection to the ALB is allowed to be idle before the ALB closes the TCP connection.
+<HclListItem name="default_action_content_type" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="should_create_access_logs_bucket" className="snap-top"></a>
+If a request to the load balancer does not match any of your listener rules, the default action will return a fixed response with this content type.
 
-* [**`should_create_access_logs_bucket`**](#should_create_access_logs_bucket) &mdash; If true, create a new S3 bucket for access logs with the name in [`access_logs_s3_bucket_name`](#access_logs_s3_bucket_name). If false, assume the S3 bucket for access logs with the name in  [`access_logs_s3_bucket_name`](#access_logs_s3_bucket_name) already exists, and don't create a new one. Note that if you set this to false, it's up to you to ensure that the S3 bucket has a bucket policy that grants Elastic Load Balancing permission to write the access logs to your bucket.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="text/plain"/>
+</HclListItem>
 
-<a name="ssl_policy" className="snap-top"></a>
+<HclListItem name="default_action_status_code" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`ssl_policy`**](#ssl_policy) &mdash; The AWS predefined TLS/SSL policy for the ALB. A List of policies can be found here: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies. AWS recommends ELBSecurityPolicy-2016-08 policy for general use but this policy includes TLSv1.0 which is rapidly being phased out. ELBSecurityPolicy-TLS-1-1-2017-01 is the next policy up that doesn't include TLSv1.0.
+If a request to the load balancer does not match any of your listener rules, the default action will return a fixed response with this status code.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="404"/>
+</HclListItem>
+
+<HclListItem name="domain_names" requirement="optional" type="list">
+<HclListItemDescription>
+
+The list of domain names for the DNS A record to add for the ALB (e.g. alb.foo.com). Only used if <a href="#create_route53_entry"><code>create_route53_entry</code></a> is true.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="drop_invalid_header_fields" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If true, the ALB will drop invalid headers. Elastic Load Balancing requires that message header names contain only alphanumeric characters and hyphens.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="enable_deletion_protection" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Enable deletion protection on the ALB instance. If this is enabled, the load balancer cannot be deleted prior to disabling
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="force_destroy" requirement="optional" type="bool">
+<HclListItemDescription>
+
+A boolean that indicates whether the access logs bucket should be destroyed, even if there are files in it, when you run Terraform destroy. Unless you are using this bucket only for test purposes, you'll want to leave this variable set to false.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="hosted_zone_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ID of the hosted zone for the DNS A record to add for the ALB. Only used if <a href="#create_route53_entry"><code>create_route53_entry</code></a> is true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="http_listener_ports" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of ports for which an HTTP Listener should be created on the ALB. Tip: When you define Listener Rules for these Listeners, be sure that, for each Listener, at least one Listener Rule  uses the '*' path to ensure that every possible request path for that Listener is handled by a Listener Rule. Otherwise some requests won't route to any Target Group.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="https_listener_ports_and_acm_ssl_certs" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of the ports for which an HTTPS Listener should be created on the ALB. Each item in the list should be a map with the keys 'port', the port number to listen on, and 'tls_domain_name', the domain name of an SSL/TLS certificate issued by the Amazon Certificate Manager (ACM) to associate with the Listener to be created. If your certificate isn't issued by ACM, specify <a href="#https_listener_ports_and_ssl_certs"><code>https_listener_ports_and_ssl_certs</code></a> instead. Tip: When you define Listener Rules for these Listeners, be sure that, for each Listener, at least one Listener Rule  uses the '*' path to ensure that every possible request path for that Listener is handled by a Listener Rule. Otherwise some requests won't route to any Target Group.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(object({
+    port            = number
+    tls_domain_name = string
+  }))
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="https_listener_ports_and_ssl_certs" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of the ports for which an HTTPS Listener should be created on the ALB. Each item in the list should be a map with the keys 'port', the port number to listen on, and 'tls_arn', the Amazon Resource Name (ARN) of the SSL/TLS certificate to associate with the Listener to be created. If your certificate is issued by the Amazon Certificate Manager (ACM), specify <a href="#https_listener_ports_and_acm_ssl_certs"><code>https_listener_ports_and_acm_ssl_certs</code></a> instead. Tip: When you define Listener Rules for these Listeners, be sure that, for each Listener, at least one Listener Rule  uses the '*' path to ensure that every possible request path for that Listener is handled by a Listener Rule. Otherwise some requests won't route to any Target Group.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(object({
+    port    = number
+    tls_arn = string
+  }))
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="idle_timeout" requirement="optional" type="number">
+<HclListItemDescription>
+
+The time in seconds that the client TCP connection to the ALB is allowed to be idle before the ALB closes the TCP connection.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="60"/>
+</HclListItem>
+
+<HclListItem name="should_create_access_logs_bucket" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If true, create a new S3 bucket for access logs with the name in <a href="#access_logs_s3_bucket_name"><code>access_logs_s3_bucket_name</code></a>. If false, assume the S3 bucket for access logs with the name in  <a href="#access_logs_s3_bucket_name"><code>access_logs_s3_bucket_name</code></a> already exists, and don't create a new one. Note that if you set this to false, it's up to you to ensure that the S3 bucket has a bucket policy that grants Elastic Load Balancing permission to write the access logs to your bucket.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="ssl_policy" requirement="optional" type="string">
+<HclListItemDescription>
+
+The AWS predefined TLS/SSL policy for the ALB. A List of policies can be found here: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies. AWS recommends ELBSecurityPolicy-2016-08 policy for general use but this policy includes TLSv1.0 which is rapidly being phased out. ELBSecurityPolicy-TLS-1-1-2017-01 is the next policy up that doesn't include TLSv1.0.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ELBSecurityPolicy-2016-08"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="alb_access_logs_bucket" className="snap-top"></a>
+<HclListItem name="alb_access_logs_bucket">
+<HclListItemDescription>
 
-* [**`alb_access_logs_bucket`**](#alb_access_logs_bucket) &mdash; The name of the S3 bucket containing the ALB access logs
+The name of the S3 bucket containing the ALB access logs
 
-<a name="alb_arn" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`alb_arn`**](#alb_arn) &mdash; The ARN of the ALB resource.
+<HclListItem name="alb_arn">
+<HclListItemDescription>
 
-<a name="alb_dns_names" className="snap-top"></a>
+The ARN of the ALB resource.
 
-* [**`alb_dns_names`**](#alb_dns_names) &mdash; The list of DNS records for the ALB as specified in the input.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="alb_hosted_zone_id" className="snap-top"></a>
+<HclListItem name="alb_dns_names">
+<HclListItemDescription>
 
-* [**`alb_hosted_zone_id`**](#alb_hosted_zone_id) &mdash; The AWS-managed zone ID for the ALB's DNS record.
+The list of DNS records for the ALB as specified in the input.
 
-<a name="alb_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`alb_name`**](#alb_name) &mdash; A human friendly name for the ALB.
+<HclListItem name="alb_hosted_zone_id">
+<HclListItemDescription>
 
-<a name="alb_security_group_id" className="snap-top"></a>
+The AWS-managed zone ID for the ALB's DNS record.
 
-* [**`alb_security_group_id`**](#alb_security_group_id) &mdash; The ID of the security group associated with the ALB.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="http_listener_arns" className="snap-top"></a>
+<HclListItem name="alb_name">
+<HclListItemDescription>
 
-* [**`http_listener_arns`**](#http_listener_arns) &mdash; The map of HTTP listener ports to ARNs. There will be one listener per entry in [`http_listener_ports`](#http_listener_ports).
+A human friendly name for the ALB.
 
-<a name="https_listener_acm_cert_arns" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`https_listener_acm_cert_arns`**](#https_listener_acm_cert_arns) &mdash; The map of HTTPS listener ports to ARNs. There will be one listener per entry in [`https_listener_ports_and_acm_ssl_certs`](#https_listener_ports_and_acm_ssl_certs).
+<HclListItem name="alb_security_group_id">
+<HclListItemDescription>
 
-<a name="https_listener_non_acm_cert_arns" className="snap-top"></a>
+The ID of the security group associated with the ALB.
 
-* [**`https_listener_non_acm_cert_arns`**](#https_listener_non_acm_cert_arns) &mdash; The map of HTTPS listener ports to ARNs. There will be one listener per entry in [`https_listener_ports_and_ssl_certs`](#https_listener_ports_and_ssl_certs).
+</HclListItemDescription>
+</HclListItem>
 
-<a name="listener_arns" className="snap-top"></a>
+<HclListItem name="http_listener_arns">
+<HclListItemDescription>
 
-* [**`listener_arns`**](#listener_arns) &mdash; The map of listener ports to ARNs. This will include all listeners both HTTP and HTTPS.
+The map of HTTP listener ports to ARNs. There will be one listener per entry in <a href="#http_listener_ports"><code>http_listener_ports</code></a>.
 
-<a name="original_alb_dns_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`original_alb_dns_name`**](#original_alb_dns_name) &mdash; The AWS-managed DNS name assigned to the ALB.
+<HclListItem name="https_listener_acm_cert_arns">
+<HclListItemDescription>
+
+The map of HTTPS listener ports to ARNs. There will be one listener per entry in <a href="#https_listener_ports_and_acm_ssl_certs"><code>https_listener_ports_and_acm_ssl_certs</code></a>.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="https_listener_non_acm_cert_arns">
+<HclListItemDescription>
+
+The map of HTTPS listener ports to ARNs. There will be one listener per entry in <a href="#https_listener_ports_and_ssl_certs"><code>https_listener_ports_and_ssl_certs</code></a>.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="listener_arns">
+<HclListItemDescription>
+
+The map of listener ports to ARNs. This will include all listeners both HTTP and HTTPS.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="original_alb_dns_name">
+<HclListItemDescription>
+
+The AWS-managed DNS name assigned to the ALB.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"f9f488faec8848bae26a5cca3f40b205"}
+{"sourcePlugin":"service-catalog-api","hash":"0167a21c8823623a72661480c27bfbef"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/networking/management-vpc.md
+++ b/docs/reference/services/networking/management-vpc.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.83.0"/>
 
@@ -98,199 +99,542 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="aws_region" className="snap-top"></a>
+<HclListItem name="aws_region" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`aws_region`**](#aws_region) &mdash; The AWS region to deploy into
+The AWS region to deploy into
 
-<a name="cidr_block" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cidr_block`**](#cidr_block) &mdash; The IP address range of the VPC in CIDR notation. A prefix of /16 is recommended. Do not use a prefix higher than /27. Examples include '10.100.0.0/16', '10.200.0.0/16', etc.
+<HclListItem name="cidr_block" requirement="required" type="string">
+<HclListItemDescription>
 
-<a name="num_nat_gateways" className="snap-top"></a>
+The IP address range of the VPC in CIDR notation. A prefix of /16 is recommended. Do not use a prefix higher than /27. Examples include '10.100.0.0/16', '10.200.0.0/16', etc.
 
-* [**`num_nat_gateways`**](#num_nat_gateways) &mdash; The number of NAT Gateways to launch for this VPC. The management VPC defaults to 1 NAT Gateway to save on cost, but to increase redundancy, you can adjust this to add additional NAT Gateways.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="vpc_name" className="snap-top"></a>
+<HclListItem name="num_nat_gateways" requirement="required" type="number">
+<HclListItemDescription>
 
-* [**`vpc_name`**](#vpc_name) &mdash; The name of the VPC. Defaults to mgmt.
+The number of NAT Gateways to launch for this VPC. The management VPC defaults to 1 NAT Gateway to save on cost, but to increase redundancy, you can adjust this to add additional NAT Gateways.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="vpc_name" requirement="required" type="string">
+<HclListItemDescription>
+
+The name of the VPC. Defaults to mgmt.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="apply_default_nacl_rules" className="snap-top"></a>
+<HclListItem name="apply_default_nacl_rules" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`apply_default_nacl_rules`**](#apply_default_nacl_rules) &mdash; If true, will apply the default NACL rules in [`default_nacl_ingress_rules`](#default_nacl_ingress_rules) and [`default_nacl_egress_rules`](#default_nacl_egress_rules) on the default NACL of the VPC. Note that every VPC must have a default NACL - when this is false, the original default NACL rules managed by AWS will be used.
+If true, will apply the default NACL rules in <a href="#default_nacl_ingress_rules"><code>default_nacl_ingress_rules</code></a> and <a href="#default_nacl_egress_rules"><code>default_nacl_egress_rules</code></a> on the default NACL of the VPC. Note that every VPC must have a default NACL - when this is false, the original default NACL rules managed by AWS will be used.
 
-<a name="associate_default_nacl_to_subnets" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`associate_default_nacl_to_subnets`**](#associate_default_nacl_to_subnets) &mdash; If true, will associate the default NACL to the public, private, and persistence subnets created by this module. Only used if [`apply_default_nacl_rules`](#apply_default_nacl_rules) is true. Note that this does not guarantee that the subnets are associated with the default NACL. Subnets can only be associated with a single NACL. The default NACL association will be dropped if the subnets are associated with a custom NACL later.
+<HclListItem name="associate_default_nacl_to_subnets" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="availability_zone_exclude_ids" className="snap-top"></a>
+If true, will associate the default NACL to the public, private, and persistence subnets created by this module. Only used if <a href="#apply_default_nacl_rules"><code>apply_default_nacl_rules</code></a> is true. Note that this does not guarantee that the subnets are associated with the default NACL. Subnets can only be associated with a single NACL. The default NACL association will be dropped if the subnets are associated with a custom NACL later.
 
-* [**`availability_zone_exclude_ids`**](#availability_zone_exclude_ids) &mdash; List of excluded Availability Zone IDs.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="availability_zone_exclude_names" className="snap-top"></a>
+<HclListItem name="availability_zone_exclude_ids" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`availability_zone_exclude_names`**](#availability_zone_exclude_names) &mdash; List of excluded Availability Zone names.
+List of excluded Availability Zone IDs.
 
-<a name="availability_zone_state" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`availability_zone_state`**](#availability_zone_state) &mdash; Allows to filter list of Availability Zones based on their current state. Can be either "available", "information", "impaired" or "unavailable". By default the list includes a complete set of Availability Zones to which the underlying AWS account has access, regardless of their state.
+```hcl
+list(string)
+```
 
-<a name="create_flow_logs" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`create_flow_logs`**](#create_flow_logs) &mdash; If you set this variable to false, this module will not create VPC Flow Logs resources. This is used as a workaround because Terraform does not allow you to use the 'count' parameter on modules. By using this parameter, you can optionally create or not create the resources within this module.
+<HclListItem name="availability_zone_exclude_names" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="create_network_acls" className="snap-top"></a>
+List of excluded Availability Zone names.
 
-* [**`create_network_acls`**](#create_network_acls) &mdash; If set to false, this module will NOT create Network ACLs. This is useful if you don't want to use Network ACLs or you want to provide your own Network ACLs outside of this module.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="custom_tags" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`custom_tags`**](#custom_tags) &mdash; A map of tags to apply to the VPC, Subnets, Route Tables, and Internet Gateway. The key is the tag name and the value is the tag value. Note that the tag 'Name' is automatically added by this module but may be optionally overwritten by this variable.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="custom_tags_vpc_only" className="snap-top"></a>
+<HclListItem name="availability_zone_state" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`custom_tags_vpc_only`**](#custom_tags_vpc_only) &mdash; A map of tags to apply just to the VPC itself, but not any of the other resources. The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as [`custom_tags`](#custom_tags) in case of conflict.
+Allows to filter list of Availability Zones based on their current state. Can be either 'available', 'information', 'impaired' or 'unavailable'. By default the list includes a complete set of Availability Zones to which the underlying AWS account has access, regardless of their state.
 
-<a name="default_nacl_egress_rules" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`default_nacl_egress_rules`**](#default_nacl_egress_rules) &mdash; The egress rules to apply to the default NACL in the VPC. This is the security group that is used by any subnet that doesn't have its own NACL attached. The value for this variable must be a map where the keys are a unique name for each rule and the values are objects with the same fields as the egress block in the [`aws_default_network_acl`](#aws_default_network_acl) resource: [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_network_acl`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_network_acl).
+<HclListItem name="create_flow_logs" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="default_nacl_ingress_rules" className="snap-top"></a>
+If you set this variable to false, this module will not create VPC Flow Logs resources. This is used as a workaround because Terraform does not allow you to use the 'count' parameter on modules. By using this parameter, you can optionally create or not create the resources within this module.
 
-* [**`default_nacl_ingress_rules`**](#default_nacl_ingress_rules) &mdash; The ingress rules to apply to the default NACL in the VPC. This is the NACL that is used by any subnet that doesn't have its own NACL attached. The value for this variable must be a map where the keys are a unique name for each rule and the values are objects with the same fields as the ingress block in the [`aws_default_network_acl`](#aws_default_network_acl) resource: [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_network_acl`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_network_acl).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="default_security_group_egress_rules" className="snap-top"></a>
+<HclListItem name="create_network_acls" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`default_security_group_egress_rules`**](#default_security_group_egress_rules) &mdash; The egress rules to apply to the default security group in the VPC. This is the security group that is used by any resource that doesn't have its own security group attached. The value for this variable must be a map where the keys are a unique name for each rule and the values are objects with the same fields as the egress block in the [`aws_default_security_group`](#aws_default_security_group) resource: [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group)#egress-block.
+If set to false, this module will NOT create Network ACLs. This is useful if you don't want to use Network ACLs or you want to provide your own Network ACLs outside of this module.
 
-<a name="default_security_group_ingress_rules" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`default_security_group_ingress_rules`**](#default_security_group_ingress_rules) &mdash; The ingress rules to apply to the default security group in the VPC. This is the security group that is used by any resource that doesn't have its own security group attached. The value for this variable must be a map where the keys are a unique name for each rule and the values are objects with the same fields as the ingress block in the [`aws_default_security_group`](#aws_default_security_group) resource: [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group)#ingress-block.
+<HclListItem name="custom_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="enable_default_security_group" className="snap-top"></a>
+A map of tags to apply to the VPC, Subnets, Route Tables, and Internet Gateway. The key is the tag name and the value is the tag value. Note that the tag 'Name' is automatically added by this module but may be optionally overwritten by this variable.
 
-* [**`enable_default_security_group`**](#enable_default_security_group) &mdash; If set to false, the default security groups will NOT be created.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="iam_role_permissions_boundary" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`iam_role_permissions_boundary`**](#iam_role_permissions_boundary) &mdash; The ARN of the policy that is used to set the permissions boundary for the IAM role.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="kms_key_arn" className="snap-top"></a>
+<HclListItem name="custom_tags_vpc_only" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`kms_key_arn`**](#kms_key_arn) &mdash; The ARN of a KMS key to use for encrypting VPC the flow log. A new KMS key will be created if this is not supplied.
+A map of tags to apply just to the VPC itself, but not any of the other resources. The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as custom_tags in case of conflict.
 
-<a name="kms_key_deletion_window_in_days" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`kms_key_deletion_window_in_days`**](#kms_key_deletion_window_in_days) &mdash; The number of days to retain this KMS Key (a Customer Master Key) after it has been marked for deletion. Setting to null defaults to the provider default, which is the maximum possible value (30 days).
+```hcl
+map(string)
+```
 
-<a name="kms_key_user_iam_arns" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`kms_key_user_iam_arns`**](#kms_key_user_iam_arns) &mdash; VPC Flow Logs will be encrypted with a KMS Key (a Customer Master Key). The IAM Users specified in this list will have access to this key.
+<HclListItem name="default_nacl_egress_rules" requirement="optional" type="any">
+<HclListItemDescription>
 
-<a name="nat_gateway_custom_tags" className="snap-top"></a>
+The egress rules to apply to the default NACL in the VPC. This is the security group that is used by any subnet that doesn't have its own NACL attached. The value for this variable must be a map where the keys are a unique name for each rule and the values are objects with the same fields as the egress block in the aws_default_network_acl resource: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_network_acl.
 
-* [**`nat_gateway_custom_tags`**](#nat_gateway_custom_tags) &mdash; A map of tags to apply to the NAT gateways, on top of the [`custom_tags`](#custom_tags). The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as [`custom_tags`](#custom_tags) in case of conflict.
+</HclListItemDescription>
+<HclListItemDefaultValue>
 
-<a name="num_availability_zones" className="snap-top"></a>
+```hcl
+{
+  AllowAll = {
+    action = "allow",
+    cidr_block = "0.0.0.0/0",
+    from_port = 0,
+    protocol = "-1",
+    rule_no = 100,
+    to_port = 0
+  }
+}
+```
 
-* [**`num_availability_zones`**](#num_availability_zones) &mdash; How many AWS Availability Zones (AZs) to use. One subnet of each type (public, private app) will be created in each AZ. Note that this must be less than or equal to the total number of AZs in a region. A value of null means all AZs should be used. For example, if you specify 3 in a region with 5 AZs, subnets will be created in just 3 AZs instead of all 5. Defaults to 3.
+</HclListItemDefaultValue>
+</HclListItem>
 
-<a name="private_subnet_bits" className="snap-top"></a>
+<HclListItem name="default_nacl_ingress_rules" requirement="optional" type="any">
+<HclListItemDescription>
 
-* [**`private_subnet_bits`**](#private_subnet_bits) &mdash; Takes the CIDR prefix and adds these many bits to it for calculating subnet ranges.  MAKE SURE if you change this you also change the CIDR spacing or you may hit errors.  See cidrsubnet interpolation in terraform config for more information.
+The ingress rules to apply to the default NACL in the VPC. This is the NACL that is used by any subnet that doesn't have its own NACL attached. The value for this variable must be a map where the keys are a unique name for each rule and the values are objects with the same fields as the ingress block in the aws_default_network_acl resource: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_network_acl.
 
-<a name="private_subnet_cidr_blocks" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue>
 
-* [**`private_subnet_cidr_blocks`**](#private_subnet_cidr_blocks) &mdash; A map listing the specific CIDR blocks desired for each private subnet. The key must be in the form AZ-0, AZ-1, ... AZ-n where n is the number of Availability Zones. If left blank, we will compute a reasonable CIDR block for each subnet.
+```hcl
+{
+  AllowAll = {
+    action = "allow",
+    cidr_block = "0.0.0.0/0",
+    from_port = 0,
+    protocol = "-1",
+    rule_no = 100,
+    to_port = 0
+  }
+}
+```
 
-<a name="private_subnet_custom_tags" className="snap-top"></a>
+</HclListItemDefaultValue>
+</HclListItem>
 
-* [**`private_subnet_custom_tags`**](#private_subnet_custom_tags) &mdash; A map of tags to apply to the private Subnet, on top of the [`custom_tags`](#custom_tags). The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as [`custom_tags`](#custom_tags) in case of conflict.
+<HclListItem name="default_security_group_egress_rules" requirement="optional" type="any">
+<HclListItemDescription>
 
-<a name="public_subnet_bits" className="snap-top"></a>
+The egress rules to apply to the default security group in the VPC. This is the security group that is used by any resource that doesn't have its own security group attached. The value for this variable must be a map where the keys are a unique name for each rule and the values are objects with the same fields as the egress block in the aws_default_security_group resource: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group#egress-block.
 
-* [**`public_subnet_bits`**](#public_subnet_bits) &mdash; Takes the CIDR prefix and adds these many bits to it for calculating subnet ranges.  MAKE SURE if you change this you also change the CIDR spacing or you may hit errors.  See cidrsubnet interpolation in terraform config for more information.
+</HclListItemDescription>
+<HclListItemDefaultValue>
 
-<a name="public_subnet_cidr_blocks" className="snap-top"></a>
+```hcl
+{
+  AllowAllOutbound = {
+    cidr_blocks = [
+      "0.0.0.0/0"
+    ],
+    from_port = 0,
+    ipv6_cidr_blocks = [
+      "::/0"
+    ],
+    protocol = "-1",
+    to_port = 0
+  }
+}
+```
 
-* [**`public_subnet_cidr_blocks`**](#public_subnet_cidr_blocks) &mdash; A map listing the specific CIDR blocks desired for each public subnet. The key must be in the form AZ-0, AZ-1, ... AZ-n where n is the number of Availability Zones. If left blank, we will compute a reasonable CIDR block for each subnet.
+</HclListItemDefaultValue>
+</HclListItem>
 
-<a name="public_subnet_custom_tags" className="snap-top"></a>
+<HclListItem name="default_security_group_ingress_rules" requirement="optional" type="any">
+<HclListItemDescription>
 
-* [**`public_subnet_custom_tags`**](#public_subnet_custom_tags) &mdash; A map of tags to apply to the public Subnet, on top of the [`custom_tags`](#custom_tags). The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as [`custom_tags`](#custom_tags) in case of conflict.
+The ingress rules to apply to the default security group in the VPC. This is the security group that is used by any resource that doesn't have its own security group attached. The value for this variable must be a map where the keys are a unique name for each rule and the values are objects with the same fields as the ingress block in the aws_default_security_group resource: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group#ingress-block.
 
-<a name="subnet_spacing" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue>
 
-* [**`subnet_spacing`**](#subnet_spacing) &mdash; The amount of spacing between the different subnet types
+```hcl
+{
+  AllowAllFromSelf = {
+    from_port = 0,
+    protocol = "-1",
+    self = true,
+    to_port = 0
+  }
+}
+```
 
-<a name="use_managed_iam_policies" className="snap-top"></a>
+</HclListItemDefaultValue>
+</HclListItem>
 
-* [**`use_managed_iam_policies`**](#use_managed_iam_policies) &mdash; When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+<HclListItem name="enable_default_security_group" requirement="optional" type="bool">
+<HclListItemDescription>
+
+If set to false, the default security groups will NOT be created.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="iam_role_permissions_boundary" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ARN of the policy that is used to set the permissions boundary for the IAM role.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ARN of a KMS key to use for encrypting VPC the flow log. A new KMS key will be created if this is not supplied.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="kms_key_deletion_window_in_days" requirement="optional" type="number">
+<HclListItemDescription>
+
+The number of days to retain this KMS Key (a Customer Master Key) after it has been marked for deletion. Setting to null defaults to the provider default, which is the maximum possible value (30 days).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="kms_key_user_iam_arns" requirement="optional" type="list">
+<HclListItemDescription>
+
+VPC Flow Logs will be encrypted with a KMS Key (a Customer Master Key). The IAM Users specified in this list will have access to this key.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="nat_gateway_custom_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of tags to apply to the NAT gateways, on top of the custom_tags. The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as custom_tags in case of conflict.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="num_availability_zones" requirement="optional" type="number">
+<HclListItemDescription>
+
+How many AWS Availability Zones (AZs) to use. One subnet of each type (public, private app) will be created in each AZ. Note that this must be less than or equal to the total number of AZs in a region. A value of null means all AZs should be used. For example, if you specify 3 in a region with 5 AZs, subnets will be created in just 3 AZs instead of all 5. Defaults to 3.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="private_subnet_bits" requirement="optional" type="number">
+<HclListItemDescription>
+
+Takes the CIDR prefix and adds these many bits to it for calculating subnet ranges.  MAKE SURE if you change this you also change the CIDR spacing or you may hit errors.  See cidrsubnet interpolation in terraform config for more information.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="4"/>
+</HclListItem>
+
+<HclListItem name="private_subnet_cidr_blocks" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map listing the specific CIDR blocks desired for each private subnet. The key must be in the form AZ-0, AZ-1, ... AZ-n where n is the number of Availability Zones. If left blank, we will compute a reasonable CIDR block for each subnet.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="private_subnet_custom_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of tags to apply to the private Subnet, on top of the custom_tags. The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as custom_tags in case of conflict.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="public_subnet_bits" requirement="optional" type="number">
+<HclListItemDescription>
+
+Takes the CIDR prefix and adds these many bits to it for calculating subnet ranges.  MAKE SURE if you change this you also change the CIDR spacing or you may hit errors.  See cidrsubnet interpolation in terraform config for more information.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="4"/>
+</HclListItem>
+
+<HclListItem name="public_subnet_cidr_blocks" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map listing the specific CIDR blocks desired for each public subnet. The key must be in the form AZ-0, AZ-1, ... AZ-n where n is the number of Availability Zones. If left blank, we will compute a reasonable CIDR block for each subnet.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="public_subnet_custom_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of tags to apply to the public Subnet, on top of the custom_tags. The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as custom_tags in case of conflict.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="subnet_spacing" requirement="optional" type="number">
+<HclListItemDescription>
+
+The amount of spacing between the different subnet types
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="8"/>
+</HclListItem>
+
+<HclListItem name="use_managed_iam_policies" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="nat_gateway_public_ips" className="snap-top"></a>
+<HclListItem name="nat_gateway_public_ips">
+<HclListItemDescription>
 
-* [**`nat_gateway_public_ips`**](#nat_gateway_public_ips) &mdash; The public IP address(es) of the NAT gateway(s) of the mgmt VPC.
+The public IP address(es) of the NAT gateway(s) of the mgmt VPC.
 
-<a name="num_availability_zones" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`num_availability_zones`**](#num_availability_zones) &mdash; The number of availability zones used by the mgmt VPC.
+<HclListItem name="num_availability_zones">
+<HclListItemDescription>
 
-<a name="private_subnet_arns" className="snap-top"></a>
+The number of availability zones used by the mgmt VPC.
 
-* [**`private_subnet_arns`**](#private_subnet_arns) &mdash; The private subnet ARNs of the mgmt VPC.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="private_subnet_cidr_blocks" className="snap-top"></a>
+<HclListItem name="private_subnet_arns">
+<HclListItemDescription>
 
-* [**`private_subnet_cidr_blocks`**](#private_subnet_cidr_blocks) &mdash; The private subnet CIDR blocks of the mgmt VPC.
+The private subnet ARNs of the mgmt VPC.
 
-<a name="private_subnet_ids" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`private_subnet_ids`**](#private_subnet_ids) &mdash; The private subnet IDs of the mgmt VPC.
+<HclListItem name="private_subnet_cidr_blocks">
+<HclListItemDescription>
 
-<a name="private_subnet_route_table_ids" className="snap-top"></a>
+The private subnet CIDR blocks of the mgmt VPC.
 
-* [**`private_subnet_route_table_ids`**](#private_subnet_route_table_ids) &mdash; The ID of the private subnet route table of the mgmt VPC.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="public_subnet_arns" className="snap-top"></a>
+<HclListItem name="private_subnet_ids">
+<HclListItemDescription>
 
-* [**`public_subnet_arns`**](#public_subnet_arns) &mdash; The public subnet ARNs of the mgmt VPC.
+The private subnet IDs of the mgmt VPC.
 
-<a name="public_subnet_cidr_blocks" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`public_subnet_cidr_blocks`**](#public_subnet_cidr_blocks) &mdash; The public subnet CIDR blocks of the mgmt VPC.
+<HclListItem name="private_subnet_route_table_ids">
+<HclListItemDescription>
 
-<a name="public_subnet_ids" className="snap-top"></a>
+The ID of the private subnet route table of the mgmt VPC.
 
-* [**`public_subnet_ids`**](#public_subnet_ids) &mdash; The public subnet IDs of the mgmt VPC.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="public_subnet_route_table_id" className="snap-top"></a>
+<HclListItem name="public_subnet_arns">
+<HclListItemDescription>
 
-* [**`public_subnet_route_table_id`**](#public_subnet_route_table_id) &mdash; The ID of the public subnet route table of the mgmt VPC.
+The public subnet ARNs of the mgmt VPC.
 
-<a name="vpc_cidr_block" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`vpc_cidr_block`**](#vpc_cidr_block) &mdash; The CIDR block of the mgmt VPC.
+<HclListItem name="public_subnet_cidr_blocks">
+<HclListItemDescription>
 
-<a name="vpc_id" className="snap-top"></a>
+The public subnet CIDR blocks of the mgmt VPC.
 
-* [**`vpc_id`**](#vpc_id) &mdash; The ID of the mgmt VPC.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="vpc_name" className="snap-top"></a>
+<HclListItem name="public_subnet_ids">
+<HclListItemDescription>
 
-* [**`vpc_name`**](#vpc_name) &mdash; The name of the mgmt VPC.
+The public subnet IDs of the mgmt VPC.
 
-<a name="vpc_ready" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`vpc_ready`**](#vpc_ready) &mdash; Indicates whether or not the VPC has finished creating
+<HclListItem name="public_subnet_route_table_id">
+<HclListItemDescription>
+
+The ID of the public subnet route table of the mgmt VPC.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="vpc_cidr_block">
+<HclListItemDescription>
+
+The CIDR block of the mgmt VPC.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="vpc_id">
+<HclListItemDescription>
+
+The ID of the mgmt VPC.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="vpc_name">
+<HclListItemDescription>
+
+The name of the mgmt VPC.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="vpc_ready">
+<HclListItemDescription>
+
+Indicates whether or not the VPC has finished creating
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"38bd65ff068f7a723d608c49556b13ae"}
+{"sourcePlugin":"service-catalog-api","hash":"239b6fdab765e54b3f019128e1cbb930"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/networking/route-53-hosted-zones.md
+++ b/docs/reference/services/networking/route-53-hosted-zones.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.83.0"/>
 
@@ -81,69 +82,163 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Optional
 
-<a name="private_zones" className="snap-top"></a>
+<HclListItem name="private_zones" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`private_zones`**](#private_zones) &mdash; A map of private Route 53 Hosted Zones. In this map, the key should be the domain name. See examples below.
+A map of private Route 53 Hosted Zones. In this map, the key should be the domain name. See examples below.
 
-<a name="public_zones" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`public_zones`**](#public_zones) &mdash; A map of public Route 53 Hosted Zones. In this map, the key should be the domain name. See examples below.
+```hcl
+map(object({
+    # An optional, arbitrary comment to attach to the private Hosted Zone
+    comment = string
+    # The list of VPCs to associate with the private Hosted Zone. You must provide at least one VPC in this list.
+    vpcs = list(object({
+      # The ID of the VPC.
+      id = string
+      # The region of the VPC. If null, defaults to the region configured on the provider.
+      region = string
+    }))
+    # A mapping of tags to assign to the private Hosted Zone
+    tags = map(string)
+    # Whether to destroy all records (possibly managed ouside of Terraform) in the zone when destroying the zone
+    force_destroy = bool
+  }))
+```
 
-<a name="service_discovery_private_namespaces" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`service_discovery_private_namespaces`**](#service_discovery_private_namespaces) &mdash; A map of domain names to configurations for setting up a new private namespace in AWS Cloud Map.
+<HclListItem name="public_zones" requirement="optional" type="any">
+<HclListItemDescription>
 
-<a name="service_discovery_public_namespaces" className="snap-top"></a>
+A map of public Route 53 Hosted Zones. In this map, the key should be the domain name. See examples below.
 
-* [**`service_discovery_public_namespaces`**](#service_discovery_public_namespaces) &mdash; A map of domain names to configurations for setting up a new public namespace in AWS Cloud Map. Note that the domain name must be registered with Route 53.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="service_discovery_private_namespaces" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of domain names to configurations for setting up a new private namespace in AWS Cloud Map.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(object({
+    # The ID of the VPC where the private hosted zone is restricted to.
+    vpc_id = string
+
+    # A user friendly description for the namespace
+    description = string
+  }))
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="service_discovery_public_namespaces" requirement="optional" type="any">
+<HclListItemDescription>
+
+A map of domain names to configurations for setting up a new public namespace in AWS Cloud Map. Note that the domain name must be registered with Route 53.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="acm_tls_certificates" className="snap-top"></a>
+<HclListItem name="acm_tls_certificates">
+<HclListItemDescription>
 
-* [**`acm_tls_certificates`**](#acm_tls_certificates) &mdash; A list of ARNs of the wildcard and service discovery certificates that were provisioned along with the Route 53 zone.
+A list of ARNs of the wildcard and service discovery certificates that were provisioned along with the Route 53 zone.
 
-<a name="private_domain_names" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`private_domain_names`**](#private_domain_names) &mdash; The names of the internal-only Route 53 Hosted Zones
+<HclListItem name="private_domain_names">
+<HclListItemDescription>
 
-<a name="private_zones_ids" className="snap-top"></a>
+The names of the internal-only Route 53 Hosted Zones
 
-* [**`private_zones_ids`**](#private_zones_ids) &mdash; The IDs of the internal-only Route 53 Hosted Zones
+</HclListItemDescription>
+</HclListItem>
 
-<a name="private_zones_name_servers" className="snap-top"></a>
+<HclListItem name="private_zones_ids">
+<HclListItemDescription>
 
-* [**`private_zones_name_servers`**](#private_zones_name_servers) &mdash; The name servers associated with the internal-only Route 53 Hosted Zones
+The IDs of the internal-only Route 53 Hosted Zones
 
-<a name="public_domain_names" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`public_domain_names`**](#public_domain_names) &mdash; The names of the public Route 53 Hosted Zones
+<HclListItem name="private_zones_name_servers">
+<HclListItemDescription>
 
-<a name="public_hosted_zone_map" className="snap-top"></a>
+The name servers associated with the internal-only Route 53 Hosted Zones
 
-* [**`public_hosted_zone_map`**](#public_hosted_zone_map) &mdash; A map of domains to their zone IDs. IDs are user inputs, when supplied, and otherwise resource IDs
+</HclListItemDescription>
+</HclListItem>
 
-<a name="public_hosted_zones_ids" className="snap-top"></a>
+<HclListItem name="public_domain_names">
+<HclListItemDescription>
 
-* [**`public_hosted_zones_ids`**](#public_hosted_zones_ids) &mdash; The IDs of the public Route 53 Hosted Zones
+The names of the public Route 53 Hosted Zones
 
-<a name="public_hosted_zones_name_servers" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`public_hosted_zones_name_servers`**](#public_hosted_zones_name_servers) &mdash; The name servers associated with the public Route 53 Hosted Zones
+<HclListItem name="public_hosted_zone_map">
+<HclListItemDescription>
 
-<a name="service_discovery_private_namespaces" className="snap-top"></a>
+A map of domains to their zone IDs. IDs are user inputs, when supplied, and otherwise resource IDs
 
-* [**`service_discovery_private_namespaces`**](#service_discovery_private_namespaces) &mdash; A map of domains to resource arns and hosted zones of the created Service Discovery Private Namespaces.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="service_discovery_public_namespaces" className="snap-top"></a>
+<HclListItem name="public_hosted_zones_ids">
+<HclListItemDescription>
 
-* [**`service_discovery_public_namespaces`**](#service_discovery_public_namespaces) &mdash; A map of domains to resource arns and hosted zones of the created Service Discovery Public Namespaces.
+The IDs of the public Route 53 Hosted Zones
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="public_hosted_zones_name_servers">
+<HclListItemDescription>
+
+The name servers associated with the public Route 53 Hosted Zones
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="service_discovery_private_namespaces">
+<HclListItemDescription>
+
+A map of domains to resource arns and hosted zones of the created Service Discovery Private Namespaces.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="service_discovery_public_namespaces">
+<HclListItemDescription>
+
+A map of domains to resource arns and hosted zones of the created Service Discovery Public Namespaces.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"0bccfeeea7055844d0c979684dcd702b"}
+{"sourcePlugin":"service-catalog-api","hash":"916cfcac2e1777663cda67d740bfbcf4"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/networking/sns-topics.md
+++ b/docs/reference/services/networking/sns-topics.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.85.0"/>
 
@@ -77,55 +78,146 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="name" className="snap-top"></a>
+<HclListItem name="name" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`name`**](#name) &mdash; The name of the SNS topic
+The name of the SNS topic
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="allow_publish_accounts" className="snap-top"></a>
+<HclListItem name="allow_publish_accounts" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`allow_publish_accounts`**](#allow_publish_accounts) &mdash; A list of IAM ARNs that will be given the rights to publish to the SNS topic.
+A list of IAM ARNs that will be given the rights to publish to the SNS topic.
 
-<a name="allow_publish_services" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`allow_publish_services`**](#allow_publish_services) &mdash; A list of AWS services that will be given the rights to publish to the SNS topic.
+```hcl
+list(string)
+```
 
-<a name="allow_subscribe_accounts" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`allow_subscribe_accounts`**](#allow_subscribe_accounts) &mdash; A list of IAM ARNs that will be given the rights to subscribe to the SNS topic.
+<HclListItem name="allow_publish_services" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="allow_subscribe_protocols" className="snap-top"></a>
+A list of AWS services that will be given the rights to publish to the SNS topic.
 
-* [**`allow_subscribe_protocols`**](#allow_subscribe_protocols) &mdash; A list of protocols that can be used to subscribe to the SNS topic.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="create_resources" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`create_resources`**](#create_resources) &mdash; Set to false to have this module create no resources. This weird parameter exists solely because Terraform does not support conditional modules. Therefore, this is a hack to allow you to conditionally decide if the resources should be created or not.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="display_name" className="snap-top"></a>
+<HclListItem name="allow_subscribe_accounts" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`display_name`**](#display_name) &mdash; The display name of the SNS topic
+A list of IAM ARNs that will be given the rights to subscribe to the SNS topic.
 
-<a name="kms_master_key_id" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`kms_master_key_id`**](#kms_master_key_id) &mdash; The ID of an AWS-managed customer master key (CMK) for Amazon SNS or a custom CMK
+```hcl
+list(string)
+```
 
-<a name="slack_webhook_url" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`slack_webhook_url`**](#slack_webhook_url) &mdash; Send topic notifications to this Slack Webhook URL (e.g., https://hooks.slack.com/services/FOO/BAR/BAZ).
+<HclListItem name="allow_subscribe_protocols" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of protocols that can be used to subscribe to the SNS topic.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue>
+
+```hcl
+[
+  "http",
+  "https",
+  "email",
+  "email-json",
+  "sms",
+  "sqs",
+  "application",
+  "lambda"
+]
+```
+
+</HclListItemDefaultValue>
+</HclListItem>
+
+<HclListItem name="create_resources" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to false to have this module create no resources. This weird parameter exists solely because Terraform does not support conditional modules. Therefore, this is a hack to allow you to conditionally decide if the resources should be created or not.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="display_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The display name of the SNS topic
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="kms_master_key_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ID of an AWS-managed customer master key (CMK) for Amazon SNS or a custom CMK
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="alias/aws/sns"/>
+</HclListItem>
+
+<HclListItem name="slack_webhook_url" requirement="optional" type="string">
+<HclListItemDescription>
+
+Send topic notifications to this Slack Webhook URL (e.g., https://hooks.slack.com/services/FOO/BAR/BAZ).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="topic_arn" className="snap-top"></a>
+<HclListItem name="topic_arn">
+<HclListItemDescription>
 
-* [**`topic_arn`**](#topic_arn) &mdash; The ARN of the SNS topic.
+The ARN of the SNS topic.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"1c8dbd5c4670fad242c114ea4ecd4e36"}
+{"sourcePlugin":"service-catalog-api","hash":"d3727100ec3042b52a6cd63c62226adc"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/networking/virtual-private-cloud-vpc.md
+++ b/docs/reference/services/networking/virtual-private-cloud-vpc.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.84.0"/>
 
@@ -98,379 +99,1038 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="aws_region" className="snap-top"></a>
+<HclListItem name="aws_region" requirement="required" type="string">
+<HclListItemDescription>
 
-* [**`aws_region`**](#aws_region) &mdash; The AWS region in which all resources will be created
+The AWS region in which all resources will be created
 
-<a name="cidr_block" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`cidr_block`**](#cidr_block) &mdash; The IP address range of the VPC in CIDR notation. A prefix of /18 is recommended. Do not use a prefix higher than /27. Examples include '10.100.0.0/18', '10.200.0.0/18', etc.
+<HclListItem name="cidr_block" requirement="required" type="string">
+<HclListItemDescription>
 
-<a name="num_nat_gateways" className="snap-top"></a>
+The IP address range of the VPC in CIDR notation. A prefix of /18 is recommended. Do not use a prefix higher than /27. Examples include '10.100.0.0/18', '10.200.0.0/18', etc.
 
-* [**`num_nat_gateways`**](#num_nat_gateways) &mdash; The number of NAT Gateways to launch for this VPC. For production VPCs, a NAT Gateway should be placed in each Availability Zone (so likely 3 total), whereas for non-prod VPCs, just one Availability Zone (and hence 1 NAT Gateway) will suffice.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="vpc_name" className="snap-top"></a>
+<HclListItem name="num_nat_gateways" requirement="required" type="number">
+<HclListItemDescription>
 
-* [**`vpc_name`**](#vpc_name) &mdash; Name of the VPC. Examples include 'prod', 'dev', 'mgmt', etc.
+The number of NAT Gateways to launch for this VPC. For production VPCs, a NAT Gateway should be placed in each Availability Zone (so likely 3 total), whereas for non-prod VPCs, just one Availability Zone (and hence 1 NAT Gateway) will suffice.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="vpc_name" requirement="required" type="string">
+<HclListItemDescription>
+
+Name of the VPC. Examples include 'prod', 'dev', 'mgmt', etc.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="allow_private_persistence_internet_access" className="snap-top"></a>
+<HclListItem name="allow_private_persistence_internet_access" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`allow_private_persistence_internet_access`**](#allow_private_persistence_internet_access) &mdash; Should the private persistence subnet be allowed outbound access to the internet?
+Should the private persistence subnet be allowed outbound access to the internet?
 
-<a name="apply_default_nacl_rules" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`apply_default_nacl_rules`**](#apply_default_nacl_rules) &mdash; If true, will apply the default NACL rules in [`default_nacl_ingress_rules`](#default_nacl_ingress_rules) and [`default_nacl_egress_rules`](#default_nacl_egress_rules) on the default NACL of the VPC. Note that every VPC must have a default NACL - when this is false, the original default NACL rules managed by AWS will be used.
+<HclListItem name="apply_default_nacl_rules" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="associate_default_nacl_to_subnets" className="snap-top"></a>
+If true, will apply the default NACL rules in <a href="#default_nacl_ingress_rules"><code>default_nacl_ingress_rules</code></a> and <a href="#default_nacl_egress_rules"><code>default_nacl_egress_rules</code></a> on the default NACL of the VPC. Note that every VPC must have a default NACL - when this is false, the original default NACL rules managed by AWS will be used.
 
-* [**`associate_default_nacl_to_subnets`**](#associate_default_nacl_to_subnets) &mdash; If true, will associate the default NACL to the public, private, and persistence subnets created by this module. Only used if [`apply_default_nacl_rules`](#apply_default_nacl_rules) is true. Note that this does not guarantee that the subnets are associated with the default NACL. Subnets can only be associated with a single NACL. The default NACL association will be dropped if the subnets are associated with a custom NACL later.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="availability_zone_exclude_names" className="snap-top"></a>
+<HclListItem name="associate_default_nacl_to_subnets" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`availability_zone_exclude_names`**](#availability_zone_exclude_names) &mdash; Specific Availability Zones in which subnets SHOULD NOT be created. Useful for when features / support is missing from a given AZ.
+If true, will associate the default NACL to the public, private, and persistence subnets created by this module. Only used if <a href="#apply_default_nacl_rules"><code>apply_default_nacl_rules</code></a> is true. Note that this does not guarantee that the subnets are associated with the default NACL. Subnets can only be associated with a single NACL. The default NACL association will be dropped if the subnets are associated with a custom NACL later.
 
-<a name="create_dns_forwarder" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`create_dns_forwarder`**](#create_dns_forwarder) &mdash; Whether or not to create DNS forwarders from the Mgmt VPC to the App VPC to resolve private Route 53 endpoints. This is most useful when you want to keep your EKS Kubernetes API endpoint private to the VPC, but want to access it from the Mgmt VPC (where your VPN/Bastion servers are).
+<HclListItem name="availability_zone_exclude_names" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="create_flow_logs" className="snap-top"></a>
+Specific Availability Zones in which subnets SHOULD NOT be created. Useful for when features / support is missing from a given AZ.
 
-* [**`create_flow_logs`**](#create_flow_logs) &mdash; If you set this variable to false, this module will not create VPC Flow Logs resources. This is used as a workaround because Terraform does not allow you to use the 'count' parameter on modules. By using this parameter, you can optionally create or not create the resources within this module.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="create_igw" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`create_igw`**](#create_igw) &mdash; Whether the VPC will create an Internet Gateway. There are use cases when the VPC is desired to not be routable from the internet, and hence, they should not have an Internet Gateway. For example, when it is desired that public subnets exist but they are not directly public facing, since they can be routed from other VPC hosting the IGW.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="create_network_acls" className="snap-top"></a>
+<HclListItem name="create_dns_forwarder" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`create_network_acls`**](#create_network_acls) &mdash; If set to false, this module will NOT create Network ACLs. This is useful if you don't want to use Network ACLs or you want to provide your own Network ACLs outside of this module.
+Whether or not to create DNS forwarders from the Mgmt VPC to the App VPC to resolve private Route 53 endpoints. This is most useful when you want to keep your EKS Kubernetes API endpoint private to the VPC, but want to access it from the Mgmt VPC (where your VPN/Bastion servers are).
 
-<a name="create_peering_connection" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`create_peering_connection`**](#create_peering_connection) &mdash; Whether or not to create a peering connection to another VPC.
+<HclListItem name="create_flow_logs" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="create_private_app_subnet_nacls" className="snap-top"></a>
+If you set this variable to false, this module will not create VPC Flow Logs resources. This is used as a workaround because Terraform does not allow you to use the 'count' parameter on modules. By using this parameter, you can optionally create or not create the resources within this module.
 
-* [**`create_private_app_subnet_nacls`**](#create_private_app_subnet_nacls) &mdash; If set to false, this module will NOT create the NACLs for the private app subnet tier.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="create_private_app_subnets" className="snap-top"></a>
+<HclListItem name="create_igw" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`create_private_app_subnets`**](#create_private_app_subnets) &mdash; If set to false, this module will NOT create the private app subnet tier.
+Whether the VPC will create an Internet Gateway. There are use cases when the VPC is desired to not be routable from the internet, and hence, they should not have an Internet Gateway. For example, when it is desired that public subnets exist but they are not directly public facing, since they can be routed from other VPC hosting the IGW.
 
-<a name="create_private_persistence_subnet_nacls" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`create_private_persistence_subnet_nacls`**](#create_private_persistence_subnet_nacls) &mdash; If set to false, this module will NOT create the NACLs for the private persistence subnet tier.
+<HclListItem name="create_network_acls" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="create_private_persistence_subnets" className="snap-top"></a>
+If set to false, this module will NOT create Network ACLs. This is useful if you don't want to use Network ACLs or you want to provide your own Network ACLs outside of this module.
 
-* [**`create_private_persistence_subnets`**](#create_private_persistence_subnets) &mdash; If set to false, this module will NOT create the private persistence subnet tier.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="create_public_subnet_nacls" className="snap-top"></a>
+<HclListItem name="create_peering_connection" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`create_public_subnet_nacls`**](#create_public_subnet_nacls) &mdash; If set to false, this module will NOT create the NACLs for the public subnet tier. This is useful for VPCs that only need private subnets.
+Whether or not to create a peering connection to another VPC.
 
-<a name="create_public_subnets" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-* [**`create_public_subnets`**](#create_public_subnets) &mdash; If set to false, this module will NOT create the public subnet tier. This is useful for VPCs that only need private subnets. Note that setting this to false also means the module will NOT create an Internet Gateway or the NAT gateways, so if you want any public Internet access in the VPC (even outbound access—e.g., to run apt get), you'll need to provide it yourself via some other mechanism (e.g., via VPC peering, a Transit Gateway, Direct Connect, etc).
+<HclListItem name="create_private_app_subnet_nacls" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="create_vpc_endpoints" className="snap-top"></a>
+If set to false, this module will NOT create the NACLs for the private app subnet tier.
 
-* [**`create_vpc_endpoints`**](#create_vpc_endpoints) &mdash; Create VPC endpoints for S3 and DynamoDB.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="custom_tags" className="snap-top"></a>
+<HclListItem name="create_private_app_subnets" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`custom_tags`**](#custom_tags) &mdash; A map of tags to apply to the VPC, Subnets, Route Tables, Internet Gateway, default security group, and default NACLs. The key is the tag name and the value is the tag value. Note that the tag 'Name' is automatically added by this module but may be optionally overwritten by this variable.
+If set to false, this module will NOT create the private app subnet tier.
 
-<a name="default_nacl_egress_rules" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`default_nacl_egress_rules`**](#default_nacl_egress_rules) &mdash; The egress rules to apply to the default NACL in the VPC. This is the security group that is used by any subnet that doesn't have its own NACL attached. The value for this variable must be a map where the keys are a unique name for each rule and the values are objects with the same fields as the egress block in the [`aws_default_network_acl`](#aws_default_network_acl) resource: [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_network_acl`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_network_acl).
+<HclListItem name="create_private_persistence_subnet_nacls" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="default_nacl_ingress_rules" className="snap-top"></a>
+If set to false, this module will NOT create the NACLs for the private persistence subnet tier.
 
-* [**`default_nacl_ingress_rules`**](#default_nacl_ingress_rules) &mdash; The ingress rules to apply to the default NACL in the VPC. This is the NACL that is used by any subnet that doesn't have its own NACL attached. The value for this variable must be a map where the keys are a unique name for each rule and the values are objects with the same fields as the ingress block in the [`aws_default_network_acl`](#aws_default_network_acl) resource: [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_network_acl`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_network_acl).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="default_security_group_egress_rules" className="snap-top"></a>
+<HclListItem name="create_private_persistence_subnets" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`default_security_group_egress_rules`**](#default_security_group_egress_rules) &mdash; The egress rules to apply to the default security group in the VPC. This is the security group that is used by any resource that doesn't have its own security group attached. The value for this variable must be a map where the keys are a unique name for each rule and the values are objects with the same fields as the egress block in the [`aws_default_security_group`](#aws_default_security_group) resource: [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group)#egress-block.
+If set to false, this module will NOT create the private persistence subnet tier.
 
-<a name="default_security_group_ingress_rules" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`default_security_group_ingress_rules`**](#default_security_group_ingress_rules) &mdash; The ingress rules to apply to the default security group in the VPC. This is the security group that is used by any resource that doesn't have its own security group attached. The value for this variable must be a map where the keys are a unique name for each rule and the values are objects with the same fields as the ingress block in the [`aws_default_security_group`](#aws_default_security_group) resource: [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group)#ingress-block.
+<HclListItem name="create_public_subnet_nacls" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="destination_vpc_resolver_name" className="snap-top"></a>
+If set to false, this module will NOT create the NACLs for the public subnet tier. This is useful for VPCs that only need private subnets.
 
-* [**`destination_vpc_resolver_name`**](#destination_vpc_resolver_name) &mdash; Name to set for the destination VPC resolver (inbound from origin VPC to destination VPC). If null (default), defaults to [`'DESTINATION_VPC_NAME-from-ORIGIN_VPC_NAME`](#'DESTINATION_VPC_NAME-from-ORIGIN_VPC_NAME)-in'.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="eks_cluster_names" className="snap-top"></a>
+<HclListItem name="create_public_subnets" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`eks_cluster_names`**](#eks_cluster_names) &mdash; The names of EKS clusters that will be deployed into the VPC, if [`tag_for_use_with_eks`](#tag_for_use_with_eks) is true.
+If set to false, this module will NOT create the public subnet tier. This is useful for VPCs that only need private subnets. Note that setting this to false also means the module will NOT create an Internet Gateway or the NAT gateways, so if you want any public Internet access in the VPC (even outbound access—e.g., to run apt get), you'll need to provide it yourself via some other mechanism (e.g., via VPC peering, a Transit Gateway, Direct Connect, etc).
 
-<a name="enable_default_security_group" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`enable_default_security_group`**](#enable_default_security_group) &mdash; If set to false, the default security groups will NOT be created.
+<HclListItem name="create_vpc_endpoints" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="flow_log_cloudwatch_iam_role_name" className="snap-top"></a>
+Create VPC endpoints for S3 and DynamoDB.
 
-* [**`flow_log_cloudwatch_iam_role_name`**](#flow_log_cloudwatch_iam_role_name) &mdash; The name to use for the flow log IAM role. This can be useful if you provision the VPC without admin privileges which needs setting IAM:PassRole on deployment role. When null, a default name based on the VPC name will be chosen.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="flow_log_cloudwatch_log_group_name" className="snap-top"></a>
+<HclListItem name="custom_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`flow_log_cloudwatch_log_group_name`**](#flow_log_cloudwatch_log_group_name) &mdash; The name to use for the CloudWatch Log group used for storing flow log. When null, a default name based on the VPC name will be chosen.
+A map of tags to apply to the VPC, Subnets, Route Tables, Internet Gateway, default security group, and default NACLs. The key is the tag name and the value is the tag value. Note that the tag 'Name' is automatically added by this module but may be optionally overwritten by this variable.
 
-<a name="flow_logs_traffic_type" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`flow_logs_traffic_type`**](#flow_logs_traffic_type) &mdash; The type of traffic to capture in the VPC flow log. Valid values include ACCEPT, REJECT, or ALL. Defaults to REJECT. Only used if [`create_flow_logs`](#create_flow_logs) is true.
+```hcl
+map(string)
+```
 
-<a name="iam_role_permissions_boundary" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`iam_role_permissions_boundary`**](#iam_role_permissions_boundary) &mdash; The ARN of the policy that is used to set the permissions boundary for the IAM role.
+<HclListItem name="default_nacl_egress_rules" requirement="optional" type="any">
+<HclListItemDescription>
 
-<a name="kms_key_arn" className="snap-top"></a>
+The egress rules to apply to the default NACL in the VPC. This is the security group that is used by any subnet that doesn't have its own NACL attached. The value for this variable must be a map where the keys are a unique name for each rule and the values are objects with the same fields as the egress block in the aws_default_network_acl resource: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_network_acl.
 
-* [**`kms_key_arn`**](#kms_key_arn) &mdash; The ARN of a KMS key to use for encrypting VPC the flow log. A new KMS key will be created if this is not supplied.
+</HclListItemDescription>
+<HclListItemDefaultValue>
 
-<a name="kms_key_deletion_window_in_days" className="snap-top"></a>
+```hcl
+{
+  AllowAll = {
+    action = "allow",
+    cidr_block = "0.0.0.0/0",
+    from_port = 0,
+    protocol = "-1",
+    rule_no = 100,
+    to_port = 0
+  }
+}
+```
 
-* [**`kms_key_deletion_window_in_days`**](#kms_key_deletion_window_in_days) &mdash; The number of days to retain this KMS Key (a Customer Master Key) after it has been marked for deletion. Setting to null defaults to the provider default, which is the maximum possible value (30 days).
+</HclListItemDefaultValue>
+</HclListItem>
 
-<a name="kms_key_user_iam_arns" className="snap-top"></a>
+<HclListItem name="default_nacl_ingress_rules" requirement="optional" type="any">
+<HclListItemDescription>
 
-* [**`kms_key_user_iam_arns`**](#kms_key_user_iam_arns) &mdash; VPC Flow Logs will be encrypted with a KMS Key (a Customer Master Key). The IAM Users specified in this list will have access to this key.
+The ingress rules to apply to the default NACL in the VPC. This is the NACL that is used by any subnet that doesn't have its own NACL attached. The value for this variable must be a map where the keys are a unique name for each rule and the values are objects with the same fields as the ingress block in the aws_default_network_acl resource: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_network_acl.
 
-<a name="nat_gateway_custom_tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue>
 
-* [**`nat_gateway_custom_tags`**](#nat_gateway_custom_tags) &mdash; A map of tags to apply to the NAT gateways, on top of the [`custom_tags`](#custom_tags). The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as [`custom_tags`](#custom_tags) in case of conflict.
+```hcl
+{
+  AllowAll = {
+    action = "allow",
+    cidr_block = "0.0.0.0/0",
+    from_port = 0,
+    protocol = "-1",
+    rule_no = 100,
+    to_port = 0
+  }
+}
+```
 
-<a name="num_availability_zones" className="snap-top"></a>
+</HclListItemDefaultValue>
+</HclListItem>
 
-* [**`num_availability_zones`**](#num_availability_zones) &mdash; How many AWS Availability Zones (AZs) to use. One subnet of each type (public, private app) will be created in each AZ. Note that this must be less than or equal to the total number of AZs in a region. A value of null means all AZs should be used. For example, if you specify 3 in a region with 5 AZs, subnets will be created in just 3 AZs instead of all 5. Defaults to all AZs in a region.
+<HclListItem name="default_security_group_egress_rules" requirement="optional" type="any">
+<HclListItemDescription>
 
-<a name="origin_vpc_cidr_block" className="snap-top"></a>
+The egress rules to apply to the default security group in the VPC. This is the security group that is used by any resource that doesn't have its own security group attached. The value for this variable must be a map where the keys are a unique name for each rule and the values are objects with the same fields as the egress block in the aws_default_security_group resource: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group#egress-block.
 
-* [**`origin_vpc_cidr_block`**](#origin_vpc_cidr_block) &mdash; The CIDR block of the origin VPC.
+</HclListItemDescription>
+<HclListItemDefaultValue>
 
-<a name="origin_vpc_id" className="snap-top"></a>
+```hcl
+{
+  AllowAllOutbound = {
+    cidr_blocks = [
+      "0.0.0.0/0"
+    ],
+    from_port = 0,
+    ipv6_cidr_blocks = [
+      "::/0"
+    ],
+    protocol = "-1",
+    to_port = 0
+  }
+}
+```
 
-* [**`origin_vpc_id`**](#origin_vpc_id) &mdash; The ID of the origin VPC to use when creating peering connections and DNS forwarding.
+</HclListItemDefaultValue>
+</HclListItem>
 
-<a name="origin_vpc_name" className="snap-top"></a>
+<HclListItem name="default_security_group_ingress_rules" requirement="optional" type="any">
+<HclListItemDescription>
 
-* [**`origin_vpc_name`**](#origin_vpc_name) &mdash; The name of the origin VPC to use when creating peering connections and DNS forwarding.
+The ingress rules to apply to the default security group in the VPC. This is the security group that is used by any resource that doesn't have its own security group attached. The value for this variable must be a map where the keys are a unique name for each rule and the values are objects with the same fields as the ingress block in the aws_default_security_group resource: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group#ingress-block.
 
-<a name="origin_vpc_public_subnet_ids" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue>
 
-* [**`origin_vpc_public_subnet_ids`**](#origin_vpc_public_subnet_ids) &mdash; The public subnets in the origin VPC to use when creating route53 resolvers. These are public subnets due to network ACLs restrictions. Although the forwarder is addressable publicly, access is blocked by security groups.
+```hcl
+{
+  AllowAllFromSelf = {
+    from_port = 0,
+    protocol = "-1",
+    self = true,
+    to_port = 0
+  }
+}
+```
 
-<a name="origin_vpc_resolver_name" className="snap-top"></a>
+</HclListItemDefaultValue>
+</HclListItem>
 
-* [**`origin_vpc_resolver_name`**](#origin_vpc_resolver_name) &mdash; Name to set for the origin VPC resolver (outbound from origin VPC to destination VPC). If null (default), defaults to [`'ORIGIN_VPC_NAME-to-DESTINATION_VPC_NAME`](#'ORIGIN_VPC_NAME-to-DESTINATION_VPC_NAME)-out'.
+<HclListItem name="destination_vpc_resolver_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="origin_vpc_route_table_ids" className="snap-top"></a>
+Name to set for the destination VPC resolver (inbound from origin VPC to destination VPC). If null (default), defaults to 'DESTINATION_VPC_NAME-from-ORIGIN_VPC_NAME-in'.
 
-* [**`origin_vpc_route_table_ids`**](#origin_vpc_route_table_ids) &mdash; A list of route tables from the origin VPC that should have routes to this app VPC.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="persistence_propagating_vgws" className="snap-top"></a>
+<HclListItem name="eks_cluster_names" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`persistence_propagating_vgws`**](#persistence_propagating_vgws) &mdash; A list of Virtual Private Gateways that will propagate routes to persistence subnets. All routes from VPN connections that use Virtual Private Gateways listed here will appear in route tables of persistence subnets. If left empty, no routes will be propagated.
+The names of EKS clusters that will be deployed into the VPC, if <a href="#tag_for_use_with_eks"><code>tag_for_use_with_eks</code></a> is true.
 
-<a name="persistence_subnet_bits" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`persistence_subnet_bits`**](#persistence_subnet_bits) &mdash; Takes the CIDR prefix and adds these many bits to it for calculating subnet ranges.  MAKE SURE if you change this you also change the CIDR spacing or you may hit errors.  See cidrsubnet interpolation in terraform config for more information.
+```hcl
+list(string)
+```
 
-<a name="persistence_subnet_spacing" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`persistence_subnet_spacing`**](#persistence_subnet_spacing) &mdash; The amount of spacing between the private persistence subnets. Default: 2 times the value of [`private_subnet_spacing`](#private_subnet_spacing).
+<HclListItem name="enable_default_security_group" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="private_app_allow_inbound_ports_from_cidr" className="snap-top"></a>
+If set to false, the default security groups will NOT be created.
 
-* [**`private_app_allow_inbound_ports_from_cidr`**](#private_app_allow_inbound_ports_from_cidr) &mdash; A map of unique names to client IP CIDR block and inbound ports that should be exposed in the private app subnet tier nACLs. This is useful when exposing your service on a privileged port with an NLB, where the address isn't translated.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="private_app_allow_outbound_ports_to_destination_cidr" className="snap-top"></a>
+<HclListItem name="flow_log_cloudwatch_iam_role_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`private_app_allow_outbound_ports_to_destination_cidr`**](#private_app_allow_outbound_ports_to_destination_cidr) &mdash; A map of unique names to destination IP CIDR block and outbound ports that should be allowed in the private app subnet tier nACLs. This is useful when allowing your VPC specific outbound communication to defined CIDR blocks(known networks)
+The name to use for the flow log IAM role. This can be useful if you provision the VPC without admin privileges which needs setting IAM:PassRole on deployment role. When null, a default name based on the VPC name will be chosen.
 
-<a name="private_app_subnet_cidr_blocks" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`private_app_subnet_cidr_blocks`**](#private_app_subnet_cidr_blocks) &mdash; A map listing the specific CIDR blocks desired for each private-app subnet. The key must be in the form AZ-0, AZ-1, ... AZ-n where n is the number of Availability Zones. If left blank, we will compute a reasonable CIDR block for each subnet.
+<HclListItem name="flow_log_cloudwatch_log_group_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="private_app_subnet_custom_tags" className="snap-top"></a>
+The name to use for the CloudWatch Log group used for storing flow log. When null, a default name based on the VPC name will be chosen.
 
-* [**`private_app_subnet_custom_tags`**](#private_app_subnet_custom_tags) &mdash; A map of tags to apply to the private-app Subnet, on top of the [`custom_tags`](#custom_tags). The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as [`custom_tags`](#custom_tags) in case of conflict.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="private_persistence_subnet_cidr_blocks" className="snap-top"></a>
+<HclListItem name="flow_logs_traffic_type" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`private_persistence_subnet_cidr_blocks`**](#private_persistence_subnet_cidr_blocks) &mdash; A map listing the specific CIDR blocks desired for each private-persistence subnet. The key must be in the form AZ-0, AZ-1, ... AZ-n where n is the number of Availability Zones. If left blank, we will compute a reasonable CIDR block for each subnet.
+The type of traffic to capture in the VPC flow log. Valid values include ACCEPT, REJECT, or ALL. Defaults to REJECT. Only used if create_flow_logs is true.
 
-<a name="private_persistence_subnet_custom_tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="REJECT"/>
+</HclListItem>
 
-* [**`private_persistence_subnet_custom_tags`**](#private_persistence_subnet_custom_tags) &mdash; A map of tags to apply to the private-persistence Subnet, on top of the [`custom_tags`](#custom_tags). The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as [`custom_tags`](#custom_tags) in case of conflict.
+<HclListItem name="iam_role_permissions_boundary" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="private_propagating_vgws" className="snap-top"></a>
+The ARN of the policy that is used to set the permissions boundary for the IAM role.
 
-* [**`private_propagating_vgws`**](#private_propagating_vgws) &mdash; A list of Virtual Private Gateways that will propagate routes to private subnets. All routes from VPN connections that use Virtual Private Gateways listed here will appear in route tables of private subnets. If left empty, no routes will be propagated.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="private_subnet_bits" className="snap-top"></a>
+<HclListItem name="kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`private_subnet_bits`**](#private_subnet_bits) &mdash; Takes the CIDR prefix and adds these many bits to it for calculating subnet ranges.  MAKE SURE if you change this you also change the CIDR spacing or you may hit errors.  See cidrsubnet interpolation in terraform config for more information.
+The ARN of a KMS key to use for encrypting VPC the flow log. A new KMS key will be created if this is not supplied.
 
-<a name="private_subnet_spacing" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`private_subnet_spacing`**](#private_subnet_spacing) &mdash; The amount of spacing between private app subnets. Defaults to [`subnet_spacing`](#subnet_spacing) in vpc-app module if not set.
+<HclListItem name="kms_key_deletion_window_in_days" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="public_propagating_vgws" className="snap-top"></a>
+The number of days to retain this KMS Key (a Customer Master Key) after it has been marked for deletion. Setting to null defaults to the provider default, which is the maximum possible value (30 days).
 
-* [**`public_propagating_vgws`**](#public_propagating_vgws) &mdash; A list of Virtual Private Gateways that will propagate routes to public subnets. All routes from VPN connections that use Virtual Private Gateways listed here will appear in route tables of public subnets. If left empty, no routes will be propagated.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="public_subnet_bits" className="snap-top"></a>
+<HclListItem name="kms_key_user_iam_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`public_subnet_bits`**](#public_subnet_bits) &mdash; Takes the CIDR prefix and adds these many bits to it for calculating subnet ranges.  MAKE SURE if you change this you also change the CIDR spacing or you may hit errors.  See cidrsubnet interpolation in terraform config for more information.
+VPC Flow Logs will be encrypted with a KMS Key (a Customer Master Key). The IAM Users specified in this list will have access to this key.
 
-<a name="public_subnet_cidr_blocks" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`public_subnet_cidr_blocks`**](#public_subnet_cidr_blocks) &mdash; A map listing the specific CIDR blocks desired for each public subnet. The key must be in the form AZ-0, AZ-1, ... AZ-n where n is the number of Availability Zones. If left blank, we will compute a reasonable CIDR block for each subnet.
+```hcl
+list(string)
+```
 
-<a name="public_subnet_custom_tags" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`public_subnet_custom_tags`**](#public_subnet_custom_tags) &mdash; A map of tags to apply to the public Subnet, on top of the [`custom_tags`](#custom_tags). The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as [`custom_tags`](#custom_tags) in case of conflict.
+<HclListItem name="nat_gateway_custom_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="security_group_tags" className="snap-top"></a>
+A map of tags to apply to the NAT gateways, on top of the custom_tags. The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as custom_tags in case of conflict.
 
-* [**`security_group_tags`**](#security_group_tags) &mdash; A map of tags to apply to the default Security Group, on top of the [`custom_tags`](#custom_tags). The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as [`custom_tags`](#custom_tags) in case of conflict.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="subnet_spacing" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`subnet_spacing`**](#subnet_spacing) &mdash; The amount of spacing between the different subnet types
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="tag_for_use_with_eks" className="snap-top"></a>
+<HclListItem name="num_availability_zones" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`tag_for_use_with_eks`**](#tag_for_use_with_eks) &mdash; The VPC resources need special tags for discoverability by Kubernetes to use with certain features, like deploying ALBs.
+How many AWS Availability Zones (AZs) to use. One subnet of each type (public, private app) will be created in each AZ. Note that this must be less than or equal to the total number of AZs in a region. A value of null means all AZs should be used. For example, if you specify 3 in a region with 5 AZs, subnets will be created in just 3 AZs instead of all 5. Defaults to all AZs in a region.
 
-<a name="tenancy" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`tenancy`**](#tenancy) &mdash; The allowed tenancy of instances launched into the selected VPC. Must be one of: default, dedicated, or host.
+<HclListItem name="origin_vpc_cidr_block" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="use_managed_iam_policies" className="snap-top"></a>
+The CIDR block of the origin VPC.
 
-* [**`use_managed_iam_policies`**](#use_managed_iam_policies) &mdash; When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="vpc_custom_tags" className="snap-top"></a>
+<HclListItem name="origin_vpc_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`vpc_custom_tags`**](#vpc_custom_tags) &mdash; A map of tags to apply just to the VPC itself, but not any of the other resources. The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as [`custom_tags`](#custom_tags) in case of conflict.
+The ID of the origin VPC to use when creating peering connections and DNS forwarding.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="origin_vpc_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of the origin VPC to use when creating peering connections and DNS forwarding.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="origin_vpc_public_subnet_ids" requirement="optional" type="list">
+<HclListItemDescription>
+
+The public subnets in the origin VPC to use when creating route53 resolvers. These are public subnets due to network ACLs restrictions. Although the forwarder is addressable publicly, access is blocked by security groups.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="origin_vpc_resolver_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+Name to set for the origin VPC resolver (outbound from origin VPC to destination VPC). If null (default), defaults to 'ORIGIN_VPC_NAME-to-DESTINATION_VPC_NAME-out'.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="origin_vpc_route_table_ids" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of route tables from the origin VPC that should have routes to this app VPC.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="persistence_propagating_vgws" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of Virtual Private Gateways that will propagate routes to persistence subnets. All routes from VPN connections that use Virtual Private Gateways listed here will appear in route tables of persistence subnets. If left empty, no routes will be propagated.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="persistence_subnet_bits" requirement="optional" type="number">
+<HclListItemDescription>
+
+Takes the CIDR prefix and adds these many bits to it for calculating subnet ranges.  MAKE SURE if you change this you also change the CIDR spacing or you may hit errors.  See cidrsubnet interpolation in terraform config for more information.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="5"/>
+</HclListItem>
+
+<HclListItem name="persistence_subnet_spacing" requirement="optional" type="number">
+<HclListItemDescription>
+
+The amount of spacing between the private persistence subnets. Default: 2 times the value of private_subnet_spacing.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="private_app_allow_inbound_ports_from_cidr" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of unique names to client IP CIDR block and inbound ports that should be exposed in the private app subnet tier nACLs. This is useful when exposing your service on a privileged port with an NLB, where the address isn't translated.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(
+    object({
+      # The CIDR block of the client IP addresses for the service. Traffic will only be exposed to IP sources of this
+      # CIDR block.
+      client_cidr_block = string
+
+      # A rule number indicating priority. A lower number has precedence. Note that the default rules created by this
+      # module start with 100.
+      rule_number = number
+
+      # Network protocol (tcp, udp, icmp, or all) to expose.
+      protocol = string
+
+      # Range of ports to expose.
+      from_port = number
+      to_port   = number
+
+      # ICMP types to expose
+      # Required if specifying ICMP for the protocol
+      icmp_type = number
+      icmp_code = number
+    })
+  )
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="private_app_allow_outbound_ports_to_destination_cidr" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of unique names to destination IP CIDR block and outbound ports that should be allowed in the private app subnet tier nACLs. This is useful when allowing your VPC specific outbound communication to defined CIDR blocks(known networks)
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(
+    object({
+      # The destination CIDR block used for leaving VPC traffic. Traffic will be allowed only from VPC to destination CIDR block.
+      client_cidr_block = string
+
+      # A rule number indicating priority. A lower number has precedence. Note that the default rules created by this
+      # module start with 100.
+      rule_number = number
+
+      # Network protocol (tcp, udp, icmp, or all) to expose.
+      protocol = string
+
+      # Range of ports to expose.
+      from_port = number
+      to_port   = number
+
+      # ICMP types to expose
+      # Required if specifying ICMP for the protocol
+      icmp_type = number
+      icmp_code = number
+    })
+  )
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="private_app_subnet_cidr_blocks" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map listing the specific CIDR blocks desired for each private-app subnet. The key must be in the form AZ-0, AZ-1, ... AZ-n where n is the number of Availability Zones. If left blank, we will compute a reasonable CIDR block for each subnet.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="private_app_subnet_custom_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of tags to apply to the private-app Subnet, on top of the custom_tags. The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as custom_tags in case of conflict.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="private_persistence_subnet_cidr_blocks" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map listing the specific CIDR blocks desired for each private-persistence subnet. The key must be in the form AZ-0, AZ-1, ... AZ-n where n is the number of Availability Zones. If left blank, we will compute a reasonable CIDR block for each subnet.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="private_persistence_subnet_custom_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of tags to apply to the private-persistence Subnet, on top of the custom_tags. The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as custom_tags in case of conflict.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="private_propagating_vgws" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of Virtual Private Gateways that will propagate routes to private subnets. All routes from VPN connections that use Virtual Private Gateways listed here will appear in route tables of private subnets. If left empty, no routes will be propagated.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="private_subnet_bits" requirement="optional" type="number">
+<HclListItemDescription>
+
+Takes the CIDR prefix and adds these many bits to it for calculating subnet ranges.  MAKE SURE if you change this you also change the CIDR spacing or you may hit errors.  See cidrsubnet interpolation in terraform config for more information.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="5"/>
+</HclListItem>
+
+<HclListItem name="private_subnet_spacing" requirement="optional" type="number">
+<HclListItemDescription>
+
+The amount of spacing between private app subnets. Defaults to subnet_spacing in vpc-app module if not set.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="public_propagating_vgws" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of Virtual Private Gateways that will propagate routes to public subnets. All routes from VPN connections that use Virtual Private Gateways listed here will appear in route tables of public subnets. If left empty, no routes will be propagated.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="public_subnet_bits" requirement="optional" type="number">
+<HclListItemDescription>
+
+Takes the CIDR prefix and adds these many bits to it for calculating subnet ranges.  MAKE SURE if you change this you also change the CIDR spacing or you may hit errors.  See cidrsubnet interpolation in terraform config for more information.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="5"/>
+</HclListItem>
+
+<HclListItem name="public_subnet_cidr_blocks" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map listing the specific CIDR blocks desired for each public subnet. The key must be in the form AZ-0, AZ-1, ... AZ-n where n is the number of Availability Zones. If left blank, we will compute a reasonable CIDR block for each subnet.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="public_subnet_custom_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of tags to apply to the public Subnet, on top of the custom_tags. The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as custom_tags in case of conflict.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="security_group_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of tags to apply to the default Security Group, on top of the custom_tags. The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as custom_tags in case of conflict.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
+
+<HclListItem name="subnet_spacing" requirement="optional" type="number">
+<HclListItemDescription>
+
+The amount of spacing between the different subnet types
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="10"/>
+</HclListItem>
+
+<HclListItem name="tag_for_use_with_eks" requirement="optional" type="bool">
+<HclListItemDescription>
+
+The VPC resources need special tags for discoverability by Kubernetes to use with certain features, like deploying ALBs.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="tenancy" requirement="optional" type="string">
+<HclListItemDescription>
+
+The allowed tenancy of instances launched into the selected VPC. Must be one of: default, dedicated, or host.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="default"/>
+</HclListItem>
+
+<HclListItem name="use_managed_iam_policies" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="vpc_custom_tags" requirement="optional" type="map">
+<HclListItemDescription>
+
+A map of tags to apply just to the VPC itself, but not any of the other resources. The key is the tag name and the value is the tag value. Note that tags defined here will override tags defined as custom_tags in case of conflict.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+map(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="availability_zones" className="snap-top"></a>
+<HclListItem name="availability_zones">
+<HclListItemDescription>
 
-* [**`availability_zones`**](#availability_zones) &mdash; The availability zones of the VPC
+The availability zones of the VPC
 
-<a name="default_security_group_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`default_security_group_id`**](#default_security_group_id) &mdash; The ID of the default security group of this VPC.
+<HclListItem name="default_security_group_id">
+<HclListItemDescription>
 
-<a name="dynamodb_vpc_endpoint_id" className="snap-top"></a>
+The ID of the default security group of this VPC.
 
-* [**`dynamodb_vpc_endpoint_id`**](#dynamodb_vpc_endpoint_id) &mdash; 
+</HclListItemDescription>
+</HclListItem>
 
-<a name="nat_gateway_public_ip_count" className="snap-top"></a>
+<HclListItem name="dynamodb_vpc_endpoint_id">
+</HclListItem>
 
-* [**`nat_gateway_public_ip_count`**](#nat_gateway_public_ip_count) &mdash; Count of public IPs from the NAT Gateway
+<HclListItem name="nat_gateway_public_ip_count">
+<HclListItemDescription>
 
-<a name="nat_gateway_public_ips" className="snap-top"></a>
+Count of public IPs from the NAT Gateway
 
-* [**`nat_gateway_public_ips`**](#nat_gateway_public_ips) &mdash; A list of public IPs from the NAT Gateway
+</HclListItemDescription>
+</HclListItem>
 
-<a name="num_availability_zones" className="snap-top"></a>
+<HclListItem name="nat_gateway_public_ips">
+<HclListItemDescription>
 
-* [**`num_availability_zones`**](#num_availability_zones) &mdash; The number of availability zones of the VPC
+A list of public IPs from the NAT Gateway
 
-<a name="private_app_subnet_cidr_blocks" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`private_app_subnet_cidr_blocks`**](#private_app_subnet_cidr_blocks) &mdash; The private IP address range of the VPC in CIDR notation.
+<HclListItem name="num_availability_zones">
+<HclListItemDescription>
 
-<a name="private_app_subnet_ids" className="snap-top"></a>
+The number of availability zones of the VPC
 
-* [**`private_app_subnet_ids`**](#private_app_subnet_ids) &mdash; A list of IDs of the private app subnets in the VPC
+</HclListItemDescription>
+</HclListItem>
 
-<a name="private_app_subnet_route_table_ids" className="snap-top"></a>
+<HclListItem name="private_app_subnet_cidr_blocks">
+<HclListItemDescription>
 
-* [**`private_app_subnet_route_table_ids`**](#private_app_subnet_route_table_ids) &mdash; A list of IDs of the private app subnet routing table.
+The private IP address range of the VPC in CIDR notation.
 
-<a name="private_app_subnets" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`private_app_subnets`**](#private_app_subnets) &mdash; A map of all private-app subnets, with the subnet name as key, and all `aws-subnet` properties as the value.
+<HclListItem name="private_app_subnet_ids">
+<HclListItemDescription>
 
-<a name="private_app_subnets_network_acl_id" className="snap-top"></a>
+A list of IDs of the private app subnets in the VPC
 
-* [**`private_app_subnets_network_acl_id`**](#private_app_subnets_network_acl_id) &mdash; The ID of the private subnet's ACL
+</HclListItemDescription>
+</HclListItem>
 
-<a name="private_persistence_route_table_ids" className="snap-top"></a>
+<HclListItem name="private_app_subnet_route_table_ids">
+<HclListItemDescription>
 
-* [**`private_persistence_route_table_ids`**](#private_persistence_route_table_ids) &mdash; A list of IDs of the private persistence subnet routing table.
+A list of IDs of the private app subnet routing table.
 
-<a name="private_persistence_subnet_cidr_blocks" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`private_persistence_subnet_cidr_blocks`**](#private_persistence_subnet_cidr_blocks) &mdash; The private IP address range of the VPC Persistence tier in CIDR notation.
+<HclListItem name="private_app_subnets">
+<HclListItemDescription>
 
-<a name="private_persistence_subnet_ids" className="snap-top"></a>
+A map of all private-app subnets, with the subnet name as key, and all `aws-subnet` properties as the value.
 
-* [**`private_persistence_subnet_ids`**](#private_persistence_subnet_ids) &mdash; The IDs of the private persistence tier subnets of the VPC.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="private_persistence_subnets" className="snap-top"></a>
+<HclListItem name="private_app_subnets_network_acl_id">
+<HclListItemDescription>
 
-* [**`private_persistence_subnets`**](#private_persistence_subnets) &mdash; A map of all private-persistence subnets, with the subnet name as key, and all `aws-subnet` properties as the value.
+The ID of the private subnet's ACL
 
-<a name="private_persistence_subnets_network_acl_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`private_persistence_subnets_network_acl_id`**](#private_persistence_subnets_network_acl_id) &mdash; The ID of the private persistence subnet's ACL
+<HclListItem name="private_persistence_route_table_ids">
+<HclListItemDescription>
 
-<a name="public_subnet_cidr_blocks" className="snap-top"></a>
+A list of IDs of the private persistence subnet routing table.
 
-* [**`public_subnet_cidr_blocks`**](#public_subnet_cidr_blocks) &mdash; The public IP address range of the VPC in CIDR notation.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="public_subnet_ids" className="snap-top"></a>
+<HclListItem name="private_persistence_subnet_cidr_blocks">
+<HclListItemDescription>
 
-* [**`public_subnet_ids`**](#public_subnet_ids) &mdash; A list of IDs of the public subnets of the VPC.
+The private IP address range of the VPC Persistence tier in CIDR notation.
 
-<a name="public_subnet_route_table_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`public_subnet_route_table_id`**](#public_subnet_route_table_id) &mdash; The ID of the public routing table.
+<HclListItem name="private_persistence_subnet_ids">
+<HclListItemDescription>
 
-<a name="public_subnets" className="snap-top"></a>
+The IDs of the private persistence tier subnets of the VPC.
 
-* [**`public_subnets`**](#public_subnets) &mdash; A map of all public subnets, with the subnet name as key, and all `aws-subnet` properties as the value.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="public_subnets_network_acl_id" className="snap-top"></a>
+<HclListItem name="private_persistence_subnets">
+<HclListItemDescription>
 
-* [**`public_subnets_network_acl_id`**](#public_subnets_network_acl_id) &mdash; The ID of the public subnet's ACL
+A map of all private-persistence subnets, with the subnet name as key, and all `aws-subnet` properties as the value.
 
-<a name="s3_vpc_endpoint_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`s3_vpc_endpoint_id`**](#s3_vpc_endpoint_id) &mdash; 
+<HclListItem name="private_persistence_subnets_network_acl_id">
+<HclListItemDescription>
 
-<a name="vpc_cidr_block" className="snap-top"></a>
+The ID of the private persistence subnet's ACL
 
-* [**`vpc_cidr_block`**](#vpc_cidr_block) &mdash; The IP address range of the VPC in CIDR notation.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="vpc_id" className="snap-top"></a>
+<HclListItem name="public_subnet_cidr_blocks">
+<HclListItemDescription>
 
-* [**`vpc_id`**](#vpc_id) &mdash; The ID of the VPC.
+The public IP address range of the VPC in CIDR notation.
 
-<a name="vpc_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`vpc_name`**](#vpc_name) &mdash; The name configured for VPC.
+<HclListItem name="public_subnet_ids">
+<HclListItemDescription>
 
-<a name="vpc_ready" className="snap-top"></a>
+A list of IDs of the public subnets of the VPC.
 
-* [**`vpc_ready`**](#vpc_ready) &mdash; Indicates whether or not the VPC has finished creating
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="public_subnet_route_table_id">
+<HclListItemDescription>
+
+The ID of the public routing table.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="public_subnets">
+<HclListItemDescription>
+
+A map of all public subnets, with the subnet name as key, and all `aws-subnet` properties as the value.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="public_subnets_network_acl_id">
+<HclListItemDescription>
+
+The ID of the public subnet's ACL
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="s3_vpc_endpoint_id">
+</HclListItem>
+
+<HclListItem name="vpc_cidr_block">
+<HclListItemDescription>
+
+The IP address range of the VPC in CIDR notation.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="vpc_id">
+<HclListItemDescription>
+
+The ID of the VPC.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="vpc_name">
+<HclListItemDescription>
+
+The name configured for VPC.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="vpc_ready">
+<HclListItemDescription>
+
+Indicates whether or not the VPC has finished creating
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"e0013955efebacbffaccab50ec2d48ae"}
+{"sourcePlugin":"service-catalog-api","hash":"51f571582e21a3df9ee4f4a09cb96c8c"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/security/bastion.md
+++ b/docs/reference/services/security/bastion.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.84.4"/>
 
@@ -108,163 +109,401 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="allow_ssh_from_cidr_list" className="snap-top"></a>
+<HclListItem name="allow_ssh_from_cidr_list" requirement="required" type="list">
+<HclListItemDescription>
 
-* [**`allow_ssh_from_cidr_list`**](#allow_ssh_from_cidr_list) &mdash; A list of IP address ranges in CIDR format from which SSH access will be permitted. Attempts to access the bastion host from all other IP addresses will be blocked. This is only used if [`allow_ssh_from_cidr`](#allow_ssh_from_cidr) is true.
+A list of IP address ranges in CIDR format from which SSH access will be permitted. Attempts to access the bastion host from all other IP addresses will be blocked. This is only used if <a href="#allow_ssh_from_cidr"><code>allow_ssh_from_cidr</code></a> is true.
 
-<a name="ami" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`ami`**](#ami) &mdash; The AMI to run on the bastion host. This should be built from the Packer template under bastion-host.json. One of var.ami or [`ami_filters`](#ami_filters) is required. Set to null if looking up the ami with filters.
+```hcl
+list(string)
+```
 
-<a name="ami_filters" className="snap-top"></a>
+</HclListItemTypeDetails>
+</HclListItem>
 
-* [**`ami_filters`**](#ami_filters) &mdash; Properties on the AMI that can be used to lookup a prebuilt AMI for use with the Bastion Host. You can build the AMI using the Packer template bastion-host.json. Only used if var.ami is null. One of var.ami or [`ami_filters`](#ami_filters) is required. Set to null if passing the ami ID directly.
+<HclListItem name="ami" requirement="required" type="string">
+<HclListItemDescription>
 
-<a name="subnet_id" className="snap-top"></a>
+The AMI to run on the bastion host. This should be built from the Packer template under bastion-host.json. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if looking up the ami with filters.
 
-* [**`subnet_id`**](#subnet_id) &mdash; The ID of the subnet in which to deploy the bastion. Must be a subnet in [`vpc_id`](#vpc_id).
+</HclListItemDescription>
+</HclListItem>
 
-<a name="vpc_id" className="snap-top"></a>
+<HclListItem name="ami_filters" requirement="required" type="object">
+<HclListItemDescription>
 
-* [**`vpc_id`**](#vpc_id) &mdash; The ID of the VPC in which to deploy the bastion.
+Properties on the AMI that can be used to lookup a prebuilt AMI for use with the Bastion Host. You can build the AMI using the Packer template bastion-host.json. Only used if var.ami is null. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if passing the ami ID directly.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+object({
+    # List of owners to limit the search. Set to null if you do not wish to limit the search by AMI owners.
+    owners = list(string)
+
+    # Name/Value pairs to filter the AMI off of. There are several valid keys, for a full reference, check out the
+    # documentation for describe-images in the AWS CLI reference
+    # (https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html).
+    filters = list(object({
+      name   = string
+      values = list(string)
+    }))
+  })
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="subnet_id" requirement="required" type="string">
+<HclListItemDescription>
+
+The ID of the subnet in which to deploy the bastion. Must be a subnet in <a href="#vpc_id"><code>vpc_id</code></a>.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="vpc_id" requirement="required" type="string">
+<HclListItemDescription>
+
+The ID of the VPC in which to deploy the bastion.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="additional_security_group_ids" className="snap-top"></a>
+<HclListItem name="additional_security_group_ids" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`additional_security_group_ids`**](#additional_security_group_ids) &mdash; A list of optional additional security group ids to assign to the bastion server.
+A list of optional additional security group ids to assign to the bastion server.
 
-<a name="alarms_sns_topic_arn" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`alarms_sns_topic_arn`**](#alarms_sns_topic_arn) &mdash; The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications.
+```hcl
+list(string)
+```
 
-<a name="base_domain_name_tags" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`base_domain_name_tags`**](#base_domain_name_tags) &mdash; Tags to use to filter the Route 53 Hosted Zones that might match the hosted zone's name (use if you have multiple public hosted zones with the same name)
+<HclListItem name="alarms_sns_topic_arn" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="cloud_init_parts" className="snap-top"></a>
+The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications.
 
-* [**`cloud_init_parts`**](#cloud_init_parts) &mdash; Cloud init scripts to run on the bastion host while it boots. See the part blocks in [`https://www.terraform.io/docs/providers/template/d/cloudinit_config`](#https://www.terraform.io/docs/providers/template/d/cloudinit_config).html for syntax.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="cloudwatch_log_group_kms_key_id" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`cloudwatch_log_group_kms_key_id`**](#cloudwatch_log_group_kms_key_id) &mdash; The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="cloudwatch_log_group_retention_in_days" className="snap-top"></a>
+<HclListItem name="base_domain_name_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`cloudwatch_log_group_retention_in_days`**](#cloudwatch_log_group_retention_in_days) &mdash; The number of days to retain log events in the log group. Refer to [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days) for all the valid values. When null, the log events are retained forever.
+Tags to use to filter the Route 53 Hosted Zones that might match the hosted zone's name (use if you have multiple public hosted zones with the same name)
 
-<a name="cloudwatch_log_group_tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`cloudwatch_log_group_tags`**](#cloudwatch_log_group_tags) &mdash; Tags to apply on the CloudWatch Log Group, encoded as a map where the keys are tag keys and values are tag values.
+```hcl
+map(string)
+```
 
-<a name="create_dns_record" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`create_dns_record`**](#create_dns_record) &mdash; Set to true to create a DNS record in Route53 pointing to the bastion. If true, be sure to set [`domain_name`](#domain_name).
+<HclListItem name="cloud_init_parts" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="default_user" className="snap-top"></a>
+Cloud init scripts to run on the bastion host while it boots. See the part blocks in https://www.terraform.io/docs/providers/template/d/cloudinit_config.html for syntax.
 
-* [**`default_user`**](#default_user) &mdash; The default OS user for the Bastion Host AMI. For AWS Ubuntu AMIs, which is what the Packer template in bastion-host.json uses, the default OS user is 'ubuntu'.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="domain_name" className="snap-top"></a>
+```hcl
+map(object({
+    filename     = string
+    content_type = string
+    content      = string
+  }))
+```
 
-* [**`domain_name`**](#domain_name) &mdash; The apex domain of the hostname for the bastion server (e.g., example.com). The complete hostname for the bastion server will be [`name.var.domain_name`](#name.var.domain_name) (e.g., bastion.example.com). Only used if [`create_dns_record`](#create_dns_record) is true.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="ebs_optimized" className="snap-top"></a>
+<HclListItem name="cloudwatch_log_group_kms_key_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`ebs_optimized`**](#ebs_optimized) &mdash; If true, the launched EC2 Instance will be EBS-optimized.
+The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data.
 
-<a name="enable_cloudwatch_alarms" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`enable_cloudwatch_alarms`**](#enable_cloudwatch_alarms) &mdash; Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using [`alarms_sns_topic_arn`](#alarms_sns_topic_arn).
+<HclListItem name="cloudwatch_log_group_retention_in_days" requirement="optional" type="number">
+<HclListItemDescription>
 
-<a name="enable_cloudwatch_log_aggregation" className="snap-top"></a>
+The number of days to retain log events in the log group. Refer to https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days for all the valid values. When null, the log events are retained forever.
 
-* [**`enable_cloudwatch_log_aggregation`**](#enable_cloudwatch_log_aggregation) &mdash; Set to true to send logs to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/logs/cloudwatch-log-aggregation-scripts to do log aggregation in CloudWatch.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="enable_cloudwatch_metrics" className="snap-top"></a>
+<HclListItem name="cloudwatch_log_group_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`enable_cloudwatch_metrics`**](#enable_cloudwatch_metrics) &mdash; Set to true to add IAM permissions to send custom metrics to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/agents/cloudwatch-agent to get memory and disk metrics in CloudWatch for your Bastion host.
+Tags to apply on the CloudWatch Log Group, encoded as a map where the keys are tag keys and values are tag values.
 
-<a name="enable_fail2ban" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`enable_fail2ban`**](#enable_fail2ban) &mdash; Enable fail2ban to block brute force log in attempts. Defaults to true.
+```hcl
+map(string)
+```
 
-<a name="enable_ip_lockdown" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`enable_ip_lockdown`**](#enable_ip_lockdown) &mdash; Enable ip-lockdown to block access to the instance metadata. Defaults to true.
+<HclListItem name="create_dns_record" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="enable_ssh_grunt" className="snap-top"></a>
+Set to true to create a DNS record in Route53 pointing to the bastion. If true, be sure to set <a href="#domain_name"><code>domain_name</code></a>.
 
-* [**`enable_ssh_grunt`**](#enable_ssh_grunt) &mdash; Set to true to add IAM permissions for ssh-grunt (https://github.com/gruntwork-io/terraform-aws-security/tree/master/modules/ssh-grunt), which will allow you to manage SSH access via IAM groups.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="external_account_ssh_grunt_role_arn" className="snap-top"></a>
+<HclListItem name="default_user" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`external_account_ssh_grunt_role_arn`**](#external_account_ssh_grunt_role_arn) &mdash; If you are using ssh-grunt and your IAM users / groups are defined in a separate AWS account, you can use this variable to specify the ARN of an IAM role that ssh-grunt can assume to retrieve IAM group and public SSH key info from that account. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+The default OS user for the Bastion Host AMI. For AWS Ubuntu AMIs, which is what the Packer template in bastion-host.json uses, the default OS user is 'ubuntu'.
 
-<a name="instance_type" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ubuntu"/>
+</HclListItem>
 
-* [**`instance_type`**](#instance_type) &mdash; The type of instance to run for the bastion host
+<HclListItem name="domain_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="keypair_name" className="snap-top"></a>
+The apex domain of the hostname for the bastion server (e.g., example.com). The complete hostname for the bastion server will be var.name.<a href="#domain_name"><code>domain_name</code></a> (e.g., bastion.example.com). Only used if create_dns_record is true.
 
-* [**`keypair_name`**](#keypair_name) &mdash; The name of a Key Pair that can be used to SSH to this instance.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
 
-<a name="name" className="snap-top"></a>
+<HclListItem name="ebs_optimized" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`name`**](#name) &mdash; The name of the bastion host and the other resources created by these templates
+If true, the launched EC2 Instance will be EBS-optimized.
 
-<a name="should_create_cloudwatch_log_group" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`should_create_cloudwatch_log_group`**](#should_create_cloudwatch_log_group) &mdash; When true, precreate the CloudWatch Log Group to use for log aggregation from the EC2 instances. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, the CloudWatch agent will automatically create a basic log group to use.
+<HclListItem name="enable_cloudwatch_alarms" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="ssh_grunt_iam_group" className="snap-top"></a>
+Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using <a href="#alarms_sns_topic_arn"><code>alarms_sns_topic_arn</code></a>.
 
-* [**`ssh_grunt_iam_group`**](#ssh_grunt_iam_group) &mdash; If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to this Bastion Host. This value is only used if [`enable_ssh_grunt`](#enable_ssh_grunt)=true.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="ssh_grunt_iam_group_sudo" className="snap-top"></a>
+<HclListItem name="enable_cloudwatch_log_aggregation" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`ssh_grunt_iam_group_sudo`**](#ssh_grunt_iam_group_sudo) &mdash; If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to this Bastion Host with sudo permissions. This value is only used if [`enable_ssh_grunt`](#enable_ssh_grunt)=true.
+Set to true to send logs to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/logs/cloudwatch-log-aggregation-scripts to do log aggregation in CloudWatch.
 
-<a name="tenancy" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`tenancy`**](#tenancy) &mdash; The tenancy of this server. Must be one of: default, dedicated, or host.
+<HclListItem name="enable_cloudwatch_metrics" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="use_managed_iam_policies" className="snap-top"></a>
+Set to true to add IAM permissions to send custom metrics to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/agents/cloudwatch-agent to get memory and disk metrics in CloudWatch for your Bastion host.
 
-* [**`use_managed_iam_policies`**](#use_managed_iam_policies) &mdash; When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_fail2ban" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Enable fail2ban to block brute force log in attempts. Defaults to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_ip_lockdown" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Enable ip-lockdown to block access to the instance metadata. Defaults to true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_ssh_grunt" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to add IAM permissions for ssh-grunt (https://github.com/gruntwork-io/terraform-aws-security/tree/master/modules/ssh-grunt), which will allow you to manage SSH access via IAM groups.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="external_account_ssh_grunt_role_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt and your IAM users / groups are defined in a separate AWS account, you can use this variable to specify the ARN of an IAM role that ssh-grunt can assume to retrieve IAM group and public SSH key info from that account. To omit this variable, set it to an empty string (do NOT use null, or Terraform will complain).
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="instance_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+The type of instance to run for the bastion host
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="t3.micro"/>
+</HclListItem>
+
+<HclListItem name="keypair_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of a Key Pair that can be used to SSH to this instance.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of the bastion host and the other resources created by these templates
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="bastion-host"/>
+</HclListItem>
+
+<HclListItem name="should_create_cloudwatch_log_group" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, precreate the CloudWatch Log Group to use for log aggregation from the EC2 instances. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, the CloudWatch agent will automatically create a basic log group to use.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="ssh_grunt_iam_group" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to this Bastion Host. This value is only used if enable_ssh_grunt=true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ssh-grunt-users"/>
+</HclListItem>
+
+<HclListItem name="ssh_grunt_iam_group_sudo" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to this Bastion Host with sudo permissions. This value is only used if enable_ssh_grunt=true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ssh-grunt-sudo-users"/>
+</HclListItem>
+
+<HclListItem name="tenancy" requirement="optional" type="string">
+<HclListItemDescription>
+
+The tenancy of this server. Must be one of: default, dedicated, or host.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="default"/>
+</HclListItem>
+
+<HclListItem name="use_managed_iam_policies" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="bastion_host_iam_role_arn" className="snap-top"></a>
+<HclListItem name="bastion_host_iam_role_arn">
+<HclListItemDescription>
 
-* [**`bastion_host_iam_role_arn`**](#bastion_host_iam_role_arn) &mdash; The ARN of the bastion host's IAM role.
+The ARN of the bastion host's IAM role.
 
-<a name="bastion_host_instance_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`bastion_host_instance_id`**](#bastion_host_instance_id) &mdash; The EC2 instance ID of the bastion host.
+<HclListItem name="bastion_host_instance_id">
+<HclListItemDescription>
 
-<a name="bastion_host_private_ip" className="snap-top"></a>
+The EC2 instance ID of the bastion host.
 
-* [**`bastion_host_private_ip`**](#bastion_host_private_ip) &mdash; The private IP address of the bastion host.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="bastion_host_public_ip" className="snap-top"></a>
+<HclListItem name="bastion_host_private_ip">
+<HclListItemDescription>
 
-* [**`bastion_host_public_ip`**](#bastion_host_public_ip) &mdash; The public IP address of the bastion host.
+The private IP address of the bastion host.
 
-<a name="bastion_host_security_group_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`bastion_host_security_group_id`**](#bastion_host_security_group_id) &mdash; The ID of the bastion hosts's security group.
+<HclListItem name="bastion_host_public_ip">
+<HclListItemDescription>
 
-<a name="dns_name" className="snap-top"></a>
+The public IP address of the bastion host.
 
-* [**`dns_name`**](#dns_name) &mdash; The fully qualified name of the bastion host.
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="bastion_host_security_group_id">
+<HclListItemDescription>
+
+The ID of the bastion hosts's security group.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="dns_name">
+<HclListItemDescription>
+
+The fully qualified name of the bastion host.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"3250b3fd97ef7d7e8738e0da6971736a"}
+{"sourcePlugin":"service-catalog-api","hash":"2e68569b512ec885db54839608723236"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/security/open-vpn.md
+++ b/docs/reference/services/security/open-vpn.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.84.4"/>
 
@@ -95,271 +96,710 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Required
 
-<a name="allow_vpn_from_cidr_list" className="snap-top"></a>
+<HclListItem name="allow_vpn_from_cidr_list" requirement="required" type="list">
+<HclListItemDescription>
 
-* [**`allow_vpn_from_cidr_list`**](#allow_vpn_from_cidr_list) &mdash; A list of IP address ranges in CIDR format from which VPN access will be permitted. Attempts to access the OpenVPN Server from all other IP addresses will be blocked.
+A list of IP address ranges in CIDR format from which VPN access will be permitted. Attempts to access the OpenVPN Server from all other IP addresses will be blocked.
 
-<a name="ami" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`ami`**](#ami) &mdash; The AMI to run on the OpenVPN Server. This should be built from the Packer template under openvpn-server.json. One of var.ami or [`ami_filters`](#ami_filters) is required. Set to null if looking up the ami with filters.
+```hcl
+list(string)
+```
 
-<a name="ami_filters" className="snap-top"></a>
+</HclListItemTypeDetails>
+</HclListItem>
 
-* [**`ami_filters`**](#ami_filters) &mdash; Properties on the AMI that can be used to lookup a prebuilt AMI for use with the OpenVPN server. You can build the AMI using the Packer template openvpn-server.json. Only used if var.ami is null. One of var.ami or [`ami_filters`](#ami_filters) is required. Set to null if passing the ami ID directly.
+<HclListItem name="ami" requirement="required" type="string">
+<HclListItemDescription>
 
-<a name="backup_bucket_name" className="snap-top"></a>
+The AMI to run on the OpenVPN Server. This should be built from the Packer template under openvpn-server.json. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if looking up the ami with filters.
 
-* [**`backup_bucket_name`**](#backup_bucket_name) &mdash; The name of the S3 bucket that will be used to backup PKI secrets. This is a required variable because bucket names must be globally unique across all AWS customers.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="ca_cert_fields" className="snap-top"></a>
+<HclListItem name="ami_filters" requirement="required" type="object">
+<HclListItemDescription>
 
-* [**`ca_cert_fields`**](#ca_cert_fields) &mdash; An object with fields for the country, state, locality, organization, organizational unit, and email address to use with the OpenVPN CA certificate.
+Properties on the AMI that can be used to lookup a prebuilt AMI for use with the OpenVPN server. You can build the AMI using the Packer template openvpn-server.json. Only used if var.ami is null. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if passing the ami ID directly.
 
-<a name="subnet_ids" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`subnet_ids`**](#subnet_ids) &mdash; The ids of the subnets where this server should be deployed.
+```hcl
+object({
+    # List of owners to limit the search. Set to null if you do not wish to limit the search by AMI owners.
+    owners = list(string)
 
-<a name="vpc_id" className="snap-top"></a>
+    # Name/Value pairs to filter the AMI off of. There are several valid keys, for a full reference, check out the
+    # documentation for describe-images in the AWS CLI reference
+    # (https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html).
+    filters = list(object({
+      name   = string
+      values = list(string)
+    }))
+  })
+```
 
-* [**`vpc_id`**](#vpc_id) &mdash; The ID of the VPC in which to deploy the OpenVPN server.
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="backup_bucket_name" requirement="required" type="string">
+<HclListItemDescription>
+
+The name of the S3 bucket that will be used to backup PKI secrets. This is a required variable because bucket names must be globally unique across all AWS customers.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="ca_cert_fields" requirement="required" type="object">
+<HclListItemDescription>
+
+An object with fields for the country, state, locality, organization, organizational unit, and email address to use with the OpenVPN CA certificate.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+object({
+    ca_country  = string
+    ca_state    = string
+    ca_locality = string
+    ca_org      = string
+    ca_org_unit = string
+    ca_email    = string
+  })
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="subnet_ids" requirement="required" type="list">
+<HclListItemDescription>
+
+The ids of the subnets where this server should be deployed.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+</HclListItem>
+
+<HclListItem name="vpc_id" requirement="required" type="string">
+<HclListItemDescription>
+
+The ID of the VPC in which to deploy the OpenVPN server.
+
+</HclListItemDescription>
+</HclListItem>
 
 ### Optional
 
-<a name="alarms_sns_topic_arn" className="snap-top"></a>
+<HclListItem name="alarms_sns_topic_arn" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`alarms_sns_topic_arn`**](#alarms_sns_topic_arn) &mdash; The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications.
+The ARNs of SNS topics where CloudWatch alarms (e.g., for CPU, memory, and disk space usage) should send notifications.
 
-<a name="allow_manage_key_permissions_with_iam" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`allow_manage_key_permissions_with_iam`**](#allow_manage_key_permissions_with_iam) &mdash; If true, both the CMK's Key Policy and IAM Policies (permissions) can be used to grant permissions on the CMK. If false, only the CMK's Key Policy can be used to grant permissions on the CMK. False is more secure (and generally preferred), but true is more flexible and convenient.
+```hcl
+list(string)
+```
 
-<a name="allow_ssh_from_cidr_list" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`allow_ssh_from_cidr_list`**](#allow_ssh_from_cidr_list) &mdash; The IP address ranges in CIDR format from which to allow incoming SSH requests to the OpenVPN server.
+<HclListItem name="allow_manage_key_permissions_with_iam" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="allow_ssh_from_security_group_ids" className="snap-top"></a>
+If true, both the CMK's Key Policy and IAM Policies (permissions) can be used to grant permissions on the CMK. If false, only the CMK's Key Policy can be used to grant permissions on the CMK. False is more secure (and generally preferred), but true is more flexible and convenient.
 
-* [**`allow_ssh_from_security_group_ids`**](#allow_ssh_from_security_group_ids) &mdash; The IDs of security groups from which to allow incoming SSH requests to the OpenVPN server.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="base_domain_name" className="snap-top"></a>
+<HclListItem name="allow_ssh_from_cidr_list" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`base_domain_name`**](#base_domain_name) &mdash; The base domain name to use for the OpenVPN server. Used to lookup the Hosted Zone ID to use for creating the Route 53 domain entry. Only used if [`create_route53_entry`](#create_route53_entry) is true.
+The IP address ranges in CIDR format from which to allow incoming SSH requests to the OpenVPN server.
 
-<a name="base_domain_name_tags" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`base_domain_name_tags`**](#base_domain_name_tags) &mdash; Tags to use to filter the Route 53 Hosted Zones that might match [`domain_name`](#domain_name).
+```hcl
+list(string)
+```
 
-<a name="cloud_init_parts" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`cloud_init_parts`**](#cloud_init_parts) &mdash; Cloud init scripts to run on the OpenVPN server while it boots. See the part blocks in [`https://www.terraform.io/docs/providers/template/d/cloudinit_config`](#https://www.terraform.io/docs/providers/template/d/cloudinit_config).html for syntax.
+<HclListItem name="allow_ssh_from_security_group_ids" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="cloudwatch_log_group_kms_key_id" className="snap-top"></a>
+The IDs of security groups from which to allow incoming SSH requests to the OpenVPN server.
 
-* [**`cloudwatch_log_group_kms_key_id`**](#cloudwatch_log_group_kms_key_id) &mdash; The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="cloudwatch_log_group_retention_in_days" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`cloudwatch_log_group_retention_in_days`**](#cloudwatch_log_group_retention_in_days) &mdash; The number of days to retain log events in the log group. Refer to [`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days`](#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days) for all the valid values. When null, the log events are retained forever.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="cloudwatch_log_group_tags" className="snap-top"></a>
+<HclListItem name="base_domain_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`cloudwatch_log_group_tags`**](#cloudwatch_log_group_tags) &mdash; Tags to apply on the CloudWatch Log Group, encoded as a map where the keys are tag keys and values are tag values.
+The base domain name to use for the OpenVPN server. Used to lookup the Hosted Zone ID to use for creating the Route 53 domain entry. Only used if <a href="#create_route53_entry"><code>create_route53_entry</code></a> is true.
 
-<a name="cmk_administrator_iam_arns" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`cmk_administrator_iam_arns`**](#cmk_administrator_iam_arns) &mdash; A list of IAM ARNs for users who should be given administrator access to this CMK (e.g. arn:aws:iam::&lt;aws-account-id>:user/&lt;iam-user-arn>). If this list is empty, and [`kms_key_arn`](#kms_key_arn) is null, the ARN of the current user will be used.
+<HclListItem name="base_domain_name_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="cmk_external_user_iam_arns" className="snap-top"></a>
+Tags to use to filter the Route 53 Hosted Zones that might match <a href="#domain_name"><code>domain_name</code></a>.
 
-* [**`cmk_external_user_iam_arns`**](#cmk_external_user_iam_arns) &mdash; A list of IAM ARNs for users from external AWS accounts who should be given permissions to use this CMK (e.g. arn:aws:iam::&lt;aws-account-id>:root).
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="cmk_user_iam_arns" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`cmk_user_iam_arns`**](#cmk_user_iam_arns) &mdash; A list of IAM ARNs for users who should be given permissions to use this KMS Master Key (e.g. arn:aws:iam::1234567890:user/foo).
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-<a name="create_route53_entry" className="snap-top"></a>
+<HclListItem name="cloud_init_parts" requirement="optional" type="map">
+<HclListItemDescription>
 
-* [**`create_route53_entry`**](#create_route53_entry) &mdash; Set to true to add [`domain_name`](#domain_name) as a Route 53 DNS A record for the OpenVPN server
+Cloud init scripts to run on the OpenVPN server while it boots. See the part blocks in https://www.terraform.io/docs/providers/template/d/cloudinit_config.html for syntax.
 
-<a name="default_user" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`default_user`**](#default_user) &mdash; The default OS user for the OpenVPN AMI. For AWS Ubuntu AMIs, which is what the Packer template in openvpn-server.json uses, the default OS user is 'ubuntu'.
+```hcl
+map(object({
+    filename     = string
+    content_type = string
+    content      = string
+  }))
+```
 
-<a name="domain_name" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="{}"/>
+</HclListItem>
 
-* [**`domain_name`**](#domain_name) &mdash; The domain name to use for the OpenVPN server. Only used if [`create_route53_entry`](#create_route53_entry) is true. If null, set to [`&lt;NAME>.&lt;BASE_DOMAIN_NAME`](#&lt;NAME>.&lt;BASE_DOMAIN_NAME)>.
+<HclListItem name="cloudwatch_log_group_kms_key_id" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="ebs_optimized" className="snap-top"></a>
+The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypting log data.
 
-* [**`ebs_optimized`**](#ebs_optimized) &mdash; If true, the launched EC2 instance will be EBS-optimized. Note that for most instance types, EBS optimization does not incur additional cost, and that many newer EC2 instance types have EBS optimization enabled by default. However, if you are running previous generation instances, there may be an additional cost per hour to run your instances with EBS optimization enabled. Please see: [`https://aws.amazon.com/ec2/pricing/on-demand/#EBS-Optimized_Instances`](#https://aws.amazon.com/ec2/pricing/on-demand/#EBS-Optimized_Instances)
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="enable_cloudwatch_alarms" className="snap-top"></a>
+<HclListItem name="cloudwatch_log_group_retention_in_days" requirement="optional" type="number">
+<HclListItemDescription>
 
-* [**`enable_cloudwatch_alarms`**](#enable_cloudwatch_alarms) &mdash; Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using [`alarms_sns_topic_arn`](#alarms_sns_topic_arn).
+The number of days to retain log events in the log group. Refer to https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#retention_in_days for all the valid values. When null, the log events are retained forever.
 
-<a name="enable_cloudwatch_log_aggregation" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-* [**`enable_cloudwatch_log_aggregation`**](#enable_cloudwatch_log_aggregation) &mdash; Set to true to send logs to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/logs/cloudwatch-log-aggregation-scripts to do log aggregation in CloudWatch.
+<HclListItem name="cloudwatch_log_group_tags" requirement="optional" type="map">
+<HclListItemDescription>
 
-<a name="enable_cloudwatch_metrics" className="snap-top"></a>
+Tags to apply on the CloudWatch Log Group, encoded as a map where the keys are tag keys and values are tag values.
 
-* [**`enable_cloudwatch_metrics`**](#enable_cloudwatch_metrics) &mdash; Set to true to add IAM permissions to send custom metrics to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/agents/cloudwatch-agent to get memory and disk metrics in CloudWatch for your OpenVPN server.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="enable_fail2ban" className="snap-top"></a>
+```hcl
+map(string)
+```
 
-* [**`enable_fail2ban`**](#enable_fail2ban) &mdash; Enable fail2ban to block brute force log in attempts. Defaults to true.
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="enable_ip_lockdown" className="snap-top"></a>
+<HclListItem name="cmk_administrator_iam_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`enable_ip_lockdown`**](#enable_ip_lockdown) &mdash; Enable ip-lockdown to block access to the instance metadata. Defaults to true.
+A list of IAM ARNs for users who should be given administrator access to this CMK (e.g. arn:aws:iam::&lt;aws-account-id>:user/&lt;iam-user-arn>). If this list is empty, and <a href="#kms_key_arn"><code>kms_key_arn</code></a> is null, the ARN of the current user will be used.
 
-<a name="enable_ssh_grunt" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`enable_ssh_grunt`**](#enable_ssh_grunt) &mdash; Set to true to add IAM permissions for ssh-grunt (https://github.com/gruntwork-io/terraform-aws-security/tree/master/modules/ssh-grunt), which will allow you to manage SSH access via IAM groups.
+```hcl
+list(string)
+```
 
-<a name="external_account_arns" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`external_account_arns`**](#external_account_arns) &mdash; The ARNs of external AWS accounts where your IAM users are defined. This module will create IAM roles that users in those accounts will be able to assume to get access to the request/revocation SQS queues.
+<HclListItem name="cmk_external_user_iam_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-<a name="external_account_ssh_grunt_role_arn" className="snap-top"></a>
+A list of IAM ARNs for users from external AWS accounts who should be given permissions to use this CMK (e.g. arn:aws:iam::&lt;aws-account-id>:root).
 
-* [**`external_account_ssh_grunt_role_arn`**](#external_account_ssh_grunt_role_arn) &mdash; Since our IAM users are defined in a separate AWS account, this variable is used to specify the ARN of an IAM role that allows ssh-grunt to retrieve IAM group and public SSH key info from that account.
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-<a name="force_destroy" className="snap-top"></a>
+```hcl
+list(string)
+```
 
-* [**`force_destroy`**](#force_destroy) &mdash; When a terraform destroy is run, should the backup s3 bucket be destroyed even if it contains files. Should only be set to true for testing/development
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-<a name="hosted_zone_id" className="snap-top"></a>
+<HclListItem name="cmk_user_iam_arns" requirement="optional" type="list">
+<HclListItemDescription>
 
-* [**`hosted_zone_id`**](#hosted_zone_id) &mdash; The ID of the Route 53 Hosted Zone in which the domain should be created. Only used if [`create_route53_entry`](#create_route53_entry) is true. If null, lookup the hosted zone ID using the [`base_domain_name`](#base_domain_name).
+A list of IAM ARNs for users who should be given permissions to use this KMS Master Key (e.g. arn:aws:iam::1234567890:user/foo).
 
-<a name="instance_type" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemTypeDetails>
 
-* [**`instance_type`**](#instance_type) &mdash; The type of instance to run for the OpenVPN Server
+```hcl
+list(object({
+    name = list(string)
+    conditions = list(object({
+      test     = string
+      variable = string
+      values   = list(string)
+    }))
+  }))
+```
 
-<a name="keypair_name" className="snap-top"></a>
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
 
-* [**`keypair_name`**](#keypair_name) &mdash; The name of a Key Pair that can be used to SSH to this instance. Leave blank if you don't want to enable Key Pair auth.
+<HclListItem name="create_route53_entry" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="kms_key_arn" className="snap-top"></a>
+Set to true to add <a href="#domain_name"><code>domain_name</code></a> as a Route 53 DNS A record for the OpenVPN server
 
-* [**`kms_key_arn`**](#kms_key_arn) &mdash; The Amazon Resource Name (ARN) of an existing KMS customer master key (CMK) that will be used to encrypt/decrypt backup files. If null, a key will be created with permissions assigned by the following variables: [`cmk_administrator_iam_arns`](#cmk_administrator_iam_arns), [`cmk_user_iam_arns`](#cmk_user_iam_arns), [`cmk_external_user_iam_arns`](#cmk_external_user_iam_arns), [`allow_manage_key_permissions`](#allow_manage_key_permissions).
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
 
-<a name="name" className="snap-top"></a>
+<HclListItem name="default_user" requirement="optional" type="string">
+<HclListItemDescription>
 
-* [**`name`**](#name) &mdash; The name of the OpenVPN Server and the other resources created by these templates
+The default OS user for the OpenVPN AMI. For AWS Ubuntu AMIs, which is what the Packer template in openvpn-server.json uses, the default OS user is 'ubuntu'.
 
-<a name="request_queue_name" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ubuntu"/>
+</HclListItem>
 
-* [**`request_queue_name`**](#request_queue_name) &mdash; The name of the sqs queue that will be used to receive new certificate requests.
+<HclListItem name="domain_name" requirement="optional" type="string">
+<HclListItemDescription>
 
-<a name="revocation_queue_name" className="snap-top"></a>
+The domain name to use for the OpenVPN server. Only used if <a href="#create_route53_entry"><code>create_route53_entry</code></a> is true. If null, set to &lt;NAME>.&lt;BASE_DOMAIN_NAME>.
 
-* [**`revocation_queue_name`**](#revocation_queue_name) &mdash; The name of the sqs queue that will be used to receive certification revocation requests. Note that the queue name will be automatically prefixed with 'openvpn-requests-'.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
 
-<a name="should_create_cloudwatch_log_group" className="snap-top"></a>
+<HclListItem name="ebs_optimized" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`should_create_cloudwatch_log_group`**](#should_create_cloudwatch_log_group) &mdash; When true, precreate the CloudWatch Log Group to use for log aggregation from the EC2 instances. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, the CloudWatch agent will automatically create a basic log group to use.
+If true, the launched EC2 instance will be EBS-optimized. Note that for most instance types, EBS optimization does not incur additional cost, and that many newer EC2 instance types have EBS optimization enabled by default. However, if you are running previous generation instances, there may be an additional cost per hour to run your instances with EBS optimization enabled. Please see: https://aws.amazon.com/ec2/pricing/on-demand/#EBS-Optimized_Instances
 
-<a name="ssh_grunt_iam_group" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`ssh_grunt_iam_group`**](#ssh_grunt_iam_group) &mdash; If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to this OpenVPN server. This value is only used if [`enable_ssh_grunt`](#enable_ssh_grunt)=true.
+<HclListItem name="enable_cloudwatch_alarms" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="ssh_grunt_iam_group_sudo" className="snap-top"></a>
+Set to true to enable several basic CloudWatch alarms around CPU usage, memory usage, and disk space usage. If set to true, make sure to specify SNS topics to send notifications to using <a href="#alarms_sns_topic_arn"><code>alarms_sns_topic_arn</code></a>.
 
-* [**`ssh_grunt_iam_group_sudo`**](#ssh_grunt_iam_group_sudo) &mdash; If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to this OpenVPN server with sudo permissions. This value is only used if [`enable_ssh_grunt`](#enable_ssh_grunt)=true.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="tenancy" className="snap-top"></a>
+<HclListItem name="enable_cloudwatch_log_aggregation" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`tenancy`**](#tenancy) &mdash; The tenancy of this server. Must be one of: default, dedicated, or host.
+Set to true to send logs to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/logs/cloudwatch-log-aggregation-scripts to do log aggregation in CloudWatch.
 
-<a name="use_managed_iam_policies" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`use_managed_iam_policies`**](#use_managed_iam_policies) &mdash; When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+<HclListItem name="enable_cloudwatch_metrics" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="use_strong_prime" className="snap-top"></a>
+Set to true to add IAM permissions to send custom metrics to CloudWatch. This is useful in combination with https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/modules/agents/cloudwatch-agent to get memory and disk metrics in CloudWatch for your OpenVPN server.
 
-* [**`use_strong_prime`**](#use_strong_prime) &mdash; When true, generate Diffie-Hellman parameters using strong primes. Note that while stronger primes make the keys more cryptographically secure, the effective security gains are known to be insignificant in practice.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-<a name="vpn_route_cidr_blocks" className="snap-top"></a>
+<HclListItem name="enable_fail2ban" requirement="optional" type="bool">
+<HclListItemDescription>
 
-* [**`vpn_route_cidr_blocks`**](#vpn_route_cidr_blocks) &mdash; A list of CIDR ranges to be routed over the VPN.
+Enable fail2ban to block brute force log in attempts. Defaults to true.
 
-<a name="vpn_search_domains" className="snap-top"></a>
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
 
-* [**`vpn_search_domains`**](#vpn_search_domains) &mdash; A list of domains to push down to the client to resolve over VPN. This will configure the OpenVPN server to pass through domains that should be resolved over the VPN connection (as opposed to the locally configured resolver) to the client. Note that for each domain, all subdomains will be resolved as well. E.g., if you pass in 'mydomain.local', subdomains such as 'hello.world.mydomain.local' and 'example.mydomain.local' will also be forwarded to through the VPN server.
+<HclListItem name="enable_ip_lockdown" requirement="optional" type="bool">
+<HclListItemDescription>
 
-<a name="vpn_subnet" className="snap-top"></a>
+Enable ip-lockdown to block access to the instance metadata. Defaults to true.
 
-* [**`vpn_subnet`**](#vpn_subnet) &mdash; The subnet IP and mask vpn clients will be assigned addresses from. For example, 172.16.1.0 255.255.255.0. This is a non-routed network that only exists between the VPN server and the client. Therefore, it should NOT overlap with VPC addressing, or the client won't be able to access any of the VPC IPs. In general, we recommend using internal, non-RFC 1918 IP addresses, such as 172.16.xx.yy.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="enable_ssh_grunt" requirement="optional" type="bool">
+<HclListItemDescription>
+
+Set to true to add IAM permissions for ssh-grunt (https://github.com/gruntwork-io/terraform-aws-security/tree/master/modules/ssh-grunt), which will allow you to manage SSH access via IAM groups.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="external_account_arns" requirement="optional" type="list">
+<HclListItemDescription>
+
+The ARNs of external AWS accounts where your IAM users are defined. This module will create IAM roles that users in those accounts will be able to assume to get access to the request/revocation SQS queues.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="external_account_ssh_grunt_role_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+Since our IAM users are defined in a separate AWS account, this variable is used to specify the ARN of an IAM role that allows ssh-grunt to retrieve IAM group and public SSH key info from that account.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue=""/>
+</HclListItem>
+
+<HclListItem name="force_destroy" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When a terraform destroy is run, should the backup s3 bucket be destroyed even if it contains files. Should only be set to true for testing/development
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="hosted_zone_id" requirement="optional" type="string">
+<HclListItemDescription>
+
+The ID of the Route 53 Hosted Zone in which the domain should be created. Only used if <a href="#create_route53_entry"><code>create_route53_entry</code></a> is true. If null, lookup the hosted zone ID using the <a href="#base_domain_name"><code>base_domain_name</code></a>.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="instance_type" requirement="optional" type="string">
+<HclListItemDescription>
+
+The type of instance to run for the OpenVPN Server
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="t3.micro"/>
+</HclListItem>
+
+<HclListItem name="keypair_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of a Key Pair that can be used to SSH to this instance. Leave blank if you don't want to enable Key Pair auth.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="kms_key_arn" requirement="optional" type="string">
+<HclListItemDescription>
+
+The Amazon Resource Name (ARN) of an existing KMS customer master key (CMK) that will be used to encrypt/decrypt backup files. If null, a key will be created with permissions assigned by the following variables: cmk_administrator_iam_arns, cmk_user_iam_arns, cmk_external_user_iam_arns, allow_manage_key_permissions.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="null"/>
+</HclListItem>
+
+<HclListItem name="name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of the OpenVPN Server and the other resources created by these templates
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="vpn"/>
+</HclListItem>
+
+<HclListItem name="request_queue_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of the sqs queue that will be used to receive new certificate requests.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="queue"/>
+</HclListItem>
+
+<HclListItem name="revocation_queue_name" requirement="optional" type="string">
+<HclListItemDescription>
+
+The name of the sqs queue that will be used to receive certification revocation requests. Note that the queue name will be automatically prefixed with 'openvpn-requests-'.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="queue"/>
+</HclListItem>
+
+<HclListItem name="should_create_cloudwatch_log_group" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, precreate the CloudWatch Log Group to use for log aggregation from the EC2 instances. This is useful if you wish to customize the CloudWatch Log Group with various settings such as retention periods and KMS encryption. When false, the CloudWatch agent will automatically create a basic log group to use.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="ssh_grunt_iam_group" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to this OpenVPN server. This value is only used if enable_ssh_grunt=true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ssh-grunt-users"/>
+</HclListItem>
+
+<HclListItem name="ssh_grunt_iam_group_sudo" requirement="optional" type="string">
+<HclListItemDescription>
+
+If you are using ssh-grunt, this is the name of the IAM group from which users will be allowed to SSH to this OpenVPN server with sudo permissions. This value is only used if enable_ssh_grunt=true.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="ssh-grunt-sudo-users"/>
+</HclListItem>
+
+<HclListItem name="tenancy" requirement="optional" type="string">
+<HclListItemDescription>
+
+The tenancy of this server. Must be one of: default, dedicated, or host.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="default"/>
+</HclListItem>
+
+<HclListItem name="use_managed_iam_policies" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, all IAM policies will be managed as dedicated policies rather than inline policies attached to the IAM roles. Dedicated managed policies are friendlier to automated policy checkers, which may scan a single resource for findings. As such, it is important to avoid inline policies when targeting compliance with various security standards.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="true"/>
+</HclListItem>
+
+<HclListItem name="use_strong_prime" requirement="optional" type="bool">
+<HclListItemDescription>
+
+When true, generate Diffie-Hellman parameters using strong primes. Note that while stronger primes make the keys more cryptographically secure, the effective security gains are known to be insignificant in practice.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
+<HclListItem name="vpn_route_cidr_blocks" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of CIDR ranges to be routed over the VPN.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="vpn_search_domains" requirement="optional" type="list">
+<HclListItemDescription>
+
+A list of domains to push down to the client to resolve over VPN. This will configure the OpenVPN server to pass through domains that should be resolved over the VPN connection (as opposed to the locally configured resolver) to the client. Note that for each domain, all subdomains will be resolved as well. E.g., if you pass in 'mydomain.local', subdomains such as 'hello.world.mydomain.local' and 'example.mydomain.local' will also be forwarded to through the VPN server.
+
+</HclListItemDescription>
+<HclListItemTypeDetails>
+
+```hcl
+list(string)
+```
+
+</HclListItemTypeDetails>
+<HclListItemDefaultValue defaultValue="[]"/>
+</HclListItem>
+
+<HclListItem name="vpn_subnet" requirement="optional" type="string">
+<HclListItemDescription>
+
+The subnet IP and mask vpn clients will be assigned addresses from. For example, 172.16.1.0 255.255.255.0. This is a non-routed network that only exists between the VPN server and the client. Therefore, it should NOT overlap with VPC addressing, or the client won't be able to access any of the VPC IPs. In general, we recommend using internal, non-RFC 1918 IP addresses, such as 172.16.xx.yy.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="172.16.1.0 255.255.255.0"/>
+</HclListItem>
 
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
-<a name="allow_certificate_requests_for_external_accounts_iam_role_arn" className="snap-top"></a>
+<HclListItem name="allow_certificate_requests_for_external_accounts_iam_role_arn">
+<HclListItemDescription>
 
-* [**`allow_certificate_requests_for_external_accounts_iam_role_arn`**](#allow_certificate_requests_for_external_accounts_iam_role_arn) &mdash; The ARN of the IAM role that can be assumed from external accounts to request certificates.
+The ARN of the IAM role that can be assumed from external accounts to request certificates.
 
-<a name="allow_certificate_requests_for_external_accounts_iam_role_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`allow_certificate_requests_for_external_accounts_iam_role_id`**](#allow_certificate_requests_for_external_accounts_iam_role_id) &mdash; The name of the IAM role that can be assumed from external accounts to request certificates.
+<HclListItem name="allow_certificate_requests_for_external_accounts_iam_role_id">
+<HclListItemDescription>
 
-<a name="allow_certificate_revocations_for_external_accounts_iam_role_arn" className="snap-top"></a>
+The name of the IAM role that can be assumed from external accounts to request certificates.
 
-* [**`allow_certificate_revocations_for_external_accounts_iam_role_arn`**](#allow_certificate_revocations_for_external_accounts_iam_role_arn) &mdash; The ARN of the IAM role that can be assumed from external accounts to revoke certificates.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="allow_certificate_revocations_for_external_accounts_iam_role_id" className="snap-top"></a>
+<HclListItem name="allow_certificate_revocations_for_external_accounts_iam_role_arn">
+<HclListItemDescription>
 
-* [**`allow_certificate_revocations_for_external_accounts_iam_role_id`**](#allow_certificate_revocations_for_external_accounts_iam_role_id) &mdash; The name of the IAM role that can be assumed from external accounts to revoke certificates.
+The ARN of the IAM role that can be assumed from external accounts to revoke certificates.
 
-<a name="autoscaling_group_id" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`autoscaling_group_id`**](#autoscaling_group_id) &mdash; The AutoScaling Group ID of the OpenVPN server.
+<HclListItem name="allow_certificate_revocations_for_external_accounts_iam_role_id">
+<HclListItemDescription>
 
-<a name="backup_bucket_name" className="snap-top"></a>
+The name of the IAM role that can be assumed from external accounts to revoke certificates.
 
-* [**`backup_bucket_name`**](#backup_bucket_name) &mdash; The S3 bucket used for backing up the OpenVPN PKI.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="client_request_queue" className="snap-top"></a>
+<HclListItem name="autoscaling_group_id">
+<HclListItemDescription>
 
-* [**`client_request_queue`**](#client_request_queue) &mdash; The SQS queue used by the openvpn-admin tool for certificate requests.
+The AutoScaling Group ID of the OpenVPN server.
 
-<a name="client_revocation_queue" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`client_revocation_queue`**](#client_revocation_queue) &mdash; The SQS queue used by the openvpn-admin tool for certificate revocations.
+<HclListItem name="backup_bucket_name">
+<HclListItemDescription>
 
-<a name="elastic_ip" className="snap-top"></a>
+The S3 bucket used for backing up the OpenVPN PKI.
 
-* [**`elastic_ip`**](#elastic_ip) &mdash; The elastic IP address of the OpenVPN server.
+</HclListItemDescription>
+</HclListItem>
 
-<a name="iam_role_id" className="snap-top"></a>
+<HclListItem name="client_request_queue">
+<HclListItemDescription>
 
-* [**`iam_role_id`**](#iam_role_id) &mdash; The ID of the IAM role used by the OpenVPN server.
+The SQS queue used by the openvpn-admin tool for certificate requests.
 
-<a name="openvpn_admins_group_name" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`openvpn_admins_group_name`**](#openvpn_admins_group_name) &mdash; The name of the OpenVPN admins IAM group (to request and revoke certificates).
+<HclListItem name="client_revocation_queue">
+<HclListItemDescription>
 
-<a name="openvpn_users_group_name" className="snap-top"></a>
+The SQS queue used by the openvpn-admin tool for certificate revocations.
 
-* [**`openvpn_users_group_name`**](#openvpn_users_group_name) &mdash; The name of the OpenVPN users IAM group (to request certificates).
+</HclListItemDescription>
+</HclListItem>
 
-<a name="private_ip" className="snap-top"></a>
+<HclListItem name="elastic_ip">
+<HclListItemDescription>
 
-* [**`private_ip`**](#private_ip) &mdash; The private IP address of the OpenVPN server.
+The elastic IP address of the OpenVPN server.
 
-<a name="public_ip" className="snap-top"></a>
+</HclListItemDescription>
+</HclListItem>
 
-* [**`public_ip`**](#public_ip) &mdash; The public IP address of the OpenVPN server.
+<HclListItem name="iam_role_id">
+<HclListItemDescription>
 
-<a name="security_group_id" className="snap-top"></a>
+The ID of the IAM role used by the OpenVPN server.
 
-* [**`security_group_id`**](#security_group_id) &mdash; The security group ID of the OpenVPN server.
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="openvpn_admins_group_name">
+<HclListItemDescription>
+
+The name of the OpenVPN admins IAM group (to request and revoke certificates).
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="openvpn_users_group_name">
+<HclListItemDescription>
+
+The name of the OpenVPN users IAM group (to request certificates).
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="private_ip">
+<HclListItemDescription>
+
+The private IP address of the OpenVPN server.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="public_ip">
+<HclListItemDescription>
+
+The public IP address of the OpenVPN server.
+
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="security_group_id">
+<HclListItemDescription>
+
+The security group ID of the OpenVPN server.
+
+</HclListItemDescription>
+</HclListItem>
 
 </TabItem>
 </Tabs>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"dc85c2cfcea5656b03e49442102f530e"}
+{"sourcePlugin":"service-catalog-api","hash":"2712c9782a44caa910440c346cd98371"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/security/tls-scripts.md
+++ b/docs/reference/services/security/tls-scripts.md
@@ -14,6 +14,7 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import VersionBadge from '../../../../src/components/VersionBadge.tsx';
+import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue } from '../../../../src/components/HclListItem.tsx';
 
 <VersionBadge version="0.85.0" lastModifiedVersion="0.77.0"/>
 
@@ -99,5 +100,5 @@ If you’ve never used the Service Catalog before, make sure to read
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"85fc6714edb956c53e4caf742adee1e4"}
+{"sourcePlugin":"service-catalog-api","hash":"01106166a8bf71fc37bb1ff2751bee26"}
 ##DOCS-SOURCER-END -->

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "^4.3.5"
   },
   "optionalDependencies": {
-    "docs-sourcer": "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.0.16"
+    "docs-sourcer": "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.0.18"
   },
   "browserslist": {
     "production": [

--- a/src/components/HclListItem.module.css
+++ b/src/components/HclListItem.module.css
@@ -1,0 +1,50 @@
+.container {
+  margin-bottom: 26px;
+}
+
+.body {
+  padding-top: 14px;
+  padding-left: 46px;
+}
+
+.description > p {
+  margin-bottom: 0px;
+}
+
+.detail {
+  margin-top: 10px;
+}
+
+.meta {
+  font-size: 14px;
+  margin-left: 14px;
+  font-weight: 600;
+  color: #666666;
+}
+
+.label {
+  display: block;
+}
+
+.inlineLabel {
+  margin-right: 9px;
+}
+
+.inlineLabel,
+.label {
+  font-weight: 600;
+  padding-bottom: 12px;
+}
+
+pre {
+  border: 1px solid #cbd5e0;
+  box-sizing: border-box;
+  border-radius: 6px;
+}
+
+.code {
+  /* display: inline; */
+  font-weight: 400 !important ;
+  font-size: 14px !important;
+  margin-bottom: 0px;
+}

--- a/src/components/HclListItem.tsx
+++ b/src/components/HclListItem.tsx
@@ -1,0 +1,67 @@
+import React, { PropsWithChildren } from "react"
+import styles from "./HclListItem.module.css"
+
+interface HclListItemProps {
+  name: string
+  requirement?: "required" | "optional"
+  type: string
+}
+
+export const HclListItem: React.FunctionComponent<
+  PropsWithChildren<HclListItemProps>
+> = ({ name, requirement, type, children }) => {
+  return (
+    <div className={styles.container}>
+      <div>
+        <a href={`#${name}`} name={name} className="snap-top">
+          <strong>
+            <code>{name}</code>
+          </strong>
+        </a>
+        <em className={styles.meta}>{type}</em>
+        {!!requirement && <em className={styles.meta}>({requirement})</em>}
+      </div>
+
+      <div className={styles.body}>{!!children && children}</div>
+    </div>
+  )
+}
+
+export const HclListItemDescription: React.FunctionComponent = ({
+  children,
+}) => {
+  return <div className={styles.description}>{children}</div>
+}
+
+export const HclListItemTypeDetails: React.FunctionComponent = ({
+  children,
+}) => {
+  return (
+    <div className={styles.detail}>
+      <label className={styles.label}>Type Details</label>
+      {children}
+    </div>
+  )
+}
+
+export const HclListItemDefaultValue: React.FunctionComponent<
+  PropsWithChildren<{ defaultValue?: string | number | boolean }>
+> = ({ defaultValue, children }) => {
+  return (
+    <div className={styles.detail}>
+      {!!children ? (
+        <>
+          <label className={styles.label}>Default</label>
+          {children}
+        </>
+      ) : (
+        <>
+          <label className={styles.inlineLabel}>Default:</label>
+          <code>{defaultValue === "" ? `""` : defaultValue}</code>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default HclListItem

--- a/yarn.lock
+++ b/yarn.lock
@@ -5341,9 +5341,9 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
-"docs-sourcer@git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.0.16":
+"docs-sourcer@git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.0.18":
   version "0.0.1"
-  resolved "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#e1fe098a7d78e9ca832658fcd3c8b95c9dab216e"
+  resolved "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#4f6d8374e89f253760414c0e64d5432ac96a97f3"
   dependencies:
     "@octokit/auth-app" "^3.6.1"
     "@octokit/plugin-retry" "^3.0.9"


### PR DESCRIPTION
[APT-1729] [APT-1730]

### TODO

- [x] Review, merge & release https://github.com/gruntwork-io/docs-sourcer/pull/38
- [x] Update package.json to this the released version of the docs-sourcer
- [x] Run yarn regenerate -p service-api

[APT-1729]: https://gruntwork.atlassian.net/browse/APT-1729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[APT-1730]: https://gruntwork.atlassian.net/browse/APT-1730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ