### PR TITLE
Add video to production framework

### DIFF
--- a/_docs-sources/guides/production-framework/index.md
+++ b/_docs-sources/guides/production-framework/index.md
@@ -12,6 +12,13 @@ actionable content. Instead, you'll find a clear mental model of how to think ab
 concrete, opinionated set of steps you can follow to make better use of the cloud at your company. Think of this as a
 concrete description of the cloud setup you should be aiming for—the "right way" to do things.
 
+## Video overview
+
+If you prefer a video over reading a talk, check out this talk from Gruntwork Co-Founder Yevgeniy Brikman which 
+introduces each ingredient of the Gruntwork Production Framework:
+
+<iframe width="560" height="315" src="//www.youtube.com/embed/sYzhlBayRpU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 ## Why you need a framework
 
 The cloud changes everything.

--- a/_docs-sources/guides/production-framework/index.md
+++ b/_docs-sources/guides/production-framework/index.md
@@ -18,8 +18,8 @@ If you prefer a video over reading a talk, check out this talk from Gruntwork Co
 introduces each ingredient of the Gruntwork Production Framework, as well as how to put them all together:
 
 <!-- Embed 100% width, responsive video as per https://www.h3xed.com/web-development/how-to-make-a-responsive-100-width-youtube-iframe-embed -->
-<div style="position: relative; width: 100%; height: 0; padding-bottom: 56.25%;">
-  <iframe width="560" height="315" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="//www.youtube.com/embed/sYzhlBayRpU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<div style={{position: 'relative', width: '100%', height: 0, paddingBottom: '56.25%'}}>
+  <iframe width="560" height="315" style={{position: 'absolute', top: 0, left: 0, width: '100%', height: '100%'}} src="//www.youtube.com/embed/sYzhlBayRpU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 ## Why you need a framework

--- a/_docs-sources/guides/production-framework/index.md
+++ b/_docs-sources/guides/production-framework/index.md
@@ -15,7 +15,7 @@ concrete description of the cloud setup you should be aiming for—the "right wa
 ## Video overview
 
 If you prefer a video over reading a talk, check out this talk from Gruntwork Co-Founder Yevgeniy Brikman which 
-introduces each ingredient of the Gruntwork Production Framework:
+introduces each ingredient of the Gruntwork Production Framework, as well as how to put them all together:
 
 <!-- Embed 100% width, responsive video as per https://www.h3xed.com/web-development/how-to-make-a-responsive-100-width-youtube-iframe-embed -->
 <div style="position: relative; width: 100%; height: 0; padding-bottom: 56.25%;">

--- a/_docs-sources/guides/production-framework/index.md
+++ b/_docs-sources/guides/production-framework/index.md
@@ -17,7 +17,10 @@ concrete description of the cloud setup you should be aiming for—the "right wa
 If you prefer a video over reading a talk, check out this talk from Gruntwork Co-Founder Yevgeniy Brikman which 
 introduces each ingredient of the Gruntwork Production Framework:
 
-<iframe width="560" height="315" src="//www.youtube.com/embed/sYzhlBayRpU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<!-- Embed 100% width, responsive video as per https://www.h3xed.com/web-development/how-to-make-a-responsive-100-width-youtube-iframe-embed -->
+<div style="position: relative; width: 100%; height: 0; padding-bottom: 56.25%;">
+  <iframe width="560" height="315" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="//www.youtube.com/embed/sYzhlBayRpU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
 
 ## Why you need a framework
 

--- a/docs/guides/production-framework/index.md
+++ b/docs/guides/production-framework/index.md
@@ -186,6 +186,6 @@ Gruntwork to help you implement this framework.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "0f5e3c087339ab8a712c9fa33f909206"
+  "hash": "78c4d740636d460cf847aafc5db122d7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/index.md
+++ b/docs/guides/production-framework/index.md
@@ -12,6 +12,13 @@ actionable content. Instead, you'll find a clear mental model of how to think ab
 concrete, opinionated set of steps you can follow to make better use of the cloud at your company. Think of this as a
 concrete description of the cloud setup you should be aiming for—the "right way" to do things.
 
