### PR TITLE
[APT-1841] Bump docs-sourcer version to v0.0.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "yargs": "^17.4.0"
   },
   "optionalDependencies": {
-    "docs-sourcer": "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.0.26"
+    "docs-sourcer": "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.0.27"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5436,9 +5436,9 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
-"docs-sourcer@git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.0.26":
+"docs-sourcer@git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.0.27":
   version "0.0.1"
-  resolved "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#7e181f92b6b4b0b11488accd4a32ea7377108474"
+  resolved "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#11f327f296a93c753b3a1a9adbd4bedb17a7ec69"
   dependencies:
     "@octokit/auth-app" "^3.6.1"
     "@octokit/plugin-retry" "^3.0.9"


### PR DESCRIPTION
This PR bumps the version of `docs-sourcer` to v0.0.27. This version removes the need for someone to have GitHub config locally when running just the local plugin of the `docs-sourcer`