### PR TITLE
[APT-1782] Fix linkifying variables without underscores

### DIFF
--- a/docs/reference/services/app-orchestration/auto-scaling-group-asg.md
+++ b/docs/reference/services/app-orchestration/auto-scaling-group-asg.md
@@ -95,7 +95,7 @@ The ID of the AMI to run on each instance in the ASG. The AMI needs to have `ec2
 <HclListItem name="ami_filters" requirement="required" type="object(…)">
 <HclListItemDescription>
 
-Properties on the AMI that can be used to lookup a prebuilt AMI for use with the Bastion Host. You can build the AMI using the Packer template bastion-host.json. Only used if var.ami is null. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if passing the ami ID directly.
+Properties on the AMI that can be used to lookup a prebuilt AMI for use with the Bastion Host. You can build the AMI using the Packer template bastion-host.json. Only used if <a href="#ami"><code>ami</code></a> is null. One of <a href="#ami"><code>ami</code></a> or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if passing the ami ID directly.
 
 </HclListItemDescription>
 <HclListItemTypeDetails>
@@ -801,5 +801,5 @@ The ID of the Security Group that belongs to the ASG.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"c7c1520d02270646839affd1e160f3f2"}
+{"sourcePlugin":"service-catalog-api","hash":"53747c812ba8d3d638524a89d5e8f547"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/app-orchestration/ec-2-instance.md
+++ b/docs/reference/services/app-orchestration/ec-2-instance.md
@@ -166,7 +166,7 @@ Accept inbound SSH from these security groups
 <HclListItem name="ami" requirement="required" type="string">
 <HclListItemDescription>
 
-The AMI to run on the EC2 instance. This should be built from the Packer template under ec2-instance.json. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if looking up the ami with filters.
+The AMI to run on the EC2 instance. This should be built from the Packer template under ec2-instance.json. One of <a href="#ami"><code>ami</code></a> or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if looking up the ami with filters.
 
 </HclListItemDescription>
 </HclListItem>
@@ -174,7 +174,7 @@ The AMI to run on the EC2 instance. This should be built from the Packer templat
 <HclListItem name="ami_filters" requirement="required" type="object(…)">
 <HclListItemDescription>
 
-Properties on the AMI that can be used to lookup a prebuilt AMI for use with the EC2 instance. You can build the AMI using the Packer template ec2-instance.json. Only used if var.ami is null. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if passing the ami ID directly.
+Properties on the AMI that can be used to lookup a prebuilt AMI for use with the EC2 instance. You can build the AMI using the Packer template ec2-instance.json. Only used if <a href="#ami"><code>ami</code></a> is null. One of <a href="#ami"><code>ami</code></a> or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if passing the ami ID directly.
 
 </HclListItemDescription>
 <HclListItemTypeDetails>
@@ -455,7 +455,7 @@ If you are using ssh-grunt and your IAM users / groups are defined in a separate
 <HclListItem name="fully_qualified_domain_name" requirement="optional" type="string">
 <HclListItemDescription>
 
-The apex domain of the hostname for the EC2 instance (e.g., example.com). The complete hostname for the EC2 instance will be var.name.<a href="#fully_qualified_domain_name"><code>fully_qualified_domain_name</code></a> (e.g., bastion.example.com). Only used if create_dns_record is true.
+The apex domain of the hostname for the EC2 instance (e.g., example.com). The complete hostname for the EC2 instance will be <a href="#name"><code>name</code></a>.<a href="#fully_qualified_domain_name"><code>fully_qualified_domain_name</code></a> (e.g., bastion.example.com). Only used if create_dns_record is true.
 
 </HclListItemDescription>
 <HclListItemDefaultValue defaultValue="&quot;&quot;"/>
@@ -639,5 +639,5 @@ The input parameters for the EBS volumes.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"9db03aaec997d7f4b88af980f1734b75"}
+{"sourcePlugin":"service-catalog-api","hash":"86e3540fbec24b6ef3109525f85eb1da"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/ci-cd-pipeline/ecs-deploy-runner.md
+++ b/docs/reference/services/ci-cd-pipeline/ecs-deploy-runner.md
@@ -685,7 +685,7 @@ The ID (ARN, alias ARN, AWS ID) of a customer managed KMS Key to use for encrypt
 <HclListItem name="ecs_task_cloudwatch_log_group_name" requirement="optional" type="string">
 <HclListItemDescription>
 
-A custom name to set for the CloudWatch Log Group used to stream the container logs. When null, the Log Group will default to /ecs/{var.name}.
+A custom name to set for the CloudWatch Log Group used to stream the container logs. When null, the Log Group will default to /ecs/{<a href="#name"><code>name</code></a>}.
 
 </HclListItemDescription>
 <HclListItemDefaultValue defaultValue="null"/>
@@ -1044,5 +1044,5 @@ Security Group ID of the ECS task
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"144c18c60086f2e999bb1627930b4e64"}
+{"sourcePlugin":"service-catalog-api","hash":"5c289c2930d86edf05908f71fb705658"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/ci-cd-pipeline/jenkins.md
+++ b/docs/reference/services/ci-cd-pipeline/jenkins.md
@@ -111,7 +111,7 @@ The IDs of the subnets in which to deploy the ALB that runs in front of Jenkins.
 <HclListItem name="ami" requirement="required" type="string">
 <HclListItemDescription>
 
-The ID of the AMI to run on the Jenkins server. This should be the AMI build from the Packer template jenkins-ubuntu.json. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if looking up the ami with filters.
+The ID of the AMI to run on the Jenkins server. This should be the AMI build from the Packer template jenkins-ubuntu.json. One of <a href="#ami"><code>ami</code></a> or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if looking up the ami with filters.
 
 </HclListItemDescription>
 </HclListItem>
@@ -119,7 +119,7 @@ The ID of the AMI to run on the Jenkins server. This should be the AMI build fro
 <HclListItem name="ami_filters" requirement="required" type="object(…)">
 <HclListItemDescription>
 
-Properties on the AMI that can be used to lookup a prebuilt AMI for use with Jenkins. You can build the AMI using the Packer template jenkins-ubuntu.json. Only used if var.ami is null. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if passing the ami ID directly.
+Properties on the AMI that can be used to lookup a prebuilt AMI for use with Jenkins. You can build the AMI using the Packer template jenkins-ubuntu.json. Only used if <a href="#ami"><code>ami</code></a> is null. One of <a href="#ami"><code>ami</code></a> or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if passing the ami ID directly.
 
 </HclListItemDescription>
 <HclListItemTypeDetails>
@@ -771,5 +771,5 @@ The ID of the Security Group attached to the Jenkins EC2 Instance
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"5da715e7bd34996f0eaa6378ae1c667f"}
+{"sourcePlugin":"service-catalog-api","hash":"96b69b9953a71a5e7d60e02c9bc1d2aa"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/ci-cd-pipeline/tailscale-subnet-router.md
+++ b/docs/reference/services/ci-cd-pipeline/tailscale-subnet-router.md
@@ -144,7 +144,7 @@ resource "aws_iam_role_policy_attachment" "attachment" {
 <HclListItem name="ami" requirement="required" type="string">
 <HclListItemDescription>
 
-The AMI to run on the Tailscale subnet router. This should be built from the Packer template under tailscale-subnet-router-ubuntu.json. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if looking up the ami with filters.
+The AMI to run on the Tailscale subnet router. This should be built from the Packer template under tailscale-subnet-router-ubuntu.json. One of <a href="#ami"><code>ami</code></a> or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if looking up the ami with filters.
 
 </HclListItemDescription>
 </HclListItem>
@@ -152,7 +152,7 @@ The AMI to run on the Tailscale subnet router. This should be built from the Pac
 <HclListItem name="ami_filters" requirement="required" type="object(…)">
 <HclListItemDescription>
 
-Properties on the AMI that can be used to lookup a prebuilt AMI for use with the Tailscale subnet router. You can build the AMI using the Packer template tailscale-subnet-router-ubuntu.json. Only used if var.ami is null. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if passing the ami ID directly.
+Properties on the AMI that can be used to lookup a prebuilt AMI for use with the Tailscale subnet router. You can build the AMI using the Packer template tailscale-subnet-router-ubuntu.json. Only used if <a href="#ami"><code>ami</code></a> is null. One of <a href="#ami"><code>ami</code></a> or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if passing the ami ID directly.
 
 </HclListItemDescription>
 <HclListItemTypeDetails>
@@ -430,7 +430,7 @@ If you are using ssh-grunt, this is the name of the IAM group from which users w
 <HclListItem name="tailnet_hostname" requirement="optional" type="string">
 <HclListItemDescription>
 
-Advertised hostname of the server on the tailnet. If null, defaults to the var.name input value.
+Advertised hostname of the server on the tailnet. If null, defaults to the <a href="#name"><code>name</code></a> input value.
 
 </HclListItemDescription>
 <HclListItemDefaultValue defaultValue="null"/>
@@ -493,5 +493,5 @@ ID of the primary security group attached to the Tailscale relay server.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"3ef866d3312e1716748261a2fb8e9963"}
+{"sourcePlugin":"service-catalog-api","hash":"67de4f538f2fedffbfe1220230c53faf"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/data-storage/amazon-rds.md
+++ b/docs/reference/services/data-storage/amazon-rds.md
@@ -103,7 +103,7 @@ The amount of storage space the DB should use, in GB.
 <HclListItem name="engine_version" requirement="required" type="string">
 <HclListItemDescription>
 
-The version of var.engine to use (e.g. 8.0.17 for mysql).
+The version of <a href="#engine"><code>engine</code></a> to use (e.g. 8.0.17 for mysql).
 
 </HclListItemDescription>
 </HclListItem>
@@ -1041,5 +1041,5 @@ The ID of the Security Group that controls access to the RDS DB instance.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"1bb2fcf1663acae8e472cd34ab649c4e"}
+{"sourcePlugin":"service-catalog-api","hash":"3193b194a930cd3815e1fae77080a36e"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/security/bastion.md
+++ b/docs/reference/services/security/bastion.md
@@ -120,7 +120,7 @@ A list of IP address ranges in CIDR format from which SSH access will be permitt
 <HclListItem name="ami" requirement="required" type="string">
 <HclListItemDescription>
 
-The AMI to run on the bastion host. This should be built from the Packer template under bastion-host.json. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if looking up the ami with filters.
+The AMI to run on the bastion host. This should be built from the Packer template under bastion-host.json. One of <a href="#ami"><code>ami</code></a> or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if looking up the ami with filters.
 
 </HclListItemDescription>
 </HclListItem>
@@ -128,7 +128,7 @@ The AMI to run on the bastion host. This should be built from the Packer templat
 <HclListItem name="ami_filters" requirement="required" type="object(…)">
 <HclListItemDescription>
 
-Properties on the AMI that can be used to lookup a prebuilt AMI for use with the Bastion Host. You can build the AMI using the Packer template bastion-host.json. Only used if var.ami is null. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if passing the ami ID directly.
+Properties on the AMI that can be used to lookup a prebuilt AMI for use with the Bastion Host. You can build the AMI using the Packer template bastion-host.json. Only used if <a href="#ami"><code>ami</code></a> is null. One of <a href="#ami"><code>ami</code></a> or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if passing the ami ID directly.
 
 </HclListItemDescription>
 <HclListItemTypeDetails>
@@ -264,7 +264,7 @@ The default OS user for the Bastion Host AMI. For AWS Ubuntu AMIs, which is what
 <HclListItem name="domain_name" requirement="optional" type="string">
 <HclListItemDescription>
 
-The apex domain of the hostname for the bastion server (e.g., example.com). The complete hostname for the bastion server will be var.name.<a href="#domain_name"><code>domain_name</code></a> (e.g., bastion.example.com). Only used if create_dns_record is true.
+The apex domain of the hostname for the bastion server (e.g., example.com). The complete hostname for the bastion server will be <a href="#name"><code>name</code></a>.<a href="#domain_name"><code>domain_name</code></a> (e.g., bastion.example.com). Only used if create_dns_record is true.
 
 </HclListItemDescription>
 <HclListItemDefaultValue defaultValue="&quot;&quot;"/>
@@ -470,5 +470,5 @@ The fully qualified name of the bastion host.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"dd365d7f7004d96a1f6d536791e841af"}
+{"sourcePlugin":"service-catalog-api","hash":"d19adb0308b0ab6089fa7efd079a1804"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/security/open-vpn.md
+++ b/docs/reference/services/security/open-vpn.md
@@ -107,7 +107,7 @@ A list of IP address ranges in CIDR format from which VPN access will be permitt
 <HclListItem name="ami" requirement="required" type="string">
 <HclListItemDescription>
 
-The AMI to run on the OpenVPN Server. This should be built from the Packer template under openvpn-server.json. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if looking up the ami with filters.
+The AMI to run on the OpenVPN Server. This should be built from the Packer template under openvpn-server.json. One of <a href="#ami"><code>ami</code></a> or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if looking up the ami with filters.
 
 </HclListItemDescription>
 </HclListItem>
@@ -115,7 +115,7 @@ The AMI to run on the OpenVPN Server. This should be built from the Packer templ
 <HclListItem name="ami_filters" requirement="required" type="object(…)">
 <HclListItemDescription>
 
-Properties on the AMI that can be used to lookup a prebuilt AMI for use with the OpenVPN server. You can build the AMI using the Packer template openvpn-server.json. Only used if var.ami is null. One of var.ami or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if passing the ami ID directly.
+Properties on the AMI that can be used to lookup a prebuilt AMI for use with the OpenVPN server. You can build the AMI using the Packer template openvpn-server.json. Only used if <a href="#ami"><code>ami</code></a> is null. One of <a href="#ami"><code>ami</code></a> or <a href="#ami_filters"><code>ami_filters</code></a> is required. Set to null if passing the ami ID directly.
 
 </HclListItemDescription>
 <HclListItemTypeDetails>
@@ -717,5 +717,5 @@ The security group ID of the OpenVPN server.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"service-catalog-api","hash":"507d533a8744c7629b9ba20936cd408c"}
+{"sourcePlugin":"service-catalog-api","hash":"817aeeee029f52d509101db669c75ea8"}
 ##DOCS-SOURCER-END -->

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "yargs": "^17.4.0"
   },
   "optionalDependencies": {
-    "docs-sourcer": "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.0.20"
+    "docs-sourcer": "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.0.21"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5341,9 +5341,9 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
-"docs-sourcer@git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.0.20":
+"docs-sourcer@git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.0.21":
   version "0.0.1"
-  resolved "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#9ef5f566f7a85238053af15aecd4235a09025ac6"
+  resolved "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#10662732e2a2dd243194b2761592fff2a9aff92b"
   dependencies:
     "@octokit/auth-app" "^3.6.1"
     "@octokit/plugin-retry" "^3.0.9"


### PR DESCRIPTION
This PR addresses a minor bug where variables were not being linkified unless they had underscores.


TODO:

- [x] Merge the associate [docs-sourcer PR](https://github.com/gruntwork-io/docs-sourcer/pull/46)/release new version
- [x] Update the ref of docs-sourcer in docs
- [x] Update the deployed webhook

Before:
<img width="963" alt="image" src="https://user-images.githubusercontent.com/34349331/160650537-1a60ac7b-90f2-4120-862c-8357417bb2fe.png">


After:
<img width="983" alt="image" src="https://user-images.githubusercontent.com/34349331/160650576-e09cb329-b7f4-4372-af09-836b481dbd3a.png">