+## Video overview
+
+If you prefer a video over reading a talk, check out this talk from Gruntwork Co-Founder Yevgeniy Brikman which 
+introduces each ingredient of the Gruntwork Production Framework:
+
+<iframe width="560" height="315" src="//www.youtube.com/embed/sYzhlBayRpU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 ## Why you need a framework
 
 The cloud changes everything.

--- a/docs/guides/production-framework/index.md
+++ b/docs/guides/production-framework/index.md
@@ -18,8 +18,8 @@ If you prefer a video over reading a talk, check out this talk from Gruntwork Co
 introduces each ingredient of the Gruntwork Production Framework, as well as how to put them all together:
 
 <!-- Embed 100% width, responsive video as per https://www.h3xed.com/web-development/how-to-make-a-responsive-100-width-youtube-iframe-embed -->
-<div style="position: relative; width: 100%; height: 0; padding-bottom: 56.25%;">
-  <iframe width="560" height="315" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="//www.youtube.com/embed/sYzhlBayRpU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<div style={{position: 'relative', width: '100%', height: 0, paddingBottom: '56.25%'}}>
+  <iframe width="560" height="315" style={{position: 'absolute', top: 0, left: 0, width: '100%', height: '100%'}} src="//www.youtube.com/embed/sYzhlBayRpU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 ## Why you need a framework

--- a/docs/guides/production-framework/index.md
+++ b/docs/guides/production-framework/index.md
@@ -15,7 +15,7 @@ concrete description of the cloud setup you should be aiming for—the "right wa
 ## Video overview
 
 If you prefer a video over reading a talk, check out this talk from Gruntwork Co-Founder Yevgeniy Brikman which 
-introduces each ingredient of the Gruntwork Production Framework:
+introduces each ingredient of the Gruntwork Production Framework, as well as how to put them all together:
 
 <!-- Embed 100% width, responsive video as per https://www.h3xed.com/web-development/how-to-make-a-responsive-100-width-youtube-iframe-embed -->
 <div style="position: relative; width: 100%; height: 0; padding-bottom: 56.25%;">

--- a/docs/guides/production-framework/index.md
+++ b/docs/guides/production-framework/index.md
@@ -17,7 +17,10 @@ concrete description of the cloud setup you should be aiming for—the "right wa
 If you prefer a video over reading a talk, check out this talk from Gruntwork Co-Founder Yevgeniy Brikman which 
 introduces each ingredient of the Gruntwork Production Framework:
 
-<iframe width="560" height="315" src="//www.youtube.com/embed/sYzhlBayRpU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<!-- Embed 100% width, responsive video as per https://www.h3xed.com/web-development/how-to-make-a-responsive-100-width-youtube-iframe-embed -->
+<div style="position: relative; width: 100%; height: 0; padding-bottom: 56.25%;">
+  <iframe width="560" height="315" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="//www.youtube.com/embed/sYzhlBayRpU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
 
 ## Why you need a framework
 

--- a/docs/guides/production-framework/index.md
+++ b/docs/guides/production-framework/index.md
@@ -189,6 +189,6 @@ Gruntwork to help you implement this framework.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "b3c2a397b709e5a53780d0c9a525ee0d"
+  "hash": "7e7969c7e2b942c3840159b6404a0685"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/index.md
+++ b/docs/guides/production-framework/index.md
@@ -189,6 +189,6 @@ Gruntwork to help you implement this framework.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "7e7969c7e2b942c3840159b6404a0685"
+  "hash": "807e76130e6f37725f946587a4c8ff0e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/index.md
+++ b/docs/guides/production-framework/index.md
@@ -189,6 +189,6 @@ Gruntwork to help you implement this framework.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "78c4d740636d460cf847aafc5db122d7"
+  "hash": "b3c2a397b709e5a53780d0c9a525ee0d"
 }
 ##DOCS-SOURCER-END -->


### PR DESCRIPTION
The video for my talk [Cloud Adoption Fails: 5 Ways Deployments Go Wrong and 5 Solutions](https://www.youtube.com/watch?v=sYzhlBayRpU) is now available. Since this talk introduces the Gruntwork Production Framework, I'm embedding the video in the guide.

Direct link to relevant page in preview env: https://deploy-preview-449--pensive-meitner-faaeee.netlify.app/guides/production-framework/