### PR TITLE
Bump docs-sourcer version

### DIFF
--- a/docs/courses.mdx
+++ b/docs/courses.mdx
@@ -58,5 +58,8 @@ Courses are offered through Teachable. Access is included with every Gruntwork s
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"33744450a711b984427abb3c19bf1c77"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "33744450a711b984427abb3c19bf1c77"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/devops-general/index.md
+++ b/docs/faq/devops-general/index.md
@@ -10,5 +10,8 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"edc21b0a2f48bdf03447da1c1cb9ac21"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "edc21b0a2f48bdf03447da1c1cb9ac21"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/eks/index.md
+++ b/docs/faq/eks/index.md
@@ -14,5 +14,8 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"d95f4a0a70695a6733735a2c67f6bd4e"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "d95f4a0a70695a6733735a2c67f6bd4e"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/iac-general/index.md
+++ b/docs/faq/iac-general/index.md
@@ -6,5 +6,8 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"36bb7ec496d13c871b1259ef31ea7b1f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "36bb7ec496d13c871b1259ef31ea7b1f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -69,5 +69,8 @@ Get answers to frequently asked questions, organized by category.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"dbdf6417d65b463c42d8decdbed70717"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "dbdf6417d65b463c42d8decdbed70717"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/pipelines/index.md
+++ b/docs/faq/pipelines/index.md
@@ -13,5 +13,8 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a07af15175a16401cffba58d7eb21ef0"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "a07af15175a16401cffba58d7eb21ef0"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/ref-arch-predeployment/index.md
+++ b/docs/faq/ref-arch-predeployment/index.md
@@ -26,5 +26,8 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"dc57285f55e7caced69fdb4052fa6264"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "dc57285f55e7caced69fdb4052fa6264"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/ref-arch/index.md
+++ b/docs/faq/ref-arch/index.md
@@ -32,5 +32,8 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"613ecde6c13ca14adbc92aac692f90bf"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "613ecde6c13ca14adbc92aac692f90bf"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/service-catalog/index.md
+++ b/docs/faq/service-catalog/index.md
@@ -10,5 +10,8 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"1ab393265d039a3821716343f10c0e0b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "1ab393265d039a3821716343f10c0e0b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/terragrunt/index.md
+++ b/docs/faq/terragrunt/index.md
@@ -16,5 +16,8 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"98df4b23885f621d3307a6112f2c6c9b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "98df4b23885f621d3307a6112f2c6c9b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/terratest/index.md
+++ b/docs/faq/terratest/index.md
@@ -12,5 +12,8 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"6d88bf0ee938daacc5ee3c6547d45d3d"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "6d88bf0ee938daacc5ee3c6547d45d3d"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/core-concepts/intro.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/core-concepts/intro.md
@@ -51,5 +51,8 @@ controls.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"306ddcbed0920339735b69c9f1a73219"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "306ddcbed0920339735b69c9f1a73219"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/core-concepts/recommendation-sections.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/core-concepts/recommendation-sections.md
@@ -58,5 +58,8 @@ suggest limiting routing for VPC peering connections based on [the principle of 
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"412cad5a976b20ef5276a584348b1e87"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "412cad5a976b20ef5276a584348b1e87"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/create-an-iam-user-in-the-root-account.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/create-an-iam-user-in-the-root-account.md
@@ -14,5 +14,8 @@ IAM user manually by
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"4d6487d6c1c3be7d2da2e166f24c93e0"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "4d6487d6c1c3be7d2da2e166f24c93e0"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/create-the-root-account.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/create-the-root-account.md
@@ -9,5 +9,8 @@ The first step is to create your root account. This account will be the parent o
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"1a99aa01895f6501a3b02d3c2c087c59"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "1a99aa01895f6501a3b02d3c2c087c59"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/create-vpc-flow-logs.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/create-vpc-flow-logs.md
@@ -155,5 +155,8 @@ default security groups from all VPCs in all regions.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"8312868084cd9973395eb4fd0af2d900"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "8312868084cd9973395eb4fd0af2d900"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-app-to-logs-account.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-app-to-logs-account.md
@@ -271,5 +271,8 @@ On some operating systems, such as MacOS, you may also need to increase your ope
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"4b5387c63b27de9f1446fe439d6438af"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "4b5387c63b27de9f1446fe439d6438af"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-app-to-other-child-accounts.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-app-to-other-child-accounts.md
@@ -309,5 +309,8 @@ the benchmark, v1.3.0; the AWS Security Hub does not support this version at the
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"33d01518a80c1b75e1bbe137ef4763ff"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "33d01518a80c1b75e1bbe137ef4763ff"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-root-to-root-account.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-root-to-root-account.md
@@ -587,5 +587,8 @@ those root users again.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"16a777737a8d6c48de0fe2f6ca292c5a"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "16a777737a8d6c48de0fe2f6ca292c5a"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-security-to-security-account.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-security-to-security-account.md
@@ -330,5 +330,8 @@ echo "<PASSWORD>" | base64 --decode | keybase pgp decrypt
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"defd1dc9d6c10d7c36b4bf207bfe074f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "defd1dc9d6c10d7c36b4bf207bfe074f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/enable-key-rotation-for-kms-keys.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/enable-key-rotation-for-kms-keys.md
@@ -6,5 +6,8 @@ to create KMS keys with key rotation enabled by default.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"61d36e4a905478a070114a1cb7e9cd4e"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "61d36e4a905478a070114a1cb7e9cd4e"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/maintain-compliance-by-following-iam-best-practices.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/maintain-compliance-by-following-iam-best-practices.md
@@ -19,5 +19,8 @@ We conclude the IAM section with a few parting words of wisdom for maintaining c
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"eb60c65580aa8aea2e2209212c54e24f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "eb60c65580aa8aea2e2209212c54e24f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/maintain-compliance-by-following-logging-best-practices.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/maintain-compliance-by-following-logging-best-practices.md
@@ -4,5 +4,8 @@ The logging section of the Benchmark includes configurations for CloudTrail, AWS
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"39456528af509fa05ddd582fa6983d8f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "39456528af509fa05ddd582fa6983d8f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/maintain-compliance-by-following-storage-best-practices.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/maintain-compliance-by-following-storage-best-practices.md
@@ -18,5 +18,8 @@ the hood.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"b2f8907a2b4273753794fb96e9f89ffe"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "b2f8907a2b4273753794fb96e9f89ffe"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/use-iam-roles-for-ec2-instances.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/use-iam-roles-for-ec2-instances.md
@@ -23,5 +23,8 @@ access to the AWS API. Using static API credentials should be avoided whenever p
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"af99b295cc0bfa675cbfdf671eb033a7"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "af99b295cc0bfa675cbfdf671eb033a7"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deployment-approach.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deployment-approach.md
@@ -9,5 +9,8 @@ The standalone modules will follow the pattern of referencing the module and pro
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a9dde76d161304ab0b3185f97436ca20"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "a9dde76d161304ab0b3185f97436ca20"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/lock-down-the-root-account-iam-users.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/lock-down-the-root-account-iam-users.md
@@ -32,5 +32,8 @@ so using a virtual or hardware MFA device is preferable; that said, MFA with SMS
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"e0e6d5a424416b59aff4c05e685cc5e9"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "e0e6d5a424416b59aff4c05e685cc5e9"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/lock-down-the-root-user.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/lock-down-the-root-user.md
@@ -62,5 +62,8 @@ your credentials) or for the
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a5b9b812a92ff9ac762947e49a73ce40"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "a5b9b812a92ff9ac762947e49a73ce40"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/pre-requisites.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/pre-requisites.md
@@ -55,5 +55,8 @@ automatically.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"cfc6e23713c964098ba9f49dbe2a448f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "cfc6e23713c964098ba9f49dbe2a448f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/prepare-your-infrastructure-live-repository.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/prepare-your-infrastructure-live-repository.md
@@ -9,5 +9,8 @@ We’ve previously described exactly how to prepare your repository in the
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"b8d57689504020947c3b27c055920715"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "b8d57689504020947c3b27c055920715"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/the-gruntwork-solution.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/the-gruntwork-solution.md
@@ -59,5 +59,8 @@ our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork) section.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"81acd02dda18bf32fb8caa79c4628c3c"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "81acd02dda18bf32fb8caa79c4628c3c"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/index.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/index.md
@@ -69,5 +69,8 @@ walkthrough.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ad41a4a60d33f97c8b859e17562bef13"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "ad41a4a60d33f97c8b859e17562bef13"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/next-steps.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/next-steps.md
@@ -13,5 +13,8 @@ Now it’s time to confirm that your configurations are correct and you didn’t
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"da234b67eaac211be828271e9d5a4a40"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "da234b67eaac211be828271e9d5a4a40"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/identity-and-access-management.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/identity-and-access-management.md
@@ -347,5 +347,8 @@ For further detail, follow the manual steps outlined in the CIS Benchmark docume
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"d8bfa6313c4037ed79aa14ac13940728"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "d8bfa6313c4037ed79aa14ac13940728"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/intro.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/intro.md
@@ -18,5 +18,8 @@ edition of Terraform Up & Running](https://blog.gruntwork.io/terraform-up-runnin
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ab4dea7e2ecd7ee7d27a518c86385d5b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "ab4dea7e2ecd7ee7d27a518c86385d5b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/logging.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/logging.md
@@ -148,5 +148,8 @@ the default VPCs which exist in all regions of the account. You can use the
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"fa7e59351da6b6e1fadfd62d09cf2c27"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "fa7e59351da6b6e1fadfd62d09cf2c27"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/monitoring.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/monitoring.md
@@ -12,5 +12,8 @@ Terraform resources.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"6f13f1638eebe902e46fb2759688903f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "6f13f1638eebe902e46fb2759688903f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/networking.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/networking.md
@@ -21,5 +21,8 @@ on the services running on those subnets. This can help to avoid exposing servic
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"eea45ba729cc31d9d27d7266188b3a58"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "eea45ba729cc31d9d27d7266188b3a58"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/storage.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/storage.md
@@ -138,5 +138,8 @@ explicit list of buckets per region, namely in the variable `buckets_to_analyze`
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a42545420e9759182b9a7727a91aab4a"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "a42545420e9759182b9a7727a91aab4a"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/traceability-matrix.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/traceability-matrix.md
@@ -734,5 +734,8 @@ sections above.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"deda90311b36e4b300a2d13b43d04817"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "deda90311b36e4b300a2d13b43d04817"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/index.md
+++ b/docs/guides/build-it-yourself/index.md
@@ -63,5 +63,8 @@ The Gruntwork IaC library empowers you to construct your own bespoke architectur
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"9e81132b36c74657d6bce6895ca8e817"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "9e81132b36c74657d6bce6895ca8e817"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/interacting-with-kubernetes.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/interacting-with-kubernetes.md
@@ -59,5 +59,8 @@ Terraform code anyway (e.g., execute a script).
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ede0867c6736ce962649a05fe05c141f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "ede0867c6736ce962649a05fe05c141f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/kubernetes-access-control.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/kubernetes-access-control.md
@@ -42,5 +42,8 @@ namespace), and associate those roles with the specific user and service account
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"d29f803c93ab0f3d203614b9f0e15d33"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "d29f803c93ab0f3d203614b9f0e15d33"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/kubernetes-architecture.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/kubernetes-architecture.md
@@ -106,5 +106,8 @@ used for Service Discovery within Kubernetes, a topic we’ll discuss later.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"42caae9827cb7b64f4c5e0b6e9d7c00d"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "42caae9827cb7b64f4c5e0b6e9d7c00d"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/kubernetes-resources.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/kubernetes-resources.md
@@ -123,5 +123,8 @@ secrets unencrypted!).
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"515b338cb8b99a1ad5127df1aa98c187"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "515b338cb8b99a1ad5127df1aa98c187"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/options-for-running-kubernetes-in-aws.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/options-for-running-kubernetes-in-aws.md
@@ -36,5 +36,8 @@ still fairly new, so some functionality is missing or more complicated to use th
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"014ad817a0f78576ebd997277ebec6a2"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "014ad817a0f78576ebd997277ebec6a2"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/what-is-kubernetes.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/what-is-kubernetes.md
@@ -41,5 +41,8 @@ Provide containers with environment-specific configuration data and secrets.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"90e5f0b5e2067db1b348484f5df12685"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "90e5f0b5e2067db1b348484f5df12685"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/why-kubernetes.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/why-kubernetes.md
@@ -38,5 +38,8 @@ continuously getting better.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"87ef2e892443e7eb5ba94d715722233f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "87ef2e892443e7eb5ba94d715722233f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/10-try-out-the-cluster.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/10-try-out-the-cluster.md
@@ -19,5 +19,8 @@ kubectl get nodes
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ce3e3dd28d904805638be7b3e6cf7bd9"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "ce3e3dd28d904805638be7b3e6cf7bd9"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/11-updating-the-worker-nodes.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/11-updating-the-worker-nodes.md
@@ -41,5 +41,8 @@ kubergrunt eks deploy --region <AWS_REGION> --asg-name <AUTO_SCALING_GROUP_NAME>
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"7e4f6f3320632a138f9f4eb9d05b2385"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "7e4f6f3320632a138f9f4eb9d05b2385"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-access-to-the-control-plane-and-worker-nodes.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-access-to-the-control-plane-and-worker-nodes.md
@@ -103,5 +103,8 @@ resource "aws_iam_role_policy" "ssh_grunt_permissions" {
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"985bfb828a22c317d6b029d2afb50f13"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "985bfb828a22c317d6b029d2afb50f13"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-logging-metrics-and-alarms-for-the-worker-nodes.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-logging-metrics-and-alarms-for-the-worker-nodes.md
@@ -95,5 +95,8 @@ data "terraform_remote_state" "sns_region" {
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"89574f3a5a0644f6cc08c0ac71026395"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "89574f3a5a0644f6cc08c0ac71026395"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-role-mapping.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-role-mapping.md
@@ -76,5 +76,8 @@ data "aws_eks_cluster_auth" "kubernetes_token" {
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"b38a1e8d5a91d55332bd4b3507773920"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "b38a1e8d5a91d55332bd4b3507773920"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-the-control-plane.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-the-control-plane.md
@@ -129,5 +129,8 @@ variable "terraform_state_s3_bucket" {
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"c117b6c75e7609d24e95b51029946518"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "c117b6c75e7609d24e95b51029946518"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-the-worker-node-user-data-script.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-the-worker-node-user-data-script.md
@@ -105,5 +105,8 @@ data "template_file" "user_data" {
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"f6e4c30ad255804535b49152c8f38011"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "f6e4c30ad255804535b49152c8f38011"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-the-worker-nodes.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-the-worker-nodes.md
@@ -74,5 +74,8 @@ variable "cluster_instance_keypair_name" {
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"5e5c32c3eb4bb045778d6baa48588f63"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "5e5c32c3eb4bb045778d6baa48588f63"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/create-the-worker-node-ami.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/create-the-worker-node-ami.md
@@ -137,5 +137,8 @@ guide.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"e5f9d652cc31940ba66f4a28616a859c"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "e5f9d652cc31940ba66f4a28616a859c"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/deploy-the-eks-cluster.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/deploy-the-eks-cluster.md
@@ -124,5 +124,8 @@ terragrunt apply
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"583d7ce531dae4a139a6d2a9be293e1d"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "583d7ce531dae4a139a6d2a9be293e1d"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/deploy-the-vpc.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/deploy-the-vpc.md
@@ -149,5 +149,8 @@ terragrunt apply
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"58b8f9e6fdf484fe77a7af365a0b1d52"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "58b8f9e6fdf484fe77a7af365a0b1d52"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/pre-requisites.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/pre-requisites.md
@@ -58,5 +58,8 @@ for instructions.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"bb604626b168b80f098c1e9b7153e517"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "bb604626b168b80f098c1e9b7153e517"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/index.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/index.md
@@ -50,5 +50,8 @@ This guide will walk you through the process of configuring a production-grade K
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"2bc76558e0896d476267b38e9d6182a1"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "2bc76558e0896d476267b38e9d6182a1"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/next-steps.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/next-steps.md
@@ -9,5 +9,8 @@ any data stores they depend on by using the following guides:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"643cf72893cefb9b09e6294e3290486f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "643cf72893cefb9b09e6294e3290486f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/authenticate.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/authenticate.md
@@ -71,5 +71,8 @@ this tool separately, so we are just recording this here for historical reasons.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"5d6b9747b406cb6ddc44edd9134b8364"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "5d6b9747b406cb6ddc44edd9134b8364"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/control-plane.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/control-plane.md
@@ -54,5 +54,8 @@ CloudWatch.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"33906f19517c426da30c4b4055e951d5"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "33906f19517c426da30c4b4055e951d5"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/iam-role-mapping-and-rbac.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/iam-role-mapping-and-rbac.md
@@ -45,5 +45,8 @@ assume those roles.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ff384b3108de45dc98d77a4b652db03c"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "ff384b3108de45dc98d77a4b652db03c"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/intro.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/intro.md
@@ -11,5 +11,8 @@ that looks something like this:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"c88f426a734a69c8fb4fe700b67ac612"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "c88f426a734a69c8fb4fe700b67ac612"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/logging.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/logging.md
@@ -27,5 +27,8 @@ the logs from the worker nodes (including all the pods on them) to CloudWatch.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"345e40c904372f680deb43eb3be26cd4"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "345e40c904372f680deb43eb3be26cd4"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/protecting-pods.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/protecting-pods.md
@@ -34,5 +34,8 @@ gives it permissions to talk solely to the other pods it should be able to acces
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"c3d9ad836a5f25fa94a9454107f65885"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "c3d9ad836a5f25fa94a9454107f65885"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/use-eks.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/use-eks.md
@@ -8,5 +8,8 @@ solutions will most likely be eclipsed very quickly by future EKS releases.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"5c1d0eaffbf00b57e330e9a2dc9dc150"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "5c1d0eaffbf00b57e330e9a2dc9dc150"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/vpc-configuration.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/vpc-configuration.md
@@ -30,5 +30,8 @@ sure that remote VPC DNS resolution is enabled on both accepter and requester si
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"13fa4dbe8f473c8e7d1a69075e8b8332"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "13fa4dbe8f473c8e7d1a69075e8b8332"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/worker-nodes.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/worker-nodes.md
@@ -66,5 +66,8 @@ a secure base image (e.g., CIS hardened images), intrusion prevention (e.g., `fa
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a43f6ca97de73dd352c53ef2b9c67447"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "a43f6ca97de73dd352c53ef2b9c67447"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/aws-account.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/aws-account.md
@@ -12,5 +12,8 @@ to share it publicly on the Internet), and you will be logged into your new AWS 
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a26a34b590ddc29e228b8a54169fe46f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "a26a34b590ddc29e228b8a54169fe46f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/aws-config.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/aws-config.md
@@ -19,5 +19,8 @@ but you can also author your own [custom rules](https://docs.aws.amazon.com/conf
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"c0738bbc3e7e12844bba76062de1f2d3"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "c0738bbc3e7e12844bba76062de1f2d3"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/aws-organizations.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/aws-organizations.md
@@ -47,5 +47,8 @@ those regions or services do not meet your company’s compliance requirements (
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"82ac4c70419f79af31d32ad9d227017f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "82ac4c70419f79af31d32ad9d227017f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/cloud-trail.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/cloud-trail.md
@@ -14,5 +14,8 @@ incidents, and maintaining audit logs for compliance.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a50f2d65b0b6df3c41b2ac3f06978253"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "a50f2d65b0b6df3c41b2ac3f06978253"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/federated-authentication.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/federated-authentication.md
@@ -34,5 +34,8 @@ requires multiple steps, including manually copy/pasting credentials.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ce9789097213ecbf3283dc36a00de4c0"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "ce9789097213ecbf3283dc36a00de4c0"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/guard-duty.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/guard-duty.md
@@ -11,5 +11,8 @@ intelligence to identify and prioritize potential threats.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"9cb49659918b9b4e5dd2a2d286b0e06e"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "9cb49659918b9b4e5dd2a2d286b0e06e"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/iam-groups.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/iam-groups.md
@@ -13,5 +13,8 @@ and assign each IAM user to the appropriate IAM groups.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"6ed6987baac0556cbd72538586818a92"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "6ed6987baac0556cbd72538586818a92"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/iam-policies.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/iam-policies.md
@@ -70,5 +70,8 @@ S3 bucket.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a4908e782e751d52c4e94bd29c054a42"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "a4908e782e751d52c4e94bd29c054a42"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/iam-roles.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/iam-roles.md
@@ -125,5 +125,8 @@ services permissions to access specific resources in your AWS account.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"4665d08042eeca71ae65dd366edfc6b6"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "4665d08042eeca71ae65dd366edfc6b6"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/iam-users.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/iam-users.md
@@ -70,5 +70,8 @@ user permissions, you will need to use IAM policies, which are the topic of the 
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"17f37d79f888c3473e9bb0d065d07342"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "17f37d79f888c3473e9bb0d065d07342"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/root-user.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/root-user.md
@@ -60,5 +60,8 @@ more limited permissions, and then you’ll likely never touch the root user acc
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"0ea3d2d2cf61de3dc23190489c4ec9d5"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "0ea3d2d2cf61de3dc23190489c4ec9d5"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/what-is-an-aws-account-structure.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/what-is-an-aws-account-structure.md
@@ -35,5 +35,8 @@ breakdowns by account, service, tag, etc.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"362ad001515117c47bdd32c727dda5cb"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "362ad001515117c47bdd32c727dda5cb"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/apply-the-security-baseline-to-the-logs-account.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/apply-the-security-baseline-to-the-logs-account.md
@@ -153,5 +153,8 @@ On some operating systems, such as MacOS, you may also need to increase your ope
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"5897f14941f18912553be9b56c315a44"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "5897f14941f18912553be9b56c315a44"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/apply-the-security-baseline-to-the-other-child-accounts.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/apply-the-security-baseline-to-the-other-child-accounts.md
@@ -163,5 +163,8 @@ Remember to repeat this process in the other child accounts too (i.e., dev, prod
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"45173e5da3f7dee7be00b3a1817b2ba5"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "45173e5da3f7dee7be00b3a1817b2ba5"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/apply-the-security-baseline-to-the-root-account.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/apply-the-security-baseline-to-the-root-account.md
@@ -81,5 +81,8 @@ echo "<PASSWORD>" | base64 --decode | keybase pgp decrypt
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"73e0abc5a85b7eed2ade8902177ee939"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "73e0abc5a85b7eed2ade8902177ee939"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/apply-the-security-baseline-to-the-security-account.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/apply-the-security-baseline-to-the-security-account.md
@@ -203,5 +203,8 @@ echo "<PASSWORD>" | base64 --decode | keybase pgp decrypt
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"6bb19e643b3460a03224cc1c7959407b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "6bb19e643b3460a03224cc1c7959407b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/configure-the-security-baseline-for-the-root-account.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/configure-the-security-baseline-for-the-root-account.md
@@ -173,5 +173,8 @@ and any other existing resources.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"30683ab11accc62e34aedda01ae175a3"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "30683ab11accc62e34aedda01ae175a3"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/create-an-iam-user-in-the-root-account.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/create-an-iam-user-in-the-root-account.md
@@ -18,5 +18,8 @@ IAM user manually by
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a101684204db60a27bcace52b801c84b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "a101684204db60a27bcace52b801c84b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/create-the-root-account.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/create-the-root-account.md
@@ -14,5 +14,8 @@ the central place where you manage billing. You create this initial account manu
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"429cdfbcd62cd69e8a3eebd428aff6a6"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "429cdfbcd62cd69e8a3eebd428aff6a6"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/import-existing-resources-from-the-root-account-into-terraform-state.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/import-existing-resources-from-the-root-account-into-terraform-state.md
@@ -145,5 +145,8 @@ rm -rf .terragrunt-cache
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"737fee69c235a1357cbc84f6f8c5ddcd"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "737fee69c235a1357cbc84f6f8c5ddcd"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/lock-down-the-root-account-iam-users.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/lock-down-the-root-account-iam-users.md
@@ -35,5 +35,8 @@ so using a virtual or hardware MFA device is preferable; that said, MFA with SMS
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"32a5dce3ef592eceb9dde972c55c3488"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "32a5dce3ef592eceb9dde972c55c3488"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/lock-down-the-root-user-in-the-child-accounts.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/lock-down-the-root-user-in-the-child-accounts.md
@@ -6,5 +6,8 @@ those root users again.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"c85c9033ffe3883e37dd273344e69c93"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "c85c9033ffe3883e37dd273344e69c93"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/lock-down-the-root-user.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/lock-down-the-root-user.md
@@ -45,5 +45,8 @@ your credentials) or for the
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"7a79f34d25438e5b383ac8ba0284b60f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "7a79f34d25438e5b383ac8ba0284b60f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/pre-requisites.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/pre-requisites.md
@@ -56,5 +56,8 @@ automatically.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"236b0439a1fea830fcd050c5a4b2bbbf"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "236b0439a1fea830fcd050c5a4b2bbbf"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/prepare-your-infrastructure-live-repository.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/prepare-your-infrastructure-live-repository.md
@@ -176,5 +176,8 @@ locals {
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"35887123ab1bc3a011216db14a532073"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "35887123ab1bc3a011216db14a532073"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/reset-the-root-user-password-in-each-child-account.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/reset-the-root-user-password-in-each-child-account.md
@@ -13,5 +13,8 @@ Use this process to reset the password for the root user of each child account y
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"15ed745884720a8772c22f6a45107605"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "15ed745884720a8772c22f6a45107605"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/try-authenticating-as-an-iam-user-to-the-child-accounts.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/try-authenticating-as-an-iam-user-to-the-child-accounts.md
@@ -25,5 +25,8 @@ authenticating:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"35cbebd2ff2edeb050efe3fdeb75a877"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "35cbebd2ff2edeb050efe3fdeb75a877"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/index.md
+++ b/docs/guides/build-it-yourself/landing-zone/index.md
@@ -97,5 +97,8 @@ Feel free to read this guide from start to finish or skip around to whatever sec
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"752e6d34077e9e0dc32fc210b7f4e60c"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "752e6d34077e9e0dc32fc210b7f4e60c"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/next-steps.md
+++ b/docs/guides/build-it-yourself/landing-zone/next-steps.md
@@ -6,5 +6,8 @@ accounts! Usually, the best starting point is to configure your network topology
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"5b9f8101edad02a62a1b7fb5f75275e6"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "5b9f8101edad02a62a1b7fb5f75275e6"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/aws-config.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/aws-config.md
@@ -17,5 +17,8 @@ We typically recommend that you aggregate AWS Config data in the logs account. T
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"fe326f40c8b8ed46a200d6adef9a1f2b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "fe326f40c8b8ed46a200d6adef9a1f2b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/child-accounts.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/child-accounts.md
@@ -68,5 +68,8 @@ for large organizations to have dozens or even hundreds of AWS accounts.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"3e830de18a177052333745fb4918957c"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "3e830de18a177052333745fb4918957c"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/cloud-trail.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/cloud-trail.md
@@ -18,5 +18,8 @@ happening in the account. We typically recommend that you aggregate these logs i
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"4ef96ebe041d1549530790269f1c7dff"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "4ef96ebe041d1549530790269f1c7dff"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/federated-auth.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/federated-auth.md
@@ -52,5 +52,8 @@ so if you want to require MFA, you need to do that in the IdP itself (i.e., in G
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"faac25bb0d3743a5cbbacf88bd4a50de"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "faac25bb0d3743a5cbbacf88bd4a50de"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/guard-duty.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/guard-duty.md
@@ -8,5 +8,8 @@ publishing GuardDuty’s findings to a dedicated Amazon SNS topic.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"f8a2464c61fa3e9f9f138b75d8cc477d"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "f8a2464c61fa3e9f9f138b75d8cc477d"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/iam-roles-for-services.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/iam-roles-for-services.md
@@ -136,5 +136,8 @@ sensitive machine user access keys.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"6a6f172c3ecdc65911aeb1e7770e05e6"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "6a6f172c3ecdc65911aeb1e7770e05e6"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/iam-roles-for-users.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/iam-roles-for-users.md
@@ -56,5 +56,8 @@ server and allows developers with access to these IAM roles to request VPN certi
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"f159d5c23afaa110863cab6ea08681f6"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "f159d5c23afaa110863cab6ea08681f6"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/iam-users-and-groups.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/iam-users-and-groups.md
@@ -45,5 +45,8 @@ You must be a <span className="js-subscribe-cta">Gruntwork subscriber</span> to 
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"99eaa2fe1ef9ded6186b0122c1e886b1"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "99eaa2fe1ef9ded6186b0122c1e886b1"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/intro.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/intro.md
@@ -13,5 +13,8 @@ we'll break it down piece by piece in the next few sections.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"cba12c0619ad568620c14ecef35e7318"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "cba12c0619ad568620c14ecef35e7318"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/mfa-policy.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/mfa-policy.md
@@ -35,5 +35,8 @@ place.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"9b3c7722e10bbb324ab1ada41fea5587"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "9b3c7722e10bbb324ab1ada41fea5587"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/password-policy.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/password-policy.md
@@ -7,5 +7,8 @@ certain compliance requirements may force you to use a specific password policy)
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a73f3b1d9fcf38b8631f4cf2f9b054e6"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "a73f3b1d9fcf38b8631f4cf2f9b054e6"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/the-root-account.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/the-root-account.md
@@ -12,5 +12,8 @@ IAM group that gives the finance team access to the billing details.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"1121dc71681544ba526d79d51610b718"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "1121dc71681544ba526d79d51610b718"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/core-concepts/ci-cd-platforms.md
+++ b/docs/guides/build-it-yourself/pipelines/core-concepts/ci-cd-platforms.md
@@ -131,5 +131,8 @@ provides, as well as how they mitigate the threat model that we cover:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"c728900868ee40f23042497e3d1c64f2"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "c728900868ee40f23042497e3d1c64f2"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/core-concepts/ci-cd-workflows.md
+++ b/docs/guides/build-it-yourself/pipelines/core-concepts/ci-cd-workflows.md
@@ -440,5 +440,8 @@ for this type of workflow.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"284f183e734e92f7edc7feef7d0fc603"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "284f183e734e92f7edc7feef7d0fc603"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/core-concepts/threat-model-of-ci-cd.md
+++ b/docs/guides/build-it-yourself/pipelines/core-concepts/threat-model-of-ci-cd.md
@@ -48,5 +48,8 @@ With this threat model in mind, let’s take a look at the different CI/CD platf
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"0405627489307382892291a16e5ecc7b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "0405627489307382892291a16e5ecc7b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/core-concepts/trunk-based-development-model.md
+++ b/docs/guides/build-it-yourself/pipelines/core-concepts/trunk-based-development-model.md
@@ -56,5 +56,8 @@ infrastructure code.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"7e5794c67b0a6291110316f83cf3ec40"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "7e5794c67b0a6291110316f83cf3ec40"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/core-concepts/types-of-infrastructure-code.md
+++ b/docs/guides/build-it-yourself/pipelines/core-concepts/types-of-infrastructure-code.md
@@ -36,5 +36,8 @@ infrastructure modules, and live infrastructure configuration.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"c2807b3ca886f83c5a5bbab1b46bbdf3"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "c2807b3ca886f83c5a5bbab1b46bbdf3"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/core-concepts/what-is-continuous-integration-and-continuous-delivery.md
+++ b/docs/guides/build-it-yourself/pipelines/core-concepts/what-is-continuous-integration-and-continuous-delivery.md
@@ -14,5 +14,8 @@ of a production-ready CI/CD pipeline for infrastructure code.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"055f3cc7ce91e5b026c8544984db2953"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "055f3cc7ce91e5b026c8544984db2953"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/core-concepts/why-is-it-important-to-have-ci-cd.md
+++ b/docs/guides/build-it-yourself/pipelines/core-concepts/why-is-it-important-to-have-ci-cd.md
@@ -38,5 +38,8 @@ ensuring that there is ample time for improvements and corrections.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a6ab72f0c256b45899a32fc4d7da617f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "a6ab72f0c256b45899a32fc4d7da617f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/configure-ci-server.md
+++ b/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/configure-ci-server.md
@@ -39,5 +39,8 @@ events!
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"80db423fbd3342a56695e95ad0398426"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "80db423fbd3342a56695e95ad0398426"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/define-pipeline-as-code.md
+++ b/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/define-pipeline-as-code.md
@@ -473,5 +473,8 @@ jobs:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"5e170f18736a77f9cef786d57bde6f1e"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "5e170f18736a77f9cef786d57bde6f1e"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/deploy-a-vpc.md
+++ b/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/deploy-a-vpc.md
@@ -37,5 +37,8 @@ infrastructure-live
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"717d3f161c59cb4de6dce9c9af8d5f46"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "717d3f161c59cb4de6dce9c9af8d5f46"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/deploy-the-ecs-deploy-runner.md
+++ b/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/deploy-the-ecs-deploy-runner.md
@@ -751,5 +751,8 @@ Repeat for each environment that you want to support the ECS Deploy Runner stack
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"8029084fb854ab63c9abd3a29140edc0"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "8029084fb854ab63c9abd3a29140edc0"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/pre-requisites.md
+++ b/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/pre-requisites.md
@@ -67,5 +67,8 @@ on alternative options, such as how to
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"791cc3285e6008466de5d18f80dec125"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "791cc3285e6008466de5d18f80dec125"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/try-out-the-ecs-deploy-runner.md
+++ b/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/try-out-the-ecs-deploy-runner.md
@@ -50,5 +50,8 @@ Running this command will provide output similar to below:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"dd6544d11642b0f43fdddbeea03cb5ba"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "dd6544d11642b0f43fdddbeea03cb5ba"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/index.md
+++ b/docs/guides/build-it-yourself/pipelines/index.md
@@ -90,5 +90,8 @@ Feel free to read this guide from start to finish or skip around to whatever sec
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"3130cb825c605b438694546804a4f87c"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "3130cb825c605b438694546804a4f87c"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/next-steps.md
+++ b/docs/guides/build-it-yourself/pipelines/next-steps.md
@@ -9,5 +9,8 @@ Now that you have a CI/CD pipeline for your infrastructure code, test it out by 
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"e60b6909a25e315724ca19125d51f4d4"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "e60b6909a25e315724ca19125d51f4d4"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/intro.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/intro.md
@@ -12,5 +12,8 @@ infrastructure code, using a platform that looks something like this:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"85dfc1646a1dc0b0f306a424397fcb8f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "85dfc1646a1dc0b0f306a424397fcb8f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/limit-triggers-for-deploy-server.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/limit-triggers-for-deploy-server.md
@@ -19,5 +19,8 @@ You can find similar mechanisms for limiting deployments in the various deploy s
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"e9c3158c4440a350fd13f6bcee185874"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "e9c3158c4440a350fd13f6bcee185874"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/lock-down-vcs-systems.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/lock-down-vcs-systems.md
@@ -38,5 +38,8 @@ internal environment variables or show infrastructure secrets using external dat
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"cd626b695d8951028daebd4a888f0a6b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "cd626b695d8951028daebd4a888f0a6b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/options-for-deploy-server.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/options-for-deploy-server.md
@@ -38,5 +38,8 @@ cover it, the design is compatible with using Terraform Enterprise as the deploy
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"b9eefadd3f55d13a074ac0ef37224cbf"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "b9eefadd3f55d13a074ac0ef37224cbf"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/summary-of-deployment-sequence.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/summary-of-deployment-sequence.md
@@ -6,5 +6,8 @@ To put it all together, the following sequence diagram shows how all the various
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"83e40872165416269a4b09b4a858fd52"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "83e40872165416269a4b09b4a858fd52"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/summary-of-mitigations.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/summary-of-mitigations.md
@@ -94,5 +94,8 @@ with the `sensitive` keyword so that terraform will mask the outputs.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a11ceab4a04a9730d22dad8113b22d42"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "a11ceab4a04a9730d22dad8113b22d42"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/use-a-vpc-to-lock-down-deploy-server.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/use-a-vpc-to-lock-down-deploy-server.md
@@ -7,5 +7,8 @@ outbound access except for the minimum required (e.g, allow access to AWS APIs).
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"31fee0a9bffad6966be2e1ab2870904e"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "31fee0a9bffad6966be2e1ab2870904e"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/use-approval-flows.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/use-approval-flows.md
@@ -12,5 +12,8 @@ can approve the workflow.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"cb8b5eba89e7858826984e3f326a831c"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "cb8b5eba89e7858826984e3f326a831c"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/use-generic-ci-cd-platforms-as-a-workflow-engine-but-run-infrastructure-deployments-from-within-your-account.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/use-generic-ci-cd-platforms-as-a-workflow-engine-but-run-infrastructure-deployments-from-within-your-account.md
@@ -28,5 +28,8 @@ builds on existing code, but they don’t get arbitrary admin access.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"9688f7f6bd80fec2188af6893093859e"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "9688f7f6bd80fec2188af6893093859e"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/use-minimal-iam-permissions-for-a-deployment.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/use-minimal-iam-permissions-for-a-deployment.md
@@ -9,5 +9,8 @@ which has more access to the environments.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a4cd5ed3be343c5f6bce08340047756b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "a4cd5ed3be343c5f6bce08340047756b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/cidr-notation.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/cidr-notation.md
@@ -42,5 +42,8 @@ CIDR notation for just one IP, `4.4.4.4`.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"7b2b8b88ad17636beedfea22b23770f8"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "7b2b8b88ad17636beedfea22b23770f8"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/default-vp-cs-and-custom-vp-cs.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/default-vp-cs-and-custom-vp-cs.md
@@ -54,5 +54,8 @@ over how to configure a VPC with the kind of security, scalability, and high ava
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"6590a3524e17c9eb1805818e98c04514"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "6590a3524e17c9eb1805818e98c04514"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/internet-gateways-public-subnets-and-private-subnets.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/internet-gateways-public-subnets-and-private-subnets.md
@@ -11,5 +11,8 @@ the VPC.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"d47dde0089191a4a4707e0f5c050d2dd"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "d47dde0089191a4a4707e0f5c050d2dd"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/nat-gateways.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/nat-gateways.md
@@ -37,5 +37,8 @@ the traffic for all other IPs, `0.0.0.0/0`, to a NAT Gateway with ID `nat-67890`
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"15d7ee1da61bdf479f662a44cee6c79a"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "15d7ee1da61bdf479f662a44cee6c79a"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/network-ac-ls.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/network-ac-ls.md
@@ -37,5 +37,8 @@ locking down source/destination IP addresses.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"7d0ca667894b24e72340105224933c82"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "7d0ca667894b24e72340105224933c82"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/regions-and-availability-zones.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/regions-and-availability-zones.md
@@ -22,5 +22,8 @@ as starting points.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"b9de64a86c71d7442fc242dad729d910"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "b9de64a86c71d7442fc242dad729d910"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/route-tables.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/route-tables.md
@@ -34,5 +34,8 @@ will be automatically routed within the subnet by AWS. This table then adds a fa
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"d8ec27c10689e15775980056dfec5918"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "d8ec27c10689e15775980056dfec5918"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/security-groups.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/security-groups.md
@@ -76,5 +76,8 @@ custom security group with rules that exactly match your use case, rather than r
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"596687737b7eef31327fd9ca1202ac12"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "596687737b7eef31327fd9ca1202ac12"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/subnets.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/subnets.md
@@ -11,5 +11,8 @@ ranges.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"9d8faa2989a62412f9b7b87826e4abea"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "9d8faa2989a62412f9b7b87826e4abea"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/vpc-endpoints.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/vpc-endpoints.md
@@ -33,5 +33,8 @@ a paid service, and includes support for CloudTrail, Secrets Manager, EC2, SNS, 
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"6ce6ec81a6a21c99701e06df1b1aa301"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "6ce6ec81a6a21c99701e06df1b1aa301"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/vpc-ip-addresses.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/vpc-ip-addresses.md
@@ -31,5 +31,8 @@ while another instance might get the private IP address `172.31.5.3` and the pub
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"9bbf0955ec269211f268d40559149a83"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "9bbf0955ec269211f268d40559149a83"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/vpc-peering.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/vpc-peering.md
@@ -26,5 +26,8 @@ connections total) can quickly become impractical. In this case, you should look
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"29e8ed8c5281f7822258c6df63ce1abf"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "29e8ed8c5281f7822258c6df63ce1abf"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/what-is-a-vpc.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/what-is-a-vpc.md
@@ -31,5 +31,8 @@ your office and all the resources in your AWS account can access the same IPs an
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"6c8bc96902491a81cc29d838b18a4226"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "6c8bc96902491a81cc29d838b18a4226"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/deployment-walkthrough/clean-up-default-vp-cs-and-security-groups.md
+++ b/docs/guides/build-it-yourself/vpc/deployment-walkthrough/clean-up-default-vp-cs-and-security-groups.md
@@ -9,5 +9,8 @@ cloud-nuke defaults-aws
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"f24a4c59eb7b0e53a6b225dd9c83ac9c"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "f24a4c59eb7b0e53a6b225dd9c83ac9c"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-a-bastion-host.md
+++ b/docs/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-a-bastion-host.md
@@ -4,5 +4,8 @@ Please check out our [Bastion Host](https://github.com/gruntwork-io/terraform-aw
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"f7a9be2aa12f7a05ca7c8cf17a38192e"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "f7a9be2aa12f7a05ca7c8cf17a38192e"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-a-management-vpc.md
+++ b/docs/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-a-management-vpc.md
@@ -214,5 +214,8 @@ terragrunt apply
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"8a19045805626f1cc39de968f2bb0727"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "8a19045805626f1cc39de968f2bb0727"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-application-vp-cs.md
+++ b/docs/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-application-vp-cs.md
@@ -245,5 +245,8 @@ terragrunt apply
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a324250d5ea77e813734245029fd8ea3"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "a324250d5ea77e813734245029fd8ea3"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/deployment-walkthrough/pre-requisites.md
+++ b/docs/guides/build-it-yourself/vpc/deployment-walkthrough/pre-requisites.md
@@ -43,5 +43,8 @@ for instructions.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"897a81f742761a069a69b560cd27a435"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "897a81f742761a069a69b560cd27a435"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/index.md
+++ b/docs/guides/build-it-yourself/vpc/index.md
@@ -47,5 +47,8 @@ Feel free to read this guide from start to finish or skip around to whatever sec
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"b18c2f59aca7f95a28b40f641a9824bc"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "b18c2f59aca7f95a28b40f641a9824bc"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/next-steps.md
+++ b/docs/guides/build-it-yourself/vpc/next-steps.md
@@ -13,5 +13,8 @@ If you’re not sure which of these options to use, check out the `Server Cluste
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"77586324e67a96b2d83aa7d115ab4a1a"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "77586324e67a96b2d83aa7d115ab4a1a"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/production-grade-design/bastion-host.md
+++ b/docs/guides/build-it-yourself/vpc/production-grade-design/bastion-host.md
@@ -20,5 +20,8 @@ allow you to manage and connect to EC2 Instances via a custom protocol managed b
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ced5f0444b037cc4e6f71ffacb6f4fdb"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "ced5f0444b037cc4e6f71ffacb6f4fdb"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/production-grade-design/defense-in-depth.md
+++ b/docs/guides/build-it-yourself/vpc/production-grade-design/defense-in-depth.md
@@ -15,5 +15,8 @@ described in the next few sections.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"241d7669f0872b5219798ddc187be0b9"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "241d7669f0872b5219798ddc187be0b9"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/production-grade-design/internet-gateways-and-nat-gateways.md
+++ b/docs/guides/build-it-yourself/vpc/production-grade-design/internet-gateways-and-nat-gateways.md
@@ -27,5 +27,8 @@ availability zone as the subnet itself).
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"22caf29ab8296f42141d487cc067867e"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "22caf29ab8296f42141d487cc067867e"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/production-grade-design/intro.md
+++ b/docs/guides/build-it-yourself/vpc/production-grade-design/intro.md
@@ -11,5 +11,8 @@ something like this:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"3f015395ed57051b605f4d66bd4e29e6"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "3f015395ed57051b605f4d66bd4e29e6"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/production-grade-design/multiple-aws-accounts.md
+++ b/docs/guides/build-it-yourself/vpc/production-grade-design/multiple-aws-accounts.md
@@ -16,5 +16,8 @@ guide for instructions.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"c17c05c07c1d9b5d5a89d0d4b54bee60"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "c17c05c07c1d9b5d5a89d0d4b54bee60"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/production-grade-design/multiple-subnet-tiers.md
+++ b/docs/guides/build-it-yourself/vpc/production-grade-design/multiple-subnet-tiers.md
@@ -37,5 +37,8 @@ discussed in the next section.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"82d0988a700d0886134f55402940d47a"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "82d0988a700d0886134f55402940d47a"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/production-grade-design/multiple-vp-cs.md
+++ b/docs/guides/build-it-yourself/vpc/production-grade-design/multiple-vp-cs.md
@@ -54,5 +54,8 @@ your corporate intranet via site-to-site VPN connections.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"784b8265b51b59059718a34b68ea4339"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "784b8265b51b59059718a34b68ea4339"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/production-grade-design/security-groups-and-nac-ls.md
+++ b/docs/guides/build-it-yourself/vpc/production-grade-design/security-groups-and-nac-ls.md
@@ -33,5 +33,8 @@ environment.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"6c6ba79465b3a5149489da3d2c535cf1"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "6c6ba79465b3a5149489da3d2c535cf1"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -22,5 +22,8 @@ We present a comprehensive model to help you establish a robust infrastructure p
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"e4a74979df7a616ab9e0822a3da5e42f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "e4a74979df7a616ab9e0822a3da5e42f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/gruntwork-solutions/index.md
+++ b/docs/guides/production-framework/gruntwork-solutions/index.md
@@ -42,5 +42,8 @@ questions, please [contact sales](https://gruntwork.io/contact/).
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"680b0acbfc7763840216253afa6e2a17"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "680b0acbfc7763840216253afa6e2a17"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/index.md
+++ b/docs/guides/production-framework/index.md
@@ -177,5 +177,8 @@ Gruntwork to help you implement this framework.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"0f5e3c087339ab8a712c9fa33f909206"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "0f5e3c087339ab8a712c9fa33f909206"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/automatic-updates/auto-update-features.md
+++ b/docs/guides/production-framework/ingredients/automatic-updates/auto-update-features.md
@@ -19,5 +19,8 @@ Your auto update solution should automatically check that none of your dependenc
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"9e7dfaaa99b9a027ed3e3f05ffad33e0"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "9e7dfaaa99b9a027ed3e3f05ffad33e0"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/automatic-updates/how-auto-update-should-work.md
+++ b/docs/guides/production-framework/ingredients/automatic-updates/how-auto-update-should-work.md
@@ -19,5 +19,8 @@ Once the update is merged, the CI / CD pipeline again kicks in, and automaticall
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"1d9283d627bcec9be8c17049eab3ad3a"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "1d9283d627bcec9be8c17049eab3ad3a"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/automatic-updates/index.md
+++ b/docs/guides/production-framework/ingredients/automatic-updates/index.md
@@ -13,5 +13,8 @@ everything up-to-date, so that all your hard work doesn't turn into tech debt.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"b1f78cbc1cf2063fa44c3a3b09932c0a"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "b1f78cbc1cf2063fa44c3a3b09932c0a"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/ci-cd-pipeline/ci-cd-only-path-to-prod.md
+++ b/docs/guides/production-framework/ingredients/ci-cd-pipeline/ci-cd-only-path-to-prod.md
@@ -16,5 +16,8 @@ It's a bad idea to have give your CI server (e.g., Jenkins)—which your entire 
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"184306807d3afdf76391109109b4fe83"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "184306807d3afdf76391109109b4fe83"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/ci-cd-pipeline/index.md
+++ b/docs/guides/production-framework/ingredients/ci-cd-pipeline/index.md
@@ -8,5 +8,8 @@ pipeline) to automate their build, test, and deployment processes.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ba6270b591efb22fbe6b9b5adb930269"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "ba6270b591efb22fbe6b9b5adb930269"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/index.md
+++ b/docs/guides/production-framework/ingredients/index.md
@@ -8,5 +8,8 @@ cloud effectively.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"dd43f8507970ba12e96d6951c5c123d3"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "dd43f8507970ba12e96d6951c5c123d3"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/landing-zone/account-vending-machine.md
+++ b/docs/guides/production-framework/ingredients/landing-zone/account-vending-machine.md
@@ -22,5 +22,8 @@ As part of the account provisioning process, the Account Vending Machine should 
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"bb70e6c37087cc1b297644eb6bccdf6e"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "bb70e6c37087cc1b297644eb6bccdf6e"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/landing-zone/index.md
+++ b/docs/guides/production-framework/ingredients/landing-zone/index.md
@@ -13,5 +13,8 @@ harder than setting up the proper controls in the first place.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"638abda85660525852f391f9d2e1a759"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "638abda85660525852f391f9d2e1a759"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/landing-zone/what-landing-zone-should-include.md
+++ b/docs/guides/production-framework/ingredients/landing-zone/what-landing-zone-should-include.md
@@ -26,5 +26,8 @@ Zone](https://docs.gruntwork.io/docs/guides/build-it-yourself/landing-zone/).
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"48f58cc321f48e30db0584fad30d84ed"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "48f58cc321f48e30db0584fad30d84ed"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/other-ingredients/index.md
+++ b/docs/guides/production-framework/ingredients/other-ingredients/index.md
@@ -22,5 +22,8 @@ Performance optimization, cost optimization, and capacity optimization ("rightsi
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"cd9b72d0289fcb3677281df788691d87"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "cd9b72d0289fcb3677281df788691d87"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/self-service/common-self-service-use-cases.md
+++ b/docs/guides/production-framework/ingredients/self-service/common-self-service-use-cases.md
@@ -17,5 +17,8 @@ Deploy a new app: that is, a web service written in a general purpose programmin
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"9c13d0c788f2295456c702e6c7da82be"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "9c13d0c788f2295456c702e6c7da82be"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/self-service/how-self-service-should-work.md
+++ b/docs/guides/production-framework/ingredients/self-service/how-self-service-should-work.md
@@ -19,5 +19,8 @@ Many Ops teams get nervous with the idea of self-service: what if the developers
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"77f527c693abd32b67e88ea9a77fe6f4"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "77f527c693abd32b67e88ea9a77fe6f4"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/self-service/index.md
+++ b/docs/guides/production-framework/ingredients/self-service/index.md
@@ -10,5 +10,8 @@ infrastructure those apps depend on.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"0d1779ee5564dd35f8deaa3ae48d81ec"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "0d1779ee5564dd35f8deaa3ae48d81ec"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/service-catalog/application-templates.md
+++ b/docs/guides/production-framework/ingredients/service-catalog/application-templates.md
@@ -72,5 +72,8 @@ You'll want to make it as simple as possible for new apps to be integrated into 
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"8fe39d263edd56aa3da7b053063169eb"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "8fe39d263edd56aa3da7b053063169eb"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/service-catalog/index.md
+++ b/docs/guides/production-framework/ingredients/service-catalog/index.md
@@ -23,5 +23,8 @@ mean by "Service Catalog" in this guide, and what a modern Service Catalog looks
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"9724455defe23434547b2c1433c89445"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "9724455defe23434547b2c1433c89445"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/service-catalog/infrastructure-templates.md
+++ b/docs/guides/production-framework/ingredients/service-catalog/infrastructure-templates.md
@@ -82,5 +82,8 @@ We'll discuss CI / CD more in a dedicated section later on.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"8453ef57b74100d6a6b9f64658b14dc3"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "8453ef57b74100d6a6b9f64658b14dc3"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/service-catalog/modern-service-catalog.md
+++ b/docs/guides/production-framework/ingredients/service-catalog/modern-service-catalog.md
@@ -48,5 +48,8 @@ For a concrete example of a Service Catalog for AWS, see the [Gruntwork Service 
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"d2c8c16c221d43b0989eeec08a273e3a"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "d2c8c16c221d43b0989eeec08a273e3a"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/recipes/dev-team-experience.md
+++ b/docs/guides/production-framework/recipes/dev-team-experience.md
@@ -94,5 +94,8 @@ Let's imagine that you've started a team with two developers, Ann and Bob. The t
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"6f688e879fc6b7981c52a0c651d4781a"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "6f688e879fc6b7981c52a0c651d4781a"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/recipes/index.md
+++ b/docs/guides/production-framework/recipes/index.md
@@ -10,5 +10,8 @@ how all these pieces can work together.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"cc18e09055167ce9e85d6ce57d2a82b7"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "cc18e09055167ce9e85d6ce57d2a82b7"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/recipes/ops-team-experience.md
+++ b/docs/guides/production-framework/recipes/ops-team-experience.md
@@ -29,5 +29,8 @@ On the Ops side, Carol and Daniel are responsible for maintaining your Service C
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"33c46b2d11c76043adf77f0a05c3c622"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "33c46b2d11c76043adf77f0a05c3c622"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/configuration-guide/index.md
+++ b/docs/guides/reference-architecture/configuration-guide/index.md
@@ -233,5 +233,8 @@ In the ref arch form, `VCSPATSecretsManagerARN` is where you enter this ARN.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"745a1271cf4657c0800489c9de81cac6"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "745a1271cf4657c0800489c9de81cac6"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/02-authenticate/01-intro.md
+++ b/docs/guides/reference-architecture/example-usage-guide/02-authenticate/01-intro.md
@@ -29,5 +29,8 @@ and connecting to all the resources in your AWS accounts:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"f851b2325036a5c724b6ad10ce9bba81"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "f851b2325036a5c724b6ad10ce9bba81"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/02-authenticate/02-setting-up-initial-access.md
+++ b/docs/guides/reference-architecture/example-usage-guide/02-authenticate/02-setting-up-initial-access.md
@@ -139,5 +139,8 @@ To deploy this new code and create the new IAM users, you will need to:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"471a3233265134ad05fc2dc635a9e664"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "471a3233265134ad05fc2dc635a9e664"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/02-authenticate/03-authenticate-to-the-aws-web-console.md
+++ b/docs/guides/reference-architecture/example-usage-guide/02-authenticate/03-authenticate-to-the-aws-web-console.md
@@ -32,5 +32,8 @@ To authenticate to any other account (e.g., dev, stage, prod), you need to:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"979ec28e782e43d075a0a2ffc0e492c6"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "979ec28e782e43d075a0a2ffc0e492c6"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/02-authenticate/04-authenticate-to-aws-via-the-cli.md
+++ b/docs/guides/reference-architecture/example-usage-guide/02-authenticate/04-authenticate-to-aws-via-the-cli.md
@@ -100,5 +100,8 @@ Be sure to read [`USAGE.md`](https://github.com/99designs/aws-vault/blob/master/
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"18111d9a15431ff8db544e24d26c278d"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "18111d9a15431ff8db544e24d26c278d"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/02-authenticate/05-authenticate-to-ec2-instances-via-ssh.md
+++ b/docs/guides/reference-architecture/example-usage-guide/02-authenticate/05-authenticate-to-ec2-instances-via-ssh.md
@@ -74,5 +74,8 @@ Key Pairs.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"7c0ac42ce4c59251e14f2f2515cde419"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "7c0ac42ce4c59251e14f2f2515cde419"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/02-authenticate/06-authenticate-to-the-vpn-server.md
+++ b/docs/guides/reference-architecture/example-usage-guide/02-authenticate/06-authenticate-to-the-vpn-server.md
@@ -62,5 +62,8 @@ network (e.g., SSH to EC2 instances in private subnets) as if you were "in" the 
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"9701399b662535fea1aae6071601c987"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "9701399b662535fea1aae6071601c987"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/01-intro.md
+++ b/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/01-intro.md
@@ -16,5 +16,8 @@ Architecture.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"aa44de3dbcbfce8dd6c85a400d5b48c4"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "aa44de3dbcbfce8dd6c85a400d5b48c4"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/02-what-is-already-deployed.md
+++ b/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/02-what-is-already-deployed.md
@@ -15,5 +15,8 @@ practices from [aws-sample-app](https://github.com/gruntwork-io/aws-sample-app/)
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"825877259e74045470098650457e418f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "825877259e74045470098650457e418f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/03-the-app.md
+++ b/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/03-the-app.md
@@ -40,5 +40,8 @@ Since we need to pull in the dependencies to run this app, we will also need a c
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"6e307243ed73a07a528949ca977e651b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "6e307243ed73a07a528949ca977e651b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/04-dockerizing.md
+++ b/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/04-dockerizing.md
@@ -65,5 +65,8 @@ Some things to note when writing up your `Dockerfile` and building your app:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"2d6fc8ba4c4927f850bd052ab8189738"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "2d6fc8ba4c4927f850bd052ab8189738"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/05-publish-docker-image.md
+++ b/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/05-publish-docker-image.md
@@ -62,5 +62,8 @@ docker push 234567890123.dkr.ecr.us-west-2.amazonaws.com/simple-web-app:v1
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"4847ef3d9ebb1415b0f6a8ce36bfdb28"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "4847ef3d9ebb1415b0f6a8ce36bfdb28"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/04-configure-gw-pipelines/01-intro.md
+++ b/docs/guides/reference-architecture/example-usage-guide/04-configure-gw-pipelines/01-intro.md
@@ -23,5 +23,8 @@ code](https://gruntwork.io/guides/automations/how-to-configure-a-production-grad
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ebe11d1c8039bdcaf654a54e2a779a21"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "ebe11d1c8039bdcaf654a54e2a779a21"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/04-configure-gw-pipelines/02-ci--cd-pipeline-for-infrastructure-code.md
+++ b/docs/guides/reference-architecture/example-usage-guide/04-configure-gw-pipelines/02-ci--cd-pipeline-for-infrastructure-code.md
@@ -99,5 +99,8 @@ For instructions on how to destroy infrastructure, see the [Undeploy guide](../0
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"b214054a49f7368da435d1d80d42ab81"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "b214054a49f7368da435d1d80d42ab81"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/04-configure-gw-pipelines/03-ci--cd-pipeline-for-app-code.md
+++ b/docs/guides/reference-architecture/example-usage-guide/04-configure-gw-pipelines/03-ci--cd-pipeline-for-app-code.md
@@ -64,5 +64,8 @@ Once the branch is merged, updates to the `main` branch will trigger a build job
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"1c2c536bc8e48c128e3d338349e0f46a"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "1c2c536bc8e48c128e3d338349e0f46a"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/04-configure-gw-pipelines/04-update-the-ci--cd-pipeline-itself.md
+++ b/docs/guides/reference-architecture/example-usage-guide/04-configure-gw-pipelines/04-update-the-ci--cd-pipeline-itself.md
@@ -70,5 +70,8 @@ pull request as your changes to the `ecs-deploy-runner` module configuration.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"6457637d554e50c34b0c4e2e1785d09b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "6457637d554e50c34b0c4e2e1785d09b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/05-monitoring-alerting-logging/01-intro.md
+++ b/docs/guides/reference-architecture/example-usage-guide/05-monitoring-alerting-logging/01-intro.md
@@ -14,5 +14,8 @@ and deploy your code, you'll want to see what's happening in your AWS account:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"4bf00ab56efc3404d9b7686ebc2efe7f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "4bf00ab56efc3404d9b7686ebc2efe7f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/05-monitoring-alerting-logging/02-metrics.md
+++ b/docs/guides/reference-architecture/example-usage-guide/05-monitoring-alerting-logging/02-metrics.md
@@ -15,5 +15,8 @@ with the most useful metrics for your services and have that open on a big scree
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"5f2fa1a102144ef3da979c801ded2487"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "5f2fa1a102144ef3da979c801ded2487"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/05-monitoring-alerting-logging/03-alerts.md
+++ b/docs/guides/reference-architecture/example-usage-guide/05-monitoring-alerting-logging/03-alerts.md
@@ -20,5 +20,8 @@ module](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/mod
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"584b4a2ae80caff18e9aabc951d9878d"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "584b4a2ae80caff18e9aabc951d9878d"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/05-monitoring-alerting-logging/04-logs.md
+++ b/docs/guides/reference-architecture/example-usage-guide/05-monitoring-alerting-logging/04-logs.md
@@ -9,5 +9,8 @@ your servers in near-real-time.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"25e86ad1c431db7ea9afe1ebe3fbdb3a"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "25e86ad1c431db7ea9afe1ebe3fbdb3a"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/01-intro.md
+++ b/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/01-intro.md
@@ -15,5 +15,8 @@ need to expand the Reference Architecture with more accounts, like a test or san
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"4642c93de8e8463703cbd58048a53b80"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "4642c93de8e8463703cbd58048a53b80"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/02-create-new-account-in-your-aws-org.md
+++ b/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/02-create-new-account-in-your-aws-org.md
@@ -24,5 +24,8 @@ At this point, you won't need to use the root credentials again until you are re
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ce81ca7d4a533a62629db83aa91e9910"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "ce81ca7d4a533a62629db83aa91e9910"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/03-update-logs-security-shared-accounts-to-allow-cross-account-access.md
+++ b/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/03-update-logs-security-shared-accounts-to-allow-cross-account-access.md
@@ -38,5 +38,8 @@ approve it to apply the updated cross account permissions.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"5bff1b351c15013c2c899f19817071e4"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "5bff1b351c15013c2c899f19817071e4"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/04-deploy-the-security-baseline.md
+++ b/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/04-deploy-the-security-baseline.md
@@ -66,5 +66,8 @@ Once you confirm you have access to the new account from the `security` account,
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"6b2971383476a10a88bcaa6c38599547"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "6b2971383476a10a88bcaa6c38599547"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/05-deploy-the-ecs-deploy-runner.md
+++ b/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/05-deploy-the-ecs-deploy-runner.md
@@ -37,5 +37,8 @@ to provision new infrastructure in the account.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"f383a1b3ce7b725423c02c57370d347b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "f383a1b3ce7b725423c02c57370d347b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/01-intro.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/01-intro.md
@@ -20,5 +20,8 @@ this section, we'll walk you through how to undeploy parts or all of the Referen
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"827378c8b6b828091bb9ce0adf1f8588"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "827378c8b6b828091bb9ce0adf1f8588"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/02-before-you-get-started.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/02-before-you-get-started.md
@@ -9,5 +9,8 @@ accidentally shooting yourself in the foot.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"29615744ecd8587257bae2b0a7a24773"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "29615744ecd8587257bae2b0a7a24773"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/03-pre-requisite-force-destroy-on-s3-buckets.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/03-pre-requisite-force-destroy-on-s3-buckets.md
@@ -21,5 +21,8 @@ services that expose this variable (note, you may not have all of these in your 
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ee44dc198c327e0255356257c89b1b77"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "ee44dc198c327e0255356257c89b1b77"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/04-pre-requisite-understand-module-dependencies.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/04-pre-requisite-understand-module-dependencies.md
@@ -21,5 +21,8 @@ You can check the module dependency tree with `graph-dependencies` and GraphViz:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"9157fe8a4406021c41bd8b94cb73d04b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "9157fe8a4406021c41bd8b94cb73d04b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/05-undeploying-modules-using-gruntwork-pipelines.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/05-undeploying-modules-using-gruntwork-pipelines.md
@@ -35,5 +35,8 @@ modules that have no existing downstream dependencies.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"8b72dc69092ed45097995a27428b543d"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "8b72dc69092ed45097995a27428b543d"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/06-manually-undeploying-a-single-module.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/06-manually-undeploying-a-single-module.md
@@ -9,5 +9,8 @@ terragrunt destroy
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"611be9e2302e61959431d8e5512fd72c"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "611be9e2302e61959431d8e5512fd72c"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/07-manually-undeploying-multiple-modules-or-an-entire-environment.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/07-manually-undeploying-multiple-modules-or-an-entire-environment.md
@@ -30,5 +30,8 @@ terragrunt destroy-all \
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"aba0a579f1326a57f833dba058bbbc67"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "aba0a579f1326a57f833dba058bbbc67"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/08-removing-the-terraform-state.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/08-removing-the-terraform-state.md
@@ -14,5 +14,8 @@ destroyed successfully**.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"9c3adf3f67ede26bb4c92a2567125676"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "9c3adf3f67ede26bb4c92a2567125676"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/09-useful-tips.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/09-useful-tips.md
@@ -25,5 +25,8 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"86b46c82511aa42dadcb6a5f347ba164"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "86b46c82511aa42dadcb6a5f347ba164"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/10-known-errors.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/10-known-errors.md
@@ -24,5 +24,8 @@ There are a few reasons your call to `destroy` may fail:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"33d1173bfb40293642e364d45877e81b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "33d1173bfb40293642e364d45877e81b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/index.md
+++ b/docs/guides/reference-architecture/example-usage-guide/index.md
@@ -161,5 +161,8 @@ Next up, let's have a look at [how to authenticate](02-authenticate/01-intro.md)
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"16a73da5e040233872dddede948a3e66"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "16a73da5e040233872dddede948a3e66"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/index.md
+++ b/docs/guides/reference-architecture/index.md
@@ -29,5 +29,8 @@ Modernize your legacy Reference Architecture to use our new Service Catalog patt
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"675db72e2d75cc00ff5d3ec1a5407f0a"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "675db72e2d75cc00ff5d3ec1a5407f0a"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/update-to-service-catalog.md
+++ b/docs/guides/reference-architecture/update-to-service-catalog.md
@@ -602,5 +602,8 @@ The following modules require a different version of the Service Catalog than `v
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"43a73701aef385b0281b0d77ec14dd2a"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "43a73701aef385b0281b0d77ec14dd2a"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.3.0/core-concepts.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.3.0/core-concepts.md
@@ -52,5 +52,8 @@ configure the newly created modules.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"43e5a48a98d74f7993a9e6a02c7570df"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "43e5a48a98d74f7993a9e6a02c7570df"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.3.0/deployment-walkthrough/step-1-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.3.0/deployment-walkthrough/step-1-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -187,5 +187,8 @@ compatible with CIS AWS v1.3.0:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"5d834f1ec7d61ca84a6b9c44079b4a27"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "5d834f1ec7d61ca84a6b9c44079b4a27"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.3.0/deployment-walkthrough/step-2-manual-steps.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.3.0/deployment-walkthrough/step-2-manual-steps.md
@@ -11,5 +11,8 @@ on the AWS website for detailed instructions.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"8f30fea3c56323b9c5c0ce3cd5fa1841"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "8f30fea3c56323b9c5c0ce3cd5fa1841"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.3.0/deployment-walkthrough/step-3-deploy-new-modules.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.3.0/deployment-walkthrough/step-3-deploy-new-modules.md
@@ -88,5 +88,8 @@ docs](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/tree/v0.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"6270eb0777685afb4bf98586be2e994f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "6270eb0777685afb4bf98586be2e994f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.3.0/index.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.3.0/index.md
@@ -23,5 +23,8 @@ tag is compatible with CIS AWS v1.3.0, as well as the manuals step you need to p
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"c2c87981bea218be1a10832343a9863b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "c2c87981bea218be1a10832343a9863b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.4.0/core-concepts.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.4.0/core-concepts.md
@@ -38,5 +38,8 @@ necessary manual steps.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"d2e11fe53ce1dd113f0a0d8ecc1e8f11"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "d2e11fe53ce1dd113f0a0d8ecc1e8f11"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.4.0/deployment-walkthrough/step-1-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.4.0/deployment-walkthrough/step-1-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -82,5 +82,8 @@ compatible with CIS AWS v1.4.0:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a05d8f4802daa27e86b50cb1724ac7e8"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "a05d8f4802daa27e86b50cb1724ac7e8"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.4.0/deployment-walkthrough/step-2-update-the-account-baseline-modules.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.4.0/deployment-walkthrough/step-2-update-the-account-baseline-modules.md
@@ -116,5 +116,8 @@ All the other child accounts (logs, stage, prod, etc) need the same configuratio
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"cb0578642a724e3749d66a16916e7194"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "cb0578642a724e3749d66a16916e7194"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.4.0/deployment-walkthrough/step-3-manual-steps.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.4.0/deployment-walkthrough/step-3-manual-steps.md
@@ -117,5 +117,8 @@ You may be using a region that doesn’t properly support AWS Config (e.g: `ap-n
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"339270287018e92e149b0be448340c4d"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "339270287018e92e149b0be448340c4d"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.4.0/finally.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.4.0/finally.md
@@ -8,5 +8,8 @@ If you’ve got any feedback or you think something’s missing from the guide, 
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"0467d5d25c74d981f3263fbe92df4204"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "0467d5d25c74d981f3263fbe92df4204"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.4.0/index.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.4.0/index.md
@@ -23,5 +23,8 @@ CIS AWS Foundations Benchmark.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"8c0f9be6013feef70b809f0778c9116f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "8c0f9be6013feef70b809f0778c9116f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/index.md
+++ b/docs/guides/stay-up-to-date/index.md
@@ -76,5 +76,8 @@ href="/guides/stay-up-to-date/terraform/terraform-1.1"
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"6108197b36342bbac59c8d32d9e3dfbb"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "6108197b36342bbac59c8d32d9e3dfbb"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/core-concepts.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/core-concepts.md
@@ -44,5 +44,8 @@ documentation](https://terragrunt.gruntwork.io/docs/features/keep-your-terragrun
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"29aa2eab851b8a4a259acf265a6c2315"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "29aa2eab851b8a4a259acf265a6c2315"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/deployment-walkthrough/intro.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/deployment-walkthrough/intro.md
@@ -41,5 +41,8 @@ include "envcommon" {
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"05542d29c57c912a1c745fa10f80a326"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "05542d29c57c912a1c745fa10f80a326"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/deployment-walkthrough/optional-even-dryer-configuration.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/deployment-walkthrough/optional-even-dryer-configuration.md
@@ -182,5 +182,8 @@ the `inputs` attribute even if it references `dependency` blocks.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"9c88b007237c084a93910cc7da9b2bad"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "9c88b007237c084a93910cc7da9b2bad"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/deployment-walkthrough/refactoring-common-configurations-for-a-component.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/deployment-walkthrough/refactoring-common-configurations-for-a-component.md
@@ -277,5 +277,8 @@ moved to the common component configuration.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"3b740cb5844fe232f5ac8126887b90d6"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "3b740cb5844fe232f5ac8126887b90d6"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/deployment-walkthrough/update-to-the-service-catalog-based-reference-architecture.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/deployment-walkthrough/update-to-the-service-catalog-based-reference-architecture.md
@@ -28,5 +28,8 @@ fully supported by Gruntwork.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"0375aad45a4e44290040bdf324035ce2"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "0375aad45a4e44290040bdf324035ce2"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/index.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/index.md
@@ -24,5 +24,8 @@ The steps you need to take to update your code to use multi-include to avoid dup
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"e6b78a8b5feffb8c40a83d5aeab2ae0b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "e6b78a8b5feffb8c40a83d5aeab2ae0b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3/core-concepts.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3/core-concepts.md
@@ -22,5 +22,8 @@ Architecture to be compatible with AWS provider version 3.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"56d01e92f2d0efef79e79bee9f272d89"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "56d01e92f2d0efef79e79bee9f272d89"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3/deployment-walkthrough.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3/deployment-walkthrough.md
@@ -182,5 +182,8 @@ on how to update your components to be compatible with AWS provider v3.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ab6bc780e5dab16724fdb9635ba78a15"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "ab6bc780e5dab16724fdb9635ba78a15"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3/index.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3/index.md
@@ -29,5 +29,8 @@ which Gruntwork Repo version tag is compatible with AWS provider v3.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"d893235577f4c44c0b19f7f0eed0a15d"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "d893235577f4c44c0b19f7f0eed0a15d"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.1/core-concepts.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.1/core-concepts.md
@@ -13,5 +13,8 @@ post](https://www.hashicorp.com/blog/terraform-1-1-improves-refactoring-and-the-
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"49defa1819542396936b1f0481640f93"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "49defa1819542396936b1f0481640f93"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.1/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-1-x.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.1/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-1-x.md
@@ -30,5 +30,8 @@ If you haven’t already, you need to:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"901f5f12726f3f8ebba1f5058c1e957a"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "901f5f12726f3f8ebba1f5058c1e957a"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.1/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.1/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -140,5 +140,8 @@ and the respective versions that are compatible with Terraform 1.1:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"2b2b98d7e75d84cb9b1df09cf54a734e"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "2b2b98d7e75d84cb9b1df09cf54a734e"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.1/index.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.1/index.md
@@ -27,5 +27,8 @@ tag is compatible with Terraform 1.1.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"de75607ce00354136cfc3f917a2f047b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "de75607ce00354136cfc3f917a2f047b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.x/core-concepts.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.x/core-concepts.md
@@ -21,5 +21,8 @@ notes](https://github.com/hashicorp/terraform/releases/tag/v1.0.0):
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ee2c203478dfbf3301d71f56df87cb65"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "ee2c203478dfbf3301d71f56df87cb65"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-15.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-15.md
@@ -27,5 +27,8 @@ If you haven’t already, you need to:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"79d751e6f54ffaa62190769a98e3b402"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "79d751e6f54ffaa62190769a98e3b402"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -174,5 +174,8 @@ and the respective versions that are compatible with Terraform 1.x:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"5de71c86b2c7405e338748eee98f96ce"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "5de71c86b2c7405e338748eee98f96ce"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.x/index.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.x/index.md
@@ -29,5 +29,8 @@ tag is compatible with Terraform 1.x.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"b902a9ed1b8a8c7ee812f8b2588235fa"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "b902a9ed1b8a8c7ee812f8b2588235fa"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-12/deployment-walkthrough.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-12/deployment-walkthrough.md
@@ -430,5 +430,8 @@ At the end of this, you should be able to run `terragrunt plan` cleanly.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"1133a6f06da0e83fa0be975301931929"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "1133a6f06da0e83fa0be975301931929"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-12/index.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-12/index.md
@@ -34,5 +34,8 @@ This means that both the modules and the live config need to be updated in order
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"18301a838452f27f0c74540894001124"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "18301a838452f27f0c74540894001124"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-12/version-compatibility-table.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-12/version-compatibility-table.md
@@ -41,5 +41,8 @@ The following lists our Terraform packages and their compatibility with Terrafor
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"3aac38d34fa5070df5bd4d9e0f13ca77"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "3aac38d34fa5070df5bd4d9e0f13ca77"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-13/core-concepts.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-13/core-concepts.md
@@ -18,5 +18,8 @@ update to these new versions and make other changes to your code, as described i
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"38ed9039f3be3645c5202dc00a7aa30b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "38ed9039f3be3645c5202dc00a7aa30b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-12.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-12.md
@@ -16,5 +16,8 @@ If you haven’t already, you need to:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"4dd0c2fb042ce6d83b7a5f20404f6b75"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "4dd0c2fb042ce6d83b7a5f20404f6b75"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-2-update-your-code-to-be-compatible-with-terraform-0-13.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-2-update-your-code-to-be-compatible-with-terraform-0-13.md
@@ -10,5 +10,8 @@ Upgrade Guide](https://www.terraform.io/upgrade-guides/0-13.html).
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"b92f87fe0e1cbc75dedb55878f8e449e"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "b92f87fe0e1cbc75dedb55878f8e449e"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -171,5 +171,8 @@ compatible with Terraform 0.13:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"df2574e2ef9ba51262631488b3dc0ae2"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "df2574e2ef9ba51262631488b3dc0ae2"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-4-update-provider-sources.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-4-update-provider-sources.md
@@ -34,5 +34,8 @@ terraform state replace-provider -- -/aws registry.terraform.io/hashicorp/aws
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"0c5aa574c82b473c254f163ea660dffa"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "0c5aa574c82b473c254f163ea660dffa"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/updating-the-gruntwork-reference-architecture-to-terraform-0-13.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/updating-the-gruntwork-reference-architecture-to-terraform-0-13.md
@@ -40,5 +40,8 @@ refer to PRs in the Standard Reference Architecture section above.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"32d87de726919474b48d92e47af026b9"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "32d87de726919474b48d92e47af026b9"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-13/index.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-13/index.md
@@ -27,5 +27,8 @@ tag is compatible with Terraform 0.13.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"be501a70cd0f8c6716015ad5523e3a3e"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "be501a70cd0f8c6716015ad5523e3a3e"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-14/core-concepts.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-14/core-concepts.md
@@ -19,5 +19,8 @@ update to these new versions and make other changes to your code, as described i
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"742b88aaf1e35809a26ab436a9804eea"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "742b88aaf1e35809a26ab436a9804eea"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-13.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-13.md
@@ -21,5 +21,8 @@ If you haven’t already, you need to:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"78154acff2abc82aa789869751dc1a07"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "78154acff2abc82aa789869751dc1a07"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-2-update-your-code-to-be-compatible-with-terraform-0-14.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-2-update-your-code-to-be-compatible-with-terraform-0-14.md
@@ -10,5 +10,8 @@ Upgrade Guide](https://www.terraform.io/upgrade-guides/0-14.html).
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"bcf8113ea4cfc97a8df30908df187cb7"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "bcf8113ea4cfc97a8df30908df187cb7"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -170,5 +170,8 @@ compatible with Terraform 0.14:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"fe5c67ca172107229a89899b73efc1ce"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "fe5c67ca172107229a89899b73efc1ce"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-4-start-using-lock-files.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-4-start-using-lock-files.md
@@ -17,5 +17,8 @@ to version control.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a8737cd633b12986e72317de6dde4a3c"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "a8737cd633b12986e72317de6dde4a3c"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-14/index.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-14/index.md
@@ -28,5 +28,8 @@ tag is compatible with Terraform 0.14.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"203575611078979267a82cc2be69911c"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "203575611078979267a82cc2be69911c"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-15/core-concepts.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-15/core-concepts.md
@@ -27,5 +27,8 @@ following section.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"11dd054fc7d70bce30badb6f78ce6f46"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "11dd054fc7d70bce30badb6f78ce6f46"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-15/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-14.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-15/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-14.md
@@ -24,5 +24,8 @@ If you haven’t already, you need to:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"23d3ea3ca81c703609b2f3704f330b34"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "23d3ea3ca81c703609b2f3704f330b34"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-15/deployment-walkthrough/step-2-update-your-code-to-be-compatible-with-terraform-0-15.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-15/deployment-walkthrough/step-2-update-your-code-to-be-compatible-with-terraform-0-15.md
@@ -10,5 +10,8 @@ Upgrade Guide](https://www.terraform.io/upgrade-guides/0-15.html).
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"54113b1e4b9c28fa1060a88404ff7a2f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "54113b1e4b9c28fa1060a88404ff7a2f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-15/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-15/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -170,5 +170,8 @@ compatible with Terraform 0.15:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"358211de8f59ad73100aa258a90b9d32"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "358211de8f59ad73100aa258a90b9d32"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-15/index.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-15/index.md
@@ -30,5 +30,8 @@ compatible with Terraform 0.15.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"5e53cb16df16edff97b8cf973cb022ac"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "5e53cb16df16edff97b8cf973cb022ac"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/style/golang-style-guide.md
+++ b/docs/guides/style/golang-style-guide.md
@@ -262,5 +262,8 @@ suffix `E` return an error as the last return value; methods without `E` mark th
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"e3576d96a0cb8b02e8913e36d63bbf90"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "e3576d96a0cb8b02e8913e36d63bbf90"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/style/index.md
+++ b/docs/guides/style/index.md
@@ -25,5 +25,8 @@ Learn how Gruntwork formats our READMEs and documentation.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"570c137a65cf9623f2e9e018df8121d1"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "570c137a65cf9623f2e9e018df8121d1"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/style/markdown-style-guide.md
+++ b/docs/guides/style/markdown-style-guide.md
@@ -823,5 +823,8 @@ This Markdown style guide is adapted from [one provided by Google](https://googl
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"3b3cc134306552881bc83ebc8cbe9531"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "3b3cc134306552881bc83ebc8cbe9531"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/style/terraform-style-guide.md
+++ b/docs/guides/style/terraform-style-guide.md
@@ -395,5 +395,8 @@ func TestECS(t *testing.T) {
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ebf33215ca11bf62867a076882927304"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "ebf33215ca11bf62867a076882927304"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/working-with-code/contributing.md
+++ b/docs/guides/working-with-code/contributing.md
@@ -52,5 +52,8 @@ code and release a new version.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"14f13b5f634ced6a221c0a69fd2fe79d"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "14f13b5f634ced6a221c0a69fd2fe79d"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/working-with-code/forking.md
+++ b/docs/guides/working-with-code/forking.md
@@ -56,5 +56,8 @@ bans all outside sources, then follow the instructions above to fork the code, a
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"030c7f00ebd4cafb747e934a52bc9170"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "030c7f00ebd4cafb747e934a52bc9170"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/working-with-code/tfc-integration.md
+++ b/docs/guides/working-with-code/tfc-integration.md
@@ -460,5 +460,8 @@ Happy Terragrunting!
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"5b20d6a539da0fdb344d84384fccbe9c"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "5b20d6a539da0fdb344d84384fccbe9c"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/working-with-code/using-modules.md
+++ b/docs/guides/working-with-code/using-modules.md
@@ -768,5 +768,8 @@ Now that you have your Terraform module deployed, you can pull in updates as fol
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"51856e814c4a4bc50bdbcab6b0aaf2ce"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "51856e814c4a4bc50bdbcab6b0aaf2ce"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/working-with-code/versioning.md
+++ b/docs/guides/working-with-code/versioning.md
@@ -68,5 +68,8 @@ Follow the steps below to keep your code up to date:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"fe3d9c21b5e21502aaef662e2618482f"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "fe3d9c21b5e21502aaef662e2618482f"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -36,5 +36,8 @@ Open `docs/intro.md` and edit some lines: the site **reloads automatically** and
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"9a76adceeb3958af906263551c8dc0c4"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "9a76adceeb3958af906263551c8dc0c4"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/core-concepts/immutable-infrastructure.md
+++ b/docs/intro/core-concepts/immutable-infrastructure.md
@@ -35,5 +35,8 @@ longer work, e.g., if certain packages have been removed from APT or YUM).
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"159cda91c449de4ffd9bc29a10116c09"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "159cda91c449de4ffd9bc29a10116c09"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/core-concepts/infrastructure-as-code.md
+++ b/docs/intro/core-concepts/infrastructure-as-code.md
@@ -60,5 +60,8 @@ Packer, Docker, and Helm, each of which we’ll discuss in the next several sect
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"e29d1b09112e97f7f9908267a676c308"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "e29d1b09112e97f7f9908267a676c308"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/core-concepts/production-framework.md
+++ b/docs/intro/core-concepts/production-framework.md
@@ -16,5 +16,8 @@ Guide](/guides/production-framework) for the full details.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"4dda35c027cc8ed707d9bf946d096d9a"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "4dda35c027cc8ed707d9bf946d096d9a"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/dev-portal/create-account.md
+++ b/docs/intro/dev-portal/create-account.md
@@ -33,5 +33,8 @@ If you are the admin for your organization, you'll be prompted to confirm detail
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"01375ec9b14d989af4af205eba101d88"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "01375ec9b14d989af4af205eba101d88"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/dev-portal/invite-team.md
+++ b/docs/intro/dev-portal/invite-team.md
@@ -42,5 +42,8 @@ The number of licenses available depends on the level of your subscription. You 
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"702a33b934d092e229bc9c8d17e92387"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "702a33b934d092e229bc9c8d17e92387"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/dev-portal/link-github-id.md
+++ b/docs/intro/dev-portal/link-github-id.md
@@ -23,5 +23,8 @@ To link a new GitHub ID, you’ll first have to unlink the current one. Although
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"d64721bb5ec4d76fd33e70913243146a"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "d64721bb5ec4d76fd33e70913243146a"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/environment-setup/recommended_tools.md
+++ b/docs/intro/environment-setup/recommended_tools.md
@@ -86,5 +86,8 @@ docker run -it -v $(pwd):/work gruntwork /bin/bash
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"a5e7757f47c27e156d50f93192c30d35"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "a5e7757f47c27e156d50f93192c30d35"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/first-deployment/deploy.md
+++ b/docs/intro/first-deployment/deploy.md
@@ -261,5 +261,8 @@ terragrunt apply-all
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"7203857858fed888b41d453b81b3e12b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "7203857858fed888b41d453b81b3e12b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/first-deployment/testing.md
+++ b/docs/intro/first-deployment/testing.md
@@ -213,5 +213,8 @@ For a lot more information on writing automated tests for Terraform code, see:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"5ab7f3dbd4aa0424b2e7611b1a4036e7"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "5ab7f3dbd4aa0424b2e7611b1a4036e7"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/first-deployment/using-terraform-modules.md
+++ b/docs/intro/first-deployment/using-terraform-modules.md
@@ -238,5 +238,8 @@ output "private_persistence_subnet_ids" {
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"22ca9d71da618bade6675c2eabc553f5"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "22ca9d71da618bade6675c2eabc553f5"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/next-steps.mdx
+++ b/docs/intro/next-steps.mdx
@@ -28,5 +28,8 @@ Now that your foundational knowledge is in place and your workspace is configure
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"096674fca64983f45542f73cc4fc7e9b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "096674fca64983f45542f73cc4fc7e9b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/overview/getting-started.mdx
+++ b/docs/intro/overview/getting-started.mdx
@@ -30,5 +30,8 @@ In this introductory guide we’ll cover the fundamentals you'll need in order t
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"2c594f2c6b6c5ab9e1c211a3475fa279"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "2c594f2c6b6c5ab9e1c211a3475fa279"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/overview/gruntwork-production-framework.md
+++ b/docs/intro/overview/gruntwork-production-framework.md
@@ -33,5 +33,8 @@ This is an overloaded term, so let's dive into the details of what we mean by a 
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ebca2e605787776f91971e9c55972a74"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "ebca2e605787776f91971e9c55972a74"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/overview/gruntwork-vs-other.md
+++ b/docs/intro/overview/gruntwork-vs-other.md
@@ -2,5 +2,8 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"c8aeff437ffbf0d5134c70daf339a109"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "c8aeff437ffbf0d5134c70daf339a109"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/overview/how-it-works.md
+++ b/docs/intro/overview/how-it-works.md
@@ -55,5 +55,8 @@ Gruntwork products strike a balance between opinionatedness and configurability.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"5e1666e99b474793677917da45890adc"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "5e1666e99b474793677917da45890adc"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/overview/intro-to-gruntwork.md
+++ b/docs/intro/overview/intro-to-gruntwork.md
@@ -18,5 +18,8 @@ All Gruntwork products are built on and fully compatible with [open source Terra
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"1b5fc69a4dbe2b64db10761645dece1b"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "1b5fc69a4dbe2b64db10761645dece1b"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/overview/use-cases.md
+++ b/docs/intro/overview/use-cases.md
@@ -2,5 +2,8 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"9e449ec8d34b49b98c1c2e301378c065"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "9e449ec8d34b49b98c1c2e301378c065"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/tool-fundamentals/docker.md
+++ b/docs/intro/tool-fundamentals/docker.md
@@ -21,5 +21,8 @@ Nomad that you can use to deploy and manage Docker images.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ac4aef92859a42de2010069751aa1766"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "ac4aef92859a42de2010069751aa1766"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/tool-fundamentals/packer.md
+++ b/docs/intro/tool-fundamentals/packer.md
@@ -52,5 +52,8 @@ its opinionated tools.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"1d077cb69e254937c2472634a22eff5d"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "1d077cb69e254937c2472634a22eff5d"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/tool-fundamentals/terraform.md
+++ b/docs/intro/tool-fundamentals/terraform.md
@@ -39,5 +39,8 @@ The Gruntwork module library and open source tools are compatible with Terraform
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"5e3e898ec4ed802c2b91154b6a9e8fad"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "5e3e898ec4ed802c2b91154b6a9e8fad"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/tool-fundamentals/terragrunt.md
+++ b/docs/intro/tool-fundamentals/terragrunt.md
@@ -35,5 +35,8 @@ Infrastructure as Code Library with plain Terraform, Terraform Enterprise, Atlan
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"e917fe5423fd33a6c7c528e404a75f40"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "e917fe5423fd33a6c7c528e404a75f40"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/intro.md
+++ b/docs/reference/intro.md
@@ -8,5 +8,8 @@ This section introduces what's found in the reference area.
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"7d8cca66029815dd0e83044962ad5bbd"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "7d8cca66029815dd0e83044962ad5bbd"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/stub.md
+++ b/docs/reference/modules/stub.md
@@ -6,5 +6,8 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"c49fe59e5436e774d662dd58b36e767c"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "c49fe59e5436e774d662dd58b36e767c"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/intro/create-your-own-service-catalog.md
+++ b/docs/reference/services/intro/create-your-own-service-catalog.md
@@ -187,5 +187,8 @@ inputs = {
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"1f4ef9cbba76e05f0cc247508e82dc54"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "1f4ef9cbba76e05f0cc247508e82dc54"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/intro/deploy-new-infrastructure.md
+++ b/docs/reference/services/intro/deploy-new-infrastructure.md
@@ -396,5 +396,8 @@ most commonly used filters will be:
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"d9f703f17d3e41684bef2ab8f2fae2a1"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "d9f703f17d3e41684bef2ab8f2fae2a1"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/intro/make-changes-to-your-infrastructure.md
+++ b/docs/reference/services/intro/make-changes-to-your-infrastructure.md
@@ -191,5 +191,8 @@ _(Documentation coming soon. If you need help with this ASAP, please contact [su
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"1da75fa30f9ba0e374e7d4940d56e9a5"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "1da75fa30f9ba0e374e7d4940d56e9a5"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/intro/overview.md
+++ b/docs/reference/services/intro/overview.md
@@ -94,5 +94,8 @@ Makes sure to ALWAYS read the release notes and migration instructions (if any) 
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"5eb1606803f10d39a682642586a222a0"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "5eb1606803f10d39a682642586a222a0"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/tools/stub.md
+++ b/docs/reference/tools/stub.md
@@ -6,5 +6,8 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"7b9768e8298d0d83fd9e1ccc3a2328b1"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "7b9768e8298d0d83fd9e1ccc3a2328b1"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/support.mdx
+++ b/docs/support.mdx
@@ -161,5 +161,8 @@ Looking for more personalized assistance using a particular Gruntwork product? O
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"0198bea2fa710edbf97ce65d2f1afcca"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "0198bea2fa710edbf97ce65d2f1afcca"
+}
 ##DOCS-SOURCER-END -->

--- a/package.json
+++ b/package.json
@@ -43,11 +43,13 @@
     "@tsconfig/docusaurus": "^1.0.4",
     "jest": "^27.4.7",
     "onchange": "^7.1.0",
+    "ts-node": "^10.7.0",
+    "tsconfig-paths": "^3.14.1",
     "typescript": "^4.3.5",
     "yargs": "^17.4.0"
   },
   "optionalDependencies": {
-    "docs-sourcer": "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.0.22"
+    "docs-sourcer": "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.0.26"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2078,6 +2078,18 @@
   resolved "https://registry.yarnpkg.com/@blakeembrey/template/-/template-1.0.0.tgz#bf8828bc3ae8004d97904d78f64e3cc2cd216438"
   integrity sha512-J6WGZqCLdRMHUkyRG6fBSIFJ0rL60/nsQNh5rQvsYZ5u0PsKw6XQcJcA3DWvd9cN3j/IQx5yB1fexhCafwwUUw==
 
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
+
 "@dabh/diagnostics@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.2.tgz#290d08f7b381b8f94607dc8f471a12c675f9db31"
@@ -2978,6 +2990,35 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@slack/logger@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@slack/logger/-/logger-3.0.0.tgz#b736d4e1c112c22a10ffab0c2d364620aedcb714"
+  integrity sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==
+  dependencies:
+    "@types/node" ">=12.0.0"
+
+"@slack/types@^2.0.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@slack/types/-/types-2.4.0.tgz#b6f6d50e9181f723080b841302e089739cef512d"
+  integrity sha512-0k8UlVEH9gUVwTbwcanS1JT2vCROkr1WESgdXW7d2maWYTuwbVEx87YvXPjsemAJfdu+RYqxGhO2oGTigprepA==
+
+"@slack/web-api@^6.7.1":
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-6.7.1.tgz#a0e983ec7925dccaf8fe15047f1a53eb82c24888"
+  integrity sha512-Aa2E/7NtGagd7mVsFCrc69iZMoviR2032SBOic06sYVvptdzJlvNsSQVqLCb1Aqz7r/jodb2fnXO1gl016OcWQ==
+  dependencies:
+    "@slack/logger" "^3.0.0"
+    "@slack/types" "^2.0.0"
+    "@types/is-stream" "^1.1.0"
+    "@types/node" ">=12.0.0"
+    axios "^0.26.1"
+    eventemitter3 "^3.1.0"
+    form-data "^2.5.0"
+    is-electron "2.2.0"
+    is-stream "^1.1.0"
+    p-queue "^6.6.1"
+    p-retry "^4.0.0"
+
 "@slorber/static-site-generator-webpack-plugin@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@slorber/static-site-generator-webpack-plugin/-/static-site-generator-webpack-plugin-4.0.1.tgz#0c8852146441aaa683693deaa5aee2f991d94841"
@@ -3218,6 +3259,26 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/docusaurus/-/docusaurus-1.0.4.tgz#fc40f87a672568678d83533dd4031a09d75877ca"
   integrity sha512-I6sziQAzLrrqj9r6S26c7aOAjfGVXIE7gWdNONPwnpDcHiMRMQut1s1YCi/APem3dOy23tAb2rvHfNtGCaWuUQ==
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.18"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.18.tgz#1a29abcc411a9c05e2094c98f9a1b7da6cdf49f8"
@@ -3357,6 +3418,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/is-stream@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/is-stream/-/is-stream-1.1.0.tgz#b84d7bb207a210f2af9bed431dc0fbe9c4143be1"
+  integrity sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
@@ -3389,6 +3457,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
 "@types/jsonwebtoken@^8.3.3":
   version "8.5.6"
   resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.5.6.tgz#1913e5a61e70a192c5a444623da4901a7b1a9d42"
@@ -3417,6 +3490,11 @@
   version "16.11.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.6.tgz#6bef7a2a0ad684cf6e90fcfe31cecabd9ce0a3ae"
   integrity sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==
+
+"@types/node@>=12.0.0":
+  version "17.0.25"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.25.tgz#527051f3c2f77aa52e5dc74e45a3da5fb2301448"
+  integrity sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==
 
 "@types/node@^15.0.1":
   version "15.14.9"
@@ -3740,7 +3818,7 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn-walk@^8.0.0:
+acorn-walk@^8.0.0, acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
@@ -3917,7 +3995,7 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-arg@^4.1.3:
+arg@^4.1.0, arg@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
@@ -4024,6 +4102,13 @@ axios@^0.21.1:
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
+
+axios@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+  dependencies:
+    follow-redirects "^1.14.8"
 
 babel-jest@^27.4.6:
   version "27.4.6"
@@ -4706,7 +4791,7 @@ combine-promises@^1.1.0:
   resolved "https://registry.yarnpkg.com/combine-promises/-/combine-promises-1.1.0.tgz#72db90743c0ca7aab7d0d8d2052fd7b0f674de71"
   integrity sha512-ZI9jvcLDxqwaXEixOhArm3r7ReIivsXkpbyEWyeOhzz1QS0iSgBPnWvEqvIQtYyamGCYA88gFhmUrs9hrrQ0pg==
 
-combined-stream@^1.0.8:
+combined-stream@^1.0.6, combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -4911,6 +4996,11 @@ cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-fetch@^3.0.4:
   version "3.1.4"
@@ -5314,6 +5404,11 @@ diff-sequences@^27.4.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.4.0.tgz#d783920ad8d06ec718a060d00196dfef25b132a5"
   integrity sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==
 
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
@@ -5341,14 +5436,15 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
-"docs-sourcer@git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.0.22":
+"docs-sourcer@git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.0.26":
   version "0.0.1"
-  resolved "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#0281ef3f193c826258ee2d8b6495609832916ae8"
+  resolved "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#7e181f92b6b4b0b11488accd4a32ea7377108474"
   dependencies:
     "@octokit/auth-app" "^3.6.1"
     "@octokit/plugin-retry" "^3.0.9"
     "@octokit/rest" "^18.12.0"
     "@octokit/webhooks" "^9.22.0"
+    "@slack/web-api" "^6.7.1"
     add "^2.0.6"
     aws-lambda "^1.0.7"
     config "^3.3.6"
@@ -5723,7 +5819,12 @@ eval@^0.1.4:
   dependencies:
     require-like ">= 0.1.1"
 
-eventemitter3@^4.0.0:
+eventemitter3@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
+
+eventemitter3@^4.0.0, eventemitter3@^4.0.4:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -6009,6 +6110,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
   integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==
 
+follow-redirects@^1.14.8:
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
+
 fork-ts-checker-webpack-plugin@^6.0.5:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.4.0.tgz#057e477cf1d8b013b2ed2669437f818680289c4c"
@@ -6027,6 +6133,15 @@ fork-ts-checker-webpack-plugin@^6.0.5:
     schema-utils "2.7.0"
     semver "^7.3.2"
     tapable "^1.0.0"
+
+form-data@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
 
 form-data@^3.0.0:
   version "3.0.1"
@@ -6850,6 +6965,11 @@ is-docker@^2.0.0, is-docker@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
+is-electron@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.2.0.tgz#8943084f09e8b731b3a7a0298a7b5d56f6b7eef0"
+  integrity sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q==
+
 is-extendable@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
@@ -6986,6 +7106,11 @@ is-shared-array-buffer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"
   integrity sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==
+
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+  integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
 is-stream@^2.0.0:
   version "2.0.1"
@@ -7963,7 +8088,7 @@ make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -8207,6 +8332,11 @@ minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
@@ -8527,6 +8657,11 @@ p-cancelable@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
   integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
 
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+  integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -8569,13 +8704,28 @@ p-map@^4.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
-p-retry@^4.5.0:
+p-queue@^6.6.1:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
+  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
+  dependencies:
+    eventemitter3 "^4.0.4"
+    p-timeout "^3.2.0"
+
+p-retry@^4.0.0, p-retry@^4.5.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.1.tgz#8fcddd5cdf7a67a0911a9cf2ef0e5df7f602316c"
   integrity sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==
   dependencies:
     "@types/retry" "^0.12.0"
     retry "^0.13.1"
+
+p-timeout@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
+  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
+  dependencies:
+    p-finally "^1.0.0"
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -10315,6 +10465,11 @@ strip-bom-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom-string/-/strip-bom-string-1.0.0.tgz#e5211e9224369fbb81d633a2f00044dc8cedad92"
   integrity sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
+
 strip-bom@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
@@ -10618,6 +10773,35 @@ ts-jest@^27.1.3:
     make-error "1.x"
     semver "7.x"
     yargs-parser "20.x"
+
+ts-node@^10.7.0:
+  version "10.7.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.7.0.tgz#35d503d0fab3e2baa672a0e94f4b40653c2463f5"
+  integrity sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==
+  dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.0"
+    yn "3.1.1"
+
+tsconfig-paths@^3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
+  integrity sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.6"
+    strip-bom "^3.0.0"
 
 tslib@^2.0.3, tslib@^2.3.1:
   version "2.3.1"
@@ -10986,6 +11170,11 @@ uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+v8-compile-cache-lib@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-to-istanbul@^8.1.0:
   version "8.1.1"
@@ -11492,6 +11681,11 @@ yargs@^17.4.0:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This PR bumps the docs-sourcer version to fix the build issues that we were having. When you pull you should run `yarn install` in order to make sure you get the latest package versions.
Also updating all of the locally sourced content as the new versions of the docs-sourcer formats the metadata differently at the end of the file.