### PR TITLE
Include how to use service catalog without for-production example

### DIFF
--- a/_docs-sources/reference/services/intro/overview.md
+++ b/_docs-sources/reference/services/intro/overview.md
@@ -63,7 +63,11 @@ The code in the `terraform-aws-service-catalog` repo is organized into three pri
       integrated tech stack on top of the Gruntwork Service Catalog. To keep the code DRY and manage dependencies
       between modules, the code is deployed using [Terragrunt](https://terragrunt.gruntwork.io/). However, Terragrunt
       is NOT required to use the Gruntwork Service Catalog: you can alternatively use vanilla Terraform or Terraform
-      Cloud / Enterprise, as described later in these docs.
+      Cloud / Enterprise, as described [here](https://docs.gruntwork.io/reference/services/intro/deploy-new-infrastructure#how-to-deploy-terraform-code-from-the-service-catalog).
+
+    1. Not all modules have a `for-production` example, but you can still create a production-grade configuration by 
+       using the template provided in this discussion question, [How do I use the modules in terraform-aws-service-catalog
+       if there is no example?](https://github.com/gruntwork-io/knowledge-base/discussions/360#discussioncomment-25705480).
 
 1. `test`: Automated tests for the code in `modules` and `examples`.
 

--- a/docs/reference/services/intro/overview.md
+++ b/docs/reference/services/intro/overview.md
@@ -100,6 +100,6 @@ Makes sure to ALWAYS read the release notes and migration instructions (if any) 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "5eb1606803f10d39a682642586a222a0"
+  "hash": "750a36ba2c3ba2455d2eba763802109d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/intro/overview.md
+++ b/docs/reference/services/intro/overview.md
@@ -65,6 +65,10 @@ The code in the `terraform-aws-service-catalog` repo is organized into three pri
       is NOT required to use the Gruntwork Service Catalog: you can alternatively use vanilla Terraform or Terraform
       Cloud / Enterprise, as described [here](https://docs.gruntwork.io/reference/services/intro/deploy-new-infrastructure#how-to-deploy-terraform-code-from-the-service-catalog).
 
+    1. Not all modules have a `for-production` example, but you can still create a production-grade configuration by 
+       using the template provided in this discussion question, [How do I use the modules in terraform-aws-service-catalog
+       if there is no example?](https://github.com/gruntwork-io/knowledge-base/discussions/360#discussioncomment-25705480).
+
 1. `test`: Automated tests for the code in `modules` and `examples`.
 
 ## Maintenance and versioning

--- a/docs/reference/services/intro/overview.md
+++ b/docs/reference/services/intro/overview.md
@@ -63,7 +63,7 @@ The code in the `terraform-aws-service-catalog` repo is organized into three pri
       integrated tech stack on top of the Gruntwork Service Catalog. To keep the code DRY and manage dependencies
       between modules, the code is deployed using [Terragrunt](https://terragrunt.gruntwork.io/). However, Terragrunt
       is NOT required to use the Gruntwork Service Catalog: you can alternatively use vanilla Terraform or Terraform
-      Cloud / Enterprise, as described later in these docs.
+      Cloud / Enterprise, as described [here](https://docs.gruntwork.io/reference/services/intro/deploy-new-infrastructure#how-to-deploy-terraform-code-from-the-service-catalog).
 
 1. `test`: Automated tests for the code in `modules` and `examples`.
 


### PR DESCRIPTION
This corresponds with the `terraform-aws-service-catalog` update in https://github.com/gruntwork-io/terraform-aws-service-catalog/pull/1708.