### PR TITLE
Include bash style guide

### DIFF
--- a/_docs-sources/guides/style/index.md
+++ b/_docs-sources/guides/style/index.md
@@ -20,5 +20,11 @@ Learn Gruntwork's Go coding style.
   href="/guides/style/markdown-style-guide">
 Learn how Gruntwork formats our READMEs and documentation.
 </Card>
+<Card
+  title="Bash Style Guide"
+  href="https://google.github.io/styleguide/shellguide.html">
+Gruntwork follows Google's shell style guide for Bash scripts.
+</Card>
+  
 
 </CardGroup>

--- a/docs/guides/style/index.md
+++ b/docs/guides/style/index.md
@@ -33,6 +33,6 @@ Gruntwork follows Google's shell style guide for Bash scripts.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "570c137a65cf9623f2e9e018df8121d1"
+  "hash": "a2e7a4dcf7d1eb2a24102927805a2a5d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/style/index.md
+++ b/docs/guides/style/index.md
@@ -20,6 +20,12 @@ Learn Gruntwork's Go coding style.
   href="/guides/style/markdown-style-guide">
 Learn how Gruntwork formats our READMEs and documentation.
 </Card>
+<Card
+  title="Bash Style Guide"
+  href="https://google.github.io/styleguide/shellguide.html">
+Gruntwork follows Google's shell style guide for Bash scripts.
+</Card>
+  
 
 </CardGroup>
 


### PR DESCRIPTION
I'd like to just start here, with this external link.

Follow-ups:
- [ ] Create our extended version of google's guide.
    - Description for this issue: We have only one extra thing to extend this base guide with so far, and that's using `local -r` instead of `local readonly`. We can add more rules as we go along, 