### PR TITLE
Remove urgent-support email address and change support URL

### DIFF
--- a/_docs-sources/support.mdx
+++ b/_docs-sources/support.mdx
@@ -38,15 +38,6 @@ We’re here to assist when you get stuck. Basic support is included with every 
     concerns you may have.
   </Card>
   <Card
-    title="Email with SLA Response"
-    icon="/img/support/email-urgent-icon.svg"
-    href="mailto:urgent-support@gruntwork.io"
-    tags={["pro", "enterprise"]}
-  >
-    Messages sent to <address>urgent-support@gruntwork.io</address> will receive
-    a response within your plan's Service Level Agreement.
-  </Card>
-  <Card
     title="Chat with Gruntwork"
     icon="/img/support/chat-icon.svg"
     href="#chat-with-us-in-slack"
@@ -116,7 +107,7 @@ If you have Professional Support and haven't yet set up your private Slack chann
 
 #### Email us
 
-Send your general support requests to support@gruntwork.io, and any urgent requests to urgent-support@gruntwork.io. You can track your request through our [support portal](https://gruntwork.zendesk.com), and you’ll receive a response within two business days.
+Send your general support requests to support@gruntwork.io. You can track your request through our [support portal](https://support.gruntwork.io), and you’ll receive a response within two business days.
 
 ### Guaranteed Response Times
 
@@ -153,7 +144,7 @@ If you have Enterprise Support and haven't yet set up your private Slack channel
 
 #### Email us
 
-Send your general support requests to support@gruntwork.io, and any urgent requests to urgent-support@gruntwork.io. You can track your request through our [support portal](https://gruntwork.zendesk.com), and you’ll receive a response within one business day.
+Send your general support requests to support@gruntwork.io. You can track your request through our [support portal](https://support.gruntwork.io), and you’ll receive a response within one business day.
 
 ### Guaranteed Response Times
 

--- a/docs/support.mdx
+++ b/docs/support.mdx
@@ -38,15 +38,6 @@ We’re here to assist when you get stuck. Basic support is included with every 
     concerns you may have.
   </Card>
   <Card
-    title="Email with SLA Response"
-    icon="/img/support/email-urgent-icon.svg"
-    href="mailto:urgent-support@gruntwork.io"
-    tags={["pro", "enterprise"]}
-  >
-    Messages sent to <address>urgent-support@gruntwork.io</address> will receive
-    a response within your plan's Service Level Agreement.
-  </Card>
-  <Card
     title="Chat with Gruntwork"
     icon="/img/support/chat-icon.svg"
     href="#chat-with-us-in-slack"
@@ -116,7 +107,7 @@ If you have Professional Support and haven't yet set up your private Slack chann
 
 #### Email us
 
-Send your general support requests to support@gruntwork.io, and any urgent requests to urgent-support@gruntwork.io. You can track your request through our [support portal](https://gruntwork.zendesk.com), and you’ll receive a response within two business days.
+Send your general support requests to support@gruntwork.io. You can track your request through our [support portal](https://support.gruntwork.io), and you’ll receive a response within two business days.
 
 ### Guaranteed Response Times
 
@@ -153,7 +144,7 @@ If you have Enterprise Support and haven't yet set up your private Slack channel
 
 #### Email us
 
-Send your general support requests to support@gruntwork.io, and any urgent requests to urgent-support@gruntwork.io. You can track your request through our [support portal](https://gruntwork.zendesk.com), and you’ll receive a response within one business day.
+Send your general support requests to support@gruntwork.io. You can track your request through our [support portal](https://support.gruntwork.io), and you’ll receive a response within one business day.
 
 ### Guaranteed Response Times
 
@@ -170,5 +161,5 @@ Looking for more personalized assistance using a particular Gruntwork product? O
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"7b8f83075597afbd09ee1dc096293a12"}
+{"sourcePlugin":"local-copier","hash":"0198bea2fa710edbf97ce65d2f1afcca"}
 ##DOCS-SOURCER-END -->


### PR DESCRIPTION
We added this email address a little while ago, but changed tack. This removes it, and also updates the Zendesk URL to be one that is on the gruntwork.io domain.