### PR TITLE
Update import-existing-resources-from-the-root-account-into-terraform…

### DIFF
--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/import-existing-resources-from-the-root-account-into-terraform-state.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/import-existing-resources-from-the-root-account-into-terraform-state.md
@@ -76,8 +76,8 @@ we need to temporarily hard-code some of the `region` and `role_arn` parameters 
 
 ```bash
 terragrunt aws-provider-patch \
-  --terragrunt-override-attr region="eu-west-1" \
-  --terragrunt-override-attr assume_role.role_arn=""
+  --terragrunt-override-attr 'region="eu-west-1"' \
+  --terragrunt-override-attr 'assume_role.role_arn=""'
 ```
 
 _Note: You can use any region you want for the `region` parameter. It’s just temporary. However, `role_arn` must be set


### PR DESCRIPTION
…-state.md

When using terragrun aws-provide-patch, the strings passed using --terragrunt-override-attr should be wrapped in single quotes.  If the strings are not surrounded by single quotes then running the command results in the error "Could not determine underlying type of JSON string".