### PR TITLE
Add new step in terraform 13 upgrade guide mentioning need to replace provider

### DIFF
--- a/_docs-sources/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-4-update-provider-sources.md
+++ b/_docs-sources/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-4-update-provider-sources.md
@@ -4,7 +4,7 @@ sidebar_label: Update provider sources
 
 # Step 4: update provider sources to the new format
 
-Terraform 13 introduced a new registry for managing provider releases. This makes it easier to publish and distribute
+Terraform 0.13 introduced a new registry for managing provider releases. This makes it easier to publish and distribute
 third party providers. As a part of this, Terraform changed the way providers are tracked in the state file. When
 running `terraform init` for the first time on a module that has been updated from <0.13 to 0.13+, you might notice
 Terraform installing two providers:

--- a/_docs-sources/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-4-update-provider-sources.md
+++ b/_docs-sources/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-4-update-provider-sources.md
@@ -1,0 +1,33 @@
+---
+sidebar_label: Update provider sources
+---
+
+# Step 4: update provider sources to the new format
+
+Terraform 13 introduced a new registry for managing provider releases. This makes it easier to publish and distribute
+third party providers. As a part of this, Terraform changed the way providers are tracked in the state file. When
+running `terraform init` for the first time on a module that has been updated from <0.13 to 0.13+, you might notice
+Terraform installing two providers:
+
+- `-/PROVIDER`
+- `hashicorp/PROVIDER`
+
+The first one is used to track legacy provider sources that are mentioned in the old state file, while the latter is
+what is configured in your module using the new `required_providers` blocks when you upgraded your modules in step 2.
+
+To avoid conflict between the two providers, it is recommended to update your state file to use the new provider
+references. This can be done by using the `state replace-provider` command.
+
+For each provider your module uses, run the following command:
+
+```
+# NOTE: Use terragrunt instead of terraform if you are using terragrunt to manage your resources.
+terraform state replace-provider -- -/PROVIDER registry.terraform.io/hashicorp/PROVIDER
+```
+
+For example, if your module uses `null` and `aws` providers, you will want to run:
+
+```
+terraform state replace-provider -- -/null registry.terraform.io/hashicorp/null
+terraform state replace-provider -- -/aws registry.terraform.io/hashicorp/aws
+```

--- a/docs/guides/stay-up-to-date/index.md
+++ b/docs/guides/stay-up-to-date/index.md
@@ -76,8 +76,5 @@ href="/guides/stay-up-to-date/terraform/terraform-1.1"
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "6108197b36342bbac59c8d32d9e3dfbb"
-}
+{"sourcePlugin":"local-copier","hash":"6108197b36342bbac59c8d32d9e3dfbb"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.1/core-concepts.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.1/core-concepts.md
@@ -13,8 +13,5 @@ post](https://www.hashicorp.com/blog/terraform-1-1-improves-refactoring-and-the-
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "49defa1819542396936b1f0481640f93"
-}
+{"sourcePlugin":"local-copier","hash":"49defa1819542396936b1f0481640f93"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.1/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-1-x.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.1/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-1-x.md
@@ -30,8 +30,5 @@ If you haven’t already, you need to:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "901f5f12726f3f8ebba1f5058c1e957a"
-}
+{"sourcePlugin":"local-copier","hash":"901f5f12726f3f8ebba1f5058c1e957a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.1/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.1/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -140,8 +140,5 @@ and the respective versions that are compatible with Terraform 1.1:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "2b2b98d7e75d84cb9b1df09cf54a734e"
-}
+{"sourcePlugin":"local-copier","hash":"2b2b98d7e75d84cb9b1df09cf54a734e"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.1/index.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.1/index.md
@@ -27,8 +27,5 @@ tag is compatible with Terraform 1.1.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "de75607ce00354136cfc3f917a2f047b"
-}
+{"sourcePlugin":"local-copier","hash":"de75607ce00354136cfc3f917a2f047b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.x/core-concepts.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.x/core-concepts.md
@@ -21,8 +21,5 @@ notes](https://github.com/hashicorp/terraform/releases/tag/v1.0.0):
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "ee2c203478dfbf3301d71f56df87cb65"
-}
+{"sourcePlugin":"local-copier","hash":"ee2c203478dfbf3301d71f56df87cb65"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.x/index.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.x/index.md
@@ -29,8 +29,5 @@ tag is compatible with Terraform 1.x.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "b902a9ed1b8a8c7ee812f8b2588235fa"
-}
+{"sourcePlugin":"local-copier","hash":"b902a9ed1b8a8c7ee812f8b2588235fa"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-4-update-provider-sources.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-4-update-provider-sources.md
@@ -4,7 +4,7 @@ sidebar_label: Update provider sources
 
 # Step 4: update provider sources to the new format
 
-Terraform 13 introduced a new registry for managing provider releases. This makes it easier to publish and distribute
+Terraform 0.13 introduced a new registry for managing provider releases. This makes it easier to publish and distribute
 third party providers. As a part of this, Terraform changed the way providers are tracked in the state file. When
 running `terraform init` for the first time on a module that has been updated from <0.13 to 0.13+, you might notice
 Terraform installing two providers:
@@ -34,5 +34,5 @@ terraform state replace-provider -- -/aws registry.terraform.io/hashicorp/aws
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"d98a8a6e1c32a10a51685f9fe5266cdd"}
+{"sourcePlugin":"local-copier","hash":"0c5aa574c82b473c254f163ea660dffa"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-4-update-provider-sources.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-4-update-provider-sources.md
@@ -1,0 +1,38 @@
+---
+sidebar_label: Update provider sources
+---
+
+# Step 4: update provider sources to the new format
+
+Terraform 13 introduced a new registry for managing provider releases. This makes it easier to publish and distribute
+third party providers. As a part of this, Terraform changed the way providers are tracked in the state file. When
+running `terraform init` for the first time on a module that has been updated from <0.13 to 0.13+, you might notice
+Terraform installing two providers:
+
+- `-/PROVIDER`
+- `hashicorp/PROVIDER`
+
+The first one is used to track legacy provider sources that are mentioned in the old state file, while the latter is
+what is configured in your module using the new `required_providers` blocks when you upgraded your modules in step 2.
+
+To avoid conflict between the two providers, it is recommended to update your state file to use the new provider
+references. This can be done by using the `state replace-provider` command.
+
+For each provider your module uses, run the following command:
+
+```
+# NOTE: Use terragrunt instead of terraform if you are using terragrunt to manage your resources.
+terraform state replace-provider -- -/PROVIDER registry.terraform.io/hashicorp/PROVIDER
+```
+
+For example, if your module uses `null` and `aws` providers, you will want to run:
+
+```
+terraform state replace-provider -- -/null registry.terraform.io/hashicorp/null
+terraform state replace-provider -- -/aws registry.terraform.io/hashicorp/aws
+```
+
+
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"local-copier","hash":"d98a8a6e1c32a10a51685f9fe5266cdd"}
+##DOCS-SOURCER-END -->


### PR DESCRIPTION
A few of our customers got tripped up with the new provider source format in the state, causing errors when upgrading from terraform <0.13 to 0.13+.

This PR updates our upgrade guide to mention an explicit step to replace the provider sources, which should avoid this error.