### PR TITLE
Updated documentation to not reference "container_path"

### DIFF
--- a/docs/reference/services/app-orchestration/amazon-ecs-service.md
+++ b/docs/reference/services/app-orchestration/amazon-ecs-service.md
@@ -482,7 +482,6 @@ A map of ports to be opened via security groups applied to the EC2 instances tha
 ```hcl
 map(object({
     file_system_id          = string # required
-    container_path          = string # required
     root_directory          = string
     transit_encryption      = string
     transit_encryption_port = number


### PR DESCRIPTION
Updated documentation to not reference ECS efs_volumes "container_path" variable since it is removed in ECS module

To be merged after removal PR:
https://github.com/gruntwork-io/terraform-aws-ecs/pull/346