### PR TITLE
[APT-1618] Support page updates

### DIFF
--- a/_docs-sources/support.mdx
+++ b/_docs-sources/support.mdx
@@ -33,43 +33,37 @@ We’re here to assist when you get stuck. Basic support is included with every 
     title="Email Us"
     icon="/img/support/email-icon.svg"
     href="mailto:support@gruntwork.io"
-    tags={["pro", "enterprise"]}
   >
     Contact <address>support@gruntwork.io</address> with any questions or
     concerns you may have.
   </Card>
-  {
-    //  We intend to add these cards in the near future, so we'll break
-    //  convention and just comment them out for now.
-    //
-    //  <Card
-    //    title="Email With Urgency"
-    //    icon="/img/support/email-urgent-icon.svg"
-    //    href="mailto:urgent-support@gruntwork.io"
-    //    tags={["pro", "enterprise"]}
-    //  >
-    //    Messages sent to <address>urgent-support@gruntwork.io</address> will
-    //    receive a response within 24 hours.
-    //  </Card>
-    //  <Card
-    //    title="Chat With Us"
-    //    icon="/img/support/chat-icon.svg"
-    //    href="#chat-with-us-in-slack"
-    //    tags={["pro", "enterprise"]}
-    //  >
-    //    Converse with Gruntwork engineers in your own <em>private</em> Slack
-    //    channel.
-    //  </Card>
-    //  <Card
-    //    title="Schedule a Call"
-    //    icon="/img/support/call-icon.svg"
-    //    href="http://calendly.com/gruntwork-live-support/one-hour"
-    //    tags={["enterprise"]}
-    //  >
-    //    Speak with a Gruntwork engineer via phone or video chat to get real-time
-    //    answers to your questions.
-    //  </Card>
-  }
+  <Card
+    title="Email With Urgency"
+    icon="/img/support/email-urgent-icon.svg"
+    href="mailto:urgent-support@gruntwork.io"
+    tags={["pro", "enterprise"]}
+  >
+    Messages sent to <address>urgent-support@gruntwork.io</address> will receive
+    a response within your support plan SLA.
+  </Card>
+  <Card
+    title="Chat With Us"
+    icon="/img/support/chat-icon.svg"
+    href="#chat-with-us-in-slack"
+    tags={["pro", "enterprise"]}
+  >
+    Converse with Gruntwork engineers in your own <em>private</em> Slack
+    channel.
+  </Card>
+  <Card
+    title="Schedule a Call"
+    icon="/img/support/call-icon.svg"
+    href="mailto:support@gruntwork.io?subject=Live Call Request"
+    tags={["enterprise"]}
+  >
+    Speak with a Gruntwork engineer via phone or video chat for real-time help.
+    For details, contact <address>support@gruntwork.io</address>.
+  </Card>
   <Card
     title="Request a Feature"
     icon="/img/support/bulb-icon.svg"

--- a/docs/support.mdx
+++ b/docs/support.mdx
@@ -33,43 +33,37 @@ We’re here to assist when you get stuck. Basic support is included with every 
     title="Email Us"
     icon="/img/support/email-icon.svg"
     href="mailto:support@gruntwork.io"
-    tags={["pro", "enterprise"]}
   >
     Contact <address>support@gruntwork.io</address> with any questions or
     concerns you may have.
   </Card>
-  {
-    //  We intend to add these cards in the near future, so we'll break
-    //  convention and just comment them out for now.
-    //
-    //  <Card
-    //    title="Email With Urgency"
-    //    icon="/img/support/email-urgent-icon.svg"
-    //    href="mailto:urgent-support@gruntwork.io"
-    //    tags={["pro", "enterprise"]}
-    //  >
-    //    Messages sent to <address>urgent-support@gruntwork.io</address> will
-    //    receive a response within 24 hours.
-    //  </Card>
-    //  <Card
-    //    title="Chat With Us"
-    //    icon="/img/support/chat-icon.svg"
-    //    href="#chat-with-us-in-slack"
-    //    tags={["pro", "enterprise"]}
-    //  >
-    //    Converse with Gruntwork engineers in your own <em>private</em> Slack
-    //    channel.
-    //  </Card>
-    //  <Card
-    //    title="Schedule a Call"
-    //    icon="/img/support/call-icon.svg"
-    //    href="http://calendly.com/gruntwork-live-support/one-hour"
-    //    tags={["enterprise"]}
-    //  >
-    //    Speak with a Gruntwork engineer via phone or video chat to get real-time
-    //    answers to your questions.
-    //  </Card>
-  }
+  <Card
+    title="Email With Urgency"
+    icon="/img/support/email-urgent-icon.svg"
+    href="mailto:urgent-support@gruntwork.io"
+    tags={["pro", "enterprise"]}
+  >
+    Messages sent to <address>urgent-support@gruntwork.io</address> will receive
+    a response within your support plan SLA.
+  </Card>
+  <Card
+    title="Chat With Us"
+    icon="/img/support/chat-icon.svg"
+    href="#chat-with-us-in-slack"
+    tags={["pro", "enterprise"]}
+  >
+    Converse with Gruntwork engineers in your own <em>private</em> Slack
+    channel.
+  </Card>
+  <Card
+    title="Schedule a Call"
+    icon="/img/support/call-icon.svg"
+    href="mailto:support@gruntwork.io?subject=Live Call Request"
+    tags={["enterprise"]}
+  >
+    Speak with a Gruntwork engineer via phone or video chat for real-time help.
+    For details, contact <address>support@gruntwork.io</address>.
+  </Card>
   <Card
     title="Request a Feature"
     icon="/img/support/bulb-icon.svg"
@@ -184,5 +178,5 @@ Looking for more personalized assistance using a particular Gruntwork product? O
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"e1cbee1edc000586481ce97a59d2b8c0"}
+{"sourcePlugin":"local-copier","hash":"c0730cdc0a0bd008be10d785b0863bf9"}
 ##DOCS-SOURCER-END -->


### PR DESCRIPTION
This includes several updates to the support page:
* Clarifies that support@ email is available to all subscribers
* Adds a card for urgent-support@ email (pro/enterprise)
* Adds a card communicating ongoing private Slack channel option (pro/enterprise)
* Adds a card indicating that enterpise support tier can schedule live calls