### PR TITLE
Update releases through Nov

### DIFF
--- a/docs/guides/stay-up-to-date/index.md
+++ b/docs/guides/stay-up-to-date/index.md
@@ -16,6 +16,7 @@ import CardGroup from "/src/components/CardGroup"
 
 <CardGroup cols={1} gap="1rem" stacked equalHeightRows={false} commonCardProps={{padding: "1.25rem"}}>
 
+<Card title="Update to 2022-12" href="/guides/stay-up-to-date/releases/2022-12" />
 <Card title="Update to 2022-11" href="/guides/stay-up-to-date/releases/2022-11" />
 <Card title="Update to 2022-10" href="/guides/stay-up-to-date/releases/2022-10" />
 <Card title="Update to 2022-09" href="/guides/stay-up-to-date/releases/2022-09" />
@@ -30,7 +31,6 @@ import CardGroup from "/src/components/CardGroup"
 <Card title="Update to 2021-12" href="/guides/stay-up-to-date/releases/2021-12" />
 <Card title="Update to 2021-11" href="/guides/stay-up-to-date/releases/2021-11" />
 <Card title="Update to 2021-10" href="/guides/stay-up-to-date/releases/2021-10" />
-<Card title="Update to 2021-09" href="/guides/stay-up-to-date/releases/2021-09" />
 <Card title="See older releases" href="/guides/stay-up-to-date/releases" />
 
 </CardGroup>
@@ -109,6 +109,6 @@ href="/guides/stay-up-to-date/terraform/terraform-1.1"
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "4d610b850fafd7a51ed2aa721262f707"
+  "hash": "8fac172fc52b3b2e79b022f7d48c6325"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-06/index.md
@@ -214,7 +214,7 @@ Here are the repos that were updated:
 ### [v0.0.1](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.0.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/7/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.0.1">Release notes</a></small>
+  <small>Published: 6/6/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.0.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -246,7 +246,7 @@ Here are the repos that were updated:
 ### [v0.0.3](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.0.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/16/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.0.3">Release notes</a></small>
+  <small>Published: 6/15/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.0.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -287,6 +287,21 @@ Here are the repos that were updated:
 
 
 ## terraform-aws-ecs
+
+
+### [v0.0.6](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.0.6)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/30/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.0.6">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  - For `ecs-cluster` and `ecs-server` modules, terraform output values containing a value like `iam_role_name` now output a human-friendly name, not a globally unique string ID as before.
+- Due to [Terraform Bug #3888](https://github.com/hashicorp/terraform/issues/3888), a bug was introduced in an earlier release when using the `ecs-cluster` module from a terraform template that is in turn called by another terraform template. This release fixes that bug by adding an explicit var `allow_ssh` to indicate whether SSH from a specific security group will be allowed. This is redundant but resolves the issue until the Terraform bug is resolved.
+
+
+</div>
 
 
 ### [v0.0.5](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.0.5)
@@ -368,7 +383,7 @@ Here are the repos that were updated:
 ### [v0.0.6](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.6)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/30/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.6">Release notes</a></small>
+  <small>Published: 6/29/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.6">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -382,7 +397,7 @@ Here are the repos that were updated:
 ### [v0.0.5](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/28/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.5">Release notes</a></small>
+  <small>Published: 6/27/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -427,7 +442,7 @@ Here are the repos that were updated:
 ### [v0.0.2](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/24/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.2">Release notes</a></small>
+  <small>Published: 6/23/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -473,7 +488,7 @@ Here are the repos that were updated:
 ### [v0.0.1](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.0.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/7/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.0.1">Release notes</a></small>
+  <small>Published: 6/6/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.0.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -491,7 +506,7 @@ Here are the repos that were updated:
 ### [v0.0.4](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.0.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/24/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.0.4">Release notes</a></small>
+  <small>Published: 6/23/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.0.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -534,7 +549,7 @@ Here are the repos that were updated:
 ### [v0.0.1](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.0.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/8/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.0.1">Release notes</a></small>
+  <small>Published: 6/7/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.0.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -550,6 +565,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "ecc40463cba924db1547732711126d2f"
+  "hash": "3b1e50f01e5e04333dbf49c1c2c67f8a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-06/index.md
@@ -237,7 +237,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - All data stores now support a `bastion_host_security_group_id` parameter that can be used to allow the bastion host (or more likely, you using the bastion host via SSH tunneling) to connect to the data store. For security reasons, the default for the `bastion_host_security_group_id` parameter is empty string, which means it's disabled.
+  - All data stores now support a `bastion_host_security_group_id` parameter that can be used to allow the bastion host (or more likely, you using the bastion host via SSH tunneling) to connect to the data store. For security reasons, the default for the `bastion_host_security_group_id` parameter is empty string, which means it&apos;s disabled.
 
 
 </div>
@@ -402,7 +402,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - The `route53-health-check` module now enforces that the CloudWatch Alarm and SNS Topic for the Route 53 Health Check are both in `us-east-1`, as that's the only place where Route 53 sends CloudWatch metrics.
+  - The `route53-health-check` module now enforces that the CloudWatch Alarm and SNS Topic for the Route 53 Health Check are both in `us-east-1`, as that&apos;s the only place where Route 53 sends CloudWatch metrics.
 
 
 </div>
@@ -416,7 +416,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - Don't trigger alarms when ELB request latency switches to `INSUFFICIENT_DATA` state, as that indicates no requests are going through the ELB, which might not be an error condition, and if it is, should be caught by the `elb_low_request_count` alarm instead.
+  - Don&apos;t trigger alarms when ELB request latency switches to `INSUFFICIENT_DATA` state, as that indicates no requests are going through the ELB, which might not be an error condition, and if it is, should be caught by the `elb_low_request_count` alarm instead.
 - Only create the `elb_low_request_count` alarm if `var.elb_low_request_count_threshold` is greater than 0.
 
 
@@ -565,6 +565,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "30eb153691339a07e58323f0cf9f594d"
+  "hash": "a6f6259935c91cca53f2c398ff2e1825"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-06/index.md
@@ -292,7 +292,7 @@ Here are the repos that were updated:
 ### [v0.0.6](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.0.6)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/30/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.0.6">Release notes</a></small>
+  <small>Published: 7/1/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.0.6">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -506,7 +506,7 @@ Here are the repos that were updated:
 ### [v0.0.4](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.0.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/23/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.0.4">Release notes</a></small>
+  <small>Published: 6/24/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.0.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -549,7 +549,7 @@ Here are the repos that were updated:
 ### [v0.0.1](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.0.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/7/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.0.1">Release notes</a></small>
+  <small>Published: 6/8/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.0.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -565,6 +565,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "466659fe5bccb1f447e4157077897140"
+  "hash": "30eb153691339a07e58323f0cf9f594d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-06/index.md
@@ -214,7 +214,7 @@ Here are the repos that were updated:
 ### [v0.0.1](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.0.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/6/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.0.1">Release notes</a></small>
+  <small>Published: 6/7/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.0.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -246,7 +246,7 @@ Here are the repos that were updated:
 ### [v0.0.3](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.0.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/15/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.0.3">Release notes</a></small>
+  <small>Published: 6/16/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.0.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -383,7 +383,7 @@ Here are the repos that were updated:
 ### [v0.0.6](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.6)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/29/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.6">Release notes</a></small>
+  <small>Published: 6/30/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.6">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -397,7 +397,7 @@ Here are the repos that were updated:
 ### [v0.0.5](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/27/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.5">Release notes</a></small>
+  <small>Published: 6/28/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -442,7 +442,7 @@ Here are the repos that were updated:
 ### [v0.0.2](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/23/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.2">Release notes</a></small>
+  <small>Published: 6/24/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -488,7 +488,7 @@ Here are the repos that were updated:
 ### [v0.0.1](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.0.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/6/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.0.1">Release notes</a></small>
+  <small>Published: 6/7/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.0.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -565,6 +565,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "3b1e50f01e5e04333dbf49c1c2c67f8a"
+  "hash": "466659fe5bccb1f447e4157077897140"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-07/index.md
@@ -88,7 +88,7 @@ Here are the repos that were updated:
 ### [v0.0.1](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.0.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/12/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.0.1">Release notes</a></small>
+  <small>Published: 7/11/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.0.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -106,7 +106,7 @@ Here are the repos that were updated:
 ### [v0.0.1](https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.0.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/30/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.0.1">Release notes</a></small>
+  <small>Published: 7/29/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.0.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -195,7 +195,7 @@ Here are the repos that were updated:
 ### [v0.0.12](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.0.12)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/12/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.0.12">Release notes</a></small>
+  <small>Published: 7/11/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.0.12">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -377,27 +377,12 @@ Here are the repos that were updated:
 ### [v0.0.7](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.0.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/3/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.0.7">Release notes</a></small>
+  <small>Published: 7/2/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.0.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
   - `ecs-cluster` and `ecs-servce` now output `ecs_cluster_arn` instead of `ecs_cluster_id`. This was done to improve clarity about what this var represents.
-
-
-</div>
-
-
-### [v0.0.6](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.0.6)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/1/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.0.6">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  - For `ecs-cluster` and `ecs-server` modules, terraform output values containing a value like `iam_role_name` now output a human-friendly name, not a globally unique string ID as before.
-- Due to [Terraform Bug #3888](https://github.com/hashicorp/terraform/issues/3888), a bug was introduced in an earlier release when using the `ecs-cluster` module from a terraform template that is in turn called by another terraform template. This release fixes that bug by adding an explicit var `allow_ssh` to indicate whether SSH from a specific security group will be allowed. This is redundant but resolves the issue until the Terraform bug is resolved.
 
 
 </div>
@@ -568,6 +553,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "0f92765d9b29fb4ea65b946448f39c67"
+  "hash": "2d6962d09a73b54c35c36d45a35502b8"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-07/index.md
@@ -157,7 +157,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - Output docs-generator binaries to a different folder during the build so they don't get pushed to the module-ci-public repo
+  - Output docs-generator binaries to a different folder during the build so they don&apos;t get pushed to the module-ci-public repo
 
 
 </div>
@@ -309,7 +309,7 @@ Here are the repos that were updated:
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
   - BREAKING CHANGE: `ecs-service` params are renamed to more cleanly separate ELB resources from non-ELB resources by namespacing vars as either `elb_` or not.
-- Rolls back #16 since this can be put in clients' infrastructure-modules repo instead.
+- Rolls back #16 since this can be put in clients&apos; infrastructure-modules repo instead.
 
 
 </div>
@@ -367,7 +367,7 @@ Here are the repos that were updated:
 
   - `ecs-service`: BREAKING CHANGE. The `name` property has been renamed to `service_name`.
 - `ecs-service`: BREAKING CHANGE. The `associate_with_elb` property has been renamed to `is_associated_with_elb` to better indicate this property accepts boolean values.
-- `ecs-service`: BREAKING CHANGE. The `ecs_cluster_vpc_name` property has been added so that the ECS Service's IAM Role is named uniquely per the environment in which it's deployed.
+- `ecs-service`: BREAKING CHANGE. The `ecs_cluster_vpc_name` property has been added so that the ECS Service&apos;s IAM Role is named uniquely per the environment in which it&apos;s deployed.
 - Tests updated to use latest gruntwork-installer.
 
 
@@ -480,7 +480,7 @@ Here are the repos that were updated:
 
   Add two new modules: 
 - `persistent-ebs-volume`: Scripts for mounting and unmounting EBS Volumes on your EC2 Instances for Volumes that need to persist between redeploys of the Instance.
-- `route53-helpers`: Scripts for working with Amazon's DNS Service, Route 53, including a script to add a DNS A record pointing to the instance's IP address.
+- `route53-helpers`: Scripts for working with Amazon&apos;s DNS Service, Route 53, including a script to add a DNS A record pointing to the instance&apos;s IP address.
 
 
 </div>
@@ -553,6 +553,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "7a4738c91d4af9cfa8b111587f84915c"
+  "hash": "02d759351302a389627c753ab5d95818"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-07/index.md
@@ -88,7 +88,7 @@ Here are the repos that were updated:
 ### [v0.0.1](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.0.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/11/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.0.1">Release notes</a></small>
+  <small>Published: 7/12/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.0.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -106,7 +106,7 @@ Here are the repos that were updated:
 ### [v0.0.1](https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.0.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/29/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.0.1">Release notes</a></small>
+  <small>Published: 7/30/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.0.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -195,7 +195,7 @@ Here are the repos that were updated:
 ### [v0.0.12](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.0.12)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/11/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.0.12">Release notes</a></small>
+  <small>Published: 7/12/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.0.12">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -377,7 +377,7 @@ Here are the repos that were updated:
 ### [v0.0.7](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.0.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/2/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.0.7">Release notes</a></small>
+  <small>Published: 7/3/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.0.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -553,6 +553,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "2d6962d09a73b54c35c36d45a35502b8"
+  "hash": "7a4738c91d4af9cfa8b111587f84915c"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-08/index.md
@@ -166,29 +166,29 @@ BREAKING CHANGE: Upgrade module parameters to take advantage of the new data typ
 
 
 - `vars.tf`:
-  - [Example diff](https://github.com/gruntwork-io/module-vpc/compare/c83c30f998f8486537e7308dcdfbcd5cdf34bffa...master?diff=unified&name=master#diff-14c7cc73490c3d2d8347d14cb8a44729) and 
+  - [Example diff](https://github.com/gruntwork-io/module-vpc/compare/c83c30f998f8486537e7308dcdfbcd5cdf34bffa...master?diff=unified&amp;name=master#diff-14c7cc73490c3d2d8347d14cb8a44729) and 
   - Remove the `aws_availability_zones` variable. 
   - Add a variable called `num_availability_zones`. This represents the number of availability zones usable by this AWS account for the current AWS region. Set its `default` value to 2, 3, or 4, depending on your region.
 - `main.tf`
-  - [Example diff](https://github.com/gruntwork-io/module-vpc/compare/c83c30f998f8486537e7308dcdfbcd5cdf34bffa...master?diff=unified&name=master#diff-8140c347465c3fb50113f34a03f9c0d1) (ignore the `user_data` stuff)
+  - [Example diff](https://github.com/gruntwork-io/module-vpc/compare/c83c30f998f8486537e7308dcdfbcd5cdf34bffa...master?diff=unified&amp;name=master#diff-8140c347465c3fb50113f34a03f9c0d1) (ignore the `user_data` stuff)
   - Update the `ref` of the `vpc-mgmt` and `vpc-mgmt-network-acls` URLs to `0.1.0`.
-  - In the `mgmt_vpc` module, instead of setting `aws_availability_zones = "${var.aws_availability_zones}"`, set `num_availability_zones = "${var.num_availability_zones}"`.
-  - In the `mgmt_vpc_network_acls` module, instead of setting `num_subnets = "${length(split(",", var.aws_availability_zones))}"`, set `num_subnets = "${var.num_availability_zones}"`. 
-  - In the `mgmt_vpc_network_acls` module, if you don't have it already, set a new parameter: `vpc_ready = "${module.mgmt_vpc.vpc_ready}"`.
+  - In the `mgmt_vpc` module, instead of setting `aws_availability_zones = &quot;$&#x7B;var.aws_availability_zones&#x7D;&quot;`, set `num_availability_zones = &quot;$&#x7B;var.num_availability_zones&#x7D;&quot;`.
+  - In the `mgmt_vpc_network_acls` module, instead of setting `num_subnets = &quot;$&#x7B;length(split(&quot;,&quot;, var.aws_availability_zones))&#x7D;&quot;`, set `num_subnets = &quot;$&#x7B;var.num_availability_zones&#x7D;&quot;`. 
+  - In the `mgmt_vpc_network_acls` module, if you don&apos;t have it already, set a new parameter: `vpc_ready = &quot;$&#x7B;module.mgmt_vpc.vpc_ready&#x7D;&quot;`.
 - Deploy:
   - Run `terragrunt get -update`
   - Run `terragrunt plan`
-  - You may see a few Network ACLs being created and destroyed. That's OK.
+  - You may see a few Network ACLs being created and destroyed. That&apos;s OK.
   - You should NOT see the VPC, any route tables, or any subnets being created or destroyed. If you do, let us know (support@gruntwork.io)!
   - If everything looks OK, run `terragrunt apply`.
 
 
 These use the exact same upgrade process as the mgmt VPC, except there are some additional steps for the peering connection:
 - `main.tf`:
-  - [Example diff](https://github.com/gruntwork-io/module-vpc/compare/c83c30f998f8486537e7308dcdfbcd5cdf34bffa...master?diff=unified&name=master#diff-3c06616a9c2b49d630e46d8439b63a8c) (ignore the `user_data` stuff)
+  - [Example diff](https://github.com/gruntwork-io/module-vpc/compare/c83c30f998f8486537e7308dcdfbcd5cdf34bffa...master?diff=unified&amp;name=master#diff-3c06616a9c2b49d630e46d8439b63a8c) (ignore the `user_data` stuff)
   - Update the `ref` of the `vpc-peering` URL to `0.1.0`.
-  - Instead of manually concatenating values in a string for the `origin_vpc_route_table_ids` and `destination_vpc_route_table_ids` parameters, use the [concat](https://www.terraform.io/docs/configuration/interpolation.html#concat_list1_list2_) and [list](https://www.terraform.io/docs/configuration/interpolation.html#list_items_) functions. You should get something like `origin_vpc_route_table_ids = "${concat(data.terraform_remote_state.mgmt_vpc.private_subnet_route_table_ids, list(data.terraform_remote_state.mgmt_vpc.public_subnet_route_table_id))}"`. 
-  - Replace `length(split(",", var.aws_availability_zones))` in the calculation of the `num_origin_vpc_route_tables` and `num_destination_vpc_route_tables` parameters with `var.num_availability_zones`. The other parts of the calculation (e.g. the +1 and the *2) stay the same.
+  - Instead of manually concatenating values in a string for the `origin_vpc_route_table_ids` and `destination_vpc_route_table_ids` parameters, use the [concat](https://www.terraform.io/docs/configuration/interpolation.html#concat_list1_list2_) and [list](https://www.terraform.io/docs/configuration/interpolation.html#list_items_) functions. You should get something like `origin_vpc_route_table_ids = &quot;$&#x7B;concat(data.terraform_remote_state.mgmt_vpc.private_subnet_route_table_ids, list(data.terraform_remote_state.mgmt_vpc.public_subnet_route_table_id))&#x7D;&quot;`. 
+  - Replace `length(split(&quot;,&quot;, var.aws_availability_zones))` in the calculation of the `num_origin_vpc_route_tables` and `num_destination_vpc_route_tables` parameters with `var.num_availability_zones`. The other parts of the calculation (e.g. the +1 and the *2) stay the same.
 - Deploy:
   - Same process as the mgmt VPC above.
   - Other than minor Network ACL changes, you should not see anything being destroyed. If you do, this could lead to outage, so please notify us (support@gruntwork.io)!
@@ -211,6 +211,6 @@ ENHANCEMENT: `vpc-app` and `vpc-mgmt` now allow for specifying the exact CIDR bl
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "549d9e469fb60e2ba4bea5f59206fa65"
+  "hash": "e847c67485b1fca089c81d3e3211211d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-08/index.md
@@ -87,7 +87,7 @@ Here are the repos that were updated:
 ### [v0.0.9](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.9)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/12/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.9">Release notes</a></small>
+  <small>Published: 8/13/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.9">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -211,6 +211,6 @@ ENHANCEMENT: `vpc-app` and `vpc-mgmt` now allow for specifying the exact CIDR bl
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "0358b1b6118a163b231ad737f91eea1e"
+  "hash": "549d9e469fb60e2ba4bea5f59206fa65"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-08/index.md
@@ -87,7 +87,7 @@ Here are the repos that were updated:
 ### [v0.0.9](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.9)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/13/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.9">Release notes</a></small>
+  <small>Published: 8/12/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.0.9">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -211,6 +211,6 @@ ENHANCEMENT: `vpc-app` and `vpc-mgmt` now allow for specifying the exact CIDR bl
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "549d9e469fb60e2ba4bea5f59206fa65"
+  "hash": "0358b1b6118a163b231ad737f91eea1e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-09/index.md
@@ -153,7 +153,7 @@ Here are the repos that were updated:
 ### [v0.1.3](https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.1.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/8/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.1.3">Release notes</a></small>
+  <small>Published: 9/9/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.1.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -168,7 +168,7 @@ Here are the repos that were updated:
 ### [v0.1.2](https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.1.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/8/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.1.2">Release notes</a></small>
+  <small>Published: 9/9/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.1.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -633,7 +633,7 @@ In `modules/ecs-cluster`:
 ### [v0.1.1](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/28/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.1">Release notes</a></small>
+  <small>Published: 9/29/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -649,6 +649,6 @@ In `modules/ecs-cluster`:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "46e770aa7bb623e6ca6df83d04092d87"
+  "hash": "fbd1c1bc0f3c7af57f509aa08c04bff7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-09/index.md
@@ -34,7 +34,7 @@ Here are the repos that were updated:
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
   BACKWARDS INCOMPATIBLE CHANGES
-- Boilerplate now supports types for variables. Each variable in the `boilerplate.yml` file can define a `type` field set to string, int, float, bool, list, map, or enum (enum variables can also include a list of `options`). This allows for some basic error checking of the variable values and, even more importantly, allows you to use the corresponding Go template syntax for those types. For example, if-statements work as you would expect with booleans (no more having to check `if eq .Foo "true"`), you can loop over lists and maps using the `range` keyword, and you can do basic arithmetic on ints and floats.
+- Boilerplate now supports types for variables. Each variable in the `boilerplate.yml` file can define a `type` field set to string, int, float, bool, list, map, or enum (enum variables can also include a list of `options`). This allows for some basic error checking of the variable values and, even more importantly, allows you to use the corresponding Go template syntax for those types. For example, if-statements work as you would expect with booleans (no more having to check `if eq .Foo &quot;true&quot;`), you can loop over lists and maps using the `range` keyword, and you can do basic arithmetic on ints and floats.
 - The `prompt` field in `boilerplate.yml` has been renamed to `description`.
 
 
@@ -49,7 +49,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - `boilerplate` now has a `--missing-config-action` flag that controls its behavior when run against a template folder that doesn't have a `boilerplate.yml` file. The default behavior is now to exit with an error.
+  - `boilerplate` now has a `--missing-config-action` flag that controls its behavior when run against a template folder that doesn&apos;t have a `boilerplate.yml` file. The default behavior is now to exit with an error.
 
 
 </div>
@@ -143,8 +143,8 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - BREAKING CHANGE: We switched the redis module's implementation from CloudFormation over to Terraform now that Terraform supports Redis replication groups. Note that if you update to this new version of the redis module, **it will delete you original ElastiCache cluster and replace it with a new one**. Therefore, it's essential that you have all your data backed up and can take a downtime before you do the upgrade.
-- Fix bugs in the outputs of both the memcached and redis module. It turns out that the Terraform (and in many cases, CloudFormation)  outputs are either missing or broken (see https://github.com/hashicorp/terraform/issues/8794 and https://github.com/hashicorp/terraform/issues/8788). We've added hacky workarounds that should do the trick for now, but we will be watching the progress of those bugs closely in the hope of getting a more reliable solution.
+  - BREAKING CHANGE: We switched the redis module&apos;s implementation from CloudFormation over to Terraform now that Terraform supports Redis replication groups. Note that if you update to this new version of the redis module, **it will delete you original ElastiCache cluster and replace it with a new one**. Therefore, it&apos;s essential that you have all your data backed up and can take a downtime before you do the upgrade.
+- Fix bugs in the outputs of both the memcached and redis module. It turns out that the Terraform (and in many cases, CloudFormation)  outputs are either missing or broken (see https://github.com/hashicorp/terraform/issues/8794 and https://github.com/hashicorp/terraform/issues/8788). We&apos;ve added hacky workarounds that should do the trick for now, but we will be watching the progress of those bugs closely in the hope of getting a more reliable solution.
 
 
 </div>
@@ -242,7 +242,7 @@ Changes in `modules/memcached`:
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
   - Added a new `scheduled-lambda-job` module that can be used to run AWS Lambda on a periodic basis. This is useful for background jobs, such as taking snapshots of servers.
-- BUGFIX: The `configure-environment-for-gruntwork-module` now properly overwrites previous installs of Terraform, Packer, and Glide and doesn't get stuck asking for a user prompt.
+- BUGFIX: The `configure-environment-for-gruntwork-module` now properly overwrites previous installs of Terraform, Packer, and Glide and doesn&apos;t get stuck asking for a user prompt.
 
 
 </div>
@@ -350,7 +350,7 @@ In `modules/ecs-cluster`:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - In the elasticsearch-alarms module, we've increased the default `low_cpu_credit_balance_period` value to 15 minutes. That metric is reported only roughly once every 5 minutes, and with the original setting, if the metric took too long, the alarm would keep flipping between OK and INSUFFICIENT_DATA. This new value should fix that issue.
+  - In the elasticsearch-alarms module, we&apos;ve increased the default `low_cpu_credit_balance_period` value to 15 minutes. That metric is reported only roughly once every 5 minutes, and with the original setting, if the metric took too long, the alarm would keep flipping between OK and INSUFFICIENT_DATA. This new value should fix that issue.
 
 
 </div>
@@ -408,7 +408,7 @@ In `modules/ecs-cluster`:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - The rds-alarms module now accepts an `is_aurora` parameter. Set it to true if you're using the module with Aurora so that the module doesn't create unnecessary disk space alarms (since Aurora automatically expands available disk space)
+  - The rds-alarms module now accepts an `is_aurora` parameter. Set it to true if you&apos;re using the module with Aurora so that the module doesn&apos;t create unnecessary disk space alarms (since Aurora automatically expands available disk space)
 
 
 </div>
@@ -436,7 +436,7 @@ In `modules/ecs-cluster`:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - Fix a bug in the ec2-disk-alarms module where it wouldn't allow you to create multiple alarms for the same EC2 Instance. The module now gives a unique name to each alarm so that you can have an alarm for multiple volumes on the same instance.
+  - Fix a bug in the ec2-disk-alarms module where it wouldn&apos;t allow you to create multiple alarms for the same EC2 Instance. The module now gives a unique name to each alarm so that you can have an alarm for multiple volumes on the same instance.
 
 
 </div>
@@ -478,7 +478,7 @@ In `modules/ecs-cluster`:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - Fix how the ELB access logs module sets the S3 bucket policy so that you don't get a diff every time you run `terraform plan`
+  - Fix how the ELB access logs module sets the S3 bucket policy so that you don&apos;t get a diff every time you run `terraform plan`
 
 
 </div>
@@ -526,7 +526,7 @@ In `modules/ecs-cluster`:
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
   - BREAKING CHANGE: We updated the `kms-master-key` module with a few changes:
-  - Previously, terraform would unnecessarily update the Key Policy on every `terraform apply`. This didn't break anything, but it confusingly reported 1 resource as being modified when in fact nothing was changed. This has now been fixed using the new [data.aws_iam_policy_document](https://www.terraform.io/docs/providers/aws/d/iam_policy_document.html).
+  - Previously, terraform would unnecessarily update the Key Policy on every `terraform apply`. This didn&apos;t break anything, but it confusingly reported 1 resource as being modified when in fact nothing was changed. This has now been fixed using the new [data.aws_iam_policy_document](https://www.terraform.io/docs/providers/aws/d/iam_policy_document.html).
   - The var `key_root_user_iam_arns` has been replaced with  `var.allow_manage_key_permissions_with_iam` (accepts true/false) to better reflect the significance of setting this value. Note that the var `aws_account_id` is also now required.
   - The vars `key_administrator_iam_arns` and `key_user_iam_arns` have been renamed to `cmk_administrator_iam_arns` and `cmk_user_iam_arns` to more accurately reflect that these vars grant access to a Customer Master Key (CMK).
   - There is a new required input variable called `aws_account_id`.
@@ -543,7 +543,7 @@ In `modules/ecs-cluster`:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - We've added a new module, `iam-groups` that configures a best-practices set of IAM Groups and corresponding IAM Policies (permissions) you can use to better manage the security of your AWS account.
+  - We&apos;ve added a new module, `iam-groups` that configures a best-practices set of IAM Groups and corresponding IAM Policies (permissions) you can use to better manage the security of your AWS account.
 
 
 </div>
@@ -557,7 +557,7 @@ In `modules/ecs-cluster`:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - On boot, `ssh-iam` now waits 90 seconds before executing to try to give other services (e.g. the EC2 metadata service) a chance to start. This should hopefully ensure that `ssh-iam` doesn't hit any errors when it configures SSH access on boot and you don't have to wait for the next cron job to run (by default, they run every 30m) before SSH access works.
+  - On boot, `ssh-iam` now waits 90 seconds before executing to try to give other services (e.g. the EC2 metadata service) a chance to start. This should hopefully ensure that `ssh-iam` doesn&apos;t hit any errors when it configures SSH access on boot and you don&apos;t have to wait for the next cron job to run (by default, they run every 30m) before SSH access works.
 
 
 </div>
@@ -649,6 +649,6 @@ In `modules/ecs-cluster`:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "8cdd869e602710719e877614de20f6a0"
+  "hash": "84c0d33a3388044e5020d21737a51165"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-09/index.md
@@ -182,7 +182,7 @@ Here are the repos that were updated:
 ### [v0.1.1](https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.1.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/8/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.1.1">Release notes</a></small>
+  <small>Published: 9/9/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.1.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -459,7 +459,7 @@ In `modules/ecs-cluster`:
 ### [v0.1.2](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.1.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/2/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.1.2">Release notes</a></small>
+  <small>Published: 9/3/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.1.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -506,7 +506,7 @@ In `modules/ecs-cluster`:
 ### [v0.2.1](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.2.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/30/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.2.1">Release notes</a></small>
+  <small>Published: 10/1/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.2.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -520,7 +520,7 @@ In `modules/ecs-cluster`:
 ### [v0.2.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.2.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/28/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.2.0">Release notes</a></small>
+  <small>Published: 9/29/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.2.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -614,7 +614,7 @@ In `modules/ecs-cluster`:
 ### [v0.1.0](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.1.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/1/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.1.0">Release notes</a></small>
+  <small>Published: 9/2/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.1.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -649,6 +649,6 @@ In `modules/ecs-cluster`:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "fbd1c1bc0f3c7af57f509aa08c04bff7"
+  "hash": "8cdd869e602710719e877614de20f6a0"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-09/index.md
@@ -153,7 +153,7 @@ Here are the repos that were updated:
 ### [v0.1.3](https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.1.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/9/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.1.3">Release notes</a></small>
+  <small>Published: 9/8/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.1.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -168,7 +168,7 @@ Here are the repos that were updated:
 ### [v0.1.2](https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.1.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/9/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.1.2">Release notes</a></small>
+  <small>Published: 9/8/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.1.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -182,7 +182,7 @@ Here are the repos that were updated:
 ### [v0.1.1](https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.1.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/9/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.1.1">Release notes</a></small>
+  <small>Published: 9/8/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.1.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -459,7 +459,7 @@ In `modules/ecs-cluster`:
 ### [v0.1.2](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.1.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/3/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.1.2">Release notes</a></small>
+  <small>Published: 9/2/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.1.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -503,10 +503,24 @@ In `modules/ecs-cluster`:
 ## terraform-aws-security
 
 
+### [v0.2.1](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.2.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 9/30/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.2.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  - NEW MODULE: In this release, we introduce the `cloudtrail` module, a streamlined way to setup [AWS CloudTrail](http://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-user-guide.html)!
+
+
+</div>
+
+
 ### [v0.2.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.2.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/29/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.2.0">Release notes</a></small>
+  <small>Published: 9/28/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.2.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -600,7 +614,7 @@ In `modules/ecs-cluster`:
 ### [v0.1.0](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.1.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/2/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.1.0">Release notes</a></small>
+  <small>Published: 9/1/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.1.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -619,7 +633,7 @@ In `modules/ecs-cluster`:
 ### [v0.1.1](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/29/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.1">Release notes</a></small>
+  <small>Published: 9/28/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -635,6 +649,6 @@ In `modules/ecs-cluster`:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "8a7d37bbbd407cd6e7cc963b6e2cf4bd"
+  "hash": "46e770aa7bb623e6ca6df83d04092d87"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-10/index.md
@@ -13,7 +13,6 @@ Here are the repos that were updated:
 - [boilerplate](#boilerplate)
 - [terraform-aws-ci](#terraform-aws-ci)
 - [terraform-aws-ecs](#terraform-aws-ecs)
-- [terraform-aws-security](#terraform-aws-security)
 - [terraform-aws-vpc](#terraform-aws-vpc)
 
 
@@ -86,24 +85,6 @@ Here are the repos that were updated:
 
 
 
-## terraform-aws-security
-
-
-### [v0.2.1](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.2.1)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/1/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.2.1">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  - NEW MODULE: In this release, we introduce the `cloudtrail` module, a streamlined way to setup [AWS CloudTrail](http://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-user-guide.html)!
-
-
-</div>
-
-
-
 ## terraform-aws-vpc
 
 
@@ -126,6 +107,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "b2a664fd844b6eea562b74440b58acd0"
+  "hash": "60e0ff41c0d465f029d2785b95b96935"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-10/index.md
@@ -78,7 +78,7 @@ Here are the repos that were updated:
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
   - The `ecs-service` module now supports [canary deployment](http://martinfowler.com/bliki/CanaryRelease.html)! To use it, set the `canary_task_arn`  and `desired_number_of_canary_tasks_to_run` parameters. See [How do I do a canary deployment?](https://github.com/gruntwork-io/module-ecs/tree/master/modules/ecs-service#how-do-i-do-a-canary-deployment) and the [docker-service-with-canary-deployment example](https://github.com/gruntwork-io/module-ecs/tree/master/examples/docker-service-with-canary-deployment) for details.
-- The `ecs-service` module's `service_with_elb_arn` and `service_without_elb_arn` output variables have been removed. Instead, use the `service_arn` and `canary_service_arn` outputs.
+- The `ecs-service` module&apos;s `service_with_elb_arn` and `service_without_elb_arn` output variables have been removed. Instead, use the `service_arn` and `canary_service_arn` outputs.
 
 
 </div>
@@ -107,6 +107,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "60e0ff41c0d465f029d2785b95b96935"
+  "hash": "2751fc58bc5f89373f2b923bc2c1b8cb"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-11/index.md
@@ -44,7 +44,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - Undo the fix in configure-environment-for-gruntwork-module from the previous release because, apprently, _only_ Terraform 0.7.7 dropped the "v" in the versioning scheme (0.7.7 and not v0.7.7). All the versions after that have re-added the "v", so this release updates the script to handle it again.
+  - Undo the fix in configure-environment-for-gruntwork-module from the previous release because, apprently, _only_ Terraform 0.7.7 dropped the &quot;v&quot; in the versioning scheme (0.7.7 and not v0.7.7). All the versions after that have re-added the &quot;v&quot;, so this release updates the script to handle it again.
 
 
 </div>
@@ -63,8 +63,8 @@ Here are the repos that were updated:
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
   - ENHANCEMENT: Many of the [CloudWatch Alarms](https://github.com/gruntwork-io/module-aws-monitoring/tree/master/modules/alarms) now expose parameters for the setting the `Evaluation Periods` and `Statistic` properties to allow finer-grained control by customers.
-  - The `Evaluation Periods` property is the number of periods over which a CloudWatch metric's data is compared to a given threshold.
-  - The `Statistic` property is the statistic to apply to a CloudWatch Alarm's associated metric. Acceptable Values are `SampleCount`, `Average`, `Sum`, `Minimum`, or `Maximum`.
+  - The `Evaluation Periods` property is the number of periods over which a CloudWatch metric&apos;s data is compared to a given threshold.
+  - The `Statistic` property is the statistic to apply to a CloudWatch Alarm&apos;s associated metric. Acceptable Values are `SampleCount`, `Average`, `Sum`, `Minimum`, or `Maximum`.
 - TWEAK: Many Amazon services report CloudWatch metrics every 60 seconds, and the [CloudWatch Alarms](https://github.com/gruntwork-io/module-aws-monitoring/tree/master/modules/alarms) now reflect that period where applicable as a default.
 
 
@@ -76,6 +76,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "64e448041eb7d3b5f05ee5193b1d9228"
+  "hash": "97ed6f463fec4ab09c0b7869f984e3e5"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-11/index.md
@@ -21,7 +21,7 @@ Here are the repos that were updated:
 ### [v0.0.4](https://github.com/gruntwork-io/gruntkms/releases/tag/v0.0.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/3/2016 | <a href="https://github.com/gruntwork-io/gruntkms/releases/tag/v0.0.4">Release notes</a></small>
+  <small>Published: 11/4/2016 | <a href="https://github.com/gruntwork-io/gruntkms/releases/tag/v0.0.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -39,7 +39,7 @@ Here are the repos that were updated:
 ### [v0.0.25](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.0.25)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/14/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.0.25">Release notes</a></small>
+  <small>Published: 11/15/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.0.25">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -76,6 +76,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "38a87e559905e7c93a7f7584d2b3ebd5"
+  "hash": "64e448041eb7d3b5f05ee5193b1d9228"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-11/index.md
@@ -21,7 +21,7 @@ Here are the repos that were updated:
 ### [v0.0.4](https://github.com/gruntwork-io/gruntkms/releases/tag/v0.0.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/4/2016 | <a href="https://github.com/gruntwork-io/gruntkms/releases/tag/v0.0.4">Release notes</a></small>
+  <small>Published: 11/3/2016 | <a href="https://github.com/gruntwork-io/gruntkms/releases/tag/v0.0.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -39,7 +39,7 @@ Here are the repos that were updated:
 ### [v0.0.25](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.0.25)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/15/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.0.25">Release notes</a></small>
+  <small>Published: 11/14/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.0.25">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -76,6 +76,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "64e448041eb7d3b5f05ee5193b1d9228"
+  "hash": "38a87e559905e7c93a7f7584d2b3ebd5"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-12/index.md
@@ -164,7 +164,7 @@ Here are the repos that were updated:
 ### [v0.1.1](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.1.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/8/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.1.1">Release notes</a></small>
+  <small>Published: 12/7/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.1.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -238,7 +238,7 @@ This change is fully backwards-compatible in terms of the vars and outputs, but 
 ### [v0.3.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.3.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/13/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.3.0">Release notes</a></small>
+  <small>Published: 12/12/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.3.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -290,6 +290,6 @@ This change is fully backwards-compatible in terms of the vars and outputs, but 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "6d2bda544f403c788e62d0d717b3bccd"
+  "hash": "75a03d272fc656941a13cd2044703ce7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-12/index.md
@@ -164,7 +164,7 @@ Here are the repos that were updated:
 ### [v0.1.1](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.1.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/7/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.1.1">Release notes</a></small>
+  <small>Published: 12/8/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.1.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -238,7 +238,7 @@ This change is fully backwards-compatible in terms of the vars and outputs, but 
 ### [v0.3.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.3.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/12/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.3.0">Release notes</a></small>
+  <small>Published: 12/13/2016 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.3.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -290,6 +290,6 @@ This change is fully backwards-compatible in terms of the vars and outputs, but 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "75a03d272fc656941a13cd2044703ce7"
+  "hash": "6d2bda544f403c788e62d0d717b3bccd"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-12/index.md
@@ -30,7 +30,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - We've updated our CI build job to use Go 1.7.3. Before, we were using Go 1.6.x, which apparently [does not work with the latest version of OS X](https://golang.org/doc/go1.7#ports). 
+  - We&apos;ve updated our CI build job to use Go 1.7.3. Before, we were using Go 1.6.x, which apparently [does not work with the latest version of OS X](https://golang.org/doc/go1.7#ports). 
 
 
 </div>
@@ -226,10 +226,10 @@ Here are the repos that were updated:
 
   This release updates the `cloudtrail` module to support archiving of logs. 
 
-Previously, you could either store logs in S3 (for $0.023 per GB) or delete them. Now, you can choose to archive [CloudTrail](https://aws.amazon.com/cloudtrail/) logs to AWS Glacier after a certain number of days, where you'll pay just $0.004 per GB.
+Previously, you could either store logs in S3 (for $0.023 per GB) or delete them. Now, you can choose to archive [CloudTrail](https://aws.amazon.com/cloudtrail/) logs to AWS Glacier after a certain number of days, where you&apos;ll pay just $0.004 per GB.
 - ENHANCEMENT: The `cloudtrail` module now exposes a new var, `num_days_after_which_archive_log_data`. If set to `0`, archiving is disabled. Otherwise, log files are automatically archived after the specified number of days.
 
-This change is fully backwards-compatible in terms of the vars and outputs, but it makes use of features new to Terraform v0.8 such as conditionals, and therefore requires that you upgrade to Terraform v0.8.1  or higher before using. For that reason we have indicated in the version release that this is a "breaking" change.
+This change is fully backwards-compatible in terms of the vars and outputs, but it makes use of features new to Terraform v0.8 such as conditionals, and therefore requires that you upgrade to Terraform v0.8.1  or higher before using. For that reason we have indicated in the version release that this is a &quot;breaking&quot; change.
 
 
 </div>
@@ -245,7 +245,7 @@ This change is fully backwards-compatible in terms of the vars and outputs, but 
 
   This release adds two new features to the `iam-groups` module:
 - ENHANCEMENT: `iam-groups` now exposes the Terraform variable `should_require_mfa`. If true, an IAM User must use multi-factor authentication (MFA) to access any AWS services, with the exception of a very limited set of permissions the IAM User needs to initialize her MFA Device and reset her password.
-- ENHANCEMENT: `iam-groups` now adds the IAM Group `developers` by default (though it's still optional). Some teams will add all IAM Users to the `full-access` IAM Group. But for those teams that wish to create an IAM User whose permissions go beyond `read-only` but below `full-access`, the `developers` IAM Group offers such an option. 
+- ENHANCEMENT: `iam-groups` now adds the IAM Group `developers` by default (though it&apos;s still optional). Some teams will add all IAM Users to the `full-access` IAM Group. But for those teams that wish to create an IAM User whose permissions go beyond `read-only` but below `full-access`, the `developers` IAM Group offers such an option. 
   
   You can customize which set of AWS Services IAM Users in `developers` will receive full access to through the `iam_group_developers_permitted_services` Terraform variable. In addition, the `developers` IAM Group grants IAM Users access to a personal S3 Bucket.
 
@@ -265,7 +265,7 @@ This change is fully backwards-compatible in terms of the vars and outputs, but 
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - Fix a bug where `mount-ebs-volume` was not detected the "VolumeInUse" error correctly due to an overflow error with bash exit codes.
+  - Fix a bug where `mount-ebs-volume` was not detected the &quot;VolumeInUse&quot; error correctly due to an overflow error with bash exit codes.
 
 
 </div>
@@ -279,7 +279,7 @@ This change is fully backwards-compatible in terms of the vars and outputs, but 
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - Fix bug in `mount-ebs-volume` where, if the EBS volume was already mounted, it would try to call a `string_contains` function that didn't exist, and the whole script would exit with an error.
+  - Fix bug in `mount-ebs-volume` where, if the EBS volume was already mounted, it would try to call a `string_contains` function that didn&apos;t exist, and the whole script would exit with an error.
 
 
 </div>
@@ -290,6 +290,6 @@ This change is fully backwards-compatible in terms of the vars and outputs, but 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "6d2bda544f403c788e62d0d717b3bccd"
+  "hash": "a6f425331e1fc9ef2bbd7d2ea1b9e904"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-01/index.md
@@ -121,9 +121,9 @@ Here are the repos that were updated:
 
   - BREAKING CHANGE: AWS made a backwards-incompatible change to their API where, if the [snapshot_retention_limit](https://www.terraform.io/docs/providers/aws/r/elasticache_replication_group.html#snapshot_retention_limit) property of the `aws_elasticache_replication_group` Terraform resource is set to `0`, you must not pass the [snapshot_window](https://www.terraform.io/docs/providers/aws/r/elasticache_replication_group.html#snapshot_window) property. Previously, the snapshot_window property was simply ignored if not needed.
   
-  Note that if you update to this new version of the redis module, it will delete your original ElastiCache cluster and replace it with a new one. Therefore, it's essential that you have all your data backed up and can take a downtime before you do the upgrade.
+  Note that if you update to this new version of the redis module, it will delete your original ElastiCache cluster and replace it with a new one. Therefore, it&apos;s essential that you have all your data backed up and can take a downtime before you do the upgrade.
   
-  Alternatively, it's possible to update without downtime by using `terraform state` commands. If you'd like assistance with this contact support@gruntwork.io.
+  Alternatively, it&apos;s possible to update without downtime by using `terraform state` commands. If you&apos;d like assistance with this contact support@gruntwork.io.
 
 
 </div>
@@ -189,7 +189,7 @@ Here are the repos that were updated:
 
   - ENHANCEMENT: Per #27, the `ecs-cluster` module now accepts the optional parameters `var.alb_security_group_ids` and `var.num_alb_security_group_ids`. 
   
-  Whereas previously, an ALB was connected to an ECS Cluster by passing the ECS Cluster's Security Group ID to the `alb` module (located in the the [Load Balancer Package](https://github.com/gruntwork-io/module-load-balancer)), now the `alb` module is unaware of an ECS Cluster or Auto Scaling Group connected to it, and that responsibility has been shifted to the `ecs-cluster` module.
+  Whereas previously, an ALB was connected to an ECS Cluster by passing the ECS Cluster&apos;s Security Group ID to the `alb` module (located in the the [Load Balancer Package](https://github.com/gruntwork-io/module-load-balancer)), now the `alb` module is unaware of an ECS Cluster or Auto Scaling Group connected to it, and that responsibility has been shifted to the `ecs-cluster` module.
 
 
 </div>
@@ -265,11 +265,11 @@ Note that we are seeing intermittent test failures with the ALB that indicate a 
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - "DISRUPTIVE" CHANGE: Previously, the `alb` module was rather opinionated about how it would name the ALB. It assumed you wanted the ALB name to be of the form `&lt;var.alb_name&gt;-&lt;var.environment_name&gt;`. But this proved to be unnecessarily opinionated, so this update changes the ALB name to be exactly the value of the `var.alb_name`. 
+  - &quot;DISRUPTIVE&quot; CHANGE: Previously, the `alb` module was rather opinionated about how it would name the ALB. It assumed you wanted the ALB name to be of the form `&lt;var.alb_name&gt;-&lt;var.environment_name&gt;`. But this proved to be unnecessarily opinionated, so this update changes the ALB name to be exactly the value of the `var.alb_name`. 
   
-  Note that the `alb` module API did not change and this is therefore not a "breaking" change, however Terraform will attempt to destroy and re-create your ALB, making this a "disruptive" change. To avoid such disruption, consider using `terraform state` commands. Due to the relative newsness (1 - 2 weeks), only a handful of Gruntwork customers are currently using the `alb` module. Therefore, we did not create documentation on migrating from the previous ALB version.
+  Note that the `alb` module API did not change and this is therefore not a &quot;breaking&quot; change, however Terraform will attempt to destroy and re-create your ALB, making this a &quot;disruptive&quot; change. To avoid such disruption, consider using `terraform state` commands. Due to the relative newsness (1 - 2 weeks), only a handful of Gruntwork customers are currently using the `alb` module. Therefore, we did not create documentation on migrating from the previous ALB version.
   
-  As always, contact us at support@gruntwork.io if you'd like help migrating this!
+  As always, contact us at support@gruntwork.io if you&apos;d like help migrating this!
 
 
 </div>
@@ -283,7 +283,7 @@ Note that we are seeing intermittent test failures with the ALB that indicate a 
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - BREAKING CHANGE: Previously the ALB depended on a previously existing ECS Cluster or Auto Scaling Group by exposing the parameters `var.ecs_cluster_security_group_ids` and `var.auto_scaling_group_security_group_ids`. But this dependency was problematic for reasons explained in #5. Now, the ALB depends on no external resources, and any resource like an ECS Cluster that wants to use the ALB can implement its own "hook" into the ALB by reading the new output `alb_security_group_id`. 
+  - BREAKING CHANGE: Previously the ALB depended on a previously existing ECS Cluster or Auto Scaling Group by exposing the parameters `var.ecs_cluster_security_group_ids` and `var.auto_scaling_group_security_group_ids`. But this dependency was problematic for reasons explained in #5. Now, the ALB depends on no external resources, and any resource like an ECS Cluster that wants to use the ALB can implement its own &quot;hook&quot; into the ALB by reading the new output `alb_security_group_id`. 
 
 
 </div>
@@ -364,6 +364,6 @@ Note that we are seeing intermittent test failures with the ALB that indicate a 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "6bf3b98cb3839a4d3adba8b7711093e6"
+  "hash": "6a01ad47fd5ff4cc2c21ffcfb2b485c7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-01/index.md
@@ -26,7 +26,7 @@ Here are the repos that were updated:
 ### [v0.2.6](https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.6)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/17/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.6">Release notes</a></small>
+  <small>Published: 1/18/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.6">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -54,7 +54,7 @@ Here are the repos that were updated:
 ### [v0.2.4](https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/13/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.4">Release notes</a></small>
+  <small>Published: 1/14/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -68,7 +68,7 @@ Here are the repos that were updated:
 ### [v0.2.3](https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/10/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.3">Release notes</a></small>
+  <small>Published: 1/11/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -82,7 +82,7 @@ Here are the repos that were updated:
 ### [v0.2.2](https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/10/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.2">Release notes</a></small>
+  <small>Published: 1/11/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -150,7 +150,7 @@ Here are the repos that were updated:
 ### [v0.3.3](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/25/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.3">Release notes</a></small>
+  <small>Published: 1/26/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -212,7 +212,7 @@ Here are the repos that were updated:
 ### [v0.3.5](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.3.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/18/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.3.5">Release notes</a></small>
+  <small>Published: 1/19/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.3.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -278,7 +278,7 @@ Note that we are seeing intermittent test failures with the ALB that indicate a 
 ### [v0.1.0](https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.1.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/24/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.1.0">Release notes</a></small>
+  <small>Published: 1/25/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.1.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -310,7 +310,7 @@ Note that we are seeing intermittent test failures with the ALB that indicate a 
 ### [v0.4.1](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.4.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/18/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.4.1">Release notes</a></small>
+  <small>Published: 1/19/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.4.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -348,7 +348,7 @@ Note that we are seeing intermittent test failures with the ALB that indicate a 
 ### [v0.1.3](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/25/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.3">Release notes</a></small>
+  <small>Published: 1/26/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -364,6 +364,6 @@ Note that we are seeing intermittent test failures with the ALB that indicate a 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "c3651933092c528f979bc801de0614bb"
+  "hash": "6bf3b98cb3839a4d3adba8b7711093e6"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-01/index.md
@@ -26,7 +26,7 @@ Here are the repos that were updated:
 ### [v0.2.6](https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.6)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/18/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.6">Release notes</a></small>
+  <small>Published: 1/17/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.6">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -54,7 +54,7 @@ Here are the repos that were updated:
 ### [v0.2.4](https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/14/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.4">Release notes</a></small>
+  <small>Published: 1/13/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -68,7 +68,7 @@ Here are the repos that were updated:
 ### [v0.2.3](https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/11/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.3">Release notes</a></small>
+  <small>Published: 1/10/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -82,7 +82,7 @@ Here are the repos that were updated:
 ### [v0.2.2](https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/11/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.2">Release notes</a></small>
+  <small>Published: 1/10/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -150,7 +150,7 @@ Here are the repos that were updated:
 ### [v0.3.3](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/26/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.3">Release notes</a></small>
+  <small>Published: 1/25/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -212,7 +212,7 @@ Here are the repos that were updated:
 ### [v0.3.5](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.3.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/19/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.3.5">Release notes</a></small>
+  <small>Published: 1/18/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.3.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -278,7 +278,7 @@ Note that we are seeing intermittent test failures with the ALB that indicate a 
 ### [v0.1.0](https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.1.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/25/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.1.0">Release notes</a></small>
+  <small>Published: 1/24/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.1.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -310,7 +310,7 @@ Note that we are seeing intermittent test failures with the ALB that indicate a 
 ### [v0.4.1](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.4.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/19/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.4.1">Release notes</a></small>
+  <small>Published: 1/18/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.4.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -348,7 +348,7 @@ Note that we are seeing intermittent test failures with the ALB that indicate a 
 ### [v0.1.3](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/26/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.3">Release notes</a></small>
+  <small>Published: 1/25/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -364,6 +364,6 @@ Note that we are seeing intermittent test failures with the ALB that indicate a 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "6bf3b98cb3839a4d3adba8b7711093e6"
+  "hash": "c3651933092c528f979bc801de0614bb"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-02/index.md
@@ -108,7 +108,7 @@ To upgrade without downtime, we recommend the following approach:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - NEW MODULE: Added a new `check-url` script that can be used to repeatedly test a URL until either it returns an expected response, and the script exits successfully, or the max number of retries is exceeded, and the script exits with an error. The driving use case for this is verifying automated ECS deployments. You can add this script to the end of your CI build to check if the new version of your ECS service actually deployed and to fail the build if it didn't.
+  - NEW MODULE: Added a new `check-url` script that can be used to repeatedly test a URL until either it returns an expected response, and the script exits successfully, or the max number of retries is exceeded, and the script exits with an error. The driving use case for this is verifying automated ECS deployments. You can add this script to the end of your CI build to check if the new version of your ECS service actually deployed and to fail the build if it didn&apos;t.
 
 
 </div>
@@ -148,7 +148,7 @@ To upgrade without downtime, we recommend the following approach:
 - `aws_appautoscaling_target`: the `scalable_dimension` and `service_namespace` parameters are now required. The `name` parameter has been removed.
 - `aws_appautoscaling_policy`. the `scalable_dimension` and `service_namespace` parameters are now required.
 
-We've updated the `ecs-service-with-alb` module and example code accordingly. Note that this included adding some `depends_on` clauses to make sure resources were created in the right order. See https://github.com/gruntwork-io/module-ecs/pull/28 for details.
+We&apos;ve updated the `ecs-service-with-alb` module and example code accordingly. Note that this included adding some `depends_on` clauses to make sure resources were created in the right order. See https://github.com/gruntwork-io/module-ecs/pull/28 for details.
 
 
 </div>
@@ -166,7 +166,7 @@ We've updated the `ecs-service-with-alb` module and example code accordingly. No
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - NEW MODULE: We're introducing the `tls-cert-private` module, which allows you to generate customized TLS certificate key pairs simply by updating a `docker-compose.yml` file and running `docker-compose up`. 
+  - NEW MODULE: We&apos;re introducing the `tls-cert-private` module, which allows you to generate customized TLS certificate key pairs simply by updating a `docker-compose.yml` file and running `docker-compose up`. 
   
   The module works by running a Docker container which downloads the latest version of OpenSSL and runs a series of commands to generate your certificates using RSA 4,096 bit encryption. The outputted files are then available on your local machine, where you may optionally encrypt the TLS private key.
   
@@ -181,6 +181,6 @@ We've updated the `ecs-service-with-alb` module and example code accordingly. No
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "a5b5a2bce7055f762ff7ebc0fc9f5cf9"
+  "hash": "642c7ace1a255d48f193946c994bea96"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-02/index.md
@@ -69,7 +69,7 @@ Here are the repos that were updated:
 ### [v0.2.0](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.2.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/27/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.2.0">Release notes</a></small>
+  <small>Published: 2/28/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.2.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -117,7 +117,7 @@ To upgrade without downtime, we recommend the following approach:
 ### [v0.3.5](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/2/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.5">Release notes</a></small>
+  <small>Published: 2/3/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -161,7 +161,7 @@ We've updated the `ecs-service-with-alb` module and example code accordingly. No
 ### [v0.4.1](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/7/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.1">Release notes</a></small>
+  <small>Published: 2/8/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -181,6 +181,6 @@ We've updated the `ecs-service-with-alb` module and example code accordingly. No
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "0c77439561deb990d57d510e4461949f"
+  "hash": "a5b5a2bce7055f762ff7ebc0fc9f5cf9"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-02/index.md
@@ -69,7 +69,7 @@ Here are the repos that were updated:
 ### [v0.2.0](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.2.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/28/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.2.0">Release notes</a></small>
+  <small>Published: 2/27/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.2.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -117,7 +117,7 @@ To upgrade without downtime, we recommend the following approach:
 ### [v0.3.5](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/3/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.5">Release notes</a></small>
+  <small>Published: 2/2/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -161,7 +161,7 @@ We've updated the `ecs-service-with-alb` module and example code accordingly. No
 ### [v0.4.1](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/8/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.1">Release notes</a></small>
+  <small>Published: 2/7/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -181,6 +181,6 @@ We've updated the `ecs-service-with-alb` module and example code accordingly. No
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "a5b5a2bce7055f762ff7ebc0fc9f5cf9"
+  "hash": "0c77439561deb990d57d510e4461949f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-03/index.md
@@ -71,7 +71,7 @@ Here are the repos that were updated:
 ### [v0.3.7](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/3/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.7">Release notes</a></small>
+  <small>Published: 3/2/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -85,6 +85,19 @@ This is useful for lambda functions that use the AWS APIs and don't need direct 
 
 
 ## terraform-aws-data-storage
+
+
+### [v0.2.2](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 3/31/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  https://github.com/gruntwork-io/module-data-storage/pull/16: The `copy-rds-shared-snapshot` module now allows you to specify a KMS key via the optional `kms_key_id` parameter. If specified, this key will be used to encrypt the RDS snapshot copy.
+
+</div>
 
 
 ### [v0.2.1](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.1)
@@ -116,7 +129,7 @@ This is useful for lambda functions that use the AWS APIs and don't need direct 
 ### [v0.1.5](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.1.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/6/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.1.5">Release notes</a></small>
+  <small>Published: 3/5/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.1.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -154,7 +167,7 @@ This is useful for lambda functions that use the AWS APIs and don't need direct 
 ### [v0.4.4](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.4.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/9/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.4.4">Release notes</a></small>
+  <small>Published: 3/8/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.4.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -198,7 +211,7 @@ This is useful for lambda functions that use the AWS APIs and don't need direct 
 ### [v0.3.0](https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.3.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/9/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.3.0">Release notes</a></small>
+  <small>Published: 3/8/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.3.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -250,6 +263,19 @@ Two bug fixes:
 
 
 ## terraform-aws-security
+
+
+### [v0.4.9](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.9)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 3/31/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.9">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  https://github.com/gruntwork-io/module-security/pull/22: In the `kms-master-key` module, KMS key users now get the `CreateGrant` permission. This makes it possible to share RDS snapshots encrypted with this KMS key with another AWS account.
+
+</div>
 
 
 ### [v0.4.8](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.8)
@@ -307,7 +333,7 @@ Two bug fixes:
 ### [v0.4.4](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/2/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.4">Release notes</a></small>
+  <small>Published: 3/1/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -438,6 +464,6 @@ To use this, you need to configure the new `iam_groups_for_cross_account_access`
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "160f0db075d051bfc8065d7d07c60599"
+  "hash": "0f0ff326ef41ea94e5e28e3f72516b29"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-03/index.md
@@ -76,9 +76,9 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-ci/pull/22: The `scheduled-lambda-job` module now makes running in a VPC optional. It exposes a new input variable called `run_in_vpc` which, if set to true, will give the lambda function access to a VPC you specify via the `vpc_id` and `subnet_ids` input variables. However, by default, it's set to false, and you can omit `vpc_id` and `subnet_ids`. 
+  https://github.com/gruntwork-io/module-ci/pull/22: The `scheduled-lambda-job` module now makes running in a VPC optional. It exposes a new input variable called `run_in_vpc` which, if set to true, will give the lambda function access to a VPC you specify via the `vpc_id` and `subnet_ids` input variables. However, by default, it&apos;s set to false, and you can omit `vpc_id` and `subnet_ids`. 
 
-This is useful for lambda functions that use the AWS APIs and don't need direct access to a VPC anyway. Moreover, a recent [bug in Terraform](https://github.com/hashicorp/terraform/issues/10272) causes issues when you try to delete a lambda function that was deployed into a VPC.
+This is useful for lambda functions that use the AWS APIs and don&apos;t need direct access to a VPC anyway. Moreover, a recent [bug in Terraform](https://github.com/hashicorp/terraform/issues/10272) causes issues when you try to delete a lambda function that was deployed into a VPC.
 
 </div>
 
@@ -108,7 +108,7 @@ This is useful for lambda functions that use the AWS APIs and don't need direct 
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-data-storage/pull/14: To allow the bastion host to talk to RDS or Aurora, you now have to explicitly set the `allow_connections_from_bastion_host` input variable to true. Before, we only exposed the `bastion_host_security_group_id` input variable, but if you fed dynamic data into that variable (e.g. from a `terraform_remote_state` data source), you'd get an error. This is now fixed.
+  https://github.com/gruntwork-io/module-data-storage/pull/14: To allow the bastion host to talk to RDS or Aurora, you now have to explicitly set the `allow_connections_from_bastion_host` input variable to true. Before, we only exposed the `bastion_host_security_group_id` input variable, but if you fed dynamic data into that variable (e.g. from a `terraform_remote_state` data source), you&apos;d get an error. This is now fixed.
 
 </div>
 
@@ -121,7 +121,7 @@ This is useful for lambda functions that use the AWS APIs and don't need direct 
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-data-storage/pull/13: The aurora module no longer specifies availability zones when creating an Aurora cluster. This is a workaround for a [strange issue](https://forums.aws.amazon.com/thread.jspa?messageID=771183&#771183) where you get the error along the lines of "Availability zone ‘us-east-1c’ is unavailable in this region, please choose another zone set."
+  https://github.com/gruntwork-io/module-data-storage/pull/13: The aurora module no longer specifies availability zones when creating an Aurora cluster. This is a workaround for a [strange issue](https://forums.aws.amazon.com/thread.jspa?messageID=771183&amp;#771183) where you get the error along the lines of &quot;Availability zone ‘us-east-1c’ is unavailable in this region, please choose another zone set.&quot;
 
 </div>
 
@@ -134,13 +134,13 @@ This is useful for lambda functions that use the AWS APIs and don't need direct 
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-data-storage/pull/12: We've added four new modules:
+  https://github.com/gruntwork-io/module-data-storage/pull/12: We&apos;ve added four new modules:
 
-1. [lambda-create-snapshot](https://github.com/gruntwork-io/module-data-storage/tree/master/modules/lambda-create-snapshot): A lambda function that runs on a scheduled basis to take snapshots of an RDS DB. Useful if the once-nightly snapshots aren't enough and, even more importantly, this is the first step if you want to backup your snapshots to another AWS account.
+1. [lambda-create-snapshot](https://github.com/gruntwork-io/module-data-storage/tree/master/modules/lambda-create-snapshot): A lambda function that runs on a scheduled basis to take snapshots of an RDS DB. Useful if the once-nightly snapshots aren&apos;t enough and, even more importantly, this is the first step if you want to backup your snapshots to another AWS account.
 
 1. [lambda-share-snapshot](https://github.com/gruntwork-io/module-data-storage/tree/master/modules/lambda-share-snapshot): A lambda function that can share an RDS snapshot with another AWS account. This is the second step in backing up your snapshots to another AWS account.
 
-1. [lambda-copy-snapshot](https://github.com/gruntwork-io/module-data-storage/tree/master/modules/lambda-copy-shared-snapshot): A lambda function that runs on a scheduled basis to make a local copies of RDS snapshots shared from an external AWS account. This is the third step and it needs to run in the AWS account you're using to backup your snapshots.
+1. [lambda-copy-snapshot](https://github.com/gruntwork-io/module-data-storage/tree/master/modules/lambda-copy-shared-snapshot): A lambda function that runs on a scheduled basis to make a local copies of RDS snapshots shared from an external AWS account. This is the third step and it needs to run in the AWS account you&apos;re using to backup your snapshots.
 
 1. [lambda-cleanup-snapshots](https://github.com/gruntwork-io/module-data-storage/tree/master/modules/lambda-cleanup-snapshots): A lambda function that runs on a scheduled basis to delete old RDS snapshots. You configure it with a maximum number of snapshots to keep, and once that number is exceeded, it deletes the oldest snapshots. This is useful to keep the number of snapshots from step 1 and 3 above from getting out of hand.
 
@@ -226,7 +226,7 @@ Two bug fixes:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-load-balancer/pull/8: To add an HTTPS listener, the ALB module originally had you pass in the `https_listener_ports_and_ssl_certs` input variable, which was a map of HTTPS ports to the ARNs of TLS certs (e.g. `443 = "arn:aws:acm:us-east-1:123456789012:certificate/12345678"`. The module now exposes a new input variable called `https_listener_ports_and_acm_ssl_certs` which is a more user-friendly map of HTTPS ports to the domain name of a TLS cert issues by the [AWS Certificate Manager](https://aws.amazon.com/certificate-manager/) (e.g. `443 = *.foo.com`). 
+  https://github.com/gruntwork-io/module-load-balancer/pull/8: To add an HTTPS listener, the ALB module originally had you pass in the `https_listener_ports_and_ssl_certs` input variable, which was a map of HTTPS ports to the ARNs of TLS certs (e.g. `443 = &quot;arn:aws:acm:us-east-1:123456789012:certificate/12345678&quot;`. The module now exposes a new input variable called `https_listener_ports_and_acm_ssl_certs` which is a more user-friendly map of HTTPS ports to the domain name of a TLS cert issues by the [AWS Certificate Manager](https://aws.amazon.com/certificate-manager/) (e.g. `443 = *.foo.com`). 
 
 </div>
 
@@ -273,7 +273,7 @@ Two bug fixes:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-security/pull/20: Fix a bug in the `aws-cli-mfa` script where it didn't properly clear the previous session token before fetching a new one.
+  https://github.com/gruntwork-io/module-security/pull/20: Fix a bug in the `aws-cli-mfa` script where it didn&apos;t properly clear the previous session token before fetching a new one.
 
 </div>
 
@@ -286,7 +286,7 @@ Two bug fixes:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-security/pull/19: We've added a new script called `aws-cli-mfa` that makes it much easier to use the AWS CLI with MFA enabled. The script can fetch temporary STS credentials and set them as environment variables in a single command. Check out [the docs](https://github.com/gruntwork-io/module-security/tree/master/modules/aws-cli-mfa) for usage instructions.
+  https://github.com/gruntwork-io/module-security/pull/19: We&apos;ve added a new script called `aws-cli-mfa` that makes it much easier to use the AWS CLI with MFA enabled. The script can fetch temporary STS credentials and set them as environment variables in a single command. Check out [the docs](https://github.com/gruntwork-io/module-security/tree/master/modules/aws-cli-mfa) for usage instructions.
 
 </div>
 
@@ -330,7 +330,7 @@ Two bug fixes:
   
   This module is our first step in providing a path to using a hardened OS Image based on the [Center for Internet Security Benchmarks](https://benchmarks.cisecurity.org/). These Benchmarks are freely downloadable and specific to a technology, which makes them straightforward to reference.
   
-  At present, we support only a hardened OS for Amazon Linux, though we are open to adding support for additional OS's if customers request it. The primary OS hardening implemented in this release is the ability to create multiple disk partitions on the root volume in a Packer build, and mount each disk partition to a file system path with unique mount options. 
+  At present, we support only a hardened OS for Amazon Linux, though we are open to adding support for additional OS&apos;s if customers request it. The primary OS hardening implemented in this release is the ability to create multiple disk partitions on the root volume in a Packer build, and mount each disk partition to a file system path with unique mount options. 
   
   For example, we can now mount `/tmp` to its own disk partition so that a runaway program that fills up all of `/tmp` will not affect disk space available on other paths like `/var/log` where logs are stored. In addition, we can mount `/tmp` with the `nosuid`, `nodev`, and `noexec` options, which say that no file in `/tmp` should be allowed to assume the permissions of its file owner (a security risk), no external devices (like a block device) can be attached to `/tmp` and no files in `/tmp` can be executed, respectively.
 
@@ -411,7 +411,7 @@ To use this, you need to configure the new `iam_groups_for_cross_account_access`
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/package-terraform-utilities/pull/1: First release! We've created an intermediate-variable module.
+  https://github.com/gruntwork-io/package-terraform-utilities/pull/1: First release! We&apos;ve created an intermediate-variable module.
 
 </div>
 
@@ -438,6 +438,6 @@ To use this, you need to configure the new `iam_groups_for_cross_account_access`
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "160f0db075d051bfc8065d7d07c60599"
+  "hash": "7cd71f432a22de3a090ebd508fcce00b"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-03/index.md
@@ -71,7 +71,7 @@ Here are the repos that were updated:
 ### [v0.3.7](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/2/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.7">Release notes</a></small>
+  <small>Published: 3/3/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -90,7 +90,7 @@ This is useful for lambda functions that use the AWS APIs and don't need direct 
 ### [v0.2.2](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/31/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.2">Release notes</a></small>
+  <small>Published: 4/1/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -129,7 +129,7 @@ This is useful for lambda functions that use the AWS APIs and don't need direct 
 ### [v0.1.5](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.1.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/5/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.1.5">Release notes</a></small>
+  <small>Published: 3/6/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.1.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -167,7 +167,7 @@ This is useful for lambda functions that use the AWS APIs and don't need direct 
 ### [v0.4.4](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.4.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/8/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.4.4">Release notes</a></small>
+  <small>Published: 3/9/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.4.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -211,7 +211,7 @@ This is useful for lambda functions that use the AWS APIs and don't need direct 
 ### [v0.3.0](https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.3.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/8/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.3.0">Release notes</a></small>
+  <small>Published: 3/9/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.3.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -268,7 +268,7 @@ Two bug fixes:
 ### [v0.4.9](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.9)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/31/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.9">Release notes</a></small>
+  <small>Published: 4/1/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.9">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -333,7 +333,7 @@ Two bug fixes:
 ### [v0.4.4](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/1/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.4">Release notes</a></small>
+  <small>Published: 3/2/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -464,6 +464,6 @@ To use this, you need to configure the new `iam_groups_for_cross_account_access`
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "0f0ff326ef41ea94e5e28e3f72516b29"
+  "hash": "bcca61444b6fa01965cb4edf3dafb76a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-03/index.md
@@ -87,19 +87,6 @@ This is useful for lambda functions that use the AWS APIs and don't need direct 
 ## terraform-aws-data-storage
 
 
-### [v0.2.2](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.2)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/1/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.2">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  https://github.com/gruntwork-io/module-data-storage/pull/16: The `copy-rds-shared-snapshot` module now allows you to specify a KMS key via the optional `kms_key_id` parameter. If specified, this key will be used to encrypt the RDS snapshot copy.
-
-</div>
-
-
 ### [v0.2.1](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
@@ -263,19 +250,6 @@ Two bug fixes:
 
 
 ## terraform-aws-security
-
-
-### [v0.4.9](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.9)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/1/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.9">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  https://github.com/gruntwork-io/module-security/pull/22: In the `kms-master-key` module, KMS key users now get the `CreateGrant` permission. This makes it possible to share RDS snapshots encrypted with this KMS key with another AWS account.
-
-</div>
 
 
 ### [v0.4.8](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.8)
@@ -464,6 +438,6 @@ To use this, you need to configure the new `iam_groups_for_cross_account_access`
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "bcca61444b6fa01965cb4edf3dafb76a"
+  "hash": "160f0db075d051bfc8065d7d07c60599"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-04/index.md
@@ -41,7 +41,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - NEW MODULE: We've added a new module [publish-ami](https://github.com/gruntwork-io/module-ci/tree/e0cbe8ee0a7c6b60a6ff59d6cc198082e7baa5c5/modules/aws-helpers) that will copy the given AMI to the desired AWS regions (or all AWS regions) and make it public. 
+  - NEW MODULE: We&apos;ve added a new module [publish-ami](https://github.com/gruntwork-io/module-ci/tree/e0cbe8ee0a7c6b60a6ff59d6cc198082e7baa5c5/modules/aws-helpers) that will copy the given AMI to the desired AWS regions (or all AWS regions) and make it public. 
 
   We added this module because Gruntwork will soon be releasing open source modules for Vault, Nomad, and Consul and we needed a way to make AMIs built by those modules globally available and usable by anyone.
 
@@ -69,7 +69,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - UPDATE: HashiCorp changed the GitHub Packer repo from github.com/mitchellh/packer to github.com/hashicorp/packer. Because our `curl` commands didn't handle a redirect, this caused some of our scripts to fail. This update fixes that issue.
+  - UPDATE: HashiCorp changed the GitHub Packer repo from github.com/mitchellh/packer to github.com/hashicorp/packer. Because our `curl` commands didn&apos;t handle a redirect, this caused some of our scripts to fail. This update fixes that issue.
 
 </div>
 
@@ -90,7 +90,7 @@ Here are the repos that were updated:
 
 https://github.com/gruntwork-io/module-data-storage/pull/20: Fix a bug where the RDS and Aurora module would exit with an error if you set `storage_encrypted` to false. 
 
-**Note**: that if you update to this new version of `module-data-storage` and run `apply`, it will undeploy your old DB and deploy a new one to replace it. That's because fixing this bug required renaming the DB resources, which Terraform sees as a delete + create. 
+**Note**: that if you update to this new version of `module-data-storage` and run `apply`, it will undeploy your old DB and deploy a new one to replace it. That&apos;s because fixing this bug required renaming the DB resources, which Terraform sees as a delete + create. 
 
 To avoid this, you will need to use the `terraform state mv` command. 
 
@@ -148,7 +148,7 @@ terraform state mv module.database.aws_db_instance.replicas module.database.aws_
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-data-storage/pull/17: Fix a bug in the `lambda-copy-shared-rds-snapshot` module where it didn't properly handle `DBSnapshotNotFound` errors.
+  https://github.com/gruntwork-io/module-data-storage/pull/17: Fix a bug in the `lambda-copy-shared-rds-snapshot` module where it didn&apos;t properly handle `DBSnapshotNotFound` errors.
 
 </div>
 
@@ -221,7 +221,7 @@ terraform state mv module.database.aws_db_instance.replicas module.database.aws_
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - NEW MODULE: We've added a module, [iam-user-password-policy](https://github.com/gruntwork-io/module-security/tree/master/modules/iam-user-password-policy) that makes it easy to use Terragrunt to create a password policy for your IAM Users.
+  - NEW MODULE: We&apos;ve added a module, [iam-user-password-policy](https://github.com/gruntwork-io/module-security/tree/master/modules/iam-user-password-policy) that makes it easy to use Terragrunt to create a password policy for your IAM Users.
 
 </div>
 
@@ -313,6 +313,6 @@ terraform state mv module.database.aws_db_instance.replicas module.database.aws_
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "e42a06253fde81a0bc4291d62a66b5f7"
+  "hash": "1469ab4d7aaf97c0ac6b6ca733e93e8f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-04/index.md
@@ -153,6 +153,19 @@ terraform state mv module.database.aws_db_instance.replicas module.database.aws_
 </div>
 
 
+### [v0.2.2](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/1/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  https://github.com/gruntwork-io/module-data-storage/pull/16: The `copy-rds-shared-snapshot` module now allows you to specify a KMS key via the optional `kms_key_id` parameter. If specified, this key will be used to encrypt the RDS snapshot copy.
+
+</div>
+
+
 
 ## terraform-aws-monitoring
 
@@ -265,6 +278,19 @@ terraform state mv module.database.aws_db_instance.replicas module.database.aws_
 </div>
 
 
+### [v0.4.9](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.9)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/1/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.9">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  https://github.com/gruntwork-io/module-security/pull/22: In the `kms-master-key` module, KMS key users now get the `CreateGrant` permission. This makes it possible to share RDS snapshots encrypted with this KMS key with another AWS account.
+
+</div>
+
+
 
 ## terraform-aws-static-assets
 
@@ -287,6 +313,6 @@ terraform state mv module.database.aws_db_instance.replicas module.database.aws_
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "49e9f67b9b028227d08cb604397adbd1"
+  "hash": "e42a06253fde81a0bc4291d62a66b5f7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-04/index.md
@@ -23,7 +23,7 @@ Here are the repos that were updated:
 ### [v0.3.12](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.12)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/23/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.12">Release notes</a></small>
+  <small>Published: 4/24/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.12">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -287,6 +287,6 @@ terraform state mv module.database.aws_db_instance.replicas module.database.aws_
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "2daadcc796962c21c590f6ffd19f075f"
+  "hash": "49e9f67b9b028227d08cb604397adbd1"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-04/index.md
@@ -23,7 +23,7 @@ Here are the repos that were updated:
 ### [v0.3.12](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.12)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/24/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.12">Release notes</a></small>
+  <small>Published: 4/23/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.12">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -153,19 +153,6 @@ terraform state mv module.database.aws_db_instance.replicas module.database.aws_
 </div>
 
 
-### [v0.2.2](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.2)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/1/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.2">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  https://github.com/gruntwork-io/module-data-storage/pull/16: The `copy-rds-shared-snapshot` module now allows you to specify a KMS key via the optional `kms_key_id` parameter. If specified, this key will be used to encrypt the RDS snapshot copy.
-
-</div>
-
-
 
 ## terraform-aws-monitoring
 
@@ -278,19 +265,6 @@ terraform state mv module.database.aws_db_instance.replicas module.database.aws_
 </div>
 
 
-### [v0.4.9](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.9)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/1/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.9">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  https://github.com/gruntwork-io/module-security/pull/22: In the `kms-master-key` module, KMS key users now get the `CreateGrant` permission. This makes it possible to share RDS snapshots encrypted with this KMS key with another AWS account.
-
-</div>
-
-
 
 ## terraform-aws-static-assets
 
@@ -313,6 +287,6 @@ terraform state mv module.database.aws_db_instance.replicas module.database.aws_
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "e42a06253fde81a0bc4291d62a66b5f7"
+  "hash": "2daadcc796962c21c590f6ffd19f075f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-05/index.md
@@ -54,7 +54,7 @@ Here are the repos that were updated:
 ### [v0.3.15](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.15)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/18/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.15">Release notes</a></small>
+  <small>Published: 5/19/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.15">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -144,7 +144,7 @@ Here are the repos that were updated:
 ### [v0.5.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.5.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/23/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.5.0">Release notes</a></small>
+  <small>Published: 5/24/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.5.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -196,7 +196,7 @@ Here are the repos that were updated:
 ### [v0.4.17](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.17)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/2/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.17">Release notes</a></small>
+  <small>Published: 5/3/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.17">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -228,6 +228,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "13cedb477ecf7011b6896a1b428f3748"
+  "hash": "3f5a0dc6b9856f39587cbf569738d12e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-05/index.md
@@ -54,7 +54,7 @@ Here are the repos that were updated:
 ### [v0.3.15](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.15)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/19/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.15">Release notes</a></small>
+  <small>Published: 5/18/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.15">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -144,7 +144,7 @@ Here are the repos that were updated:
 ### [v0.5.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.5.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/24/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.5.0">Release notes</a></small>
+  <small>Published: 5/23/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.5.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -196,7 +196,7 @@ Here are the repos that were updated:
 ### [v0.4.17](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.17)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/3/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.17">Release notes</a></small>
+  <small>Published: 5/2/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.4.17">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -228,6 +228,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "3f5a0dc6b9856f39587cbf569738d12e"
+  "hash": "13cedb477ecf7011b6896a1b428f3748"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-05/index.md
@@ -162,7 +162,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-security/pull/25: We've added a new module called [fail2ban](https://github.com/gruntwork-io/module-security/tree/master/modules/fail2ban) that you can use to install fail2ban on your servers and automatically have it ban malicious looking traffic (e.g. someone hammering SSH). The module includes integration with CloudWatch, so you can trigger CloudWatch alarms any time someone is banned.
+  https://github.com/gruntwork-io/module-security/pull/25: We&apos;ve added a new module called [fail2ban](https://github.com/gruntwork-io/module-security/tree/master/modules/fail2ban) that you can use to install fail2ban on your servers and automatically have it ban malicious looking traffic (e.g. someone hammering SSH). The module includes integration with CloudWatch, so you can trigger CloudWatch alarms any time someone is banned.
 
 </div>
 
@@ -228,6 +228,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "3f5a0dc6b9856f39587cbf569738d12e"
+  "hash": "4112ccf9d597769aa8ff56b54189b6c0"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-06/index.md
@@ -76,7 +76,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - #38: Update the `publish-ami` bash script to support an argument `--markdown-description-text` that allows adding arbitrary description text to the markdown text that's output as part of the AMIs that are found.
+  - #38: Update the `publish-ami` bash script to support an argument `--markdown-description-text` that allows adding arbitrary description text to the markdown text that&apos;s output as part of the AMIs that are found.
 
 </div>
 
@@ -311,6 +311,6 @@ Please note that this is a backwards incompatible release:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "437a4d3e57ee48da52e84b8c88902884"
+  "hash": "02d85bddd42c3bcba7755dab222a7aba"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-06/index.md
@@ -178,7 +178,7 @@ Please note that this is a backwards incompatible release:
 ### [v0.2.1](https://github.com/gruntwork-io/terraform-aws-mongodb/releases/tag/v0.2.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/29/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-mongodb/releases/tag/v0.2.1">Release notes</a></small>
+  <small>Published: 6/30/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-mongodb/releases/tag/v0.2.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -191,7 +191,7 @@ Please note that this is a backwards incompatible release:
 ### [v0.2.0](https://github.com/gruntwork-io/terraform-aws-mongodb/releases/tag/v0.2.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/29/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-mongodb/releases/tag/v0.2.0">Release notes</a></small>
+  <small>Published: 6/30/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-mongodb/releases/tag/v0.2.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -238,7 +238,7 @@ Please note that this is a backwards incompatible release:
 ### [v0.2.2](https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.2.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/27/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.2.2">Release notes</a></small>
+  <small>Published: 6/28/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.2.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -311,6 +311,6 @@ Please note that this is a backwards incompatible release:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "f236f7230ff4940bf73d79551502b5ba"
+  "hash": "437a4d3e57ee48da52e84b8c88902884"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-06/index.md
@@ -178,7 +178,7 @@ Please note that this is a backwards incompatible release:
 ### [v0.2.1](https://github.com/gruntwork-io/terraform-aws-mongodb/releases/tag/v0.2.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/30/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-mongodb/releases/tag/v0.2.1">Release notes</a></small>
+  <small>Published: 6/29/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-mongodb/releases/tag/v0.2.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -191,7 +191,7 @@ Please note that this is a backwards incompatible release:
 ### [v0.2.0](https://github.com/gruntwork-io/terraform-aws-mongodb/releases/tag/v0.2.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/30/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-mongodb/releases/tag/v0.2.0">Release notes</a></small>
+  <small>Published: 6/29/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-mongodb/releases/tag/v0.2.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -238,7 +238,7 @@ Please note that this is a backwards incompatible release:
 ### [v0.2.2](https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.2.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/28/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.2.2">Release notes</a></small>
+  <small>Published: 6/27/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.2.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -311,6 +311,6 @@ Please note that this is a backwards incompatible release:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "437a4d3e57ee48da52e84b8c88902884"
+  "hash": "f236f7230ff4940bf73d79551502b5ba"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-07/index.md
@@ -45,7 +45,7 @@ Here are the repos that were updated:
 ### [v0.2.14](https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.14)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/13/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.14">Release notes</a></small>
+  <small>Published: 7/14/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.14">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -230,7 +230,7 @@ Here are the repos that were updated:
 ### [v0.5.1](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.5.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/13/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.5.1">Release notes</a></small>
+  <small>Published: 7/14/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.5.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -409,7 +409,7 @@ Here are the repos that were updated:
 ### [v0.1.8](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.8)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/25/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.8">Release notes</a></small>
+  <small>Published: 7/26/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.8">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -422,7 +422,7 @@ Here are the repos that were updated:
 ### [v0.1.7](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/25/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.7">Release notes</a></small>
+  <small>Published: 7/26/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -482,6 +482,6 @@ The basic implementation and example code is in place, but docs and tests are st
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "3d71e341b458835441a8b7002970feab"
+  "hash": "4d115e08e6f995e89d33664c173ec164"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-07/index.md
@@ -45,7 +45,7 @@ Here are the repos that were updated:
 ### [v0.2.14](https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.14)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/14/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.14">Release notes</a></small>
+  <small>Published: 7/13/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.14">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -58,7 +58,7 @@ Here are the repos that were updated:
 ### [v0.2.13](https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.13)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/14/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.13">Release notes</a></small>
+  <small>Published: 7/13/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.13">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -131,7 +131,7 @@ Here are the repos that were updated:
 ### [v0.3.21](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.21)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/26/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.21">Release notes</a></small>
+  <small>Published: 7/25/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.21">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -230,7 +230,7 @@ Here are the repos that were updated:
 ### [v0.5.1](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.5.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/14/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.5.1">Release notes</a></small>
+  <small>Published: 7/13/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.5.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -263,7 +263,7 @@ Here are the repos that were updated:
 ### [v0.0.4](https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.0.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/19/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.0.4">Release notes</a></small>
+  <small>Published: 7/18/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.0.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -361,7 +361,7 @@ Here are the repos that were updated:
 ### [v0.5.3](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.5.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/26/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.5.3">Release notes</a></small>
+  <small>Published: 7/25/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.5.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -409,7 +409,7 @@ Here are the repos that were updated:
 ### [v0.1.8](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.8)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/26/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.8">Release notes</a></small>
+  <small>Published: 7/25/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.8">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -422,7 +422,7 @@ Here are the repos that were updated:
 ### [v0.1.7](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/26/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.7">Release notes</a></small>
+  <small>Published: 7/25/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -448,7 +448,7 @@ Here are the repos that were updated:
 ### [v0.1.5](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/25/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.5">Release notes</a></small>
+  <small>Published: 7/24/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -482,6 +482,6 @@ The basic implementation and example code is in place, but docs and tests are st
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "2fa7bacd48c5bdd410242e29d1e5da34"
+  "hash": "3d71e341b458835441a8b7002970feab"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-07/index.md
@@ -58,7 +58,7 @@ Here are the repos that were updated:
 ### [v0.2.13](https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.13)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/13/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.13">Release notes</a></small>
+  <small>Published: 7/14/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.13">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -131,7 +131,7 @@ Here are the repos that were updated:
 ### [v0.3.21](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.21)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/25/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.21">Release notes</a></small>
+  <small>Published: 7/26/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.3.21">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -263,7 +263,7 @@ Here are the repos that were updated:
 ### [v0.0.4](https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.0.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/18/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.0.4">Release notes</a></small>
+  <small>Published: 7/19/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.0.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -361,7 +361,7 @@ Here are the repos that were updated:
 ### [v0.5.3](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.5.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/25/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.5.3">Release notes</a></small>
+  <small>Published: 7/26/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.5.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -448,7 +448,7 @@ Here are the repos that were updated:
 ### [v0.1.5](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/24/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.5">Release notes</a></small>
+  <small>Published: 7/25/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.1.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -482,6 +482,6 @@ The basic implementation and example code is in place, but docs and tests are st
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "4d115e08e6f995e89d33664c173ec164"
+  "hash": "2fa7bacd48c5bdd410242e29d1e5da34"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-07/index.md
@@ -255,7 +255,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/package-lambda/pull/6: BACKWARDS INCOMPATIBLE CHANGE. We've renamed the `source_dir` parameter to `source_path` to better reflect that the variable may point to a directory *or* a single zip file.
+  https://github.com/gruntwork-io/package-lambda/pull/6: BACKWARDS INCOMPATIBLE CHANGE. We&apos;ve renamed the `source_dir` parameter to `source_path` to better reflect that the variable may point to a directory *or* a single zip file.
 
 </div>
 
@@ -380,7 +380,7 @@ Here are the repos that were updated:
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
   - ENHANCEMENT/#41: The `iam-groups` modules now lets you optionally add an IAM Group specially for granting the permissions necessary for automated deployment.
-- BUG FIX/#40: IAM Users with the "self-management" IAM Policy can now delete an SSH Key they've uploaded.
+- BUG FIX/#40: IAM Users with the &quot;self-management&quot; IAM Policy can now delete an SSH Key they&apos;ve uploaded.
 
 </div>
 
@@ -472,7 +472,7 @@ Here are the repos that were updated:
 
   First release! 
 
-The basic implementation and example code is in place, but docs and tests are still a TODO, so I'm marking this as a pre-release.
+The basic implementation and example code is in place, but docs and tests are still a TODO, so I&apos;m marking this as a pre-release.
 
 </div>
 
@@ -482,6 +482,6 @@ The basic implementation and example code is in place, but docs and tests are st
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "2fa7bacd48c5bdd410242e29d1e5da34"
+  "hash": "089d1458b000318e102abf570b28a344"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-08/index.md
@@ -109,7 +109,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - UPDATE/#24: Previously, it was not possible to launch an Aurora cluster from a snapshot. The `aurora` module now accepts a new var, `snapshot_identifier`, which is the Snapshot ID from which you'd like to launch a new Aurora cluster. 
+  - UPDATE/#24: Previously, it was not possible to launch an Aurora cluster from a snapshot. The `aurora` module now accepts a new var, `snapshot_identifier`, which is the Snapshot ID from which you&apos;d like to launch a new Aurora cluster. 
 
 NOTE: This release a has a bug! Please use [v0.2.10](https://github.com/gruntwork-io/module-data-storage/releases/tag/v0.2.10) instead.
 
@@ -130,7 +130,7 @@ NOTE: This release a has a bug! Please use [v0.2.10](https://github.com/gruntwor
 
   - NEW FEATURE/BREAKING CHANGE: The `ecs-service-with-alb` module now supports host-based routing! In addition, we used this opportunity to simplify the interface to the module. The major change is that you now specify ALB Listener Rules using Terraform code in the same Terraform file that calls the `ecs-service-with-alb` module, giving users total flexibility on routing rules. (#37)
 
-NOTE: This release also updates the ECS Cluster module so that it [no longer adds a rule to the ALB Security Group](https://github.com/gruntwork-io/module-ecs/pull/37/files#diff-d72db0b293516646f6d2af03f815cde2L149) to allow outbound traffic from the ALB to the ECS Cluster. That's because, as of [v0.6.0 of the ALB Module](https://github.com/gruntwork-io/module-load-balancer/releases/tag/v0.6.0), the ALB now enables all outbound traffic by default. 
+NOTE: This release also updates the ECS Cluster module so that it [no longer adds a rule to the ALB Security Group](https://github.com/gruntwork-io/module-ecs/pull/37/files#diff-d72db0b293516646f6d2af03f815cde2L149) to allow outbound traffic from the ALB to the ECS Cluster. That&apos;s because, as of [v0.6.0 of the ALB Module](https://github.com/gruntwork-io/module-load-balancer/releases/tag/v0.6.0), the ALB now enables all outbound traffic by default. 
 
 Therefore, be sure to also upgrade to [v0.6.0 or higher of module alb](https://github.com/gruntwork-io/module-load-balancer/releases) when using this release!
 
@@ -237,13 +237,13 @@ The changes include:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - BREAKING CHANGE: The module `alb` now opens all outbound ports by default. You can preserve the previous default behavior of opening no outbound ports by default by explicitly setting `var.allow_all_outbound = false` when calling this module. Although the previous default was slightly more secure, several users didn't realize the additional steps they needed to take to correctly use the ALB, so we feel this new default behavior is a better balance between security and convenience. (#16)
+  - BREAKING CHANGE: The module `alb` now opens all outbound ports by default. You can preserve the previous default behavior of opening no outbound ports by default by explicitly setting `var.allow_all_outbound = false` when calling this module. Although the previous default was slightly more secure, several users didn&apos;t realize the additional steps they needed to take to correctly use the ALB, so we feel this new default behavior is a better balance between security and convenience. (#16)
 
 _**Additional Background**_
 
-_Previously, when you created an ALB, by default, its Security Group blocked all outbound traffic. When you added an ALB to an ECS Cluster, the ECS Cluster module updated the ALB's Security Group to allow outbound traffic only to the specific ECS Cluster being created._
+_Previously, when you created an ALB, by default, its Security Group blocked all outbound traffic. When you added an ALB to an ECS Cluster, the ECS Cluster module updated the ALB&apos;s Security Group to allow outbound traffic only to the specific ECS Cluster being created._
 
-_But this proved to be confusing to people and didn't give us much security benefit anyway, so with this release, we change the default behavior of the ALB module to allow all outbound connections by default. At the same time, we [updated the ECS Cluster module](https://github.com/gruntwork-io/module-ecs/releases/tag/v0.6.0) to no longer modify the ALB's Security Group to allow outbound connections from the ALB to the ECS Cluster since the ALB now allows all outbound traffic by default._
+_But this proved to be confusing to people and didn&apos;t give us much security benefit anyway, so with this release, we change the default behavior of the ALB module to allow all outbound connections by default. At the same time, we [updated the ECS Cluster module](https://github.com/gruntwork-io/module-ecs/releases/tag/v0.6.0) to no longer modify the ALB&apos;s Security Group to allow outbound connections from the ALB to the ECS Cluster since the ALB now allows all outbound traffic by default._
 
 _Therefore, if you use this release or higher with an ECS Cluster, be sure to use [v0.6.0](https://github.com/gruntwork-io/module-ecs/releases/tag/v0.6.0) or higher of that module as well!_
 
@@ -287,7 +287,7 @@ For example:
 terraform state mv module.alb_access_logs_bucket.aws_s3_bucket.access_logs_with_logs_archived module.alb_access_logs_bucket.aws_s3_bucket.access_logs_with_logs_archived_and_deleted
 ```
 
-You can run `terraform plan` before the above to know the new destination to move the source to. Also, ensure that you don't change any variables that'll force a new ALB creation.
+You can run `terraform plan` before the above to know the new destination to move the source to. Also, ensure that you don&apos;t change any variables that&apos;ll force a new ALB creation.
 
 For assistance, please contact Gruntwork support. (#33)
 
@@ -327,7 +327,7 @@ For assistance, please contact Gruntwork support. (#33)
 
 Fix several issues:
 
-1. Fix the apt repo URL for installing OpenVPN. It's not clear what happened to the old URL, but when you ran `install-openvpn`, you would get the error `404  Not Found [IP: 104.20.194.50 80]`.
+1. Fix the apt repo URL for installing OpenVPN. It&apos;s not clear what happened to the old URL, but when you ran `install-openvpn`, you would get the error `404  Not Found [IP: 104.20.194.50 80]`.
 1. The `push route` configuration in `server.conf` had a syntactic issue where the word `route` was outside of double quotes.
 1. Reduce logging verbosity for OpenVPN to production levels.
 
@@ -392,7 +392,7 @@ Fix several issues:
   https://github.com/gruntwork-io/module-server/pull/14: 
 
 * Added a new `attach-eni` script which can be used to attach an ENI to an EC2 Instance. 
-* Updated the `mount-ebs-volume` script so it can automatically find an attach an EBS Volume that has the same tag as the EC2 Instance. This is handy when you create EBS Volumes and Instances in matching "pairs."
+* Updated the `mount-ebs-volume` script so it can automatically find an attach an EBS Volume that has the same tag as the EC2 Instance. This is handy when you create EBS Volumes and Instances in matching &quot;pairs.&quot;
 
 </div>
 
@@ -432,7 +432,7 @@ This release fixes two bugs:
 
   **UPDATE: DO NOT USE THIS RELEASE. IT CONTAINS A BAD BUG. SEE #27 FOR DETAILS.**
 
-https://github.com/gruntwork-io/module-vpc/pull/26: Fix a bug where the `num_availability_zones` output variable would report the wrong value (-1) if you didn't set the optional `num_availability_zones` input variable.
+https://github.com/gruntwork-io/module-vpc/pull/26: Fix a bug where the `num_availability_zones` output variable would report the wrong value (-1) if you didn&apos;t set the optional `num_availability_zones` input variable.
 
 </div>
 
@@ -447,7 +447,7 @@ https://github.com/gruntwork-io/module-vpc/pull/26: Fix a bug where the `num_ava
 
   **UPDATE: DO NOT USE THIS RELEASE. IT CONTAINS A BAD BUG. SEE #27 FOR DETAILS.**
 
-- UPDATE: The modules `vpc-app` and `vpc-mgmt` now make `var.num_availability_zones` optional. If it's non-empty, the created VPC will only use the specified number of Availability Zones, not *all* Availability Zones. Otherwise, the VPC will be created to use all Availability Zones. As an example, `us-east-1` now has 6 Availability Zones, but users may wish to utilize just 3 of them. This release if fully backwards-compatible. (#22)
+- UPDATE: The modules `vpc-app` and `vpc-mgmt` now make `var.num_availability_zones` optional. If it&apos;s non-empty, the created VPC will only use the specified number of Availability Zones, not *all* Availability Zones. Otherwise, the VPC will be created to use all Availability Zones. As an example, `us-east-1` now has 6 Availability Zones, but users may wish to utilize just 3 of them. This release if fully backwards-compatible. (#22)
 
 </div>
 
@@ -539,6 +539,6 @@ https://github.com/gruntwork-io/module-vpc/pull/26: Fix a bug where the `num_ava
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "2c1bb27c940ead4ec47e04e845a0bb80"
+  "hash": "a9944f9fcfdcd0016eb96f4f66f788ee"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-08/index.md
@@ -74,7 +74,7 @@ Here are the repos that were updated:
 ### [v0.4.0](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.4.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/14/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.4.0">Release notes</a></small>
+  <small>Published: 8/15/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.4.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -104,7 +104,7 @@ Here are the repos that were updated:
 ### [v0.2.9](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.9)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/25/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.9">Release notes</a></small>
+  <small>Published: 8/26/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.9">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -163,7 +163,7 @@ The changes include:
 ### [v0.0.4](https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/16/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.4">Release notes</a></small>
+  <small>Published: 8/17/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -176,7 +176,7 @@ The changes include:
 ### [v0.0.3](https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/15/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.3">Release notes</a></small>
+  <small>Published: 8/16/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -202,7 +202,7 @@ The changes include:
 ### [v0.0.1](https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/14/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.1">Release notes</a></small>
+  <small>Published: 8/15/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -524,7 +524,7 @@ https://github.com/gruntwork-io/module-vpc/pull/26: Fix a bug where the `num_ava
 ### [v0.0.2](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.0.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/14/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.0.2">Release notes</a></small>
+  <small>Published: 8/15/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.0.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -539,6 +539,6 @@ https://github.com/gruntwork-io/module-vpc/pull/26: Fix a bug where the `num_ava
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "07915c9251ed8402f146e42e8ad26aa6"
+  "hash": "2c1bb27c940ead4ec47e04e845a0bb80"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-08/index.md
@@ -74,7 +74,7 @@ Here are the repos that were updated:
 ### [v0.4.0](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.4.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/15/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.4.0">Release notes</a></small>
+  <small>Published: 8/14/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.4.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -104,7 +104,7 @@ Here are the repos that were updated:
 ### [v0.2.9](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.9)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/26/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.9">Release notes</a></small>
+  <small>Published: 8/25/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.2.9">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -163,7 +163,7 @@ The changes include:
 ### [v0.0.4](https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/17/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.4">Release notes</a></small>
+  <small>Published: 8/16/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -176,7 +176,7 @@ The changes include:
 ### [v0.0.3](https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/16/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.3">Release notes</a></small>
+  <small>Published: 8/15/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -202,7 +202,7 @@ The changes include:
 ### [v0.0.1](https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/15/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.1">Release notes</a></small>
+  <small>Published: 8/14/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -524,7 +524,7 @@ https://github.com/gruntwork-io/module-vpc/pull/26: Fix a bug where the `num_ava
 ### [v0.0.2](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.0.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/15/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.0.2">Release notes</a></small>
+  <small>Published: 8/14/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.0.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -539,6 +539,6 @@ https://github.com/gruntwork-io/module-vpc/pull/26: Fix a bug where the `num_ava
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "2c1bb27c940ead4ec47e04e845a0bb80"
+  "hash": "07915c9251ed8402f146e42e8ad26aa6"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-09/index.md
@@ -43,7 +43,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-asg/pull/10: The `server-group` module now assigns EBS permissions based on the `ServerGroupName` tag instead of the `Name` tag, as the latter is too brittle. This change is backwards incompatible, so we're bumping the patch version number, but unless you are doing something weird and overriding `ServerGroupName` (very unlikely!), you shouldn't have to do anything to make this work with your code.
+  https://github.com/gruntwork-io/module-asg/pull/10: The `server-group` module now assigns EBS permissions based on the `ServerGroupName` tag instead of the `Name` tag, as the latter is too brittle. This change is backwards incompatible, so we&apos;re bumping the patch version number, but unless you are doing something weird and overriding `ServerGroupName` (very unlikely!), you shouldn&apos;t have to do anything to make this work with your code.
 
 </div>
 
@@ -155,24 +155,24 @@ The `iam_groups_for_cross_account_access` input parameter of the `iam-groups` mo
 To use the new version of the `iam-groups` module, instead of specifying a map:
 
 ```hcl
-iam_groups_for_cross_account_access  = {
-  "stage-full-access": "arn:aws:iam::123445678910:role/mgmt-full-access",
-  "prod-read-only-access": "arn:aws:iam::9876543210:role/prod-read-only-access"
-}
+iam_groups_for_cross_account_access  = &#x7B;
+  &quot;stage-full-access&quot;: &quot;arn:aws:iam::123445678910:role/mgmt-full-access&quot;,
+  &quot;prod-read-only-access&quot;: &quot;arn:aws:iam::9876543210:role/prod-read-only-access&quot;
+&#x7D;
 ```
 
 You need to specify a list of maps:
 
 ```hcl
 iam_groups_for_cross_account_access = [
-  {
-    group_name   = "stage-full-access"
-    iam_role_arn = "arn:aws:iam::123445678910:role/mgmt-full-access"
-  },
-  {
-    group_name   = "prod-read-only-access"
-    iam_role_arn = "arn:aws:iam::9876543210:role/prod-read-only-access"
-  }
+  &#x7B;
+    group_name   = &quot;stage-full-access&quot;
+    iam_role_arn = &quot;arn:aws:iam::123445678910:role/mgmt-full-access&quot;
+  &#x7D;,
+  &#x7B;
+    group_name   = &quot;prod-read-only-access&quot;
+    iam_role_arn = &quot;arn:aws:iam::9876543210:role/prod-read-only-access&quot;
+  &#x7D;
 ]
 ```
 
@@ -191,7 +191,7 @@ iam_groups_for_cross_account_access = [
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-server/pull/18: The `attach-eni` script will now automatically configure route tables on Debian servers. This should allow ENIs to work "automagically" just like they do on Amazon Linux. This release is backwards compatible from an API perspective, but we've bumped the minor version number to indicate that it's a fairly large change in terms of behavior.
+  https://github.com/gruntwork-io/module-server/pull/18: The `attach-eni` script will now automatically configure route tables on Debian servers. This should allow ENIs to work &quot;automagically&quot; just like they do on Amazon Linux. This release is backwards compatible from an API perspective, but we&apos;ve bumped the minor version number to indicate that it&apos;s a fairly large change in terms of behavior.
 
 </div>
 
@@ -269,6 +269,6 @@ https://github.com/gruntwork-io/package-static-assets/pull/3: The `s3-cloudfront
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "427fd0260ae9bd9d9a4374f1a64ef548"
+  "hash": "8a6374d2defa5976b21ea46fa6fdc485"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-09/index.md
@@ -25,7 +25,7 @@ Here are the repos that were updated:
 ### [v0.6.1](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/30/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.1">Release notes</a></small>
+  <small>Published: 9/29/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -38,7 +38,7 @@ Here are the repos that were updated:
 ### [v0.6.0](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/29/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.0">Release notes</a></small>
+  <small>Published: 9/28/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -241,7 +241,7 @@ https://github.com/gruntwork-io/package-static-assets/pull/3: The `s3-cloudfront
 ### [v0.0.7](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.0.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/29/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.0.7">Release notes</a></small>
+  <small>Published: 9/28/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.0.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -269,6 +269,6 @@ https://github.com/gruntwork-io/package-static-assets/pull/3: The `s3-cloudfront
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "427fd0260ae9bd9d9a4374f1a64ef548"
+  "hash": "86ae4f3d9a83d76e0e99bb883eae26b9"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-09/index.md
@@ -25,7 +25,7 @@ Here are the repos that were updated:
 ### [v0.6.1](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/29/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.1">Release notes</a></small>
+  <small>Published: 9/30/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -38,7 +38,7 @@ Here are the repos that were updated:
 ### [v0.6.0](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/28/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.0">Release notes</a></small>
+  <small>Published: 9/29/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -241,7 +241,7 @@ https://github.com/gruntwork-io/package-static-assets/pull/3: The `s3-cloudfront
 ### [v0.0.7](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.0.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/28/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.0.7">Release notes</a></small>
+  <small>Published: 9/29/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.0.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -269,6 +269,6 @@ https://github.com/gruntwork-io/package-static-assets/pull/3: The `s3-cloudfront
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "86ae4f3d9a83d76e0e99bb883eae26b9"
+  "hash": "427fd0260ae9bd9d9a4374f1a64ef548"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-10/index.md
@@ -41,7 +41,7 @@ Here are the repos that were updated:
 ### [v0.2.21](https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.21)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/20/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.21">Release notes</a></small>
+  <small>Published: 10/21/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.21">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -97,7 +97,7 @@ Here are the repos that were updated:
 ### [v0.0.6](https://github.com/gruntwork-io/gruntkms/releases/tag/v0.0.6)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/22/2017 | <a href="https://github.com/gruntwork-io/gruntkms/releases/tag/v0.0.6">Release notes</a></small>
+  <small>Published: 10/23/2017 | <a href="https://github.com/gruntwork-io/gruntkms/releases/tag/v0.0.6">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -208,7 +208,7 @@ Here are the repos that were updated:
 ### [v0.7.0](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.7.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/14/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.7.0">Release notes</a></small>
+  <small>Published: 10/15/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.7.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -342,6 +342,6 @@ This change is backwards compatible from a code perspective, but it changes the 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "42fbc767427f9b39f1b764a22797d616"
+  "hash": "ab82012a30740afac66d9af2f1f2a6e7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-10/index.md
@@ -233,7 +233,7 @@ BACKWARDS INCOMPATIBLE CHANGE
 The `asg-xxx-alarms` modules now allow you to create alarms for a list of ASGs, rather than just one. This is necessary to use the alarms with, for example, the [server-group](https://github.com/gruntwork-io/module-asg/tree/master/modules/server-group) module. To support this, instead of taking in a single `asg_name` parameter, these modules now take in two parameters:
 
 * `asg_names`: A list of ASG names.
-* `num_asg_names`: The number of ASG names in `asg_names`. We should be able to compute this automatically, but can't due to a Terraform limitation (https://github.com/hashicorp/terraform/issues/4149).
+* `num_asg_names`: The number of ASG names in `asg_names`. We should be able to compute this automatically, but can&apos;t due to a Terraform limitation (https://github.com/hashicorp/terraform/issues/4149).
 
 </div>
 
@@ -342,6 +342,6 @@ This change is backwards compatible from a code perspective, but it changes the 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "ab82012a30740afac66d9af2f1f2a6e7"
+  "hash": "f71d5fc40322ebcc98b1229774280099"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-10/index.md
@@ -41,7 +41,7 @@ Here are the repos that were updated:
 ### [v0.2.21](https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.21)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/21/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.21">Release notes</a></small>
+  <small>Published: 10/20/2017 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.21">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -97,7 +97,7 @@ Here are the repos that were updated:
 ### [v0.0.6](https://github.com/gruntwork-io/gruntkms/releases/tag/v0.0.6)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/23/2017 | <a href="https://github.com/gruntwork-io/gruntkms/releases/tag/v0.0.6">Release notes</a></small>
+  <small>Published: 10/22/2017 | <a href="https://github.com/gruntwork-io/gruntkms/releases/tag/v0.0.6">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -161,7 +161,7 @@ Here are the repos that were updated:
 ### [v0.0.9](https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.9)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/9/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.9">Release notes</a></small>
+  <small>Published: 10/8/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.9">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -208,7 +208,7 @@ Here are the repos that were updated:
 ### [v0.7.0](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.7.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/15/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.7.0">Release notes</a></small>
+  <small>Published: 10/14/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.7.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -314,7 +314,7 @@ This change is backwards compatible from a code perspective, but it changes the 
 ### [v0.0.9](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.0.9)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/8/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.0.9">Release notes</a></small>
+  <small>Published: 10/7/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.0.9">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -342,6 +342,6 @@ This change is backwards compatible from a code perspective, but it changes the 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "ab82012a30740afac66d9af2f1f2a6e7"
+  "hash": "812cd4e503b2aae87da0805def73aac9"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-10/index.md
@@ -161,7 +161,7 @@ Here are the repos that were updated:
 ### [v0.0.9](https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.9)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/8/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.9">Release notes</a></small>
+  <small>Published: 10/9/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.0.9">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -314,7 +314,7 @@ This change is backwards compatible from a code perspective, but it changes the 
 ### [v0.0.9](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.0.9)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/7/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.0.9">Release notes</a></small>
+  <small>Published: 10/8/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.0.9">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -342,6 +342,6 @@ This change is backwards compatible from a code perspective, but it changes the 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "812cd4e503b2aae87da0805def73aac9"
+  "hash": "42fbc767427f9b39f1b764a22797d616"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-11/index.md
@@ -41,7 +41,7 @@ Here are the repos that were updated:
 ### [v0.0.7](https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/27/2017 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.7">Release notes</a></small>
+  <small>Published: 11/28/2017 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -106,7 +106,7 @@ Here are the repos that were updated:
 ### [v0.0.2](https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/20/2017 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.2">Release notes</a></small>
+  <small>Published: 11/21/2017 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -166,7 +166,7 @@ Here are the repos that were updated:
 ### [v0.5.0](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.5.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/29/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.5.0">Release notes</a></small>
+  <small>Published: 11/30/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.5.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -476,6 +476,6 @@ https_listener_ports_and_acm_ssl_certs = [
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "f10bb538ce48f8fd45885ba254d0dfb7"
+  "hash": "31a4f6aabd9dca89f36c64fd4a86b86a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-11/index.md
@@ -41,7 +41,7 @@ Here are the repos that were updated:
 ### [v0.0.7](https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/28/2017 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.7">Release notes</a></small>
+  <small>Published: 11/27/2017 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -106,7 +106,7 @@ Here are the repos that were updated:
 ### [v0.0.2](https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/21/2017 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.2">Release notes</a></small>
+  <small>Published: 11/20/2017 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -166,7 +166,7 @@ Here are the repos that were updated:
 ### [v0.5.0](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.5.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/30/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.5.0">Release notes</a></small>
+  <small>Published: 11/29/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.5.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -476,6 +476,6 @@ https_listener_ports_and_acm_ssl_certs = [
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "31a4f6aabd9dca89f36c64fd4a86b86a"
+  "hash": "f10bb538ce48f8fd45885ba254d0dfb7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-11/index.md
@@ -240,7 +240,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-data-storage/pull/28: The `aurora` module now exposes `engine` and `engine_version` parameters so you have more control over what type of Aurora engine you're running (e.g., you can use the Postgres-compatible one).
+  https://github.com/gruntwork-io/module-data-storage/pull/28: The `aurora` module now exposes `engine` and `engine_version` parameters so you have more control over what type of Aurora engine you&apos;re running (e.g., you can use the Postgres-compatible one).
 
 </div>
 
@@ -274,26 +274,26 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-load-balancer/pull/20: We've converted the `https_listener_ports_and_ssl_certs` and `https_listener_ports_and_acm_ssl_certs` input variables on the `alb` module from maps to lists of maps. The problem with using maps is that in Go—which Terraform uses under the hood—the iteration order for maps is (intentionally) randomized, so with multiple ports and certs in these variables, you would get spurious diffs in the `plan` command as Terraform would swap their order and assume listeners had to created/destroyed. By using lists, we can make the sort order consistent.
+  https://github.com/gruntwork-io/module-load-balancer/pull/20: We&apos;ve converted the `https_listener_ports_and_ssl_certs` and `https_listener_ports_and_acm_ssl_certs` input variables on the `alb` module from maps to lists of maps. The problem with using maps is that in Go—which Terraform uses under the hood—the iteration order for maps is (intentionally) randomized, so with multiple ports and certs in these variables, you would get spurious diffs in the `plan` command as Terraform would swap their order and assume listeners had to created/destroyed. By using lists, we can make the sort order consistent.
 
 **Upgrade instructions for https_listener_ports_and_ssl_certs**
 
 Old `https_listener_ports_and_ssl_certs` format:
 
 ```hcl
-https_listener_ports_and_ssl_certs = {
-  "443" = "arn:aws:iam::123456789012:server-certificate/ProdServerCert"
-}
+https_listener_ports_and_ssl_certs = &#x7B;
+  &quot;443&quot; = &quot;arn:aws:iam::123456789012:server-certificate/ProdServerCert&quot;
+&#x7D;
 ```
 
 New `https_listener_ports_and_ssl_certs` format:
 
 ```hcl
 https_listener_ports_and_ssl_certs = [
-  {
+  &#x7B;
     port = 443
-    tls_arn = "arn:aws:iam::123456789012:server-certificate/ProdServerCert"
-  }
+    tls_arn = &quot;arn:aws:iam::123456789012:server-certificate/ProdServerCert&quot;
+  &#x7D;
 ]
 ```
 
@@ -302,19 +302,19 @@ https_listener_ports_and_ssl_certs = [
 Old `https_listener_ports_and_acm_ssl_certs` format:
 
 ```hcl
-https_listener_ports_and_acm_ssl_certs = {
-  "443" = "*.foo.com"
-}
+https_listener_ports_and_acm_ssl_certs = &#x7B;
+  &quot;443&quot; = &quot;*.foo.com&quot;
+&#x7D;
 ```
 
 New `https_listener_ports_and_acm_ssl_certs` format:
 
 ```hcl
 https_listener_ports_and_acm_ssl_certs = [
-  {
+  &#x7B;
     port = 443
-    tls_domain_name = "*.foo.com"
-  }
+    tls_domain_name = &quot;*.foo.com&quot;
+  &#x7D;
 ]
 ```
 
@@ -333,7 +333,7 @@ https_listener_ports_and_acm_ssl_certs = [
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/package-mongodb/pull/24: If you set the `cluster_size` param of the  `mongodb-cluster` module to 0, it will now create no resources whatsoever. Since Terraform doesn't allow you to use `count` with `module` directly, this provides a convenient way to disable the `mongodb-cluster` module in certain environments (e.g., disable the backup jobs in pre-prod environments).
+  https://github.com/gruntwork-io/package-mongodb/pull/24: If you set the `cluster_size` param of the  `mongodb-cluster` module to 0, it will now create no resources whatsoever. Since Terraform doesn&apos;t allow you to use `count` with `module` directly, this provides a convenient way to disable the `mongodb-cluster` module in certain environments (e.g., disable the backup jobs in pre-prod environments).
 
 </div>
 
@@ -389,7 +389,7 @@ https_listener_ports_and_acm_ssl_certs = [
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-security/pull/59: `ssh-iam` will now do a better job of reporting error messages if it reads an OS user that is missing the "comment field", which ssh-iam uses for storing the IAM user name.
+  https://github.com/gruntwork-io/module-security/pull/59: `ssh-iam` will now do a better job of reporting error messages if it reads an OS user that is missing the &quot;comment field&quot;, which ssh-iam uses for storing the IAM user name.
 
 </div>
 
@@ -476,6 +476,6 @@ https_listener_ports_and_acm_ssl_certs = [
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "31a4f6aabd9dca89f36c64fd4a86b86a"
+  "hash": "80306ca869ea0df18de235753d5520e8"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-12/index.md
@@ -39,7 +39,7 @@ Here are the repos that were updated:
 ### [v0.0.13](https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.13)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/18/2017 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.13">Release notes</a></small>
+  <small>Published: 12/17/2017 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.13">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -142,7 +142,7 @@ Here are the repos that were updated:
 ### [v0.4.1](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.4.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/19/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.4.1">Release notes</a></small>
+  <small>Published: 12/18/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.4.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -250,6 +250,6 @@ We also suggest explicitly providing values for the `--request-url` parameter to
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "4a730d17952dd1207b4f4dbf95d42298"
+  "hash": "85c52a35510044fbbcafb9ad935b7f19"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-12/index.md
@@ -177,7 +177,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-aws-monitoring/pull/38: Fig `logrotate` settings to use `copytruncate` (so files are rotated properly even if a process maintains the old file handle) and `maxsize` instead of `size` (as `size` conflicts with `daily`). To use `maxsize`, we also had to install a newer version of `logrotate` on Amazon Linux distros, which, by default, run a version that's more than 7 years old. 
+  https://github.com/gruntwork-io/module-aws-monitoring/pull/38: Fig `logrotate` settings to use `copytruncate` (so files are rotated properly even if a process maintains the old file handle) and `maxsize` instead of `size` (as `size` conflicts with `daily`). To use `maxsize`, we also had to install a newer version of `logrotate` on Amazon Linux distros, which, by default, run a version that&apos;s more than 7 years old. 
 
 </div>
 
@@ -250,6 +250,6 @@ We also suggest explicitly providing values for the `--request-url` parameter to
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "4a730d17952dd1207b4f4dbf95d42298"
+  "hash": "5e3e9b626b86adeb24d45ec58c421053"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-12/index.md
@@ -39,7 +39,7 @@ Here are the repos that were updated:
 ### [v0.0.13](https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.13)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/17/2017 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.13">Release notes</a></small>
+  <small>Published: 12/18/2017 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.13">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -142,7 +142,7 @@ Here are the repos that were updated:
 ### [v0.4.1](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.4.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/18/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.4.1">Release notes</a></small>
+  <small>Published: 12/19/2017 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.4.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -250,6 +250,6 @@ We also suggest explicitly providing values for the `--request-url` parameter to
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "85c52a35510044fbbcafb9ad935b7f19"
+  "hash": "4a730d17952dd1207b4f4dbf95d42298"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-01/index.md
@@ -37,7 +37,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/gruntwork/pull/21: `gruntwork` now checks that you're logged in as an IAM user and not a root user.
+  https://github.com/gruntwork-io/gruntwork/pull/21: `gruntwork` now checks that you&apos;re logged in as an IAM user and not a root user.
 
 </div>
 
@@ -50,7 +50,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/gruntwork/pull/19: Check that the account you're logged into is the root of your AWS Organization, as that's the only account that can create child accounts.
+  https://github.com/gruntwork-io/gruntwork/pull/19: Check that the account you&apos;re logged into is the root of your AWS Organization, as that&apos;s the only account that can create child accounts.
 
 </div>
 
@@ -144,7 +144,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  * #49: The `roll-out-ecs-cluster-update.py` script will now display better error messages if it can't find your ECS cluster for some reason (e.g., you specified the wrong region).
+  * #49: The `roll-out-ecs-cluster-update.py` script will now display better error messages if it can&apos;t find your ECS cluster for some reason (e.g., you specified the wrong region).
 
 * #50: The package now supports [placement_strategy](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#placement_strategy-1) and [placement_constraints](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#placement_constraints-1)
 
@@ -293,7 +293,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/package-static-assets/pull/4: The `cloudfront` module now enables gzip compression by default. This is a backwards incompatible change, so if for some reason you don't want to enable gzip compression, you'll need to set `compress = false`. 
+  https://github.com/gruntwork-io/package-static-assets/pull/4: The `cloudfront` module now enables gzip compression by default. This is a backwards incompatible change, so if for some reason you don&apos;t want to enable gzip compression, you&apos;ll need to set `compress = false`. 
 
 </div>
 
@@ -342,7 +342,7 @@ add new tests for num_nat_gateways=0
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/package-zookeeper/pull/17: In the previous release, we tried to move away from the webupd8 JDK installer for Ubuntu, which stopped working for the latest version of JDK8, to a custom one, but it turns out the webupd8 had a huge amount of custom code (e.g., creating symlinks, configuring fonts, setting up env vars, etc) that we were missing. In this release, we've gone back to the webupd8, but with a patch that makes it work again with the latest JDK8. That means that we are back to the `--version` flag for Ubuntu installs and `--download-url` and `--checksum` for Amazon Linux / CentOS.
+  https://github.com/gruntwork-io/package-zookeeper/pull/17: In the previous release, we tried to move away from the webupd8 JDK installer for Ubuntu, which stopped working for the latest version of JDK8, to a custom one, but it turns out the webupd8 had a huge amount of custom code (e.g., creating symlinks, configuring fonts, setting up env vars, etc) that we were missing. In this release, we&apos;ve gone back to the webupd8, but with a patch that makes it work again with the latest JDK8. That means that we are back to the `--version` flag for Ubuntu installs and `--download-url` and `--checksum` for Amazon Linux / CentOS.
 
 </div>
 
@@ -367,6 +367,6 @@ add new tests for num_nat_gateways=0
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "a1b9c2767ee48c4662a1f657a5da479a"
+  "hash": "01a260348b1816c0f90927cc89485eb7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-01/index.md
@@ -32,7 +32,7 @@ Here are the repos that were updated:
 ### [v0.0.16](https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.16)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/17/2018 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.16">Release notes</a></small>
+  <small>Published: 1/18/2018 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.16">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -122,7 +122,7 @@ Here are the repos that were updated:
 ### [v0.5.0](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.5.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/12/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.5.0">Release notes</a></small>
+  <small>Published: 1/13/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.5.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -160,7 +160,7 @@ Here are the repos that were updated:
 ### [v0.2.0](https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.2.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/12/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.2.0">Release notes</a></small>
+  <small>Published: 1/13/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.2.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -350,7 +350,7 @@ add new tests for num_nat_gateways=0
 ### [v0.2.0](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.2.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/16/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.2.0">Release notes</a></small>
+  <small>Published: 1/17/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.2.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -367,6 +367,6 @@ add new tests for num_nat_gateways=0
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "725a724f156903d2a4006a0499c72561"
+  "hash": "a1b9c2767ee48c4662a1f657a5da479a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-01/index.md
@@ -32,7 +32,7 @@ Here are the repos that were updated:
 ### [v0.0.16](https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.16)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/18/2018 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.16">Release notes</a></small>
+  <small>Published: 1/17/2018 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.16">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -122,7 +122,7 @@ Here are the repos that were updated:
 ### [v0.5.0](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.5.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/13/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.5.0">Release notes</a></small>
+  <small>Published: 1/12/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.5.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -160,7 +160,7 @@ Here are the repos that were updated:
 ### [v0.2.0](https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.2.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/13/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.2.0">Release notes</a></small>
+  <small>Published: 1/12/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.2.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -350,7 +350,7 @@ add new tests for num_nat_gateways=0
 ### [v0.2.0](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.2.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/17/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.2.0">Release notes</a></small>
+  <small>Published: 1/16/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.2.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -367,6 +367,6 @@ add new tests for num_nat_gateways=0
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "a1b9c2767ee48c4662a1f657a5da479a"
+  "hash": "725a724f156903d2a4006a0499c72561"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-02/index.md
@@ -28,7 +28,7 @@ Here are the repos that were updated:
 ### [v0.6.7](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/28/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.7">Release notes</a></small>
+  <small>Published: 3/1/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -170,7 +170,7 @@ Warning: this release contains BACKWARDS INCOMPATIBLE CHANGES to `scheduled-lamb
 ### [v0.7.2](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.7.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/28/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.7.2">Release notes</a></small>
+  <small>Published: 3/1/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.7.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -200,7 +200,7 @@ Warning: this release contains BACKWARDS INCOMPATIBLE CHANGES to `scheduled-lamb
 ### [v0.4.1](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.4.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/22/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.4.1">Release notes</a></small>
+  <small>Published: 2/23/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.4.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -241,7 +241,7 @@ Note, this release contains BACKWARDS INCOMPATIBLE CHANGES to the `single-server
 ### [v0.0.2](https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.0.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/28/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.0.2">Release notes</a></small>
+  <small>Published: 3/1/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.0.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -262,6 +262,6 @@ The primary use case is so we can format paths properly on Windows vs Linux.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "4c2256518f8d43f8bfec9e1f720d3f15"
+  "hash": "6bde12561481b749707c50008c24b9ed"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-02/index.md
@@ -69,9 +69,9 @@ Warning: this release contains BACKWARDS INCOMPATIBLE CHANGES to `scheduled-lamb
 * Add a module for running a Lambda function on a scheduled basis to take snapshots of your servers: `ec2-backup`.
 * Delete the `scheduled-lambda-job` module. Please migrate to [package-lambda](https://github.com/gruntwork-io/package-lambda) instead. You can create the Lambda functions with the [lambda module](https://github.com/gruntwork-io/package-lambda/tree/master/modules/lambda) and run them on a scheduled basis using the [scheduled-lambda-job module](https://github.com/gruntwork-io/package-lambda/tree/master/modules/scheduled-lambda-job) in that repo.
 * Update this repo to use CircleCI 2.0 with the machine executor.
-* Add a new `--circle-ci-2-machine-executor` flag to `configure-environment-for-gruntwork-module` so you can use the script with CircleCI 2.0's machine executor.
-* Add an example for how to create "unit tests" for modules that run locally and relatively quickly using Docker and Docker Compose. See `jenkins_test.go`.
-* Add an example for how to create "integration tests" out of multiple "stages," where any one of the stages can be skipped to speed up local iterative development.  See `jenkins_test.go`.
+* Add a new `--circle-ci-2-machine-executor` flag to `configure-environment-for-gruntwork-module` so you can use the script with CircleCI 2.0&apos;s machine executor.
+* Add an example for how to create &quot;unit tests&quot; for modules that run locally and relatively quickly using Docker and Docker Compose. See `jenkins_test.go`.
+* Add an example for how to create &quot;integration tests&quot; out of multiple &quot;stages,&quot; where any one of the stages can be skipped to speed up local iterative development.  See `jenkins_test.go`.
 
 </div>
 
@@ -88,7 +88,7 @@ Warning: this release contains BACKWARDS INCOMPATIBLE CHANGES to `scheduled-lamb
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-ecs/pull/54: You can now configure a health check grace period for your ECS services using the new `health_check_grace_period_seconds` parameter! Also, we've added another `depends_on` clause for the ALB Target Group in the `ecs-service-with-alb` module, which should help work around https://github.com/hashicorp/terraform/issues/12634.
+  https://github.com/gruntwork-io/module-ecs/pull/54: You can now configure a health check grace period for your ECS services using the new `health_check_grace_period_seconds` parameter! Also, we&apos;ve added another `depends_on` clause for the ALB Target Group in the `ecs-service-with-alb` module, which should help work around https://github.com/hashicorp/terraform/issues/12634.
 
 </div>
 
@@ -194,7 +194,7 @@ Note, this release contains BACKWARDS INCOMPATIBLE CHANGES to the `single-server
 
 1. Fixed a number of minor bugs in the `persistent-ebs-volume` module. All AWS API calls in `mount-ebs-volume` are now done with retries, as there are transient reasons why they might fail (e.g., IAM permissions taking a while to propagate). Fix a syntax error in `unmount-ebs-volume`.
 
-1. The `aws_security_group` in now uses `name_prefix` instead of `name` and sets `create_before_destroy` to `true`. This should fix the `DependencyViolation: resource sg-XXX has a dependent object` error described in https://github.com/terraform-providers/terraform-provider-aws/issues/1671. However, this will result in the Security Group being renamed and therefore, recreated. To update to this new version of `single-server`, which is used in the bastion host, OpenVPN server, Jenkins, and elsewhere, you'll need to:
+1. The `aws_security_group` in now uses `name_prefix` instead of `name` and sets `create_before_destroy` to `true`. This should fix the `DependencyViolation: resource sg-XXX has a dependent object` error described in https://github.com/terraform-providers/terraform-provider-aws/issues/1671. However, this will result in the Security Group being renamed and therefore, recreated. To update to this new version of `single-server`, which is used in the bastion host, OpenVPN server, Jenkins, and elsewhere, you&apos;ll need to:
     1. Find all resources that depend on this security group and remove that dependency. It is OK to do this in the AWS UI.
     1. Run `apply` with this new `single-server` version to create the new security group.
     1. Run `apply` in each module from step 1 to recreate the dependency.
@@ -207,6 +207,6 @@ Note, this release contains BACKWARDS INCOMPATIBLE CHANGES to the `single-server
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "eff1f0d48ffa60842a06c1c976d0d9d7"
+  "hash": "81f0ec519aced1abf80d1b739c4471f4"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-02/index.md
@@ -10,6 +10,7 @@ documentation](/guides/working-with-code/using-modules#updating).
 
 Here are the repos that were updated:
 
+- [terraform-aws-asg](#terraform-aws-asg)
 - [terraform-aws-cache](#terraform-aws-cache)
 - [terraform-aws-ci](#terraform-aws-ci)
 - [terraform-aws-ecs](#terraform-aws-ecs)
@@ -18,6 +19,24 @@ Here are the repos that were updated:
 - [terraform-aws-sam](#terraform-aws-sam)
 - [terraform-aws-security](#terraform-aws-security)
 - [terraform-aws-server](#terraform-aws-server)
+- [terraform-aws-utilities](#terraform-aws-utilities)
+
+
+## terraform-aws-asg
+
+
+### [v0.6.7](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.7)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 2/28/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.7">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  https://github.com/gruntwork-io/module-asg/pull/23: Fix rolling deployment script path on Windows.
+
+</div>
+
 
 
 ## terraform-aws-cache
@@ -148,6 +167,19 @@ Warning: this release contains BACKWARDS INCOMPATIBLE CHANGES to `scheduled-lamb
 ## terraform-aws-security
 
 
+### [v0.7.2](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.7.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 2/28/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.7.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  https://github.com/gruntwork-io/module-security/pull/74: Add a new module called `ssh-iam-selinux-policy`. If you are using `ssh-iam` on CentOS, you should install this module so that SELinux doesn't prevent `ssh-iam` from working!
+
+</div>
+
+
 ### [v0.7.1](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.7.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
@@ -168,7 +200,7 @@ Warning: this release contains BACKWARDS INCOMPATIBLE CHANGES to `scheduled-lamb
 ### [v0.4.1](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.4.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/23/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.4.1">Release notes</a></small>
+  <small>Published: 2/22/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.4.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -203,10 +235,33 @@ Note, this release contains BACKWARDS INCOMPATIBLE CHANGES to the `single-server
 
 
 
+## terraform-aws-utilities
+
+
+### [v0.0.2](https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.0.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 2/28/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.0.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  https://github.com/gruntwork-io/package-terraform-utilities/pull/3: Added two new modules:
+
+1. `operating-system`: This can be used to detect the operating system on which Terraform is currently running.
+
+1. `join-path`: This can be used to join multiple path parts (folders, files) into a single path, using the proper separator for the current OS.
+
+The primary use case is so we can format paths properly on Windows vs Linux.
+
+</div>
+
+
+
 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "eff1f0d48ffa60842a06c1c976d0d9d7"
+  "hash": "4c2256518f8d43f8bfec9e1f720d3f15"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-02/index.md
@@ -10,7 +10,6 @@ documentation](/guides/working-with-code/using-modules#updating).
 
 Here are the repos that were updated:
 
-- [terraform-aws-asg](#terraform-aws-asg)
 - [terraform-aws-cache](#terraform-aws-cache)
 - [terraform-aws-ci](#terraform-aws-ci)
 - [terraform-aws-ecs](#terraform-aws-ecs)
@@ -19,24 +18,6 @@ Here are the repos that were updated:
 - [terraform-aws-sam](#terraform-aws-sam)
 - [terraform-aws-security](#terraform-aws-security)
 - [terraform-aws-server](#terraform-aws-server)
-- [terraform-aws-utilities](#terraform-aws-utilities)
-
-
-## terraform-aws-asg
-
-
-### [v0.6.7](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.7)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/1/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.7">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  https://github.com/gruntwork-io/module-asg/pull/23: Fix rolling deployment script path on Windows.
-
-</div>
-
 
 
 ## terraform-aws-cache
@@ -167,19 +148,6 @@ Warning: this release contains BACKWARDS INCOMPATIBLE CHANGES to `scheduled-lamb
 ## terraform-aws-security
 
 
-### [v0.7.2](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.7.2)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/1/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.7.2">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  https://github.com/gruntwork-io/module-security/pull/74: Add a new module called `ssh-iam-selinux-policy`. If you are using `ssh-iam` on CentOS, you should install this module so that SELinux doesn't prevent `ssh-iam` from working!
-
-</div>
-
-
 ### [v0.7.1](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.7.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
@@ -235,33 +203,10 @@ Note, this release contains BACKWARDS INCOMPATIBLE CHANGES to the `single-server
 
 
 
-## terraform-aws-utilities
-
-
-### [v0.0.2](https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.0.2)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/1/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.0.2">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  https://github.com/gruntwork-io/package-terraform-utilities/pull/3: Added two new modules:
-
-1. `operating-system`: This can be used to detect the operating system on which Terraform is currently running.
-
-1. `join-path`: This can be used to join multiple path parts (folders, files) into a single path, using the proper separator for the current OS.
-
-The primary use case is so we can format paths properly on Windows vs Linux.
-
-</div>
-
-
-
 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "6bde12561481b749707c50008c24b9ed"
+  "hash": "eff1f0d48ffa60842a06c1c976d0d9d7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-03/index.md
@@ -73,6 +73,19 @@ Here are the repos that were updated:
 </div>
 
 
+### [v0.6.7](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.7)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 3/1/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.7">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  https://github.com/gruntwork-io/module-asg/pull/23: Fix rolling deployment script path on Windows.
+
+</div>
+
+
 
 ## terraform-aws-cache
 
@@ -339,6 +352,19 @@ THIS VERSION IS NOT BACKWARDS COMPATIBLE AND ANY CODE REFERENCING AUTO-GENERATED
 </div>
 
 
+### [v0.7.2](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.7.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 3/1/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.7.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  https://github.com/gruntwork-io/module-security/pull/74: Add a new module called `ssh-iam-selinux-policy`. If you are using `ssh-iam` on CentOS, you should install this module so that SELinux doesn't prevent `ssh-iam` from working!
+
+</div>
+
+
 
 ## terraform-aws-server
 
@@ -420,6 +446,25 @@ The `s3-static-website` module now enables server-side encryption by default. Th
 </div>
 
 
+### [v0.0.2](https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.0.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 3/1/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.0.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  https://github.com/gruntwork-io/package-terraform-utilities/pull/3: Added two new modules:
+
+1. `operating-system`: This can be used to detect the operating system on which Terraform is currently running.
+
+1. `join-path`: This can be used to join multiple path parts (folders, files) into a single path, using the proper separator for the current OS.
+
+The primary use case is so we can format paths properly on Windows vs Linux.
+
+</div>
+
+
 
 ## terraform-aws-zookeeper
 
@@ -491,6 +536,6 @@ The `s3-static-website` module now enables server-side encryption by default. Th
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "c111a7d2fc37c926167bfa0159eb5268"
+  "hash": "aa44892194431d08d7da4ea149998348"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-03/index.md
@@ -33,7 +33,7 @@ Here are the repos that were updated:
 ### [v0.0.17](https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.17)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/26/2018 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.17">Release notes</a></small>
+  <small>Published: 3/27/2018 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.17">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -283,7 +283,7 @@ Going forward, we will immediately be investing in a new approach to writing mod
 ### [v0.1.1](https://github.com/gruntwork-io/terraform-aws-sam/releases/tag/v0.1.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/21/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-sam/releases/tag/v0.1.1">Release notes</a></small>
+  <small>Published: 3/22/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-sam/releases/tag/v0.1.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -296,7 +296,7 @@ Going forward, we will immediately be investing in a new approach to writing mod
 ### [v0.1.0](https://github.com/gruntwork-io/terraform-aws-sam/releases/tag/v0.1.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/20/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-sam/releases/tag/v0.1.0">Release notes</a></small>
+  <small>Published: 3/21/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-sam/releases/tag/v0.1.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -346,7 +346,7 @@ THIS VERSION IS NOT BACKWARDS COMPATIBLE AND ANY CODE REFERENCING AUTO-GENERATED
 ### [v0.4.2](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.4.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/11/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.4.2">Release notes</a></small>
+  <small>Published: 3/12/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.4.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -389,7 +389,7 @@ THIS VERSION IS NOT BACKWARDS COMPATIBLE AND ANY CODE REFERENCING AUTO-GENERATED
 ### [v0.3.0](https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.3.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/13/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.3.0">Release notes</a></small>
+  <small>Published: 3/14/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.3.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -440,7 +440,7 @@ The `s3-static-website` module now enables server-side encryption by default. Th
 ### [v0.4.0](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/22/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.0">Release notes</a></small>
+  <small>Published: 3/23/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -491,6 +491,6 @@ The `s3-static-website` module now enables server-side encryption by default. Th
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "272765537f4bff1dded237cc94f090b2"
+  "hash": "167b543b46cc6c1e9aea096dd670f512"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-03/index.md
@@ -152,7 +152,7 @@ Replaces `bastion_host_security_group_id` with `allow_connections_from_security_
 **NOTE**: due to a bug in Terraform, if you update an existing cluster with a spot price, you might see an error like this when you run `apply`:
 
 ```
-* module.ecs_cluster.aws_launch_configuration.ecs: aws_launch_configuration.ecs: diffs didn't match during apply. This is a bug with Terraform and should be reported as a GitHub Issue.
+* module.ecs_cluster.aws_launch_configuration.ecs: aws_launch_configuration.ecs: diffs didn&apos;t match during apply. This is a bug with Terraform and should be reported as a GitHub Issue.
 ```
 
 Running `apply` a second time seems to complete without errors.
@@ -201,11 +201,11 @@ Please note that this is a **pre-release**.  See [v0.2.0](https://github.com/gru
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  We've updated the Kafka module to include support for Confluent Schema Registry, REST Proxy, and Kafka Connect! These services also include support for SSL. We've also introduced a new, simpler configuration file approach where you can specify any number of well-defined "replacement variables" that will automatically be updated when you call the appropriate `run-xxx` script at boot in user data (e.g. `run-schema-registry`).
+  We&apos;ve updated the Kafka module to include support for Confluent Schema Registry, REST Proxy, and Kafka Connect! These services also include support for SSL. We&apos;ve also introduced a new, simpler configuration file approach where you can specify any number of well-defined &quot;replacement variables&quot; that will automatically be updated when you call the appropriate `run-xxx` script at boot in user data (e.g. `run-schema-registry`).
 
 Unfortunately, our automated tests consistently fail for Amazon Linux only, and we encountered what appear to be several bugs with Schema Registry itself in how forwarding is handled. Diagnosing these issues has proven to be very trying because after we make a fix, it takes another 45 minutes for a full build to complete, leading to an incredibly long feedback loop.
 
-As a result, we're marking this as **pre-release**. That means that you are free to begin using this code, but you should know that, until our automated tests pass, you may encounter subtle issues, especially around forwarding from non-master nodes.
+As a result, we&apos;re marking this as **pre-release**. That means that you are free to begin using this code, but you should know that, until our automated tests pass, you may encounter subtle issues, especially around forwarding from non-master nodes.
 
 Going forward, we will immediately be investing in a new approach to writing modules that makes our cycle time about 10x faster. In particular, we intend to run the Confluent Stack using Docker Compose for local testing so that we can restart it multiple times without having to wait either for Packer to build a new AMI or for AWS to launch a whole cluster of EC2 Instances. Stay tuned!
 
@@ -271,7 +271,7 @@ Going forward, we will immediately be investing in a new approach to writing mod
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-aws-monitoring/pull/47: Fix `run-cloudwatch-logs-agent.sh` so for Amazon Linux and CentOS so instead of sending `/var/log/auth.log`, which doesn't exist, it sends `/var/log/secure` to CloudWatch Logs. 
+  https://github.com/gruntwork-io/module-aws-monitoring/pull/47: Fix `run-cloudwatch-logs-agent.sh` so for Amazon Linux and CentOS so instead of sending `/var/log/auth.log`, which doesn&apos;t exist, it sends `/var/log/secure` to CloudWatch Logs. 
 
 </div>
 
@@ -360,7 +360,7 @@ THIS VERSION IS NOT BACKWARDS COMPATIBLE AND ANY CODE REFERENCING AUTO-GENERATED
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-security/pull/74: Add a new module called `ssh-iam-selinux-policy`. If you are using `ssh-iam` on CentOS, you should install this module so that SELinux doesn't prevent `ssh-iam` from working!
+  https://github.com/gruntwork-io/module-security/pull/74: Add a new module called `ssh-iam-selinux-policy`. If you are using `ssh-iam` on CentOS, you should install this module so that SELinux doesn&apos;t prevent `ssh-iam` from working!
 
 </div>
 
@@ -424,7 +424,7 @@ THIS VERSION IS NOT BACKWARDS COMPATIBLE AND ANY CODE REFERENCING AUTO-GENERATED
 
 BACKWARDS INCOMPATIBLE CHANGE
 
-The `s3-static-website` module now enables server-side encryption by default. The encryption settings can be configured by a new input variable called `server_side_encryption_configuration`. If you'd like to disable server-side encryption, set `server_side_encryption_configuration = []`.
+The `s3-static-website` module now enables server-side encryption by default. The encryption settings can be configured by a new input variable called `server_side_encryption_configuration`. If you&apos;d like to disable server-side encryption, set `server_side_encryption_configuration = []`.
 
 </div>
 
@@ -490,14 +490,14 @@ The primary use case is so we can format paths properly on Windows vs Linux.
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  - #22: This repo now has its own standalone "bash commons" module.
+  - #22: This repo now has its own standalone &quot;bash commons&quot; module.
 
-   Recently, we've begun introducing Docker containers into our repos to enable a much faster cycle time when building the module. As part of this effort, we've consolidated all our generic bash functions into a "bash commons" library that can be shared among multiple modules in this repo.
+   Recently, we&apos;ve begun introducing Docker containers into our repos to enable a much faster cycle time when building the module. As part of this effort, we&apos;ve consolidated all our generic bash functions into a &quot;bash commons&quot; library that can be shared among multiple modules in this repo.
 
    With this update we place the bash-commons libraries into their own module. Although the interface to all the script modules in this repo remains unchanged, you now have to `gruntwork-install` the bash-commons module in order for many of the modules to work. You can install the bash-commons module like this:
 
    ```
-   gruntwork-install --module-name 'bash-commons' --tag '~&gt;0.4.0' --repo https://github.com/gruntwork-io/package-zookeeper
+   gruntwork-install --module-name &apos;bash-commons&apos; --tag &apos;~&gt;0.4.0&apos; --repo https://github.com/gruntwork-io/package-zookeeper
    ```
 
 </div>
@@ -536,6 +536,6 @@ The primary use case is so we can format paths properly on Windows vs Linux.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "aa44892194431d08d7da4ea149998348"
+  "hash": "8a43269a02939f4430d666805617cbeb"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-03/index.md
@@ -33,7 +33,7 @@ Here are the repos that were updated:
 ### [v0.0.17](https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.17)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/27/2018 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.17">Release notes</a></small>
+  <small>Published: 3/26/2018 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.17">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -69,19 +69,6 @@ Here are the repos that were updated:
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
   https://github.com/gruntwork-io/module-asg/pull/24: Update to latest `package-terraform-utilities` to fix a bug where the `join-path` module doesn’t work with newer versions of Python.
-
-</div>
-
-
-### [v0.6.7](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.7)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/1/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.7">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  https://github.com/gruntwork-io/module-asg/pull/23: Fix rolling deployment script path on Windows.
 
 </div>
 
@@ -296,7 +283,7 @@ Going forward, we will immediately be investing in a new approach to writing mod
 ### [v0.1.1](https://github.com/gruntwork-io/terraform-aws-sam/releases/tag/v0.1.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/22/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-sam/releases/tag/v0.1.1">Release notes</a></small>
+  <small>Published: 3/21/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-sam/releases/tag/v0.1.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -309,7 +296,7 @@ Going forward, we will immediately be investing in a new approach to writing mod
 ### [v0.1.0](https://github.com/gruntwork-io/terraform-aws-sam/releases/tag/v0.1.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/21/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-sam/releases/tag/v0.1.0">Release notes</a></small>
+  <small>Published: 3/20/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-sam/releases/tag/v0.1.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -352,19 +339,6 @@ THIS VERSION IS NOT BACKWARDS COMPATIBLE AND ANY CODE REFERENCING AUTO-GENERATED
 </div>
 
 
-### [v0.7.2](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.7.2)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/1/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.7.2">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  https://github.com/gruntwork-io/module-security/pull/74: Add a new module called `ssh-iam-selinux-policy`. If you are using `ssh-iam` on CentOS, you should install this module so that SELinux doesn't prevent `ssh-iam` from working!
-
-</div>
-
-
 
 ## terraform-aws-server
 
@@ -372,7 +346,7 @@ THIS VERSION IS NOT BACKWARDS COMPATIBLE AND ANY CODE REFERENCING AUTO-GENERATED
 ### [v0.4.2](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.4.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/12/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.4.2">Release notes</a></small>
+  <small>Published: 3/11/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.4.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -415,7 +389,7 @@ THIS VERSION IS NOT BACKWARDS COMPATIBLE AND ANY CODE REFERENCING AUTO-GENERATED
 ### [v0.3.0](https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.3.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/14/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.3.0">Release notes</a></small>
+  <small>Published: 3/13/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.3.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -446,25 +420,6 @@ The `s3-static-website` module now enables server-side encryption by default. Th
 </div>
 
 
-### [v0.0.2](https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.0.2)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/1/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.0.2">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  https://github.com/gruntwork-io/package-terraform-utilities/pull/3: Added two new modules:
-
-1. `operating-system`: This can be used to detect the operating system on which Terraform is currently running.
-
-1. `join-path`: This can be used to join multiple path parts (folders, files) into a single path, using the proper separator for the current OS.
-
-The primary use case is so we can format paths properly on Windows vs Linux.
-
-</div>
-
-
 
 ## terraform-aws-zookeeper
 
@@ -472,7 +427,7 @@ The primary use case is so we can format paths properly on Windows vs Linux.
 ### [v0.4.1](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/30/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.1">Release notes</a></small>
+  <small>Published: 3/29/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -485,7 +440,7 @@ The primary use case is so we can format paths properly on Windows vs Linux.
 ### [v0.4.0](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/23/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.0">Release notes</a></small>
+  <small>Published: 3/22/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -536,6 +491,6 @@ The primary use case is so we can format paths properly on Windows vs Linux.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "aa44892194431d08d7da4ea149998348"
+  "hash": "272765537f4bff1dded237cc94f090b2"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-03/index.md
@@ -427,7 +427,7 @@ The `s3-static-website` module now enables server-side encryption by default. Th
 ### [v0.4.1](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/29/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.1">Release notes</a></small>
+  <small>Published: 3/30/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -491,6 +491,6 @@ The `s3-static-website` module now enables server-side encryption by default. Th
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "167b543b46cc6c1e9aea096dd670f512"
+  "hash": "c111a7d2fc37c926167bfa0159eb5268"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-04/index.md
@@ -368,7 +368,7 @@ The main motivation for locking down EC2 metadata is as follows:
 ### [v0.4.3](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/25/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.3">Release notes</a></small>
+  <small>Published: 4/26/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -396,6 +396,6 @@ The main motivation for locking down EC2 metadata is as follows:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "12eb772ba238756a2bb027f2f7daaa28"
+  "hash": "663afa12cc91701ee6680fe83d1f300b"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-04/index.md
@@ -53,11 +53,11 @@ Here are the repos that were updated:
 * redis_without_snapshotting_without_auth_token
 * redis_without_snapshotting_with_auth_token
 
-To update your existing Redis cluster ensure you use `terragrunt state mv &lt;old_address&gt; &lt;new_address&gt;` to ensure that your cluster isn't deleted when you run `terraform apply`
+To update your existing Redis cluster ensure you use `terragrunt state mv &lt;old_address&gt; &lt;new_address&gt;` to ensure that your cluster isn&apos;t deleted when you run `terraform apply`
 
 For example:
 
-To update a Redis cluster that was deployed using the `redis_without_snapshotting` resource to one of the new resources, you'll simply run:
+To update a Redis cluster that was deployed using the `redis_without_snapshotting` resource to one of the new resources, you&apos;ll simply run:
 
 ```
 terragrunt state mv module.redis.aws_elasticache_replication_group.redis_without_snapshotting module.redis.aws_elasticache_replication_group.redis_without_snapshotting_without_auth_token
@@ -98,7 +98,7 @@ terragrunt state mv module.redis.aws_elasticache_replication_group.redis_without
   https://github.com/gruntwork-io/module-data-storage/pull/40, https://github.com/gruntwork-io/module-data-storage/pull/41: The `aurora` module now exposes two new input variables:
 
 * `monitoring_role_arn`: specify an IAM role to associate with the Aurora DB.
-* `monitoring_interval`: enable enhanced monitoring. Note that enhanced monitoring requires IAM permissions. If you don't specify `monitoring_role_arn` yourself, the `aurora` module will add the appropriate permissions automatically. If you do specify a custom `monitoring_role_arn`, make sure it has the IAM permissions required for enhanced monitoring.
+* `monitoring_interval`: enable enhanced monitoring. Note that enhanced monitoring requires IAM permissions. If you don&apos;t specify `monitoring_role_arn` yourself, the `aurora` module will add the appropriate permissions automatically. If you do specify a custom `monitoring_role_arn`, make sure it has the IAM permissions required for enhanced monitoring.
 
 This release also fixes a bug in v0.6.1 where the `monitoring_role_arn` param was not properly used in the `rds` module.
 
@@ -116,7 +116,7 @@ This release also fixes a bug in v0.6.1 where the `monitoring_role_arn` param wa
   https://github.com/gruntwork-io/module-data-storage/pull/39: The `rds` module now exposes two new input variables:
 
 * `monitoring_role_arn`: specify an IAM role to associate with the RDS DB.
-* `monitoring_interval`: enable enhanced monitoring. Note that enhanced monitoring requires IAM permissions. If you don't specify `monitoring_role_arn` yourself, the `rds` module will add the appropriate permissions automatically. If you do specify a custom `monitoring_role_arn`, make sure it has the IAM permissions required for enhanced monitoring.
+* `monitoring_interval`: enable enhanced monitoring. Note that enhanced monitoring requires IAM permissions. If you don&apos;t specify `monitoring_role_arn` yourself, the `rds` module will add the appropriate permissions automatically. If you do specify a custom `monitoring_role_arn`, make sure it has the IAM permissions required for enhanced monitoring.
 
 
 </div>
@@ -155,9 +155,9 @@ Please note that this is a **pre-release**. See [v0.3.0](https://github.com/grun
 - Update Kafka to work with CentOS.
 - You can now assign DNS names to the ENIs used by Kafka, and optionally make ENIs public (though we strongly advise keeping ENIs private for all production deployments)
 - We now bundle the running of [kafka-health-check](https://github.com/andreas-schroeder/kafka-health-check) directly with `run-kafka`. This is because a  more sophisticated health check tool is needed by Kafka in order for Kafka to accurately report its health status to the Elastic Load Balancer. Unfortunately, this required a backwards-incompatible change to the `run-kafka` interface.
-- The configuration files are now easier to customize by using a "variable substitution" paradigm (See the [run-kafka config README](https://github.com/gruntwork-io/package-kafka/tree/master/modules/run-kafka/config) for additional details).
-- We've introduced a `bash-commons` module that consolidates all the common bash functions we use into a single module. This makes all bash scripts shorter and gives us higher-quality more reusable bash functions. Just be sure to `gruntwork-install` the `bash-commons` module! See below for details.
-- For developers of this module, we introduced a number of improved patterns for building and testing the module including running the Kafka cluster in Docker and being able to selectively disable some stages of the automated tests from running (e.g. don't rebuild the AMI every time, just reuse the previous AMI).
+- The configuration files are now easier to customize by using a &quot;variable substitution&quot; paradigm (See the [run-kafka config README](https://github.com/gruntwork-io/package-kafka/tree/master/modules/run-kafka/config) for additional details).
+- We&apos;ve introduced a `bash-commons` module that consolidates all the common bash functions we use into a single module. This makes all bash scripts shorter and gives us higher-quality more reusable bash functions. Just be sure to `gruntwork-install` the `bash-commons` module! See below for details.
+- For developers of this module, we introduced a number of improved patterns for building and testing the module including running the Kafka cluster in Docker and being able to selectively disable some stages of the automated tests from running (e.g. don&apos;t rebuild the AMI every time, just reuse the previous AMI).
 
 Related PRs: #27, #28, #29, #30 
 
@@ -177,7 +177,7 @@ All tests are passing for Kafka, and the following Kafka modules are all product
   
   - One important change is that we now bundle [kafka-health-check](https://github.com/andreas-schroeder/kafka-health-check) directly with `run-kafka`. Previously, this script did not install any health check tool. Kafka-health-check runs locally on a Kafka broker and exposes an HTTP interface (by default, port 8000) that will return an HTTP 200 response when the broker is healthy. 
     
-    Technically, this isn't a backwards-incompatible change because you can still query the Kafka listener directly on port 9092, but we want to make sure you're aware that there is now a better way to check the health status of Kafka.
+    Technically, this isn&apos;t a backwards-incompatible change because you can still query the Kafka listener directly on port 9092, but we want to make sure you&apos;re aware that there is now a better way to check the health status of Kafka.
 
    - In order to accommodate the kafka-health-check tool, we needed to define three separate listeners for Kafka in the [listeners](https://github.com/gruntwork-io/package-kafka/blob/master/modules/run-kafka/config/kafka/server-4.0.x.properties#L45) and [advertised.listeners](https://github.com/gruntwork-io/package-kafka/blob/master/modules/run-kafka/config/kafka/server-4.0.x.properties#L50) properties of the Kafka configuration file:
 
@@ -185,7 +185,7 @@ All tests are passing for Kafka, and the following Kafka modules are all product
      - `INTERNAL`: Accepts traffic from fellow Kafka brokers.
      - `HEALTHCHECK`: Only accepts traffic from `127.0.0.1` and intended for use with kafka-health-check
 
-      We need multiple listeners so that external Kafka clients, fellow Kafka brokers, and the kafka-health-check tool each receive the appropriate "advertised listener" property when connecting to Kafka. This was especially useful for supporting Kafka in a local Docker environment as well.
+      We need multiple listeners so that external Kafka clients, fellow Kafka brokers, and the kafka-health-check tool each receive the appropriate &quot;advertised listener&quot; property when connecting to Kafka. This was especially useful for supporting Kafka in a local Docker environment as well.
 
      #### Example
 
@@ -201,11 +201,11 @@ All tests are passing for Kafka, and the following Kafka modules are all product
       inter.broker.listener.name=INTERNAL
       ```
    
-      This indicates that Kafka will accept connections from any IP address on ports 9092 and 9093, and only from `127.0.0.1` on port 9094. Suppose Kafka were to receive a connection on port 9093. It would then return an "advertised listener" value to the client of `172.21.0.3:9093`, the advertised listener value that corresponds to the `INTERNAL` listener. The idea here is that a Kafka client may have used any IP address that reaches the Kafka broker to connect initially, but going forward the client should specifically use `172.21.0.3:9093` to connect.
+      This indicates that Kafka will accept connections from any IP address on ports 9092 and 9093, and only from `127.0.0.1` on port 9094. Suppose Kafka were to receive a connection on port 9093. It would then return an &quot;advertised listener&quot; value to the client of `172.21.0.3:9093`, the advertised listener value that corresponds to the `INTERNAL` listener. The idea here is that a Kafka client may have used any IP address that reaches the Kafka broker to connect initially, but going forward the client should specifically use `172.21.0.3:9093` to connect.
 
    - Finally, the interface to `run-kafka` has changed. It now requires the following arguments:
-      - `--config-path "/path/to/kafka.properties"` 
-      - `--log4j-config-path "/path/to/log4j.properties"`
+      - `--config-path &quot;/path/to/kafka.properties&quot;` 
+      - `--log4j-config-path &quot;/path/to/log4j.properties&quot;`
 
       In addition, there are a some new arguments. See the [updated run-kafka docs](https://github.com/gruntwork-io/package-kafka/blob/master/modules/run-kafka/bin/run-kafka#L84)
 
@@ -217,21 +217,21 @@ All tests are passing for Kafka, and the following Kafka modules are all product
 
    - `kafka-iam-permissions`: We fixed and issue where Kafka brokers did not have the appropriate IAM permissions to discover the Elastic Network Interfaces (ENIs) of themselves or other Kafka brokers.
 
-   - `kafka-cluster`: We added the ability to assign a DNS name and public IP to each Elastic Network Interface. Note that we NOT recommend exposing Kafka on public IPs for production usage. Note also that Kafka does not listen over HTTPS, so DNS names are a convenient way to address a Kafka cluster, but you'll still need to use TCP-based Kafka clients to connect. We'll soon be releasing REST Proxy, which does expose an HTTPS interface to Kafka.
+   - `kafka-cluster`: We added the ability to assign a DNS name and public IP to each Elastic Network Interface. Note that we NOT recommend exposing Kafka on public IPs for production usage. Note also that Kafka does not listen over HTTPS, so DNS names are a convenient way to address a Kafka cluster, but you&apos;ll still need to use TCP-based Kafka clients to connect. We&apos;ll soon be releasing REST Proxy, which does expose an HTTPS interface to Kafka.
        - If you wish to assign a DNS name to each Kafka broker, set the `var.dns_name_common_portion` or `var.dns_names` variables, and also the `var.route53_hosted_zone_id` variable.
-       - To expose Kafka's ENIs publicly, set `var.enable_elastic_ips` to `true`. (WARNING: Do not do this in a production setting!)
+       - To expose Kafka&apos;s ENIs publicly, set `var.enable_elastic_ips` to `true`. (WARNING: Do not do this in a production setting!)
 
 1. For your Packer template, make the following updates:
  
-   - You'll now need to install the `bash-commons` module from this repo. That's because almost all bash scripts in this repo now use the common bash functions in bash-commons rather than duplicating the same bash functions each time.
+   - You&apos;ll now need to install the `bash-commons` module from this repo. That&apos;s because almost all bash scripts in this repo now use the common bash functions in bash-commons rather than duplicating the same bash functions each time.
 
    To install this, add the following line to your Packer template above all the other `gruntwork-install` calls for `package-kafka`:
 
    ```bash
-    gruntwork-install --module-name 'bash-commons' --tag 'v0.3.0' --repo https://github.com/gruntwork-io/package-kafka
+    gruntwork-install --module-name &apos;bash-commons&apos; --tag &apos;v0.3.0&apos; --repo https://github.com/gruntwork-io/package-kafka
    ```
 
-   - You'll need to do the same when installing Zookeeper. See the [zookeeper-ami example](https://github.com/gruntwork-io/package-kafka/blob/master/examples/zookeeper-ami/configure-zookeeper-server.sh#L8)
+   - You&apos;ll need to do the same when installing Zookeeper. See the [zookeeper-ami example](https://github.com/gruntwork-io/package-kafka/blob/master/examples/zookeeper-ami/configure-zookeeper-server.sh#L8)
 
    - Upgrade to the newest `install-kafka` script, which now downloads Kafka v1.0.0 and validates the downloaded binary with the Apacha Kafka GPG key.
 
@@ -239,9 +239,9 @@ All tests are passing for Kafka, and the following Kafka modules are all product
 
 1. Next, update the user data for your Kafka brokers by making sure your arguments to `run-kafka` match the new `run-kafka` interface. 
 
-   Note that the default values for `run-kafka` will "just work", however if you previously added optional arguments, you may need to update the argument values or argument names you pass in. See the [kafka user data example](https://github.com/gruntwork-io/package-kafka/blob/master/examples/kafka-zookeeper-standalone-clusters/user-data/kafka-user-data.sh#L39-L59) for a good reference, as well as the [updated run-kafka docs](https://github.com/gruntwork-io/package-kafka/blob/master/modules/run-kafka/bin/run-kafka#L84).
+   Note that the default values for `run-kafka` will &quot;just work&quot;, however if you previously added optional arguments, you may need to update the argument values or argument names you pass in. See the [kafka user data example](https://github.com/gruntwork-io/package-kafka/blob/master/examples/kafka-zookeeper-standalone-clusters/user-data/kafka-user-data.sh#L39-L59) for a good reference, as well as the [updated run-kafka docs](https://github.com/gruntwork-io/package-kafka/blob/master/modules/run-kafka/bin/run-kafka#L84).
 
-1. Finally, we've updated the way that configuration files are customized for Kafka. See the new [run-kafka config README](https://github.com/gruntwork-io/package-kafka/tree/master/modules/run-kafka/config) for additional details.
+1. Finally, we&apos;ve updated the way that configuration files are customized for Kafka. See the new [run-kafka config README](https://github.com/gruntwork-io/package-kafka/tree/master/modules/run-kafka/config) for additional details.
 
 </div>
 
@@ -396,6 +396,6 @@ The main motivation for locking down EC2 metadata is as follows:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "6649cb31f081d2307e950c928bae22dd"
+  "hash": "0e05e70d5b1cd9e6f7ce27c4137b2719"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-04/index.md
@@ -144,7 +144,7 @@ Please note that this is a **pre-release**. See [v0.3.0](https://github.com/grun
 ### [v0.3.0](https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.3.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/9/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.3.0">Release notes</a></small>
+  <small>Published: 4/8/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.3.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -253,7 +253,7 @@ All tests are passing for Kafka, and the following Kafka modules are all product
 ### [v0.8.1](https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.8.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/30/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.8.1">Release notes</a></small>
+  <small>Published: 4/29/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.8.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -368,7 +368,7 @@ The main motivation for locking down EC2 metadata is as follows:
 ### [v0.4.3](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/26/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.3">Release notes</a></small>
+  <small>Published: 4/25/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -396,6 +396,6 @@ The main motivation for locking down EC2 metadata is as follows:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "6649cb31f081d2307e950c928bae22dd"
+  "hash": "12eb772ba238756a2bb027f2f7daaa28"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-04/index.md
@@ -144,7 +144,7 @@ Please note that this is a **pre-release**. See [v0.3.0](https://github.com/grun
 ### [v0.3.0](https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.3.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/8/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.3.0">Release notes</a></small>
+  <small>Published: 4/9/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.3.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -253,7 +253,7 @@ All tests are passing for Kafka, and the following Kafka modules are all product
 ### [v0.8.1](https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.8.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/29/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.8.1">Release notes</a></small>
+  <small>Published: 4/30/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.8.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -396,6 +396,6 @@ The main motivation for locking down EC2 metadata is as follows:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "663afa12cc91701ee6680fe83d1f300b"
+  "hash": "6649cb31f081d2307e950c928bae22dd"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-05/index.md
@@ -80,7 +80,7 @@ Here are the repos that were updated:
 
   The following changes were made to the `server-group` module:
 
-- IMPROVEMENT: Fixed an issue where an Auto Scaling Group's `DesiredInstances` property was left at 0 after the `rolling_deployment.py` script failed to reach a passing health check before timing out. (#29)
+- IMPROVEMENT: Fixed an issue where an Auto Scaling Group&apos;s `DesiredInstances` property was left at 0 after the `rolling_deployment.py` script failed to reach a passing health check before timing out. (#29)
 - IMPROVEMENT: Expose `var.deployment_health_check_max_retries` and `var.deployment_health_check_retry_interval_in_seconds` so that Terraform code that calls the `server-group` module can control how long the `rolling_deployment.py` will run before timing out. (#29)
 - IMPROVEMENT: Updated to latest version of Boto to address transient AWS issues. (#29)
 - IMPROVEMENT: Expose `var.additional_security_group_ids` to add arbitrary Security Groups to the Launch Configuration created.
@@ -242,7 +242,7 @@ All the pre-commit hooks that were in `modules/pre-commit` are now in their own 
 
 Support added with merge of #15 
 
-Marking this as a pre-release given that we're introducing `elasticsearch-cluster` mostly so that other modules (namely: Logstash and Kibana) can begin integrating and using our own elasticsearch module. More features and enhancements will be added.
+Marking this as a pre-release given that we&apos;re introducing `elasticsearch-cluster` mostly so that other modules (namely: Logstash and Kibana) can begin integrating and using our own elasticsearch module. More features and enhancements will be added.
 
 </div>
 
@@ -272,12 +272,12 @@ Marking this as a pre-release given that we're introducing `elasticsearch-cluste
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  This release features a stable implementation of Kafka and all the Confluent Tools, and we consider this code production-ready. We are still marking this as a pre-release because we've discovered an unusual edge case with Zookeeper. 
+  This release features a stable implementation of Kafka and all the Confluent Tools, and we consider this code production-ready. We are still marking this as a pre-release because we&apos;ve discovered an unusual edge case with Zookeeper. 
 
-In particular, when Zookeeper is colocated with multiple other services and re-deployed one server at a time, one of the Zookeeper nodes will remain in the Ensemble, but fail to sync all the znodes (key/value pairs). As a result, when Kafka looks up information about a broker from the out-of-sync node, it receives the error "znode not found" and fails to start correctly. We have not seen any evidence that this issue affects a standalone Zookeeper cluster.
+In particular, when Zookeeper is colocated with multiple other services and re-deployed one server at a time, one of the Zookeeper nodes will remain in the Ensemble, but fail to sync all the znodes (key/value pairs). As a result, when Kafka looks up information about a broker from the out-of-sync node, it receives the error &quot;znode not found&quot; and fails to start correctly. We have not seen any evidence that this issue affects a standalone Zookeeper cluster.
 
 
-See "Backwards-Incompatible Changes" in [release v0.3.0](https://github.com/gruntwork-io/package-kafka/releases/tag/v0.3.0) for important background on the `EXTERNAL`, `INTERNAL`, and `HEALTHCHECK` Kafka listeners.
+See &quot;Backwards-Incompatible Changes&quot; in [release v0.3.0](https://github.com/gruntwork-io/package-kafka/releases/tag/v0.3.0) for important background on the `EXTERNAL`, `INTERNAL`, and `HEALTHCHECK` Kafka listeners.
 
 
 The changes in this release from v0.3.1 include the following:
@@ -291,7 +291,7 @@ The changes in this release from v0.3.1 include the following:
 The `source_ami_filter` used in all example Packer templates now species the additional filter:
 
   ```
-  "block-device-mapping.volume-type": "gp2",
+  &quot;block-device-mapping.volume-type&quot;: &quot;gp2&quot;,
   ```
 
 This ensures that the CentOS 7 AMI will use a `gp2` (SSD) EBS Volume by default.
@@ -300,13 +300,13 @@ This ensures that the CentOS 7 AMI will use a `gp2` (SSD) EBS Volume by default.
 All the `run-xxx` scripts now use a common pattern of arguments like `--kafka-brokers-eni-tag` and `--schema-registry-eni-tag-dns`. Previously, some arguments that made reference to ENI values did not have `eni` in their argument name.
 
 
-Previously, whenever a script searched for an Elastic Network Interface (ENI), it queried AWS for all a given EC2 Instance's ENIs and arbitrarily returned information about the first ENI in the results. Now, we explicitly look for the ENI whose [DeviceIndex](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-interface-attachment.html#w2ab2c21c10d438b9) is `1` to guarantee that we will get the ENI that re-attaches after an EC2 Instance re-spawns.
+Previously, whenever a script searched for an Elastic Network Interface (ENI), it queried AWS for all a given EC2 Instance&apos;s ENIs and arbitrarily returned information about the first ENI in the results. Now, we explicitly look for the ENI whose [DeviceIndex](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-interface-attachment.html#w2ab2c21c10d438b9) is `1` to guarantee that we will get the ENI that re-attaches after an EC2 Instance re-spawns.
 
 
 All Bash scripts have been updated to use the `bash-commons` module in this repo. Note that Gruntwork has also released an [official bash-commons repo](https://github.com/gruntwork-io/bash-commons) that we hope to migrate to in the future.
 
 
-One of our customers wished to assign their own Security Groups to the Kafka Cluster, in addition to the Security Group that's automatically created by the `kafka-cluster` module. So we added `var.additional_security_group_ids` to each of `kafka-cluster` and `confluent-tools-cluster`.
+One of our customers wished to assign their own Security Groups to the Kafka Cluster, in addition to the Security Group that&apos;s automatically created by the `kafka-cluster` module. So we added `var.additional_security_group_ids` to each of `kafka-cluster` and `confluent-tools-cluster`.
 
 
 Previously, Kafka Connect was not configured correctly to handle SSL. We made some updates to the default configuration so that Kafka Connect and connectors correctly connect to Kafka over SSL when applicable.
@@ -314,18 +314,18 @@ Previously, Kafka Connect was not configured correctly to handle SSL. We made so
 
 Previously, Schema Registry listed every possible Kafka listener, including the `EXTERNAL`, `INTERNAL`, and `HEALTHCHECK` listeners. This caused an issue where Schema Registry would choose a listener at random, sometimes fail to connect, and therefore fail to start.
 
-Schema Registry's configuration now lists only the `EXTERNAL` listeners for Kafka.
+Schema Registry&apos;s configuration now lists only the `EXTERNAL` listeners for Kafka.
 
 
-Previously, we evaluated every possible configuration variable that _could_ be used, which caused an issue when we attempted to resolve `&lt;__PUBLIC_IP__&gt;` even though there was no public IP address defined for an EC2 Instance. At the time, we solved this issue by "downgrading" to a private IP address, but this behavior was error prone.
+Previously, we evaluated every possible configuration variable that _could_ be used, which caused an issue when we attempted to resolve `&lt;__PUBLIC_IP__&gt;` even though there was no public IP address defined for an EC2 Instance. At the time, we solved this issue by &quot;downgrading&quot; to a private IP address, but this behavior was error prone.
 
-We now do "lazy evaluation" of configuration variables so that a configuration variable is only evaluated if it's actually used in a configuration file or script argument. Now, if you attempt to use `&lt;__PUBLIC_IP__&gt;` when there is no public IP address defined for the EC2 Instance, it will throw an error.
+We now do &quot;lazy evaluation&quot; of configuration variables so that a configuration variable is only evaluated if it&apos;s actually used in a configuration file or script argument. Now, if you attempt to use `&lt;__PUBLIC_IP__&gt;` when there is no public IP address defined for the EC2 Instance, it will throw an error.
 
 
 We now have an end-to-end integration tests for Kafka Connect, which helps us discover and fix some configuration issues!
 
 
-Over the next few weeks, we plan to dig in deeper to the Zookeeper issue. Once fixed, we'll make the appropriate changes and issue a final release.
+Over the next few weeks, we plan to dig in deeper to the Zookeeper issue. Once fixed, we&apos;ll make the appropriate changes and issue a final release.
 
 </div>
 
@@ -342,7 +342,7 @@ Over the next few weeks, we plan to dig in deeper to the Zookeeper issue. Once f
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/package-lambda/pull/13, https://github.com/gruntwork-io/package-lambda/pull/14: We've added a new `keep-warm` module that can be used to invoke your Lambda functions on a scheduled basis, and with a configurable concurrency level, keeping those functions warm to avoid the cold start overhead.
+  https://github.com/gruntwork-io/package-lambda/pull/13, https://github.com/gruntwork-io/package-lambda/pull/14: We&apos;ve added a new `keep-warm` module that can be used to invoke your Lambda functions on a scheduled basis, and with a configurable concurrency level, keeping those functions warm to avoid the cold start overhead.
 
 </div>
 
@@ -477,6 +477,6 @@ BACKWARDS INCOMPATIBLE CHANGES
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "be750d798971a76d4304fb57d1d5f7f7"
+  "hash": "6e8c25ab79a44d7d9214f70da4531085"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-05/index.md
@@ -233,7 +233,7 @@ All the pre-commit hooks that were in `modules/pre-commit` are now in their own 
 ### [v0.0.2](https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.0.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/29/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.0.2">Release notes</a></small>
+  <small>Published: 5/30/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.0.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -477,6 +477,6 @@ BACKWARDS INCOMPATIBLE CHANGES
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "2967d19d30589272b3dcb2578e3f3cad"
+  "hash": "1ed8dc47ed090725370906f449fee56d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-05/index.md
@@ -43,7 +43,7 @@ Here are the repos that were updated:
 ### [v0.0.18](https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.18)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/8/2018 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.18">Release notes</a></small>
+  <small>Published: 5/9/2018 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.18">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -108,7 +108,7 @@ Here are the repos that were updated:
 ### [v0.9.0](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.9.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/23/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.9.0">Release notes</a></small>
+  <small>Published: 5/24/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.9.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -160,7 +160,7 @@ All the pre-commit hooks that were in `modules/pre-commit` are now in their own 
 ### [v0.6.5](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.6.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/16/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.6.5">Release notes</a></small>
+  <small>Published: 5/17/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.6.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -477,6 +477,6 @@ BACKWARDS INCOMPATIBLE CHANGES
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "1ed8dc47ed090725370906f449fee56d"
+  "hash": "be750d798971a76d4304fb57d1d5f7f7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-05/index.md
@@ -43,7 +43,7 @@ Here are the repos that were updated:
 ### [v0.0.18](https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.18)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/9/2018 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.18">Release notes</a></small>
+  <small>Published: 5/8/2018 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.0.18">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -108,7 +108,7 @@ Here are the repos that were updated:
 ### [v0.9.0](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.9.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/24/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.9.0">Release notes</a></small>
+  <small>Published: 5/23/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.9.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -160,7 +160,7 @@ All the pre-commit hooks that were in `modules/pre-commit` are now in their own 
 ### [v0.6.5](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.6.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/17/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.6.5">Release notes</a></small>
+  <small>Published: 5/16/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.6.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -233,7 +233,7 @@ All the pre-commit hooks that were in `modules/pre-commit` are now in their own 
 ### [v0.0.2](https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.0.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/30/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.0.2">Release notes</a></small>
+  <small>Published: 5/29/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.0.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -477,6 +477,6 @@ BACKWARDS INCOMPATIBLE CHANGES
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "be750d798971a76d4304fb57d1d5f7f7"
+  "hash": "2967d19d30589272b3dcb2578e3f3cad"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-06/index.md
@@ -39,7 +39,7 @@ Here are the repos that were updated:
 ### [v0.6.12](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.12)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/4/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.12">Release notes</a></small>
+  <small>Published: 6/5/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.12">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -103,7 +103,7 @@ Here are the repos that were updated:
 ### [v0.0.3](https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.0.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/9/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.0.3">Release notes</a></small>
+  <small>Published: 6/10/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.0.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -299,6 +299,6 @@ The `saml-iam-roles` module now sets a default max expiration of 12 hours for IA
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "1509fa1bc51118a3da9b1d37ee6151ca"
+  "hash": "d39531ce0c85815913734a9a7452cb28"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-06/index.md
@@ -39,7 +39,7 @@ Here are the repos that were updated:
 ### [v0.6.12](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.12)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/5/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.12">Release notes</a></small>
+  <small>Published: 6/4/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.12">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -69,7 +69,7 @@ Here are the repos that were updated:
 ### [v0.11.0](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.11.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/19/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.11.0">Release notes</a></small>
+  <small>Published: 6/18/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.11.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -103,7 +103,7 @@ Here are the repos that were updated:
 ### [v0.0.3](https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.0.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/10/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.0.3">Release notes</a></small>
+  <small>Published: 6/9/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.0.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -171,7 +171,7 @@ This is another pre-release as these modules are still very green and require ad
 ### [v0.13.1](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.13.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/29/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.13.1">Release notes</a></small>
+  <small>Published: 6/28/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.13.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -267,7 +267,7 @@ The `saml-iam-roles` module now sets a default max expiration of 12 hours for IA
 ### [v0.5.0](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.5.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/18/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.5.0">Release notes</a></small>
+  <small>Published: 6/17/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.5.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -299,6 +299,6 @@ The `saml-iam-roles` module now sets a default max expiration of 12 hours for IA
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "828ba11ef410c7ae530b6ee814d786b9"
+  "hash": "1509fa1bc51118a3da9b1d37ee6151ca"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-06/index.md
@@ -61,7 +61,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-ci/pull/66: The `terraform-update-variable` script used to require setting `--skip-git "true"`, which is a non-idiomatic way to do flags in bash, and the parsing for it could fail silently. The script has now been updated so you just specify `--skip-git` to disable Git, without any need to say "true". Note that if you were using the `--skip-git` param before, this is a backwards incompatible change!
+  https://github.com/gruntwork-io/module-ci/pull/66: The `terraform-update-variable` script used to require setting `--skip-git &quot;true&quot;`, which is a non-idiomatic way to do flags in bash, and the parsing for it could fail silently. The script has now been updated so you just specify `--skip-git` to disable Git, without any need to say &quot;true&quot;. Note that if you were using the `--skip-git` param before, this is a backwards incompatible change!
 
 </div>
 
@@ -74,7 +74,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-ci/pull/62: The `git-add-commit-push` script will now detect "Updates were rejected because the remote contains work that you do not have locally" errors and automatically `git pull --rebase` and `git push` in a retry loop (up to a max number of retries). This allows the script to work properly even if someone else happened to push some code to the same branch at the exact same time.
+  https://github.com/gruntwork-io/module-ci/pull/62: The `git-add-commit-push` script will now detect &quot;Updates were rejected because the remote contains work that you do not have locally&quot; errors and automatically `git pull --rebase` and `git push` in a retry loop (up to a max number of retries). This allows the script to work properly even if someone else happened to push some code to the same branch at the exact same time.
 
 </div>
 
@@ -159,7 +159,7 @@ This is another pre-release as these modules are still very green and require ad
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/package-openvpn/pull/45: The `supervisor` install has been moved from the `run-process-requests` and `run-process-revokes` scripts to the `install-openvpn` script where it belongs. You'll need to build a new OpenVPN AMI to take advantage of this change.
+  https://github.com/gruntwork-io/package-openvpn/pull/45: The `supervisor` install has been moved from the `run-process-requests` and `run-process-revokes` scripts to the `install-openvpn` script where it belongs. You&apos;ll need to build a new OpenVPN AMI to take advantage of this change.
 
 </div>
 
@@ -192,7 +192,7 @@ This is another pre-release as these modules are still very green and require ad
   https://github.com/gruntwork-io/module-security/pull/99
 
 
-This release includes MAJOR changes to `ssh-iam` that are backwards incompatible. These changes make it possible to add powerful new features to `ssh-iam` (more on that soon!), but if you're an existing user of `ssh-iam`, you will need to read these instructions carefully and do some work to upgrade without losing SSH access!
+This release includes MAJOR changes to `ssh-iam` that are backwards incompatible. These changes make it possible to add powerful new features to `ssh-iam` (more on that soon!), but if you&apos;re an existing user of `ssh-iam`, you will need to read these instructions carefully and do some work to upgrade without losing SSH access!
 
 
 1. `ssh-iam` has been renamed to `ssh-grunt`. This is because we are updating it to support Identity Providers (IdPs) other than just IAM!
@@ -205,24 +205,24 @@ This release includes MAJOR changes to `ssh-iam` that are backwards incompatible
 
 1. All `ssh-iam` commands now use the form `ssh-grunt &lt;idp&gt; &lt;command&gt;`. For example, `ssh-iam install` is now `ssh-grunt iam install` and `ssh-iam print-keys` is now `ssh-grunt iam print-keys`. This allows us to add other IdPs in the future.
 
-1. When a user is removed from an `ssh-grunt` managed IdP group (e.g., a user is removed from an IAM group), `ssh-grunt` will delete the synced OS user from your server, but it will no longer delete that user's home directory. You can enable the old behavior with `--force-user-deletion`. 
+1. When a user is removed from an `ssh-grunt` managed IdP group (e.g., a user is removed from an IAM group), `ssh-grunt` will delete the synced OS user from your server, but it will no longer delete that user&apos;s home directory. You can enable the old behavior with `--force-user-deletion`. 
 
 
-If you're already using `ssh-iam`, here is how to upgrade to `ssh-grunt`:
+If you&apos;re already using `ssh-iam`, here is how to upgrade to `ssh-grunt`:
 
 1. Update your Packer templates:
 
     1. Change the `--binary-name` param from `ssh-iam` to `ssh-grunt`. 
-    1. If you're using SELinux (e.g., you're on CentOS), update `ssh-iam-selinux-policy` to `ssh-grunt-selinux-policy` in your Packer template too. 
+    1. If you&apos;re using SELinux (e.g., you&apos;re on CentOS), update `ssh-iam-selinux-policy` to `ssh-grunt-selinux-policy` in your Packer template too. 
     1. Change `ssh-iam install` to `ssh-grunt iam install` (all other params remain the same).
     1. Build a new AMI and update your Terraform code to deploy it. 
 
 1. If you update to the new `cross-account-iam-roles`, `iam-groups`, or `saml-iam-roles` modules, you will need to:
-    1. Rename any parameters you're passing as inputs to these modules, and any variables you're reading as outputs from these modules, form the form `xxx_ssh_iam_xxx` to the form `xxx_ssh_grunt_xxx`. For example, `allow_ssh_iam_access_from_other_account_arns` is now `allow_ssh_grunt_access_from_other_account_arns`. 
+    1. Rename any parameters you&apos;re passing as inputs to these modules, and any variables you&apos;re reading as outputs from these modules, form the form `xxx_ssh_iam_xxx` to the form `xxx_ssh_grunt_xxx`. For example, `allow_ssh_iam_access_from_other_account_arns` is now `allow_ssh_grunt_access_from_other_account_arns`. 
     1. Explicitly set the names of any `ssh-iam` / `ssh-grunt` IAM roles and groups created by these modules so you retain the old names you had before. The output of the `plan` command will tell if you any are being renamed and what the old names were.
 
 
-Here are the updates we've done to the Acme sample Reference Architectures that show the type of changes you'll need to make:
+Here are the updates we&apos;ve done to the Acme sample Reference Architectures that show the type of changes you&apos;ll need to make:
 
 [infrastructure-modules changes](https://github.com/gruntwork-io/infrastructure-modules-multi-account-acme/commit/922aa698b5f035e3af83c6ffd78804aed0192d01)
 [infrastructure-live changes](https://github.com/gruntwork-io/infrastructure-live-multi-account-acme/commit/98204b60e1fed47cbaaf041772c67eaeb3d3f2ba)
@@ -299,6 +299,6 @@ The `saml-iam-roles` module now sets a default max expiration of 12 hours for IA
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "828ba11ef410c7ae530b6ee814d786b9"
+  "hash": "1703257e06be0434d794daeb7deeecc5"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-06/index.md
@@ -69,7 +69,7 @@ Here are the repos that were updated:
 ### [v0.11.0](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.11.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/18/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.11.0">Release notes</a></small>
+  <small>Published: 6/19/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.11.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -171,7 +171,7 @@ This is another pre-release as these modules are still very green and require ad
 ### [v0.13.1](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.13.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/28/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.13.1">Release notes</a></small>
+  <small>Published: 6/29/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.13.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -267,7 +267,7 @@ The `saml-iam-roles` module now sets a default max expiration of 12 hours for IA
 ### [v0.5.0](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.5.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/17/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.5.0">Release notes</a></small>
+  <small>Published: 6/18/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.5.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -299,6 +299,6 @@ The `saml-iam-roles` module now sets a default max expiration of 12 hours for IA
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "d39531ce0c85815913734a9a7452cb28"
+  "hash": "828ba11ef410c7ae530b6ee814d786b9"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-07/index.md
@@ -84,7 +84,7 @@ Here are the repos that were updated:
 ### [v0.0.8](https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.0.8)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/31/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.0.8">Release notes</a></small>
+  <small>Published: 7/30/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.0.8">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -156,7 +156,7 @@ PRs #25 #29
 ### [v0.7.1](https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.7.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/3/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.7.1">Release notes</a></small>
+  <small>Published: 7/2/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.7.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -209,6 +209,6 @@ PRs #25 #29
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "6fd88d7c66da46d25f0d766e59cc4a64"
+  "hash": "c6824372a5349d68cd78b41bc7c677a7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-07/index.md
@@ -84,7 +84,7 @@ Here are the repos that were updated:
 ### [v0.0.8](https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.0.8)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/30/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.0.8">Release notes</a></small>
+  <small>Published: 7/31/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.0.8">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -156,7 +156,7 @@ PRs #25 #29
 ### [v0.7.1](https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.7.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/2/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.7.1">Release notes</a></small>
+  <small>Published: 7/3/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.7.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -209,6 +209,6 @@ PRs #25 #29
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "c6824372a5349d68cd78b41bc7c677a7"
+  "hash": "6fd88d7c66da46d25f0d766e59cc4a64"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-08/index.md
@@ -49,7 +49,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/module-ci/pull/75: The `git-add-commit-push` script will now retry on "cannot lock ref" errors that seem to come up if two `git push` calls happen simultaneously.
+  https://github.com/gruntwork-io/module-ci/pull/75: The `git-add-commit-push` script will now retry on &quot;cannot lock ref&quot; errors that seem to come up if two `git push` calls happen simultaneously.
 
 </div>
 
@@ -271,7 +271,7 @@ Unfortunately, this does constitute a breaking change for the `ecs-service` modu
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
   
-**Important:** If you are using `var.allow_inbound_from_security_group_ids` you will now **need** to set `var.allow_inbound_from_security_group_ids_num` because the default is `0`. If your code was already working correctly with the old approach, there is no reason why you can't just set `var.allow_inbound_from_security_group_ids_num` to be `length(var.allow_inbound_from_security_group_ids)`. 
+**Important:** If you are using `var.allow_inbound_from_security_group_ids` you will now **need** to set `var.allow_inbound_from_security_group_ids_num` because the default is `0`. If your code was already working correctly with the old approach, there is no reason why you can&apos;t just set `var.allow_inbound_from_security_group_ids_num` to be `length(var.allow_inbound_from_security_group_ids)`. 
 
 The only reason for changing the behavior in the module is to address the issue when someone has dynamic resources in the `var.allow_inbound_from_security_group_ids` array (For example, you specify an array with exactly one thing in it, the security group id that is an _output_ variable from another module).
 
@@ -327,7 +327,7 @@ The only reason for changing the behavior in the module is to address the issue 
 This PR contains a BACKWARDS INCOMPATIBLE CHANGE to the `iam-policies` module. Instead of a `should_require_mfa` parameter, it now takes in two parameters:
 
 1. `trust_policy_should_require_mfa`: Set to true to require MFA in Trust Policies. You should typically set this to true to make sure your IAM Roles can only be assumed by users with an MFA token.
-1. `iam_policy_should_require_mfa`: Set to true to require MFA in all other IAM Policies. You should typically set this to false on IAM Roles, as the MFA requirement is already handled by `trust_policy_should_require_mfa`, and it turns out that requiring MFA in both places doesn't work with `aws sts assume-role`. However, you should set this to true on other IAM policies that don't involve IAM Roles (e.g., in IAM Group policies).
+1. `iam_policy_should_require_mfa`: Set to true to require MFA in all other IAM Policies. You should typically set this to false on IAM Roles, as the MFA requirement is already handled by `trust_policy_should_require_mfa`, and it turns out that requiring MFA in both places doesn&apos;t work with `aws sts assume-role`. However, you should set this to true on other IAM policies that don&apos;t involve IAM Roles (e.g., in IAM Group policies).
 
 
 Per the above, the `cross-account-iam-policy` module now sets `trust_policy_should_require_mfa` based on the specified `should_require_mfa` input and always sets `iam_policy_should_require_mfa` to false.
@@ -373,6 +373,6 @@ Fix a bug in the `aws-auth` script so that you can now assume an IAM role _and_ 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "8cdf3a491d4ad10403c14b2497f9f815"
+  "hash": "d5553f3752b51e277ca4989f2b7e51b0"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-08/index.md
@@ -71,7 +71,7 @@ Here are the repos that were updated:
 ### [v0.12.2](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.12.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/7/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.12.2">Release notes</a></small>
+  <small>Published: 8/6/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.12.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -119,7 +119,7 @@ Special thanks to @natefaerber for the contribution!
 ### [v0.8.3](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.8.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/30/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.8.3">Release notes</a></small>
+  <small>Published: 8/29/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.8.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -198,7 +198,7 @@ Currently our module supports public or private hostnames, examples are provided
 ### [v0.7.0](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.7.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/8/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.7.0">Release notes</a></small>
+  <small>Published: 8/7/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.7.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -282,7 +282,7 @@ The only reason for changing the behavior in the module is to address the issue 
 ### [v0.10.0](https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.10.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/6/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.10.0">Release notes</a></small>
+  <small>Published: 8/5/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.10.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -373,6 +373,6 @@ Fix a bug in the `aws-auth` script so that you can now assume an IAM role _and_ 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "8cdf3a491d4ad10403c14b2497f9f815"
+  "hash": "41477db3b490ac088a84566260dec957"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-08/index.md
@@ -71,7 +71,7 @@ Here are the repos that were updated:
 ### [v0.12.2](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.12.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/6/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.12.2">Release notes</a></small>
+  <small>Published: 8/7/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.12.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -282,7 +282,7 @@ The only reason for changing the behavior in the module is to address the issue 
 ### [v0.10.0](https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.10.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/5/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.10.0">Release notes</a></small>
+  <small>Published: 8/6/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.10.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -373,6 +373,6 @@ Fix a bug in the `aws-auth` script so that you can now assume an IAM role _and_ 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "1e865c408df9dec85b7d5e9454673e29"
+  "hash": "8cdf3a491d4ad10403c14b2497f9f815"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-08/index.md
@@ -119,7 +119,7 @@ Special thanks to @natefaerber for the contribution!
 ### [v0.8.3](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.8.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/29/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.8.3">Release notes</a></small>
+  <small>Published: 8/30/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.8.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -198,7 +198,7 @@ Currently our module supports public or private hostnames, examples are provided
 ### [v0.7.0](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.7.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/7/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.7.0">Release notes</a></small>
+  <small>Published: 8/8/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.7.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -373,6 +373,6 @@ Fix a bug in the `aws-auth` script so that you can now assume an IAM role _and_ 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "41477db3b490ac088a84566260dec957"
+  "hash": "1e865c408df9dec85b7d5e9454673e29"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-09/index.md
@@ -74,7 +74,7 @@ Here are the repos that were updated:
 ### [v0.6.8](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.6.8)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/20/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.6.8">Release notes</a></small>
+  <small>Published: 9/19/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.6.8">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -341,6 +341,6 @@ This release is **BACKWARD INCOMPATIBLE** with previous releases only if you wer
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "1dc417805641cd37020784adaf77ee5c"
+  "hash": "ad6819ab1c971b67df9c3e24674e0409"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-09/index.md
@@ -74,7 +74,7 @@ Here are the repos that were updated:
 ### [v0.6.8](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.6.8)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/19/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.6.8">Release notes</a></small>
+  <small>Published: 9/20/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.6.8">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -341,6 +341,6 @@ This release is **BACKWARD INCOMPATIBLE** with previous releases only if you wer
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "ad6819ab1c971b67df9c3e24674e0409"
+  "hash": "1dc417805641cd37020784adaf77ee5c"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-09/index.md
@@ -184,9 +184,9 @@ Also added proper plumbing for `allow_ssh_from_security_group_ids` to be specifi
 All other cluster outputs (elastalert, elasticsearch, kibana) have an iam_role_id output but logstash-cluster was missing this variable:
 
 ```Hcl
-output "iam_role_id" {
-  value = "${module.logstash_cluster.iam_role_id}"
-}
+output &quot;iam_role_id&quot; &#x7B;
+  value = &quot;$&#x7B;module.logstash_cluster.iam_role_id&#x7D;&quot;
+&#x7D;
 ```
 
 This variable is useful for adding ssh-grunt IAM policies to this ASG. Thank you to @Merlz for pointing out the oversight.
@@ -208,17 +208,17 @@ This variable is useful for adding ssh-grunt IAM policies to this ASG. Thank you
 1. Replaces the usage of an NLB with an ALB instead
 1. Adds an auto discovery script to the Filebeat deployment to bypass the need for a load balancer between the application server and Logstash cluster.
 
-Here's why we removed the NLB:
+Here&apos;s why we removed the NLB:
 
-* The NLB can't [route back requests to the same node that initiated the request](https://forums.aws.amazon.com/thread.jspa?threadID=265344).
-* An internal NLB in a private subnet can't be accessed from a peered VPC. In a production environment (especially the one deployed with our reference architecture), this makes it impossible to access the NLB.
+* The NLB can&apos;t [route back requests to the same node that initiated the request](https://forums.aws.amazon.com/thread.jspa?threadID=265344).
+* An internal NLB in a private subnet can&apos;t be accessed from a peered VPC. In a production environment (especially the one deployed with our reference architecture), this makes it impossible to access the NLB.
 
 This release is backwards incompatible with previous releases. To upgrade you need to follow the following steps:
 
 1. Remove your use of the `nlb` module and replace with an `alb`. See example here: https://github.com/gruntwork-io/package-elk/blob/master/examples/elk-multi-cluster/main.tf#L436
 1. Replace your use of the `load-balancer-target-group` module with `load-balancer-alb-target-group`. See example of using the new module https://github.com/gruntwork-io/package-elk/blob/master/examples/elk-multi-cluster/main.tf#L71
 1. Finally update the various `target_group_arns` arguments passed to the cluster modules. https://github.com/gruntwork-io/package-elk/blob/master/examples/elk-multi-cluster/main.tf#L40
-1. If you're using SSL with the ALB, you'll need to take note of the upgrade notes here: https://github.com/gruntwork-io/module-load-balancer/releases/tag/v0.12.0
+1. If you&apos;re using SSL with the ALB, you&apos;ll need to take note of the upgrade notes here: https://github.com/gruntwork-io/module-load-balancer/releases/tag/v0.12.0
 
 </div>
 
@@ -232,7 +232,7 @@ This release is backwards incompatible with previous releases. To upgrade you ne
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
   
-Going forward, the ALB will be our "front facing" load balancer that will be how users access apps like Kibana. The ultimate goal will be to remove the NLB entirely rather than having to run both kinds of load balancers. We should be able to achieve this goal with #43 
+Going forward, the ALB will be our &quot;front facing&quot; load balancer that will be how users access apps like Kibana. The ultimate goal will be to remove the NLB entirely rather than having to run both kinds of load balancers. We should be able to achieve this goal with #43 
 
 </div>
 
@@ -271,7 +271,7 @@ Going forward, the ALB will be our "front facing" load balancer that will be how
 
 This helps bypass the Terraform bug where the contents of those variables depend on dynamic resources hashicorp/terraform#11482.
 
-This release is **BACKWARD INCOMPATIBLE** with previous releases only if you were using SSL certs. To upgrade you'll need to specify the newly added variables and run `terraform apply`.
+This release is **BACKWARD INCOMPATIBLE** with previous releases only if you were using SSL certs. To upgrade you&apos;ll need to specify the newly added variables and run `terraform apply`.
 
 </div>
 
@@ -341,6 +341,6 @@ This release is **BACKWARD INCOMPATIBLE** with previous releases only if you wer
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "1dc417805641cd37020784adaf77ee5c"
+  "hash": "2ea7257d7ea11dfc2b8f1834ceee76e6"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-10/index.md
@@ -92,7 +92,7 @@ module "b" {
 ### [v0.6.18](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.18)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/15/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.18">Release notes</a></small>
+  <small>Published: 10/16/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.18">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -109,7 +109,7 @@ module "b" {
 ### [v0.13.3](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.13.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/17/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.13.3">Release notes</a></small>
+  <small>Published: 10/18/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.13.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -297,7 +297,7 @@ The `scheduled-lambda-job` module now namespaces all of its resources with the f
 ### [v0.10.0](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.10.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/15/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.10.0">Release notes</a></small>
+  <small>Published: 10/16/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.10.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -402,7 +402,7 @@ A special thanks to @jeckhart for contributing all of these PRs!
 ### [v0.4.8](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.8)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/17/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.8">Release notes</a></small>
+  <small>Published: 10/18/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.8">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -417,6 +417,6 @@ A special thanks to @jeckhart for contributing all of these PRs!
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "9a9bbb0b3cec2a952e7b8b668272d957"
+  "hash": "a0fdc730782cfaf0cdc5cee68157b086"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-10/index.md
@@ -184,7 +184,7 @@ The binary will automatically be triggered with each deploy when you update to `
 ### [v0.9.0](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.9.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/19/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.9.0">Release notes</a></small>
+  <small>Published: 10/20/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.9.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -340,7 +340,7 @@ The `scheduled-lambda-job` module now namespaces all of its resources with the f
 ### [v0.8.0](https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.8.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/9/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.8.0">Release notes</a></small>
+  <small>Published: 10/10/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.8.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -417,6 +417,6 @@ A special thanks to @jeckhart for contributing all of these PRs!
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "a0fdc730782cfaf0cdc5cee68157b086"
+  "hash": "27878e6c232272ca1b9bb794a882d95d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-10/index.md
@@ -50,7 +50,7 @@ This also adds additional logging that shows you which github user you are authe
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/gruntwork/pull/32: This PR updates the IAM role the gruntwork CLI creates in each of the customer's AWS accounts so that it can be assumed not only from Gruntwork's master account (so we can deploy the Ref Arch), but also so it can be assumed from the customer's own security account (or, in a single-account deployment, that same account). The reason to add this is that we now deploy the Reference Architecture by launching an EC2 Instance in the customer's security account and letting it do the deployment. This includes assuming an IAM Role to get access to each of the customer's other accounts.
+  https://github.com/gruntwork-io/gruntwork/pull/32: This PR updates the IAM role the gruntwork CLI creates in each of the customer&apos;s AWS accounts so that it can be assumed not only from Gruntwork&apos;s master account (so we can deploy the Ref Arch), but also so it can be assumed from the customer&apos;s own security account (or, in a single-account deployment, that same account). The reason to add this is that we now deploy the Reference Architecture by launching an EC2 Instance in the customer&apos;s security account and letting it do the deployment. This includes assuming an IAM Role to get access to each of the customer&apos;s other accounts.
 
 </div>
 
@@ -68,22 +68,22 @@ This also adds additional logging that shows you which github user you are authe
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
   
-Here's an example of how to first launch Module A and then launch Module B:
+Here&apos;s an example of how to first launch Module A and then launch Module B:
 
 ```hcl
-module "a" {
+module &quot;a&quot; &#x7B;
   # Be sure to update to the latest version of this module
-  source = "git::git@github.com:gruntwork-io/module-asg.git//modules/server-group?ref=v0.6.19"
+  source = &quot;git::git@github.com:gruntwork-io/module-asg.git//modules/server-group?ref=v0.6.19&quot;
   ...
-}
+&#x7D;
 
-module "b" {
-  source = "git::git@github.com:gruntwork-io/module-asg.git//modules/server-group?ref=v0.6.19"
+module &quot;b&quot; &#x7B;
+  source = &quot;git::git@github.com:gruntwork-io/module-asg.git//modules/server-group?ref=v0.6.19&quot;
 
-  # It's important that you use the "rolling_deployment_done" output of module A, not just any output
-  wait_for = "${module.a.rolling_deployment_done}"
+  # It&apos;s important that you use the &quot;rolling_deployment_done&quot; output of module A, not just any output
+  wait_for = &quot;$&#x7B;module.a.rolling_deployment_done&#x7D;&quot;
   ...
-}
+&#x7D;
 ```
 
 </div>
@@ -143,12 +143,12 @@ Changes to the `lambda-cleanup-snapshots`, `lambda-copy-shared-snapshot`, `lambd
 
 1. The `aws_region` data source no longer uses the `current` parameter, which is deprecated.
 
-If you're already using these lambda modules and update, all the old lambda functions and schedule resources will be deleted and new ones created to replace them. Since these are just scheduled background jobs, this should not cause any problems, but just be aware that there will be lots of "delete and recreate" in your Terraform plan.
+If you&apos;re already using these lambda modules and update, all the old lambda functions and schedule resources will be deleted and new ones created to replace them. Since these are just scheduled background jobs, this should not cause any problems, but just be aware that there will be lots of &quot;delete and recreate&quot; in your Terraform plan.
 
 
 Changes to the `rds` module:
 
-1. Added a `depends_on` clause for the `aws_subnet_group` resource so that `terraform destroy` happens in the right order and doesn't intermittently hit errors.
+1. Added a `depends_on` clause for the `aws_subnet_group` resource so that `terraform destroy` happens in the right order and doesn&apos;t intermittently hit errors.
 
 </div>
 
@@ -285,7 +285,7 @@ The `run-kafka` script now allows you to configure the ZooKeeper chroot and enab
 
 BACKWARDS INCOMPATIBLE CHANGE
 
-The `scheduled-lambda-job` module now namespaces all of its resources with the format `"${var.lambda_function_name}-scheduled"` instead of `"${var.lambda_function_name}-scheduled-lambda-job"`. This makes names shorter and less likely to exceed AWS name length limits. If you `apply` this new version, your CloudWatch events, targets, and permissions will be destroyed and recreated, which is typically harmless. If you wish to override the namespacing behavior, you now set a new input variable called `namespace`. 
+The `scheduled-lambda-job` module now namespaces all of its resources with the format `&quot;$&#x7B;var.lambda_function_name&#x7D;-scheduled&quot;` instead of `&quot;$&#x7B;var.lambda_function_name&#x7D;-scheduled-lambda-job&quot;`. This makes names shorter and less likely to exceed AWS name length limits. If you `apply` this new version, your CloudWatch events, targets, and permissions will be destroyed and recreated, which is typically harmless. If you wish to override the namespacing behavior, you now set a new input variable called `namespace`. 
 
 </div>
 
@@ -352,7 +352,7 @@ The `scheduled-lambda-job` module now namespaces all of its resources with the f
 `package-openvpn` now uses [bash-commons](https://github.com/gruntwork-io/bash-commons/) under the hood. The behavior is identical, but you must now install `bash-commons` *before* installing any of the `package-openvpn` modules. For example, in your OpenVPN packer template, you should add `bash-commons` as one of the very first items:
 
 ```json
-gruntwork-install --module-name 'bash-commons' --repo 'https://github.com/gruntwork-io/bash-commons' --tag 'v0.0.6'
+gruntwork-install --module-name &apos;bash-commons&apos; --repo &apos;https://github.com/gruntwork-io/bash-commons&apos; --tag &apos;v0.0.6&apos;
 ```
 
 </div>
@@ -417,6 +417,6 @@ A special thanks to @jeckhart for contributing all of these PRs!
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "27878e6c232272ca1b9bb794a882d95d"
+  "hash": "cf9de13c26ce9312f8f44a3702ed7ae6"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-10/index.md
@@ -92,7 +92,7 @@ module "b" {
 ### [v0.6.18](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.18)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/16/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.18">Release notes</a></small>
+  <small>Published: 10/15/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.18">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -109,7 +109,7 @@ module "b" {
 ### [v0.13.3](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.13.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/18/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.13.3">Release notes</a></small>
+  <small>Published: 10/17/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.13.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -184,7 +184,7 @@ The binary will automatically be triggered with each deploy when you update to `
 ### [v0.9.0](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.9.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/20/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.9.0">Release notes</a></small>
+  <small>Published: 10/19/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.9.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -297,7 +297,7 @@ The `scheduled-lambda-job` module now namespaces all of its resources with the f
 ### [v0.10.0](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.10.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/16/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.10.0">Release notes</a></small>
+  <small>Published: 10/15/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.10.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -340,7 +340,7 @@ The `scheduled-lambda-job` module now namespaces all of its resources with the f
 ### [v0.8.0](https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.8.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/10/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.8.0">Release notes</a></small>
+  <small>Published: 10/9/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.8.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -402,7 +402,7 @@ A special thanks to @jeckhart for contributing all of these PRs!
 ### [v0.4.8](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.8)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/18/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.8">Release notes</a></small>
+  <small>Published: 10/17/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.4.8">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -417,6 +417,6 @@ A special thanks to @jeckhart for contributing all of these PRs!
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "27878e6c232272ca1b9bb794a882d95d"
+  "hash": "9a9bbb0b3cec2a952e7b8b668272d957"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-11/index.md
@@ -71,6 +71,41 @@ Here are the repos that were updated:
 ## package-k8s
 
 
+### [v0.1.0](https://github.com/gruntwork-io/package-k8s/releases/tag/v0.1.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 11/30/2018 | Modules affected: eks-k8s-role-mapping, kubergrunt, k8s-scripts, install-aws-iam-authenticator | <a href="https://github.com/gruntwork-io/package-k8s/releases/tag/v0.1.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+- `eks-k8s-role-mapping`
+- `kubergrunt` **[New]** 
+- `k8s-scripts` **[Breaking Change]** 
+- `install-aws-iam-authenticator` **[Breaking Change]** 
+
+
+- `eks-k8s-role-mapping` scripts are no longer baked into the PEX binary and instead loaded via the `PYTHONPATH`.
+- **New**: This release introduces `kubergrunt`, an encompassing tool that supports the configuration and management of a Kubernetes cluster. This command replaces both `eks-configure-kubectl` and `aws-iam-authenticator` by embedding the functionalities of those commands under different subcommands in `kubergrunt`. By doing so, we cut out the dependency on the awscli and `aws-iam-authenticator`, and so you only need to install this tool.
+- **Breaking Change**: `k8s-scripts` has been completely rewritten. As a result, `eks-configure-kubectl` is no longer provided as a stand alone script. Instead, it has been embedded into the new `kubergrunt` CLI tool.
+- **Breaking Change**: `aws-iam-authenticator` will no longer be provided as a part of this repo. You can use `kubergrunt` instead, or install directly from the links in [the official AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/configure-kubectl.html).
+
+
+To upgrade to this version, install `kubergrunt` by following [the installation instructions](https://github.com/gruntwork-io/package-k8s/tree/master/modules/kubergrunt).
+
+
+
+- This release is not intended to be used in production, as core features of a production grade infrastructure are still missing. This is currently intended to be used for development and learning purposes so that you can plan out a migration to Gruntwork modules for managing EKS.
+- This release is not tested with windows. Please file any bugs/issues you run into on [the issue tracker](https://github.com/gruntwork-io/package-k8s/issues).
+
+
+- https://github.com/gruntwork-io/package-k8s/pull/29
+- https://github.com/gruntwork-io/package-k8s/pull/30
+
+</div>
+
+
 ### [v0.0.2](https://github.com/gruntwork-io/package-k8s/releases/tag/v0.0.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
@@ -160,7 +195,7 @@ The above commit message will only run `SomeTestFunc` test function in the CI se
 ### [v0.8.1](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.8.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/22/2018 | Modules affected: aurora | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.8.1">Release notes</a></small>
+  <small>Published: 11/21/2018 | Modules affected: aurora | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.8.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -305,7 +340,7 @@ terragrunt state mv module.&lt;module-name&gt;.aws_rds_cluster.cluster_with_encr
 ### [v0.4.0](https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.4.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/29/2018 | Modules affected: s3-cloudfront | <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.4.0">Release notes</a></small>
+  <small>Published: 11/28/2018 | Modules affected: s3-cloudfront | <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.4.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -346,7 +381,7 @@ You can now specify custom tags for all S3 buckets created by these modules usin
 ### [v0.3.3](https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.3.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/12/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.3.3">Release notes</a></small>
+  <small>Published: 11/11/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.3.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -378,6 +413,6 @@ You can now specify custom tags for all S3 buckets created by these modules usin
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "762cb1013260625d4e99d9e30f9782a4"
+  "hash": "4235ac4f560b81944da62b1fa21b8b60"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-11/index.md
@@ -74,7 +74,7 @@ Here are the repos that were updated:
 ### [v0.1.0](https://github.com/gruntwork-io/package-k8s/releases/tag/v0.1.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/30/2018 | Modules affected: eks-k8s-role-mapping, kubergrunt, k8s-scripts, install-aws-iam-authenticator | <a href="https://github.com/gruntwork-io/package-k8s/releases/tag/v0.1.0">Release notes</a></small>
+  <small>Published: 12/1/2018 | Modules affected: eks-k8s-role-mapping, kubergrunt, k8s-scripts, install-aws-iam-authenticator | <a href="https://github.com/gruntwork-io/package-k8s/releases/tag/v0.1.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -195,7 +195,7 @@ The above commit message will only run `SomeTestFunc` test function in the CI se
 ### [v0.8.1](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.8.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/21/2018 | Modules affected: aurora | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.8.1">Release notes</a></small>
+  <small>Published: 11/22/2018 | Modules affected: aurora | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.8.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -340,7 +340,7 @@ terragrunt state mv module.&lt;module-name&gt;.aws_rds_cluster.cluster_with_encr
 ### [v0.4.0](https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.4.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/28/2018 | Modules affected: s3-cloudfront | <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.4.0">Release notes</a></small>
+  <small>Published: 11/29/2018 | Modules affected: s3-cloudfront | <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.4.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -381,7 +381,7 @@ You can now specify custom tags for all S3 buckets created by these modules usin
 ### [v0.3.3](https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.3.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/11/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.3.3">Release notes</a></small>
+  <small>Published: 11/12/2018 | <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.3.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -413,6 +413,6 @@ You can now specify custom tags for all S3 buckets created by these modules usin
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "4235ac4f560b81944da62b1fa21b8b60"
+  "hash": "f7827ef5042d83cd103915cb3838f7c7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-11/index.md
@@ -118,7 +118,7 @@ This initial release contains implementations for the following modules:
 - `eks-cluster-control-plane`: Provision an EKS cluster resource with recommended IAM policies and security groups that can be extended.
 - `eks-cluster-workers`: Provision a set of EC2 instances that EKS can use as worker nodes.
 - `eks-k8s-role-mapping`: Map AWS IAM roles to Kubernetes RBAC roles to allow authentication and authorization to Kubernetes via AWS credentials.
-- `install-eks-aws-iam-authenticator`: Prebuilt binaries for the [AWS IAM Authenticator for Kubernetes](https://github.com/kubernetes-sigs/aws-iam-authenticator) that can be installed without a working golang environment. This binary is used to support authenticating to EKS by providing IAM roles to the EKS cluster's Kubernetes API.
+- `install-eks-aws-iam-authenticator`: Prebuilt binaries for the [AWS IAM Authenticator for Kubernetes](https://github.com/kubernetes-sigs/aws-iam-authenticator) that can be installed without a working golang environment. This binary is used to support authenticating to EKS by providing IAM roles to the EKS cluster&apos;s Kubernetes API.
 - `k8s-scripts`: Helper scripts to configure [`kubectl`](https://kubernetes.io/docs/reference/kubectl/overview/) and [`helm`](https://helm.sh/) on the various flavors of Kubernetes clusters.
 
 
@@ -187,7 +187,7 @@ The above commit message will only run `SomeTestFunc` test function in the CI se
 
   
 
-To update your existing encryption enabled RDS cluster (which most likely uses serverless engine mode, else you'd have run into an error), simply run:
+To update your existing encryption enabled RDS cluster (which most likely uses serverless engine mode, else you&apos;d have run into an error), simply run:
 
 ```
 terragrunt state mv module.&lt;module-name&gt;.aws_rds_cluster.cluster_with_encryption module.&lt;module-name&gt;.aws_rds_cluster.cluster_with_encryption_serverless
@@ -378,6 +378,6 @@ You can now specify custom tags for all S3 buckets created by these modules usin
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "762cb1013260625d4e99d9e30f9782a4"
+  "hash": "5d1eeca96c0b2e3eac47c85853a8fa90"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-11/index.md
@@ -71,41 +71,6 @@ Here are the repos that were updated:
 ## package-k8s
 
 
-### [v0.1.0](https://github.com/gruntwork-io/package-k8s/releases/tag/v0.1.0)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/1/2018 | Modules affected: eks-k8s-role-mapping, kubergrunt, k8s-scripts, install-aws-iam-authenticator | <a href="https://github.com/gruntwork-io/package-k8s/releases/tag/v0.1.0">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  
-- `eks-k8s-role-mapping`
-- `kubergrunt` **[New]** 
-- `k8s-scripts` **[Breaking Change]** 
-- `install-aws-iam-authenticator` **[Breaking Change]** 
-
-
-- `eks-k8s-role-mapping` scripts are no longer baked into the PEX binary and instead loaded via the `PYTHONPATH`.
-- **New**: This release introduces `kubergrunt`, an encompassing tool that supports the configuration and management of a Kubernetes cluster. This command replaces both `eks-configure-kubectl` and `aws-iam-authenticator` by embedding the functionalities of those commands under different subcommands in `kubergrunt`. By doing so, we cut out the dependency on the awscli and `aws-iam-authenticator`, and so you only need to install this tool.
-- **Breaking Change**: `k8s-scripts` has been completely rewritten. As a result, `eks-configure-kubectl` is no longer provided as a stand alone script. Instead, it has been embedded into the new `kubergrunt` CLI tool.
-- **Breaking Change**: `aws-iam-authenticator` will no longer be provided as a part of this repo. You can use `kubergrunt` instead, or install directly from the links in [the official AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/configure-kubectl.html).
-
-
-To upgrade to this version, install `kubergrunt` by following [the installation instructions](https://github.com/gruntwork-io/package-k8s/tree/master/modules/kubergrunt).
-
-
-
-- This release is not intended to be used in production, as core features of a production grade infrastructure are still missing. This is currently intended to be used for development and learning purposes so that you can plan out a migration to Gruntwork modules for managing EKS.
-- This release is not tested with windows. Please file any bugs/issues you run into on [the issue tracker](https://github.com/gruntwork-io/package-k8s/issues).
-
-
-- https://github.com/gruntwork-io/package-k8s/pull/29
-- https://github.com/gruntwork-io/package-k8s/pull/30
-
-</div>
-
-
 ### [v0.0.2](https://github.com/gruntwork-io/package-k8s/releases/tag/v0.0.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
@@ -413,6 +378,6 @@ You can now specify custom tags for all S3 buckets created by these modules usin
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "f7827ef5042d83cd103915cb3838f7c7"
+  "hash": "762cb1013260625d4e99d9e30f9782a4"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-12/index.md
@@ -181,7 +181,7 @@ To upgrade to this version, install `kubergrunt` by following [the installation 
 * `server-group`
 
 
-* Fix a bug where you'd get an error if you passed more than one CIDR block into the `allow_ssh_from_cidr_blocks` parameter.
+* Fix a bug where you&apos;d get an error if you passed more than one CIDR block into the `allow_ssh_from_cidr_blocks` parameter.
 
 
 * https://github.com/gruntwork-io/module-asg/pull/54
@@ -201,7 +201,7 @@ To upgrade to this version, install `kubergrunt` by following [the installation 
 * `server-group`
 
 
-* Fix an issue where destroying a `server-group` would cause the error `Resource 'data.template_file.rolling_deployment' does not have attribute 'rendered' for variable 'data.template_file.rolling_deployment.rendered'`.
+* Fix an issue where destroying a `server-group` would cause the error `Resource &apos;data.template_file.rolling_deployment&apos; does not have attribute &apos;rendered&apos; for variable &apos;data.template_file.rolling_deployment.rendered&apos;`.
 
 
 * https://github.com/gruntwork-io/module-asg/pull/52
@@ -271,7 +271,7 @@ Added extra retry logic to application_deployer
   
 This is needed because:
 1. It is cleaner to package up the implementation behind a module
-1. It's not possible to refer to the actual python script with a relative path based of of `path.module` so we actually need this code to be wrapped
+1. It&apos;s not possible to refer to the actual python script with a relative path based of of `path.module` so we actually need this code to be wrapped
 
 Secondarily - change the bucket_id input to be a bucket_name input in the application version deployer. This will make it easier to use the module when something else is creating a bucket or if the bucket already exists as it will in the Houston self service template.
 
@@ -482,8 +482,8 @@ Postgres 10 on RDS uses a slightly different format for the default parameter gr
 - `lambda_edge` **[Breaking Change]** 
 
 
-- **Breaking Change**: the `lambda` and `lambda_edge` modules no longer export the zip file to the `source_dir`, but rather to the module path under the name `${var.name}-lambda.zip`. This is customizable using the `zip_output_path`. You can set this to variable to `${var.source_dir}/lambda.zip` to get the old behavior.
-- This release fixes a bug where you could end up with a perpetual diff in the terraform plan, caused by zipping up the previous runs' archive file.
+- **Breaking Change**: the `lambda` and `lambda_edge` modules no longer export the zip file to the `source_dir`, but rather to the module path under the name `$&#x7B;var.name&#x7D;-lambda.zip`. This is customizable using the `zip_output_path`. You can set this to variable to `$&#x7B;var.source_dir&#x7D;/lambda.zip` to get the old behavior.
+- This release fixes a bug where you could end up with a perpetual diff in the terraform plan, caused by zipping up the previous runs&apos; archive file.
 
 
 - https://github.com/gruntwork-io/package-lambda/pull/28
@@ -503,7 +503,7 @@ Postgres 10 on RDS uses a slightly different format for the default parameter gr
 - `lambda` **[Breaking Change]** 
 
 
-- **Breaking Change**: the `lambda` module removes the `wait_for` variable as it was not working as intended due to a limitation in terraform's use of `depends_on` with data sources. Additionally, the implementation of `wait_for` introduced a perpetual diff issue where the `plan` would always detect a change. The removal of `wait_for` fixes that.
+- **Breaking Change**: the `lambda` module removes the `wait_for` variable as it was not working as intended due to a limitation in terraform&apos;s use of `depends_on` with data sources. Additionally, the implementation of `wait_for` introduced a perpetual diff issue where the `plan` would always detect a change. The removal of `wait_for` fixes that.
 
 
 To upgrade to this version, remove the `wait_for` input parameter in all calls to the `lambda` module.
@@ -731,6 +731,6 @@ To upgrade to this version, simply bump the value of the `ref` parameter on your
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "38d7a6b66fb257bfb84e605065ed13b9"
+  "hash": "75a6878b62a9d40866921da46353c162"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-12/index.md
@@ -130,41 +130,6 @@ ap-northeast-1
 </div>
 
 
-### [v0.1.0](https://github.com/gruntwork-io/package-k8s/releases/tag/v0.1.0)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/1/2018 | Modules affected: eks-k8s-role-mapping, kubergrunt, k8s-scripts, install-aws-iam-authenticator | <a href="https://github.com/gruntwork-io/package-k8s/releases/tag/v0.1.0">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  
-- `eks-k8s-role-mapping`
-- `kubergrunt` **[New]** 
-- `k8s-scripts` **[Breaking Change]** 
-- `install-aws-iam-authenticator` **[Breaking Change]** 
-
-
-- `eks-k8s-role-mapping` scripts are no longer baked into the PEX binary and instead loaded via the `PYTHONPATH`.
-- **New**: This release introduces `kubergrunt`, an encompassing tool that supports the configuration and management of a Kubernetes cluster. This command replaces both `eks-configure-kubectl` and `aws-iam-authenticator` by embedding the functionalities of those commands under different subcommands in `kubergrunt`. By doing so, we cut out the dependency on the awscli and `aws-iam-authenticator`, and so you only need to install this tool.
-- **Breaking Change**: `k8s-scripts` has been completely rewritten. As a result, `eks-configure-kubectl` is no longer provided as a stand alone script. Instead, it has been embedded into the new `kubergrunt` CLI tool.
-- **Breaking Change**: `aws-iam-authenticator` will no longer be provided as a part of this repo. You can use `kubergrunt` instead, or install directly from the links in [the official AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/configure-kubectl.html).
-
-
-To upgrade to this version, install `kubergrunt` by following [the installation instructions](https://github.com/gruntwork-io/package-k8s/tree/master/modules/kubergrunt).
-
-
-
-- This release is not intended to be used in production, as core features of a production grade infrastructure are still missing. This is currently intended to be used for development and learning purposes so that you can plan out a migration to Gruntwork modules for managing EKS.
-- This release is not tested with windows. Please file any bugs/issues you run into on [the issue tracker](https://github.com/gruntwork-io/package-k8s/issues).
-
-
-- https://github.com/gruntwork-io/package-k8s/pull/29
-- https://github.com/gruntwork-io/package-k8s/pull/30
-
-</div>
-
-
 
 ## terraform-aws-asg
 
@@ -374,7 +339,7 @@ Postgres 10 on RDS uses a slightly different format for the default parameter gr
 ### [v0.8.3](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.8.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/11/2018 | Modules affected: lambda-cleanup-snapshots, lambda-copy-shared-snapshot, lambda-create-snapshot, lambda-share-snapshot | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.8.3">Release notes</a></small>
+  <small>Published: 12/10/2018 | Modules affected: lambda-cleanup-snapshots, lambda-copy-shared-snapshot, lambda-create-snapshot, lambda-share-snapshot | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.8.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -424,7 +389,7 @@ Postgres 10 on RDS uses a slightly different format for the default parameter gr
 ### [v0.10.3](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.10.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/8/2018 | Modules affected: ecs-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.10.3">Release notes</a></small>
+  <small>Published: 12/7/2018 | Modules affected: ecs-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.10.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -731,6 +696,6 @@ To upgrade to this version, simply bump the value of the `ref` parameter on your
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "38d7a6b66fb257bfb84e605065ed13b9"
+  "hash": "8aa4d00a14d134d76516518aa87913a8"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-12/index.md
@@ -339,7 +339,7 @@ Postgres 10 on RDS uses a slightly different format for the default parameter gr
 ### [v0.8.3](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.8.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/10/2018 | Modules affected: lambda-cleanup-snapshots, lambda-copy-shared-snapshot, lambda-create-snapshot, lambda-share-snapshot | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.8.3">Release notes</a></small>
+  <small>Published: 12/11/2018 | Modules affected: lambda-cleanup-snapshots, lambda-copy-shared-snapshot, lambda-create-snapshot, lambda-share-snapshot | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.8.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -389,7 +389,7 @@ Postgres 10 on RDS uses a slightly different format for the default parameter gr
 ### [v0.10.3](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.10.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/7/2018 | Modules affected: ecs-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.10.3">Release notes</a></small>
+  <small>Published: 12/8/2018 | Modules affected: ecs-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.10.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -696,6 +696,6 @@ To upgrade to this version, simply bump the value of the `ref` parameter on your
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "8aa4d00a14d134d76516518aa87913a8"
+  "hash": "d4167b35cebcdcaaf33f374745f62af6"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-12/index.md
@@ -130,6 +130,41 @@ ap-northeast-1
 </div>
 
 
+### [v0.1.0](https://github.com/gruntwork-io/package-k8s/releases/tag/v0.1.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 12/1/2018 | Modules affected: eks-k8s-role-mapping, kubergrunt, k8s-scripts, install-aws-iam-authenticator | <a href="https://github.com/gruntwork-io/package-k8s/releases/tag/v0.1.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+- `eks-k8s-role-mapping`
+- `kubergrunt` **[New]** 
+- `k8s-scripts` **[Breaking Change]** 
+- `install-aws-iam-authenticator` **[Breaking Change]** 
+
+
+- `eks-k8s-role-mapping` scripts are no longer baked into the PEX binary and instead loaded via the `PYTHONPATH`.
+- **New**: This release introduces `kubergrunt`, an encompassing tool that supports the configuration and management of a Kubernetes cluster. This command replaces both `eks-configure-kubectl` and `aws-iam-authenticator` by embedding the functionalities of those commands under different subcommands in `kubergrunt`. By doing so, we cut out the dependency on the awscli and `aws-iam-authenticator`, and so you only need to install this tool.
+- **Breaking Change**: `k8s-scripts` has been completely rewritten. As a result, `eks-configure-kubectl` is no longer provided as a stand alone script. Instead, it has been embedded into the new `kubergrunt` CLI tool.
+- **Breaking Change**: `aws-iam-authenticator` will no longer be provided as a part of this repo. You can use `kubergrunt` instead, or install directly from the links in [the official AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/configure-kubectl.html).
+
+
+To upgrade to this version, install `kubergrunt` by following [the installation instructions](https://github.com/gruntwork-io/package-k8s/tree/master/modules/kubergrunt).
+
+
+
+- This release is not intended to be used in production, as core features of a production grade infrastructure are still missing. This is currently intended to be used for development and learning purposes so that you can plan out a migration to Gruntwork modules for managing EKS.
+- This release is not tested with windows. Please file any bugs/issues you run into on [the issue tracker](https://github.com/gruntwork-io/package-k8s/issues).
+
+
+- https://github.com/gruntwork-io/package-k8s/pull/29
+- https://github.com/gruntwork-io/package-k8s/pull/30
+
+</div>
+
+
 
 ## terraform-aws-asg
 
@@ -696,6 +731,6 @@ To upgrade to this version, simply bump the value of the `ref` parameter on your
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "d4167b35cebcdcaaf33f374745f62af6"
+  "hash": "38d7a6b66fb257bfb84e605065ed13b9"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-01/index.md
@@ -520,7 +520,7 @@ This release is backwards incompatible and to update an existing metric widget, 
 ### [v0.1.8](https://github.com/gruntwork-io/terraform-aws-sam/releases/tag/v0.1.8)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/24/2019 | <a href="https://github.com/gruntwork-io/terraform-aws-sam/releases/tag/v0.1.8">Release notes</a></small>
+  <small>Published: 1/23/2019 | <a href="https://github.com/gruntwork-io/terraform-aws-sam/releases/tag/v0.1.8">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -649,7 +649,7 @@ This release introduces modules that support running python PEX files in Terrafo
 ### [v0.0.5](https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.0.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/9/2019 | Modules affected: require-executable | <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.0.5">Release notes</a></small>
+  <small>Published: 1/8/2019 | Modules affected: require-executable | <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.0.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -693,7 +693,7 @@ This release introduces modules that support running python PEX files in Terrafo
 ### [v0.5.5](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.5.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/29/2019 | Modules affected: vpc-app, vpc-mgmt | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.5.5">Release notes</a></small>
+  <small>Published: 1/28/2019 | Modules affected: vpc-app, vpc-mgmt | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.5.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -757,7 +757,7 @@ This release introduces modules that support running python PEX files in Terrafo
 ### [v0.5.2](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.5.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/4/2019 | Modules affected: vpc-app | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.5.2">Release notes</a></small>
+  <small>Published: 1/3/2019 | Modules affected: vpc-app | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.5.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -781,7 +781,7 @@ This release introduces modules that support running python PEX files in Terrafo
 ### [v0.5.2](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.5.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/29/2019 | Modules affected: zookeeper-cluster, zookeeper-security-group-rules | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.5.2">Release notes</a></small>
+  <small>Published: 1/28/2019 | Modules affected: zookeeper-cluster, zookeeper-security-group-rules | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.5.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -802,7 +802,7 @@ This release introduces modules that support running python PEX files in Terrafo
 ### [v0.5.1](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.5.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/29/2019 | Modules affected: run-health-checker | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.5.1">Release notes</a></small>
+  <small>Published: 1/28/2019 | Modules affected: run-health-checker | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.5.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -903,6 +903,6 @@ This is a backwards incompatible change. Specifically, the modules no longer nee
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "dd899d78c485aff364599ddcd36a7902"
+  "hash": "87a70a6176fb63e2a10776a88fa9a41a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-01/index.md
@@ -120,9 +120,9 @@ Here are the repos that were updated:
 - `redis`: Adds 4 new `aws_replication_group` permutations to the Redis module, to workaround the inability to use interpolations in `ignore_changes` field in a `lifecycle` block (hashicorp/terraform#3116) which will have been the ideal solution to ignoring the `number_cache_cluster` field when in `cluster_mode` to prevent `terraform plan` diffs due to cluster resizing.
 
 
-This release is backwards incompatible and to update an existing Redis cluster, use `terragrunt state mv &lt;old_address&gt; &lt;new_address&gt;` to ensure that your cluster isn't deleted when you run `terraform apply`.
+This release is backwards incompatible and to update an existing Redis cluster, use `terragrunt state mv &lt;old_address&gt; &lt;new_address&gt;` to ensure that your cluster isn&apos;t deleted when you run `terraform apply`.
 
-For example, to migrate a cluster mode Redis cluster deployed via the `aws_elasticache_replication_group.redis_with_snapshotting_without_auth_token` resource, you'd simply run:
+For example, to migrate a cluster mode Redis cluster deployed via the `aws_elasticache_replication_group.redis_with_snapshotting_without_auth_token` resource, you&apos;d simply run:
 
 ```bash
 terraform state mv module.&lt;your-module-name&gt;.aws_elasticache_replication_group.redis_with_snapshotting_without_auth_token module.&lt;your-module-name&gt;.aws_elasticache_replication_group.redis_with_snapshotting_without_auth_token_with_cluster_mode 
@@ -170,7 +170,7 @@ terraform state mv module.&lt;your-module-name&gt;.aws_elasticache_replication_g
 * `git-helpers`
 
 
-* The `git-add-commit-push` script will now retry on the "failed to update ref" error, which seems to come up occasionally.
+* The `git-add-commit-push` script will now retry on the &quot;failed to update ref&quot; error, which seems to come up occasionally.
 
 
 * https://github.com/gruntwork-io/module-ci/pull/82
@@ -278,7 +278,7 @@ terraform state mv module.&lt;your-module-name&gt;.aws_elasticache_replication_g
 * `ecs-daemon-service`
 
 
-* The `ecs-daemon-service` module now exposes a `deployment_minimum_healthy_percent` parameter you can use to set the lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment.
+* The `ecs-daemon-service` module now exposes a `deployment_minimum_healthy_percent` parameter you can use to set the lower limit (as a percentage of the service&apos;s desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment.
 
 
 * https://github.com/gruntwork-io/module-ecs/pull/111
@@ -318,7 +318,7 @@ terraform state mv module.&lt;your-module-name&gt;.aws_elasticache_replication_g
 * `ecs-service-with-discovery` **[Breaking Change]**
 
 
-* The `ecs-service-with-discovery` module now sets the default family name for the ECS Task Definition to `${var.service_name}` rather than `"${var.service_name}-task-definition"` to be consistent with the other ECS modules. If you wish to retain the old naming convention, you can now explicitly set the family name using the new `task_definition_family_name` parameter.
+* The `ecs-service-with-discovery` module now sets the default family name for the ECS Task Definition to `$&#x7B;var.service_name&#x7D;` rather than `&quot;$&#x7B;var.service_name&#x7D;-task-definition&quot;` to be consistent with the other ECS modules. If you wish to retain the old naming convention, you can now explicitly set the family name using the new `task_definition_family_name` parameter.
 
 
 * https://github.com/gruntwork-io/module-ecs/pull/108
@@ -433,7 +433,7 @@ You can find examples of how to do this upgrade in [this commit](https://github.
 * `alb` **[BREAKING CHANGE]**
 
 
-* The ALB requires all listeners to have a "default action" that defines what to do for a request that doesn't match any listener rule. In the past, the only supported action was to forward requests to a target group, so we used to forward to an empty "black hole" target group, resulting in a 503. The ALB now supports fixed responses, so we've updated the default action of the `alb` module to return a blank 404 page, which is a more appropriate status code. 
+* The ALB requires all listeners to have a &quot;default action&quot; that defines what to do for a request that doesn&apos;t match any listener rule. In the past, the only supported action was to forward requests to a target group, so we used to forward to an empty &quot;black hole&quot; target group, resulting in a 503. The ALB now supports fixed responses, so we&apos;ve updated the default action of the `alb` module to return a blank 404 page, which is a more appropriate status code. 
 
 
 For most teams, the new 404 behavior is better, so no code changes will be necessary. However, if you wish to override this 404 behavior, you have two options:
@@ -546,7 +546,7 @@ This release is backwards incompatible and to update an existing metric widget, 
 * `fail2ban`
 
 
-* Add `DEBIAN_FRONTEND=noninteractive` to calls to `apt-get` so that the install doesn't hang during automated builds. Use `systemctl` instead of `update-rc.d` to boot `fail2ban` on Ubuntu.
+* Add `DEBIAN_FRONTEND=noninteractive` to calls to `apt-get` so that the install doesn&apos;t hang during automated builds. Use `systemctl` instead of `update-rc.d` to boot `fail2ban` on Ubuntu.
 
 
 * https://github.com/gruntwork-io/module-security/pull/125
@@ -811,7 +811,7 @@ This release introduces modules that support running python PEX files in Terrafo
 * `run-health-checker`
 
 
-* The `run-health-checker` module will now properly pass healthchecks for single-node ZooKeeper clusters running in "standalone" mode (e.g., in pre-prod environments).
+* The `run-health-checker` module will now properly pass healthchecks for single-node ZooKeeper clusters running in &quot;standalone&quot; mode (e.g., in pre-prod environments).
 
 
 * https://github.com/gruntwork-io/package-zookeeper/pull/38
@@ -903,6 +903,6 @@ This is a backwards incompatible change. Specifically, the modules no longer nee
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "dd899d78c485aff364599ddcd36a7902"
+  "hash": "d2ddc44546d039c7caefd791a9c0e757"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-01/index.md
@@ -520,7 +520,7 @@ This release is backwards incompatible and to update an existing metric widget, 
 ### [v0.1.8](https://github.com/gruntwork-io/terraform-aws-sam/releases/tag/v0.1.8)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/23/2019 | <a href="https://github.com/gruntwork-io/terraform-aws-sam/releases/tag/v0.1.8">Release notes</a></small>
+  <small>Published: 1/24/2019 | <a href="https://github.com/gruntwork-io/terraform-aws-sam/releases/tag/v0.1.8">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -649,7 +649,7 @@ This release introduces modules that support running python PEX files in Terrafo
 ### [v0.0.5](https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.0.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/8/2019 | Modules affected: require-executable | <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.0.5">Release notes</a></small>
+  <small>Published: 1/9/2019 | Modules affected: require-executable | <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.0.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -693,7 +693,7 @@ This release introduces modules that support running python PEX files in Terrafo
 ### [v0.5.5](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.5.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/28/2019 | Modules affected: vpc-app, vpc-mgmt | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.5.5">Release notes</a></small>
+  <small>Published: 1/29/2019 | Modules affected: vpc-app, vpc-mgmt | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.5.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -757,7 +757,7 @@ This release introduces modules that support running python PEX files in Terrafo
 ### [v0.5.2](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.5.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/3/2019 | Modules affected: vpc-app | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.5.2">Release notes</a></small>
+  <small>Published: 1/4/2019 | Modules affected: vpc-app | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.5.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -781,7 +781,7 @@ This release introduces modules that support running python PEX files in Terrafo
 ### [v0.5.2](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.5.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/28/2019 | Modules affected: zookeeper-cluster, zookeeper-security-group-rules | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.5.2">Release notes</a></small>
+  <small>Published: 1/29/2019 | Modules affected: zookeeper-cluster, zookeeper-security-group-rules | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.5.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -802,7 +802,7 @@ This release introduces modules that support running python PEX files in Terrafo
 ### [v0.5.1](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.5.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/28/2019 | Modules affected: run-health-checker | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.5.1">Release notes</a></small>
+  <small>Published: 1/29/2019 | Modules affected: run-health-checker | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.5.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -903,6 +903,6 @@ This is a backwards incompatible change. Specifically, the modules no longer nee
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "87a70a6176fb63e2a10776a88fa9a41a"
+  "hash": "dd899d78c485aff364599ddcd36a7902"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-02/index.md
@@ -50,7 +50,7 @@ Here are the repos that were updated:
 ### [v0.6.25](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.25)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/20/2019 | Modules affected: server-group | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.25">Release notes</a></small>
+  <small>Published: 2/21/2019 | Modules affected: server-group | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.25">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -475,7 +475,7 @@ Other changes:
 ### [v0.2.0](https://github.com/gruntwork-io/terraform-kubernetes-helm/releases/tag/v0.2.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/1/2019 | Modules affected: k8s-namespace, k8s-service-account | <a href="https://github.com/gruntwork-io/terraform-kubernetes-helm/releases/tag/v0.2.0">Release notes</a></small>
+  <small>Published: 2/2/2019 | Modules affected: k8s-namespace, k8s-service-account | <a href="https://github.com/gruntwork-io/terraform-kubernetes-helm/releases/tag/v0.2.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -495,6 +495,6 @@ Other changes:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "8619852df7bdd40f37c2eea5d9c49408"
+  "hash": "925856cc94f71eb99a4b691de26c10a0"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-02/index.md
@@ -79,7 +79,7 @@ Here are the repos that were updated:
 * `terraform-helpers`
 
 
-* The `update-terraform-variable` script now uses pipes (`|`) instead of slashes (`/`) in a `sed` call so that you don't get errors if the `--value` parameter contains a slash.
+* The `update-terraform-variable` script now uses pipes (`|`) instead of slashes (`/`) in a `sed` call so that you don&apos;t get errors if the `--value` parameter contains a slash.
 
 
 * https://github.com/gruntwork-io/module-ci/pull/88
@@ -103,7 +103,7 @@ Here are the repos that were updated:
 * `ecs-cluster`
 
 
-* Fix bug in `roll-out-ecs-cluster-update.py` where it wouldn't do the proper rollout for clusters bigger than 10 instances. 
+* Fix bug in `roll-out-ecs-cluster-update.py` where it wouldn&apos;t do the proper rollout for clusters bigger than 10 instances. 
 
 
 * #118 
@@ -150,7 +150,7 @@ Here are the repos that were updated:
 
 This release adds ability for the user to pass through custom JVM options for logstash.  Previously we were relying on default JVM options.
 
-Now - our installation will pass through a templated `jvm.options` file. The user can then pass parameters through terraform/user-data script to the `run-logstash` script via a new parameter `--auto-fill-jvm` (eg:  `--auto-fill-jvm '&lt;__XMS__&gt;=4g'`)
+Now - our installation will pass through a templated `jvm.options` file. The user can then pass parameters through terraform/user-data script to the `run-logstash` script via a new parameter `--auto-fill-jvm` (eg:  `--auto-fill-jvm &apos;&lt;__XMS__&gt;=4g&apos;`)
 
 https://github.com/gruntwork-io/package-elk/issues/70
 https://github.com/gruntwork-io/package-elk/pull/69
@@ -251,7 +251,7 @@ https://github.com/gruntwork-io/package-elk/pull/69
 
   
 
-- Fix errors in the new connection count and low request count alarms to remove the "client-tls-negotiation-error" portion that was accidentally copy/pasted into them.
+- Fix errors in the new connection count and low request count alarms to remove the &quot;client-tls-negotiation-error&quot; portion that was accidentally copy/pasted into them.
 
 
 
@@ -311,8 +311,8 @@ Special thanks to @ksemaev for these contributions.
 
   
 
-- Update the `fail2ban` module so it works properly on Amazon Linux 2. We've also updated how we install it on Ubuntu (using `pip` to install `aws` instead of `apt`) and changed the jail files a bit to take advantage of fail2ban interpolation
-- Update the `ami-builder` in `os-hardening` to support a new `parallel_build` param that lets you control whether the builds run in parallel. It's set to true `true` by default, as before, but you may need to disable it for use with nvme.
+- Update the `fail2ban` module so it works properly on Amazon Linux 2. We&apos;ve also updated how we install it on Ubuntu (using `pip` to install `aws` instead of `apt`) and changed the jail files a bit to take advantage of fail2ban interpolation
+- Update the `ami-builder` in `os-hardening` to support a new `parallel_build` param that lets you control whether the builds run in parallel. It&apos;s set to true `true` by default, as before, but you may need to disable it for use with nvme.
 - Call `udevadm settle` in the `partition-volume` script to ensure all symlinks are in place before going on to subsequent steps (e.g., formatting).
 
 
@@ -495,6 +495,6 @@ Other changes:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "925856cc94f71eb99a4b691de26c10a0"
+  "hash": "c4beb2d3e2605faf2048c11762158a4e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-02/index.md
@@ -50,7 +50,7 @@ Here are the repos that were updated:
 ### [v0.6.25](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.25)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/21/2019 | Modules affected: server-group | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.25">Release notes</a></small>
+  <small>Published: 2/20/2019 | Modules affected: server-group | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.6.25">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -475,7 +475,7 @@ Other changes:
 ### [v0.2.0](https://github.com/gruntwork-io/terraform-kubernetes-helm/releases/tag/v0.2.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/2/2019 | Modules affected: k8s-namespace, k8s-service-account | <a href="https://github.com/gruntwork-io/terraform-kubernetes-helm/releases/tag/v0.2.0">Release notes</a></small>
+  <small>Published: 2/1/2019 | Modules affected: k8s-namespace, k8s-service-account | <a href="https://github.com/gruntwork-io/terraform-kubernetes-helm/releases/tag/v0.2.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -495,6 +495,6 @@ Other changes:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "925856cc94f71eb99a4b691de26c10a0"
+  "hash": "8619852df7bdd40f37c2eea5d9c49408"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-03/index.md
@@ -25,7 +25,7 @@ Here are the repos that were updated:
 ### [v0.13.11](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.13.11)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/27/2019 | Modules affected: ec2-backup | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.13.11">Release notes</a></small>
+  <small>Published: 3/26/2019 | Modules affected: ec2-backup | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.13.11">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -129,7 +129,7 @@ Additionally, this release introduces a few bug fixes for working with multiple 
 ### [v0.1.5](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.1.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/5/2019 | Modules affected: eks-k8s-role-mapping, eks-cluster-workers, eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.1.5">Release notes</a></small>
+  <small>Published: 3/4/2019 | Modules affected: eks-k8s-role-mapping, eks-cluster-workers, eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.1.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -279,6 +279,6 @@ The `kinesis` module now supports server-side encryption.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "61163ab82821640f8c815266920df348"
+  "hash": "b7bf9b8dc129b9d7f131d7413b8cc41d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-03/index.md
@@ -25,7 +25,7 @@ Here are the repos that were updated:
 ### [v0.13.11](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.13.11)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/26/2019 | Modules affected: ec2-backup | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.13.11">Release notes</a></small>
+  <small>Published: 3/27/2019 | Modules affected: ec2-backup | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.13.11">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -129,7 +129,7 @@ Additionally, this release introduces a few bug fixes for working with multiple 
 ### [v0.1.5](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.1.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/4/2019 | Modules affected: eks-k8s-role-mapping, eks-cluster-workers, eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.1.5">Release notes</a></small>
+  <small>Published: 3/5/2019 | Modules affected: eks-k8s-role-mapping, eks-cluster-workers, eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.1.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -279,6 +279,6 @@ The `kinesis` module now supports server-side encryption.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "b7bf9b8dc129b9d7f131d7413b8cc41d"
+  "hash": "61163ab82821640f8c815266920df348"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-03/index.md
@@ -261,7 +261,7 @@ The `kinesis` module now supports server-side encryption.
 * `vpc-peering`
 
 
-* You can now customize the CIDR block calculations for each "tier" of subnet in the `vpc-app` module using the `public_subnet_bits`, `private_subnet_bits`, and `persistence_subnet_bits` input variables, each of which specifies the number of bits to add to the CIDR prefix when calculating subnet ranges.
+* You can now customize the CIDR block calculations for each &quot;tier&quot; of subnet in the `vpc-app` module using the `public_subnet_bits`, `private_subnet_bits`, and `persistence_subnet_bits` input variables, each of which specifies the number of bits to add to the CIDR prefix when calculating subnet ranges.
 * You can now enable public IPs to be enabled by default on public subnets in the `vpc-app` module by setting the `map_public_ip_on_launch` input variable to `true`.
 * You can now configure the VPC peering connection using the new `allow_remote_vpc_dns_resolution`, `allow_classic_link_to_remote_vpc`, and `allow_vpc_to_remote_classic_link` input variables in the `vpc-peering` module.
 
@@ -279,6 +279,6 @@ The `kinesis` module now supports server-side encryption.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "61163ab82821640f8c815266920df348"
+  "hash": "88dbf9bda48a4f76f4362342a54d41c8"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-04/index.md
@@ -51,7 +51,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/gruntwork/pull/40: Fix a bug in how we picked the name of the "security" account so it works correctly when granting access to `__current__`.
+  https://github.com/gruntwork-io/gruntwork/pull/40: Fix a bug in how we picked the name of the &quot;security&quot; account so it works correctly when granting access to `__current__`.
 
 </div>
 
@@ -415,7 +415,7 @@ This release introduces the `eks-cloudwatch-container-logs` module, which instal
 * `alb`
 
 
-* This release fixes an issue with multiple duplicate ACM certs - e.g. you're rotating to a new cert and still have systems using the old cert - where previously it errored out if multiple ACM certs matched the domain. Instead, we will now pick the newer one.
+* This release fixes an issue with multiple duplicate ACM certs - e.g. you&apos;re rotating to a new cert and still have systems using the old cert - where previously it errored out if multiple ACM certs matched the domain. Instead, we will now pick the newer one.
 
 
 Special thanks to @jasonmcintosh for the contribution!
@@ -690,6 +690,6 @@ This release introduces two new modules that can be used to setup Route 53 Resol
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "9332ff27c5ee2dfb56015c3686d4b43b"
+  "hash": "71020b8e360eaa97bb8043c922e21447"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-04/index.md
@@ -227,23 +227,6 @@ This release introduces scripts that help with setting up a Kubernetes testing e
 ## terraform-aws-eks
 
 
-### [v0.5.3](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.5.3)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/1/2019 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.5.3">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  
-
-This release confirms that `external-dns` and ALB ingress controller support ACM certificates. Additionally, this release extends the timeout for EKS cluster creation as some regions take longer than 15 minutes to provision the EKS cluster.
-
-
-
-</div>
-
-
 ### [v0.5.2](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.5.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
@@ -707,6 +690,6 @@ This release introduces two new modules that can be used to setup Route 53 Resol
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "581c10df16280a8e7ae855b4289ff43a"
+  "hash": "9332ff27c5ee2dfb56015c3686d4b43b"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-04/index.md
@@ -209,7 +209,7 @@ This release introduces scripts that help with setting up a Kubernetes testing e
 ### [v0.12.1](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.12.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/2/2019 | Modules affected: ecs-service, ecs-service-with-discovery, ecs-service-with-alb, ecs-fargate | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.12.1">Release notes</a></small>
+  <small>Published: 4/1/2019 | Modules affected: ecs-service, ecs-service-with-discovery, ecs-service-with-alb, ecs-fargate | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.12.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -225,6 +225,23 @@ This release introduces scripts that help with setting up a Kubernetes testing e
 
 
 ## terraform-aws-eks
+
+
+### [v0.5.3](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.5.3)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/30/2019 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.5.3">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+This release confirms that `external-dns` and ALB ingress controller support ACM certificates. Additionally, this release extends the timeout for EKS cluster creation as some regions take longer than 15 minutes to provision the EKS cluster.
+
+
+
+</div>
 
 
 ### [v0.5.2](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.5.2)
@@ -470,7 +487,7 @@ Special thanks to @jasonmcintosh for the contribution!
 ### [v0.12.1](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.12.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/2/2019 | Modules affected: alarms/sqs-alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.12.1">Release notes</a></small>
+  <small>Published: 4/1/2019 | Modules affected: alarms/sqs-alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.12.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -553,7 +570,7 @@ Special thanks to @jasonmcintosh for the contribution!
 ### [v0.4.3](https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.4.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/4/2019 | Modules affected: s3-static-website | <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.4.3">Release notes</a></small>
+  <small>Published: 4/3/2019 | Modules affected: s3-static-website | <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.4.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -690,6 +707,6 @@ This release introduces two new modules that can be used to setup Route 53 Resol
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "9332ff27c5ee2dfb56015c3686d4b43b"
+  "hash": "aa89de1672577a4313781ed5f70da91f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-04/index.md
@@ -209,7 +209,7 @@ This release introduces scripts that help with setting up a Kubernetes testing e
 ### [v0.12.1](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.12.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/1/2019 | Modules affected: ecs-service, ecs-service-with-discovery, ecs-service-with-alb, ecs-fargate | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.12.1">Release notes</a></small>
+  <small>Published: 4/2/2019 | Modules affected: ecs-service, ecs-service-with-discovery, ecs-service-with-alb, ecs-fargate | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.12.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -230,7 +230,7 @@ This release introduces scripts that help with setting up a Kubernetes testing e
 ### [v0.5.3](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.5.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/30/2019 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.5.3">Release notes</a></small>
+  <small>Published: 5/1/2019 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.5.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -487,7 +487,7 @@ Special thanks to @jasonmcintosh for the contribution!
 ### [v0.12.1](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.12.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/1/2019 | Modules affected: alarms/sqs-alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.12.1">Release notes</a></small>
+  <small>Published: 4/2/2019 | Modules affected: alarms/sqs-alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.12.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -570,7 +570,7 @@ Special thanks to @jasonmcintosh for the contribution!
 ### [v0.4.3](https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.4.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/3/2019 | Modules affected: s3-static-website | <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.4.3">Release notes</a></small>
+  <small>Published: 4/4/2019 | Modules affected: s3-static-website | <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.4.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -707,6 +707,6 @@ This release introduces two new modules that can be used to setup Route 53 Resol
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "aa89de1672577a4313781ed5f70da91f"
+  "hash": "581c10df16280a8e7ae855b4289ff43a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-05/index.md
@@ -49,14 +49,14 @@ The following functions overlap with sprig, but have different functionality. Th
 above under a different name. These point to the boilerplate implementations for backwards compatibility. Please migrate
 to using the new naming scheme, as they will be updated to use the sprig versions in future versions of boilerplate.
 
-* `round`: In boilerplate, `round` returns the integer form as opposed to float. E.g `{{ round 123.5555 }}` will return
+* `round`: In boilerplate, `round` returns the integer form as opposed to float. E.g `&#x7B;&#x7B; round 123.5555 &#x7D;&#x7D;` will return
   `124`. The following supported alternative functions are available:
     - `roundFloat`: The sprig version of [round](http://masterminds.github.io/sprig/math.html#round), which supports
-      arbitrary decimal rounding. E.g `{{ round 123.5555 3 }}` returns `123.556`. Note that `{{ round 123.5555 0 }}`
+      arbitrary decimal rounding. E.g `&#x7B;&#x7B; round 123.5555 3 &#x7D;&#x7D;` returns `123.556`. Note that `&#x7B;&#x7B; round 123.5555 0 &#x7D;&#x7D;`
       returns `124.0`.
     - `roundInt`: Another name for the boilerplate version of `round`. Use this if you would like to keep old behavior.
-* `ceil` and `floor`: In boilerplate, `ceil` and `floor` return integer forms as opposed to floats. E.g `{{ ceil 1.1
-  }}` returns `2`, as opposed to `2.0` in the sprig version. The following supported alternative functions are
+* `ceil` and `floor`: In boilerplate, `ceil` and `floor` return integer forms as opposed to floats. E.g `&#x7B;&#x7B; ceil 1.1
+  &#x7D;&#x7D;` returns `2`, as opposed to `2.0` in the sprig version. The following supported alternative functions are
   available:
     - `ceilFloat` and `floorFloat`: The sprig version of [ceil](http://masterminds.github.io/sprig/math.html#ceil) and
       [floor](http://masterminds.github.io/sprig/math.html#floor).
@@ -78,17 +78,17 @@ to using the new naming scheme, as they will be updated to use the sprig version
     - `replaceAll`: The sprig version of [replace](http://masterminds.github.io/sprig/strings.html#replace).
     - `replaceOne`: Another name for the boilerplate version of `replace`. Use this if you would like to keep old
       behavior.
-* `slice`: In boilerplate, `slice` returns a list of numbers in the provided range. E.g `{{ slice 1 5 1 }}` returns
+* `slice`: In boilerplate, `slice` returns a list of numbers in the provided range. E.g `&#x7B;&#x7B; slice 1 5 1 &#x7D;&#x7D;` returns
   the list `[1, 2, 3, 4]`. The following supported alternative functions are available:
     - `sliceList`: The sprig version of [slice](http://masterminds.github.io/sprig/lists.html#slice), which returns the
-      slice of the given list. E.g `{{ slice list n m }}` returns `list[n:m]`.
+      slice of the given list. E.g `&#x7B;&#x7B; slice list n m &#x7D;&#x7D;` returns `list[n:m]`.
     - `numRange`: Another name for the boilerplate version of `slice`. Use this if you would like to keep old
       behavior.
 * `trimPrefix` and `trimSuffix`: In boilerplate, `trimPrefix` and `trimSuffix` takes the base string first. E.g
-  `{{ trimPrefix hello-world hello }}` returns `-world`. The following supported alternative functions are available:
+  `&#x7B;&#x7B; trimPrefix hello-world hello &#x7D;&#x7D;` returns `-world`. The following supported alternative functions are available:
     - `trimPrefixSprig` and `trimSuffixSprig`: The sprig version of
       [trimPrefix](http://masterminds.github.io/sprig/strings.html#trimPrefix) and
-      [trimSuffix](http://masterminds.github.io/sprig/strings.html#trimSuffix). Unlike the boilerplate version, this takes the trim text first so that you can pipeline the trimming. E.g `{{ "hello-world" | trimPrefix "hello" }}` returns `{{ -world }}`.
+      [trimSuffix](http://masterminds.github.io/sprig/strings.html#trimSuffix). Unlike the boilerplate version, this takes the trim text first so that you can pipeline the trimming. E.g `&#x7B;&#x7B; &quot;hello-world&quot; | trimPrefix &quot;hello&quot; &#x7D;&#x7D;` returns `&#x7B;&#x7B; -world &#x7D;&#x7D;`.
     - `trimPrefixBoilerplate` and `trimSuffixBoilerplate`: Another name for the boilerplate versions of `trimPrefix`
       and `trimSuffix`. Use this if you would like to keep old behavior.
 
@@ -165,7 +165,7 @@ to using the new naming scheme, as they will be updated to use the sprig version
 
   
 
-- This release fixes a bug where the `fargate_without_lb` resource incorrectly set a `health_check_grace_period_seconds`. From [the terraform documentation](https://www.terraform.io/docs/providers/aws/r/ecs_service.html), "Health check grace period is only valid for services configured to use load balancers".
+- This release fixes a bug where the `fargate_without_lb` resource incorrectly set a `health_check_grace_period_seconds`. From [the terraform documentation](https://www.terraform.io/docs/providers/aws/r/ecs_service.html), &quot;Health check grace period is only valid for services configured to use load balancers&quot;.
 
 
 </div>
@@ -348,7 +348,7 @@ A huge thanks to @burtino for spotting this and providing a fix.
 
   
 
-- You can now tell the `iam-groups` module to not create the "access-all" group by setting the new input variable `should_create_iam_group_cross_account_access_all` to false. This can help work around an AWS limitation where we exceed the max IAM policy length.
+- You can now tell the `iam-groups` module to not create the &quot;access-all&quot; group by setting the new input variable `should_create_iam_group_cross_account_access_all` to false. This can help work around an AWS limitation where we exceed the max IAM policy length.
 
 
 </div>
@@ -366,7 +366,7 @@ A huge thanks to @burtino for spotting this and providing a fix.
 
 This release fixes https://github.com/gruntwork-io/module-security/issues/89, where `fail2ban` was not correctly working on non-ubuntu instances. Specifically:
 
-- For CentOS and Amazon Linux 2, `fail2ban` installed `firewalld`. `firewalld` by default disallows all inbound access except for SSH, which leads to frustrating UX where you have to explicitly enable your web services running on the instance. Additionally, this behavior doesn't play well with docker clusters like ECS and EKS, where the service ports are dynamic. This release fixes this behavior by updating `firewalld` to default to trust all traffic. See https://github.com/gruntwork-io/module-security/blob/master/modules/fail2ban/README.md#default-zone-for-firewalld-amazon-linux-2-and-centos for more info.
+- For CentOS and Amazon Linux 2, `fail2ban` installed `firewalld`. `firewalld` by default disallows all inbound access except for SSH, which leads to frustrating UX where you have to explicitly enable your web services running on the instance. Additionally, this behavior doesn&apos;t play well with docker clusters like ECS and EKS, where the service ports are dynamic. This release fixes this behavior by updating `firewalld` to default to trust all traffic. See https://github.com/gruntwork-io/module-security/blob/master/modules/fail2ban/README.md#default-zone-for-firewalld-amazon-linux-2-and-centos for more info.
 - For Amazon Linux 1, the `fail2ban` configuration had a bug where it was not starting up correctly. This release fixes that so that `fail2ban` starts correctly.
 - For Amazon Linux 1, the default regex for searching for failed SSH attempts was incorrect for the messages actually emitted by sshd on the platform. This release installs updated regex rules that properly detect the failing messages.
 - For CentOS and RHEL, the `configure-fail2ban-cloudwatch.sh` script had a bug preventing execution. This release fixes that.
@@ -394,7 +394,7 @@ This brings in TLS generation into the `k8s-tiller` module. In particular, `k8s-
 
 - `kubergrunt`: Use the [kubergrunt utility](https://github.com/gruntwork-io/kubergrunt) to generate the TLS certificates and upload as a Kubernetes `Secret` resource.
 - `provider`: Use the [tls Terraform provider](https://www.terraform.io/docs/providers/tls/index.html) to generate the TLS certs, and then use the [kubernetes provider](https://www.terraform.io/docs/providers/kubernetes/index.html) to upload them as a Kubernetes `Secret` resource.
-- `none`: Don't generate any TLS certs and look them up based on the input variable `tiller_tls_secret_name`.
+- `none`: Don&apos;t generate any TLS certs and look them up based on the input variable `tiller_tls_secret_name`.
 
 The characteristics of the three approaches are summarized in the table below. You can refer to the [module README](https://github.com/gruntwork-io/terraform-kubernetes-helm/tree/master/modules/k8s-tiller) for more details.
 
@@ -471,6 +471,6 @@ The other modules have backwards compatible minor changes in the way dependencie
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "81a6b8a8adbbd70ff61aea8c428b3ada"
+  "hash": "3569b5b8aa1b42051d948aff9d3c4cc7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-05/index.md
@@ -192,6 +192,23 @@ to using the new naming scheme, as they will be updated to use the sprig version
 </div>
 
 
+### [v0.5.3](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.5.3)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 5/1/2019 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.5.3">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+This release confirms that `external-dns` and ALB ingress controller support ACM certificates. Additionally, this release extends the timeout for EKS cluster creation as some regions take longer than 15 minutes to provision the EKS cluster.
+
+
+
+</div>
+
+
 
 ## terraform-aws-elk
 
@@ -454,6 +471,6 @@ The other modules have backwards compatible minor changes in the way dependencie
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "10f05cb3dba32a5da9ab03fb80ef77d7"
+  "hash": "81a6b8a8adbbd70ff61aea8c428b3ada"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-05/index.md
@@ -192,23 +192,6 @@ to using the new naming scheme, as they will be updated to use the sprig version
 </div>
 
 
-### [v0.5.3](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.5.3)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/1/2019 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.5.3">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  
-
-This release confirms that `external-dns` and ALB ingress controller support ACM certificates. Additionally, this release extends the timeout for EKS cluster creation as some regions take longer than 15 minutes to provision the EKS cluster.
-
-
-
-</div>
-
-
 
 ## terraform-aws-elk
 
@@ -471,6 +454,6 @@ The other modules have backwards compatible minor changes in the way dependencie
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "81a6b8a8adbbd70ff61aea8c428b3ada"
+  "hash": "10f05cb3dba32a5da9ab03fb80ef77d7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-06/index.md
@@ -37,7 +37,7 @@ Here are the repos that were updated:
 ### [v0.7.1](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.7.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/19/2019 | Modules affected: server-group | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.7.1">Release notes</a></small>
+  <small>Published: 6/20/2019 | Modules affected: server-group | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.7.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -54,7 +54,7 @@ Here are the repos that were updated:
 ### [v0.7.0](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.7.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/10/2019 | Modules affected: server-group, asg-rolling-deploy | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.7.0">Release notes</a></small>
+  <small>Published: 6/11/2019 | Modules affected: server-group, asg-rolling-deploy | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.7.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -95,7 +95,7 @@ This release fixes a bug where the module errors on the output if you set both `
 ### [v0.6.0](https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.6.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/10/2019 | Modules affected: redis, memcached | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.6.0">Release notes</a></small>
+  <small>Published: 6/11/2019 | Modules affected: redis, memcached | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.6.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -307,7 +307,7 @@ This release fixes a bug in the install scripts where for some base AMIs, the in
 ### [v0.3.0](https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.3.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/18/2019 | Modules affected: elasticsearch-cluster-backup | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.3.0">Release notes</a></small>
+  <small>Published: 6/19/2019 | Modules affected: elasticsearch-cluster-backup | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.3.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -376,7 +376,7 @@ Fixes a bug that arises when using terraform &gt;=0.12.2 with the `nlb` module. 
 ### [v0.14.0](https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.14.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/10/2019 | Modules affected: alb, nlb, acm-tls-certificate | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.14.0">Release notes</a></small>
+  <small>Published: 6/11/2019 | Modules affected: alb, nlb, acm-tls-certificate | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.14.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -436,7 +436,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 ### [v0.13.2](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.13.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/26/2019 | Modules affected: cloudwatch-dashboard-metric-widget | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.13.2">Release notes</a></small>
+  <small>Published: 6/27/2019 | Modules affected: cloudwatch-dashboard-metric-widget | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.13.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -491,7 +491,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 ### [v0.12.7](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.12.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/19/2019 | Modules affected: alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.12.7">Release notes</a></small>
+  <small>Published: 6/20/2019 | Modules affected: alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.12.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -551,7 +551,7 @@ Thanks to @bendavies for the PR!
 ### [v0.9.1](https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/19/2019 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.1">Release notes</a></small>
+  <small>Published: 6/20/2019 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -727,7 +727,7 @@ This release introduces a new module `ssm-healthchecks-iam-permissions` which pr
 ### [v0.7.0](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.7.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/10/2019 | Modules affected: single-server | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.7.0">Release notes</a></small>
+  <small>Published: 6/11/2019 | Modules affected: single-server | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.7.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -790,7 +790,7 @@ This fixes a bug that was introduced in upgrading to terraform 0.12, where `prep
 ### [v0.1.0](https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.1.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/5/2019 | <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.1.0">Release notes</a></small>
+  <small>Published: 6/6/2019 | <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.1.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -827,7 +827,7 @@ Additionally, we have deprecated and removed the `intermediate-variable` module 
 ### [v0.6.0](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.6.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/10/2019 | Modules affected: vpc-peering, vpc-peering-external, vpc-mgmt, vpc-mgmt-network-acls | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.6.0">Release notes</a></small>
+  <small>Published: 6/11/2019 | Modules affected: vpc-peering, vpc-peering-external, vpc-mgmt, vpc-mgmt-network-acls | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.6.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -900,7 +900,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 ### [v0.5.0](https://github.com/gruntwork-io/terraform-kubernetes-helm/releases/tag/v0.5.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/10/2019 | Modules affected: k8s-tiller, k8s-tiller-tls-certs, k8s-service-account, k8s-namespace | <a href="https://github.com/gruntwork-io/terraform-kubernetes-helm/releases/tag/v0.5.0">Release notes</a></small>
+  <small>Published: 6/11/2019 | Modules affected: k8s-tiller, k8s-tiller-tls-certs, k8s-service-account, k8s-namespace | <a href="https://github.com/gruntwork-io/terraform-kubernetes-helm/releases/tag/v0.5.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -926,6 +926,6 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "17625460266689baf0987b7d5df93796"
+  "hash": "0047f6c2e2cf33fe1a599f598f8c4f53"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-06/index.md
@@ -124,7 +124,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 ### [v0.14.0](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.14.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/21/2019 | Modules affected: jenkins-server, iam-policies, ec2-backup | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.14.0">Release notes</a></small>
+  <small>Published: 6/22/2019 | Modules affected: jenkins-server, iam-policies, ec2-backup | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.14.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -589,7 +589,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 ### [v0.8.2](https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.8.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/17/2019 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.8.2">Release notes</a></small>
+  <small>Published: 6/18/2019 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.8.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -926,6 +926,6 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "0047f6c2e2cf33fe1a599f598f8c4f53"
+  "hash": "92e5e55fa54353033c0a42565852258e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-06/index.md
@@ -37,7 +37,7 @@ Here are the repos that were updated:
 ### [v0.7.1](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.7.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/20/2019 | Modules affected: server-group | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.7.1">Release notes</a></small>
+  <small>Published: 6/19/2019 | Modules affected: server-group | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.7.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -54,7 +54,7 @@ Here are the repos that were updated:
 ### [v0.7.0](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.7.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/11/2019 | Modules affected: server-group, asg-rolling-deploy | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.7.0">Release notes</a></small>
+  <small>Published: 6/10/2019 | Modules affected: server-group, asg-rolling-deploy | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.7.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -95,7 +95,7 @@ This release fixes a bug where the module errors on the output if you set both `
 ### [v0.6.0](https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.6.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/11/2019 | Modules affected: redis, memcached | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.6.0">Release notes</a></small>
+  <small>Published: 6/10/2019 | Modules affected: redis, memcached | <a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.6.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -124,7 +124,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 ### [v0.14.0](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.14.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/22/2019 | Modules affected: jenkins-server, iam-policies, ec2-backup | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.14.0">Release notes</a></small>
+  <small>Published: 6/21/2019 | Modules affected: jenkins-server, iam-policies, ec2-backup | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.14.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -307,7 +307,7 @@ This release fixes a bug in the install scripts where for some base AMIs, the in
 ### [v0.3.0](https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.3.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/19/2019 | Modules affected: elasticsearch-cluster-backup | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.3.0">Release notes</a></small>
+  <small>Published: 6/18/2019 | Modules affected: elasticsearch-cluster-backup | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.3.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -376,7 +376,7 @@ Fixes a bug that arises when using terraform &gt;=0.12.2 with the `nlb` module. 
 ### [v0.14.0](https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.14.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/11/2019 | Modules affected: alb, nlb, acm-tls-certificate | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.14.0">Release notes</a></small>
+  <small>Published: 6/10/2019 | Modules affected: alb, nlb, acm-tls-certificate | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.14.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -436,7 +436,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 ### [v0.13.2](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.13.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/27/2019 | Modules affected: cloudwatch-dashboard-metric-widget | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.13.2">Release notes</a></small>
+  <small>Published: 6/26/2019 | Modules affected: cloudwatch-dashboard-metric-widget | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.13.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -491,7 +491,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 ### [v0.12.7](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.12.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/20/2019 | Modules affected: alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.12.7">Release notes</a></small>
+  <small>Published: 6/19/2019 | Modules affected: alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.12.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -551,7 +551,7 @@ Thanks to @bendavies for the PR!
 ### [v0.9.1](https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/20/2019 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.1">Release notes</a></small>
+  <small>Published: 6/19/2019 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -589,7 +589,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 ### [v0.8.2](https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.8.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/18/2019 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.8.2">Release notes</a></small>
+  <small>Published: 6/17/2019 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.8.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -727,7 +727,7 @@ This release introduces a new module `ssm-healthchecks-iam-permissions` which pr
 ### [v0.7.0](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.7.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/11/2019 | Modules affected: single-server | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.7.0">Release notes</a></small>
+  <small>Published: 6/10/2019 | Modules affected: single-server | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.7.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -790,7 +790,7 @@ This fixes a bug that was introduced in upgrading to terraform 0.12, where `prep
 ### [v0.1.0](https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.1.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/6/2019 | <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.1.0">Release notes</a></small>
+  <small>Published: 6/5/2019 | <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.1.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -827,7 +827,7 @@ Additionally, we have deprecated and removed the `intermediate-variable` module 
 ### [v0.6.0](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.6.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/11/2019 | Modules affected: vpc-peering, vpc-peering-external, vpc-mgmt, vpc-mgmt-network-acls | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.6.0">Release notes</a></small>
+  <small>Published: 6/10/2019 | Modules affected: vpc-peering, vpc-peering-external, vpc-mgmt, vpc-mgmt-network-acls | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.6.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -900,7 +900,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 ### [v0.5.0](https://github.com/gruntwork-io/terraform-kubernetes-helm/releases/tag/v0.5.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/11/2019 | Modules affected: k8s-tiller, k8s-tiller-tls-certs, k8s-service-account, k8s-namespace | <a href="https://github.com/gruntwork-io/terraform-kubernetes-helm/releases/tag/v0.5.0">Release notes</a></small>
+  <small>Published: 6/10/2019 | Modules affected: k8s-tiller, k8s-tiller-tls-certs, k8s-service-account, k8s-namespace | <a href="https://github.com/gruntwork-io/terraform-kubernetes-helm/releases/tag/v0.5.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -926,6 +926,6 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "92e5e55fa54353033c0a42565852258e"
+  "hash": "17625460266689baf0987b7d5df93796"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-06/index.md
@@ -109,7 +109,7 @@ This release fixes a bug where the module errors on the output if you set both `
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 - https://github.com/gruntwork-io/module-cache/pull/31
@@ -135,7 +135,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 
@@ -197,7 +197,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 
@@ -238,7 +238,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 
@@ -342,7 +342,7 @@ This release fixes a bug where AWS region of the s3 bucket was hardcoded to `us-
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 
@@ -391,7 +391,7 @@ Fixes a bug that arises when using terraform &gt;=0.12.2 with the `nlb` module. 
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 * https://github.com/gruntwork-io/module-load-balancer/pull/58
@@ -421,7 +421,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 * https://github.com/gruntwork-io/package-messaging/pull/22
@@ -481,7 +481,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 
@@ -517,7 +517,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 * `alarms/sqs-alarms`
 
 
-* Fix the `period` setting for the SQS alarm to use a minimum of 5 minutes rather than 1 minute, as SQS metrics are only collected once every 5 minutes, so trying to alert more often doesn't work.
+* Fix the `period` setting for the SQS alarm to use a minimum of 5 minutes rather than 1 minute, as SQS metrics are only collected once every 5 minutes, so trying to alert more often doesn&apos;t work.
 
 
 Thanks to @bendavies for the PR!
@@ -579,7 +579,7 @@ Thanks to @bendavies for the PR!
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 
@@ -639,7 +639,7 @@ This release introduces the ability to set an expiration lifecycle on the object
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `vars.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `vars.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 
@@ -680,7 +680,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 
@@ -738,7 +738,7 @@ This release introduces a new module `ssm-healthchecks-iam-permissions` which pr
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 
@@ -810,7 +810,7 @@ This fixes a bug that was introduced in upgrading to terraform 0.12, where `prep
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 Additionally, we have deprecated and removed the `intermediate-variable` module in this release. This module has been superseded by [terraform local values](https://www.terraform.io/docs/configuration/locals.html). To upgrade, switch usage of `intermediate-variable` with `locals`.
 
@@ -838,7 +838,7 @@ Additionally, we have deprecated and removed the `intermediate-variable` module 
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 
@@ -885,7 +885,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 * https://github.com/gruntwork-io/package-zookeeper/pull/45
@@ -911,7 +911,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 **Note:** there is one major interface change due to the upgrade. For the TLS modules, we no longer cannot pass through the subject info of the TLS cert as an inline block due to type issues. The main issue here is with the street_address attribute, which is of type `list(string)`. To support the types, the `street_address` must be provided as newline delimited `string`, which will be later converted to `list(string)`.
 
@@ -926,6 +926,6 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "92e5e55fa54353033c0a42565852258e"
+  "hash": "32778004facafcb944ab1e3d80c772ea"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-07/index.md
@@ -79,7 +79,7 @@ Here are the repos that were updated:
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 
@@ -104,7 +104,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 
@@ -129,7 +129,7 @@ This release updates `terraform-helpers/terraform-update-variable` for better te
 
 - The vars file that it searches for by default is now `terragrunt.hcl` instead of `terraform.tfvars`.
 - The vars file argument is now `--vars-path`, as opposed to `--tfvars-file`.
-- The quoting rules have changed to support more complex types. Now, instead of auto injecting quotes, it will inject the value literally. E.g if you pass in `terraform-update-variable --name "foo" --value "9"`, this will inject the string `foo = 9` instead of `foo = "9"`. If you want the old behavior, you will need to pass in the value quoted: `terraform-update-variable --name "foo" --value "\"9\""`
+- The quoting rules have changed to support more complex types. Now, instead of auto injecting quotes, it will inject the value literally. E.g if you pass in `terraform-update-variable --name &quot;foo&quot; --value &quot;9&quot;`, this will inject the string `foo = 9` instead of `foo = &quot;9&quot;`. If you want the old behavior, you will need to pass in the value quoted: `terraform-update-variable --name &quot;foo&quot; --value &quot;\&quot;9\&quot;&quot;`
 - The resulting file will now be passed through `terraform fmt` so that it is formatted.
 
 
@@ -231,7 +231,7 @@ Fixes a bug where `var.allow_incoming_http_from_security_group_ids` was not crea
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 
@@ -256,7 +256,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `vars.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `vars.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 
@@ -288,7 +288,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `vars.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `vars.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 * https://github.com/gruntwork-io/package-kafka/pull/59
@@ -314,7 +314,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `vars.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `vars.tf` file to double check if the 0 value has been converted to a `null`.
 
 
 
@@ -514,7 +514,7 @@ s3-cloud front [**BACKWARDS INCOMPATIBLE**]
 
 All the module variables have been updated to use concrete types based on the new type system introduced in terraform 0.12.0. You can learn more about the types in [the official documentation](https://www.terraform.io/docs/configuration/types.html).
 
-Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`""` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
+Note that as part of this, we switched to using `null` to indicate unset values when passing them through to resources. If you were previously using a 0 value (`&quot;&quot;` for strings and `0` for numbers), review the module `variables.tf` file to double check if the 0 value has been converted to a `null`.
 
 **Related links**
 
@@ -606,6 +606,6 @@ Starting this release, all the modules are tested and verified to work with Ubun
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "5de5dc1eff2feff3a6503810908b6b48"
+  "hash": "e8a622ecc024f396e52fcdcfc03e5925"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-07/index.md
@@ -139,7 +139,7 @@ This release updates `terraform-helpers/terraform-update-variable` for better te
 ### [v0.14.2](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.14.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/26/2019 | Modules affected: jenkins-server | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.14.2">Release notes</a></small>
+  <small>Published: 7/27/2019 | Modules affected: jenkins-server | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.14.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -270,7 +270,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 ### [v0.6.0](https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.6.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/5/2019 | Modules affected: kafka-security-group-rules, confluent-tools-cluster, kafka-cluster, kafka-iam-permissions | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.6.0">Release notes</a></small>
+  <small>Published: 7/6/2019 | Modules affected: kafka-security-group-rules, confluent-tools-cluster, kafka-cluster, kafka-iam-permissions | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.6.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -606,6 +606,6 @@ Starting this release, all the modules are tested and verified to work with Ubun
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "a3d3ebe5634e28747ca9d5271b7b48e2"
+  "hash": "5de5dc1eff2feff3a6503810908b6b48"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-07/index.md
@@ -139,7 +139,7 @@ This release updates `terraform-helpers/terraform-update-variable` for better te
 ### [v0.14.2](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.14.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/27/2019 | Modules affected: jenkins-server | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.14.2">Release notes</a></small>
+  <small>Published: 7/26/2019 | Modules affected: jenkins-server | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.14.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -270,7 +270,7 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 ### [v0.6.0](https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.6.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/6/2019 | Modules affected: kafka-security-group-rules, confluent-tools-cluster, kafka-cluster, kafka-iam-permissions | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.6.0">Release notes</a></small>
+  <small>Published: 7/5/2019 | Modules affected: kafka-security-group-rules, confluent-tools-cluster, kafka-cluster, kafka-iam-permissions | <a href="https://github.com/gruntwork-io/terraform-aws-kafka/releases/tag/v0.6.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -606,6 +606,6 @@ Starting this release, all the modules are tested and verified to work with Ubun
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "5de5dc1eff2feff3a6503810908b6b48"
+  "hash": "a3d3ebe5634e28747ca9d5271b7b48e2"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-08/index.md
@@ -158,7 +158,7 @@ The cloudtrail and kms-master-key modules each create KMS key resources. Previou
 ### [v0.18.1](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.18.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/13/2019 | Modules affected: iam-groups | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.18.1">Release notes</a></small>
+  <small>Published: 8/14/2019 | Modules affected: iam-groups | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.18.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -175,7 +175,7 @@ The cloudtrail and kms-master-key modules each create KMS key resources. Previou
 ### [v0.18.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.18.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/8/2019 | Modules affected: ssh-grunt, iam-groups | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.18.0">Release notes</a></small>
+  <small>Published: 8/9/2019 | Modules affected: ssh-grunt, iam-groups | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.18.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -333,6 +333,6 @@ The module has support for the following features:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "9066e63e0eca66cf3d684b1dfde3fee5"
+  "hash": "a5c00770d9e0a5f4ecadbe659ad512dd"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-08/index.md
@@ -106,7 +106,7 @@ This release adds a module for [AWS Config](https://aws.amazon.com/config/). The
 ### [v0.18.4: Updates to the CloudTrail module](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.18.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/28/2019 | Modules affected: cloudtrail | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.18.4">Release notes</a></small>
+  <small>Published: 8/29/2019 | Modules affected: cloudtrail | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.18.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -333,6 +333,6 @@ The module has support for the following features:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "e35c8371f9372095fcb9b8a0a3c0f6da"
+  "hash": "9066e63e0eca66cf3d684b1dfde3fee5"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-08/index.md
@@ -106,7 +106,7 @@ This release adds a module for [AWS Config](https://aws.amazon.com/config/). The
 ### [v0.18.4: Updates to the CloudTrail module](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.18.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/29/2019 | Modules affected: cloudtrail | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.18.4">Release notes</a></small>
+  <small>Published: 8/28/2019 | Modules affected: cloudtrail | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.18.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -158,7 +158,7 @@ The cloudtrail and kms-master-key modules each create KMS key resources. Previou
 ### [v0.18.1](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.18.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/14/2019 | Modules affected: iam-groups | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.18.1">Release notes</a></small>
+  <small>Published: 8/13/2019 | Modules affected: iam-groups | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.18.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -175,7 +175,7 @@ The cloudtrail and kms-master-key modules each create KMS key resources. Previou
 ### [v0.18.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.18.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/9/2019 | Modules affected: ssh-grunt, iam-groups | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.18.0">Release notes</a></small>
+  <small>Published: 8/8/2019 | Modules affected: ssh-grunt, iam-groups | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.18.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -333,6 +333,6 @@ The module has support for the following features:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "a5c00770d9e0a5f4ecadbe659ad512dd"
+  "hash": "e35c8371f9372095fcb9b8a0a3c0f6da"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-08/index.md
@@ -131,7 +131,7 @@ This release adds a module for [AWS Config](https://aws.amazon.com/config/). The
 
   
 
-- We've added a new module called `iam-users` that you can use to create and manage IAM users as code. The module can create IAM users, add them to IAM groups, and generate console passwords and access keys for them, encrypting each with PGP so they don't end up in plaintext in Terraform state.
+- We&apos;ve added a new module called `iam-users` that you can use to create and manage IAM users as code. The module can create IAM users, add them to IAM groups, and generate console passwords and access keys for them, encrypting each with PGP so they don&apos;t end up in plaintext in Terraform state.
 
 
 
@@ -165,7 +165,7 @@ The cloudtrail and kms-master-key modules each create KMS key resources. Previou
 
   
 
-- Fix bug where when upgrading the `iam-groups` module to tf12 with existing resources, `terraform` gets into a state where you can't `apply`, `plan`, or `destroy`.
+- Fix bug where when upgrading the `iam-groups` module to tf12 with existing resources, `terraform` gets into a state where you can&apos;t `apply`, `plan`, or `destroy`.
 
 
 
@@ -301,7 +301,7 @@ The module has support for the following features:
 
   
 
-- The `vpc-app-network-acls` module now sets `allow_access_from_mgmt_vpc` to `false` by default. This is a more sane default because (a) it's more secure and (b) `mgmt_vpc_cidr_block` is `null` by default, so if you left all parameters at their defaults, it doesn't actually work. If you are upgrading to this new version and you want to allow access to an app VPC from a mgmt VPC via VPC peering, you must now explicitly set `allow_access_from_mgmt_vpc` to true.
+- The `vpc-app-network-acls` module now sets `allow_access_from_mgmt_vpc` to `false` by default. This is a more sane default because (a) it&apos;s more secure and (b) `mgmt_vpc_cidr_block` is `null` by default, so if you left all parameters at their defaults, it doesn&apos;t actually work. If you are upgrading to this new version and you want to allow access to an app VPC from a mgmt VPC via VPC peering, you must now explicitly set `allow_access_from_mgmt_vpc` to true.
 
 
 
@@ -333,6 +333,6 @@ The module has support for the following features:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "a5c00770d9e0a5f4ecadbe659ad512dd"
+  "hash": "a1f56f71ba6cfb43db1dcdca38b687ac"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-09/index.md
@@ -56,7 +56,7 @@ Here are the repos that were updated:
 
   
 
-- This release adds a wrapper module for the [`cloudwatch-logs-metric-filters' module](https://github.com/gruntwork-io/module-aws-monitoring/blob/master/modules/logs/cloudwatch-logs-metric-filters/README.md). The wrapper creates metric filters as required by the CIS Foundations Benchmark.
+- This release adds a wrapper module for the [`cloudwatch-logs-metric-filters&apos; module](https://github.com/gruntwork-io/module-aws-monitoring/blob/master/modules/logs/cloudwatch-logs-metric-filters/README.md). The wrapper creates metric filters as required by the CIS Foundations Benchmark.
 
 
 
@@ -304,7 +304,7 @@ This release updates the modules and examples to ensure that they are compatible
 Note that in order to use the modules with Ubuntu 18.04, you need to:
 
 - Install OpenJDK 11 using the [install-open-jdk module](https://github.com/gruntwork-io/package-zookeeper/tree/master/modules/install-open-jdk)
-- Use version `5.7.2` of `collectd` (`gruntwork-install --module-name 'install-collectd' --repo 'https://github.com/gruntwork-io/package-elk' --tag 'v0.5.0' --module-param 'apt-version=5.7.2'"`)
+- Use version `5.7.2` of `collectd` (`gruntwork-install --module-name &apos;install-collectd&apos; --repo &apos;https://github.com/gruntwork-io/package-elk&apos; --tag &apos;v0.5.0&apos; --module-param &apos;apt-version=5.7.2&apos;&quot;`)
 - Use an ELK version that is compatible with Ubuntu 18.04. The following versions are known to be compatible:
     - 6.7.2
     - 6.8.3
@@ -379,7 +379,7 @@ Refer to the provided [migration guide](https://github.com/gruntwork-io/module-l
 
   
 
-- The `cloudwatch-logs-metric-filters` module uses syntax that wasn't available prior to Terraform version `0.12.6`. This version is now required by the module.
+- The `cloudwatch-logs-metric-filters` module uses syntax that wasn&apos;t available prior to Terraform version `0.12.6`. This version is now required by the module.
 
 
 
@@ -487,7 +487,7 @@ Refer to the provided [migration guide](https://github.com/gruntwork-io/module-l
 
   
 
-- A new variable, `sns_topic_already_exists`, is now required for the `aws-config` module. This addresses an issue with using `sns_topic_arn`. If the SNS topic was created in Terraform and the ARN was passed in via interpolation, the module would crash because Terraform can't resolve the count at plan time. We work around this limitation by instead using a boolean value which can be hard coded to `true` or `false` and thus does not hit this limitation.
+- A new variable, `sns_topic_already_exists`, is now required for the `aws-config` module. This addresses an issue with using `sns_topic_arn`. If the SNS topic was created in Terraform and the ARN was passed in via interpolation, the module would crash because Terraform can&apos;t resolve the count at plan time. We work around this limitation by instead using a boolean value which can be hard coded to `true` or `false` and thus does not hit this limitation.
 - Updated the IAM role in `aws-config` to account for a policy change made by AWS.
 - Updated the `iam-admin` group test to use a unique name to avoid conflicts
 
@@ -506,9 +506,9 @@ Refer to the provided [migration guide](https://github.com/gruntwork-io/module-l
   
 
 
-- Added some new policies to the `iam-policies` module: an "IAM admin" policy that permits `iam:*` (with MFA) but nothing else, and a new "require MFA" policy. It denies access to all actions except MFA self-management unless an MFA device is already enabled. You can attach this policy to users, groups, or roles alongside other policies that do not have an MFA condition of their own to ensure that an MFA device is be required for any of the combined actions to be allowed. For example, the AWS managed policies do not have an MFA condition, but if you attach this alongside them, MFA will be required.
+- Added some new policies to the `iam-policies` module: an &quot;IAM admin&quot; policy that permits `iam:*` (with MFA) but nothing else, and a new &quot;require MFA&quot; policy. It denies access to all actions except MFA self-management unless an MFA device is already enabled. You can attach this policy to users, groups, or roles alongside other policies that do not have an MFA condition of their own to ensure that an MFA device is be required for any of the combined actions to be allowed. For example, the AWS managed policies do not have an MFA condition, but if you attach this alongside them, MFA will be required.
 - Updated `iam-groups` to optionally create an `iam-admin` group that uses the policy mentioned above, and also optionally a `support` group with access to interact with AWS support (and nothing else).
-- Added new `custom-iam-group` module. This module can create a new IAM group and attach a set of policies by ARN or name. It can also ensure that the entire group requires MFA by attaching the "require MFA" policy mentioned above.
+- Added new `custom-iam-group` module. This module can create a new IAM group and attach a set of policies by ARN or name. It can also ensure that the entire group requires MFA by attaching the &quot;require MFA&quot; policy mentioned above.
 - Updated the `cloudtrail` module to optionally have separate names for the CloudWatch Logs Group and IAM role. Previously, the name of the role was based on the log group name.
 
 
@@ -628,6 +628,6 @@ The `run-pex-as-resource` module now exposes the `null_resource` triggers and th
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "ba4f25164ed554367e1b9c7bb80ee022"
+  "hash": "b773d9817618d974c357085319d84767"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-10/index.md
@@ -148,7 +148,7 @@ This release consolidates `ecs-service-with-alb`, `ecs-service-with-discovery`, 
 ### [v0.15.2](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.15.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/26/2019 | Modules affected: ecs-fargate | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.15.2">Release notes</a></small>
+  <small>Published: 10/25/2019 | Modules affected: ecs-fargate | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.15.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -235,7 +235,7 @@ Check out [the updated README](https://github.com/gruntwork-io/terraform-aws-eks
 ### [v0.9.6](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.9.6)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/18/2019 | Modules affected: eks-k8s-role-mapping, eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.9.6">Release notes</a></small>
+  <small>Published: 10/17/2019 | Modules affected: eks-k8s-role-mapping, eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.9.6">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -321,7 +321,7 @@ This fixes a bug with `eks-cloudwatch-container-logs`, where `fluentd` was redep
 ### [v0.9.1](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.9.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/9/2019 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.9.1">Release notes</a></small>
+  <small>Published: 10/8/2019 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.9.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -338,7 +338,7 @@ This release exposes the ability to tag the EKS cluster using the `custom_tags_e
 ### [v0.9.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.9.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/9/2019 | Modules affected: eks-vpc-tags, eks-cluster-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.9.0">Release notes</a></small>
+  <small>Published: 10/8/2019 | Modules affected: eks-vpc-tags, eks-cluster-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.9.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -374,7 +374,7 @@ Add support for multiple ASGs in `eks-cluster-workers` so that you can manage on
 ### [v0.14.2](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.14.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/26/2019 | Modules affected: alarms/elasticsearch-alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.14.2">Release notes</a></small>
+  <small>Published: 10/25/2019 | Modules affected: alarms/elasticsearch-alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.14.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -419,7 +419,7 @@ The alarms are defaulted to use the values that AWS recommend.
 ### [v0.9.7](https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/18/2019 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.7">Release notes</a></small>
+  <small>Published: 10/17/2019 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -547,7 +547,7 @@ Fix regression bug introduced in `v0.7.4` with `attach-eni`, where some error me
 ### [v0.7.4](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.7.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/18/2019 | Modules affected: attach-eni | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.7.4">Release notes</a></small>
+  <small>Published: 10/17/2019 | Modules affected: attach-eni | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.7.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -722,6 +722,6 @@ Listening on localhost is now optional. To disable localhost listening, set the 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "93c800b3734cf2ce3d9530c750d50245"
+  "hash": "a1337b4949629c9fa90246095c7b0816"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-10/index.md
@@ -235,7 +235,7 @@ Check out [the updated README](https://github.com/gruntwork-io/terraform-aws-eks
 ### [v0.9.6](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.9.6)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/17/2019 | Modules affected: eks-k8s-role-mapping, eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.9.6">Release notes</a></small>
+  <small>Published: 10/18/2019 | Modules affected: eks-k8s-role-mapping, eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.9.6">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -374,7 +374,7 @@ Add support for multiple ASGs in `eks-cluster-workers` so that you can manage on
 ### [v0.14.2](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.14.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/25/2019 | Modules affected: alarms/elasticsearch-alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.14.2">Release notes</a></small>
+  <small>Published: 10/26/2019 | Modules affected: alarms/elasticsearch-alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.14.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -419,7 +419,7 @@ The alarms are defaulted to use the values that AWS recommend.
 ### [v0.9.7](https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/17/2019 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.7">Release notes</a></small>
+  <small>Published: 10/18/2019 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -722,6 +722,6 @@ Listening on localhost is now optional. To disable localhost listening, set the 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "a1337b4949629c9fa90246095c7b0816"
+  "hash": "6f40d91c3b67354316336c93254eb124"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-10/index.md
@@ -148,7 +148,7 @@ This release consolidates `ecs-service-with-alb`, `ecs-service-with-discovery`, 
 ### [v0.15.2](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.15.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/25/2019 | Modules affected: ecs-fargate | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.15.2">Release notes</a></small>
+  <small>Published: 10/26/2019 | Modules affected: ecs-fargate | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.15.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -321,7 +321,7 @@ This fixes a bug with `eks-cloudwatch-container-logs`, where `fluentd` was redep
 ### [v0.9.1](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.9.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/8/2019 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.9.1">Release notes</a></small>
+  <small>Published: 10/9/2019 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.9.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -338,7 +338,7 @@ This release exposes the ability to tag the EKS cluster using the `custom_tags_e
 ### [v0.9.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.9.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/8/2019 | Modules affected: eks-vpc-tags, eks-cluster-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.9.0">Release notes</a></small>
+  <small>Published: 10/9/2019 | Modules affected: eks-vpc-tags, eks-cluster-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.9.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -547,7 +547,7 @@ Fix regression bug introduced in `v0.7.4` with `attach-eni`, where some error me
 ### [v0.7.4](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.7.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/17/2019 | Modules affected: attach-eni | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.7.4">Release notes</a></small>
+  <small>Published: 10/18/2019 | Modules affected: attach-eni | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.7.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -722,6 +722,6 @@ Listening on localhost is now optional. To disable localhost listening, set the 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "6f40d91c3b67354316336c93254eb124"
+  "hash": "93c800b3734cf2ce3d9530c750d50245"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-10/index.md
@@ -54,8 +54,8 @@ Here are the repos that were updated:
 
   
 
-- The `memcached` version now sets the default version to `1.5.16`. We were using `1.4.24` before, but that's no longer supported. If you wish to use a different version, use the `memcached_version` input variable.
-- The `redis` module now sets the default version to `5.0.5`. We were using `2.8.24` before, but that's now quite out of date. If you wish to use a different version, use the `redis_version` input variable.
+- The `memcached` version now sets the default version to `1.5.16`. We were using `1.4.24` before, but that&apos;s no longer supported. If you wish to use a different version, use the `memcached_version` input variable.
+- The `redis` module now sets the default version to `5.0.5`. We were using `2.8.24` before, but that&apos;s now quite out of date. If you wish to use a different version, use the `redis_version` input variable.
 
 
 
@@ -461,7 +461,7 @@ The EIP resource in `openvpn-server` is now optional. You can set the `enable_ei
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  This alpha release bumps the version of Go used with `ssh-grunt` from `1.11` to `1.13.3` to address an issue with long delays under certain (mysterious) conditions. We'll confirm the fix before releasing `v0.20.1`.
+  This alpha release bumps the version of Go used with `ssh-grunt` from `1.11` to `1.13.3` to address an issue with long delays under certain (mysterious) conditions. We&apos;ll confirm the fix before releasing `v0.20.1`.
 
 </div>
 
@@ -496,10 +496,10 @@ The EIP resource in `openvpn-server` is now optional. You can set the `enable_ei
 - The recently-created `custom-iam-group` module has been renamed to `custom-iam-entity`. The new module has support for creating roles in addition to groups.
 - The `saml-iam-roles` and `cross-account-iam-roles` modules now support tags. Use a map of tags to create tagged roles. For example:
 ```
-    tags = {
-        Department = "IT"
-        Environment = "Production"
-    }
+    tags = &#x7B;
+        Department = &quot;IT&quot;
+        Environment = &quot;Production&quot;
+    &#x7D;
 ```
 
 
@@ -722,6 +722,6 @@ Listening on localhost is now optional. To disable localhost listening, set the 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "93c800b3734cf2ce3d9530c750d50245"
+  "hash": "931ea36a7936ff7577f48de7b011ad5a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-11/index.md
@@ -38,7 +38,7 @@ Here are the repos that were updated:
 - Simplify permutations In the `redis` module. As the resource names change within the module, this is a backwards incompatible change.
 
 
-This release is backwards incompatible and to update an existing Redis cluster, use `terraform state mv &lt;old_address&gt; &lt;new_address&gt;` to ensure that your cluster isn't deleted when you run `terraform apply`.
+This release is backwards incompatible and to update an existing Redis cluster, use `terraform state mv &lt;old_address&gt; &lt;new_address&gt;` to ensure that your cluster isn&apos;t deleted when you run `terraform apply`.
 
 Depending on your configuration, your current resource name is one of
 - `redis_with_snapshotting_without_auth_token_without_cluster_mode`
@@ -55,7 +55,7 @@ To find out which one it is, run `terraform state list`.
 For example, if your current resource name is `module.redis.aws_elasticache_replication_group.redis_without_snapshotting_without_auth_token_with_cluster_mode[0]`, you can migrate the resource by running: 
 
 ```bash
-terraform state mv "module.redis.aws_elasticache_replication_group.redis_without_snapshotting_without_auth_token_with_cluster_mode[0]" module.redis.aws_elasticache_replication_group.redis
+terraform state mv &quot;module.redis.aws_elasticache_replication_group.redis_without_snapshotting_without_auth_token_with_cluster_mode[0]&quot; module.redis.aws_elasticache_replication_group.redis
 ```
 Note that you will have to use the quotes around the indexed resource to avoid `terraform` error `no matches found: module.redis....`
 
@@ -145,7 +145,7 @@ This is the initial release of wrapper modules for v1.2.0 of the AWS Foundations
 
   
 
-- Fixed a bug where ECS Auto Scaling was only working for "scale out" but not "scale in."
+- Fixed a bug where ECS Auto Scaling was only working for &quot;scale out&quot; but not &quot;scale in.&quot;
 
 
 
@@ -260,13 +260,13 @@ NOTE: If you are using `terragrunt`, the `state mv` calls should be done using `
 If you had `var.enable_alb_access_logs = true`:
 ```
  export MODULE_ADDRESS=module.alb # This should be the address of the module block used to call `alb`
-terraform state mv "$MODULE_ADDRESS.aws_alb.alb_with_logs[0]" "$MODULE_ADDRESS.aws_alb.alb"
+terraform state mv &quot;$MODULE_ADDRESS.aws_alb.alb_with_logs[0]&quot; &quot;$MODULE_ADDRESS.aws_alb.alb&quot;
 ```
 
 Otherwise:
 ``` 
 export MODULE_ADDRESS=module.alb # This should be the address of the module block used to call `alb`
-terraform state mv "$MODULE_ADDRESS.aws_alb.alb_without_logs[0]" "$MODULE_ADDRESS.aws_alb.alb"
+terraform state mv &quot;$MODULE_ADDRESS.aws_alb.alb_without_logs[0]&quot; &quot;$MODULE_ADDRESS.aws_alb.alb&quot;
 ```
 
 
@@ -300,6 +300,6 @@ terraform state mv "$MODULE_ADDRESS.aws_alb.alb_without_logs[0]" "$MODULE_ADDRES
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "b41d41b10a77eee593e6a4cc056f2c08"
+  "hash": "2f81ced76025981db3031d283a8397e4"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-12/index.md
@@ -37,7 +37,7 @@ Here are the repos that were updated:
 ### [v0.2.26](https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.26)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/16/2019 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.26">Release notes</a></small>
+  <small>Published: 12/17/2019 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.26">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -54,7 +54,7 @@ Here are the repos that were updated:
 ### [v0.0.1](https://github.com/gruntwork-io/infrastructure-live-acme/releases/tag/v0.0.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/10/2019 | <a href="https://github.com/gruntwork-io/infrastructure-live-acme/releases/tag/v0.0.1">Release notes</a></small>
+  <small>Published: 12/11/2019 | <a href="https://github.com/gruntwork-io/infrastructure-live-acme/releases/tag/v0.0.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -71,7 +71,7 @@ Here are the repos that were updated:
 ### [v0.0.1](https://github.com/gruntwork-io/infrastructure-live-multi-account-acme/releases/tag/v0.0.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/10/2019 | <a href="https://github.com/gruntwork-io/infrastructure-live-multi-account-acme/releases/tag/v0.0.1">Release notes</a></small>
+  <small>Published: 12/11/2019 | <a href="https://github.com/gruntwork-io/infrastructure-live-multi-account-acme/releases/tag/v0.0.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -122,7 +122,7 @@ Here are the repos that were updated:
 ### [v0.16.2](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.16.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/13/2019 | Modules affected: ec2-backup | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.16.2">Release notes</a></small>
+  <small>Published: 12/14/2019 | Modules affected: ec2-backup | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.16.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -138,7 +138,7 @@ Here are the repos that were updated:
 ### [v0.16.1](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.16.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/11/2019 | Modules affected: terraform-helpers | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.16.1">Release notes</a></small>
+  <small>Published: 12/12/2019 | Modules affected: terraform-helpers | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.16.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -163,7 +163,7 @@ This release fixes two bugs with `terraform-update-variable`:
 ### [v0.3.0](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.3.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/19/2019 | Modules affected: cloudtrail, cloudwatch-logs-metric-filters, aws-securityhub | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.3.0">Release notes</a></small>
+  <small>Published: 12/20/2019 | Modules affected: cloudtrail, cloudwatch-logs-metric-filters, aws-securityhub | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.3.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -194,7 +194,7 @@ This release fixes two bugs with `terraform-update-variable`:
 ### [v0.2.1](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.2.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/17/2019 | Modules affected: custom-iam-entity | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.2.1">Release notes</a></small>
+  <small>Published: 12/18/2019 | Modules affected: custom-iam-entity | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.2.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -322,7 +322,7 @@ You can now provide lifecycle hooks to the `eks-alb-ingress-controller` module t
 ### [v0.11.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.11.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/3/2019 | Modules affected: eks-vpc-tags | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.11.0">Release notes</a></small>
+  <small>Published: 12/4/2019 | Modules affected: eks-vpc-tags | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.11.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -342,7 +342,7 @@ The VPC subnet tags generated for EKS by `eks-vpc-tags` now supports multiple EK
 ### [v0.7.1](https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.7.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/5/2019 | Modules affected: lambda, lambda-edge | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.7.1">Release notes</a></small>
+  <small>Published: 12/6/2019 | Modules affected: lambda, lambda-edge | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.7.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -433,7 +433,7 @@ Special thanks to @scottclk for the contribution!
 ### [v0.15.0](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.15.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/19/2019 | Modules affected: logs/cloudwatch-logs-metric-filters | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.15.0">Release notes</a></small>
+  <small>Published: 12/20/2019 | Modules affected: logs/cloudwatch-logs-metric-filters | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.15.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -454,7 +454,7 @@ The `cloudwatch-logs-metric-filters` module no longer configures an aws provider
 ### [v0.22.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.22.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/19/2019 | Modules affected: cloudtrail, ssh-grunt, aws-organizations, aws-organizations-config-rules | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.22.0">Release notes</a></small>
+  <small>Published: 12/20/2019 | Modules affected: cloudtrail, ssh-grunt, aws-organizations, aws-organizations-config-rules | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.22.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -531,7 +531,7 @@ The `cloudtrail` module will no longer attempt to create the server access loggi
 ### [v0.21.1](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.21.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/10/2019 | Modules affected: aws-organizations | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.21.1">Release notes</a></small>
+  <small>Published: 12/11/2019 | Modules affected: aws-organizations | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.21.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -725,6 +725,6 @@ Bump maven version to install exhibitor since 3.6.1 is no longer available
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "84b15cb160c3f71d3968cc3c16c4106d"
+  "hash": "de5c9c10ed1ad22081bb40e78838b466"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-12/index.md
@@ -561,7 +561,7 @@ The `cloudtrail` module will no longer attempt to create the server access loggi
 
 `aws-config` module now supports conditional logic to turn off all resources in the module. When you set the `create_resources` input variable to `false`, no resources will be created by the module. This is useful to conditionally turn off the module call in your code.
 
-Additionally, this fixes a bug where the AWS provider was being configured within the `aws-config` module. This makes the module less flexible for use since you can't override the provider configuration. As a result, the `aws-config` module no longer needs the `aws_region` parameter to be passed in.
+Additionally, this fixes a bug where the AWS provider was being configured within the `aws-config` module. This makes the module less flexible for use since you can&apos;t override the provider configuration. As a result, the `aws-config` module no longer needs the `aws_region` parameter to be passed in.
 
 
 </div>
@@ -627,7 +627,7 @@ Additionally, this fixes a bug where the AWS provider was being configured withi
 
   
 
-- Due to a change in AWS, the `s3-cloudfront` module was not able to send CloudFront access logs to the S3 bucket. This has now been fixed by updating the policy on that S3 bucket. Note that due to a Terraform or AWS bug, you need to set `use_cloudfront_arn_for_bucket_policy` to `true` in old AWS accounts and `use_cloudfront_arn_for_bucket_policy` to `false` in old accounts, or you'll get a perpetual diff from the `plan` output. 
+- Due to a change in AWS, the `s3-cloudfront` module was not able to send CloudFront access logs to the S3 bucket. This has now been fixed by updating the policy on that S3 bucket. Note that due to a Terraform or AWS bug, you need to set `use_cloudfront_arn_for_bucket_policy` to `true` in old AWS accounts and `use_cloudfront_arn_for_bucket_policy` to `false` in old accounts, or you&apos;ll get a perpetual diff from the `plan` output. 
 
 
 
@@ -725,6 +725,6 @@ Bump maven version to install exhibitor since 3.6.1 is no longer available
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "de5c9c10ed1ad22081bb40e78838b466"
+  "hash": "dda7bc4e1720eede9484ffe8d7bc5edf"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-12/index.md
@@ -37,7 +37,7 @@ Here are the repos that were updated:
 ### [v0.2.26](https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.26)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/17/2019 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.26">Release notes</a></small>
+  <small>Published: 12/16/2019 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.2.26">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -54,7 +54,7 @@ Here are the repos that were updated:
 ### [v0.0.1](https://github.com/gruntwork-io/infrastructure-live-acme/releases/tag/v0.0.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/11/2019 | <a href="https://github.com/gruntwork-io/infrastructure-live-acme/releases/tag/v0.0.1">Release notes</a></small>
+  <small>Published: 12/10/2019 | <a href="https://github.com/gruntwork-io/infrastructure-live-acme/releases/tag/v0.0.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -71,7 +71,7 @@ Here are the repos that were updated:
 ### [v0.0.1](https://github.com/gruntwork-io/infrastructure-live-multi-account-acme/releases/tag/v0.0.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/11/2019 | <a href="https://github.com/gruntwork-io/infrastructure-live-multi-account-acme/releases/tag/v0.0.1">Release notes</a></small>
+  <small>Published: 12/10/2019 | <a href="https://github.com/gruntwork-io/infrastructure-live-multi-account-acme/releases/tag/v0.0.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -122,7 +122,7 @@ Here are the repos that were updated:
 ### [v0.16.2](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.16.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/14/2019 | Modules affected: ec2-backup | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.16.2">Release notes</a></small>
+  <small>Published: 12/13/2019 | Modules affected: ec2-backup | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.16.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -138,7 +138,7 @@ Here are the repos that were updated:
 ### [v0.16.1](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.16.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/12/2019 | Modules affected: terraform-helpers | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.16.1">Release notes</a></small>
+  <small>Published: 12/11/2019 | Modules affected: terraform-helpers | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.16.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -163,7 +163,7 @@ This release fixes two bugs with `terraform-update-variable`:
 ### [v0.3.0](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.3.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/20/2019 | Modules affected: cloudtrail, cloudwatch-logs-metric-filters, aws-securityhub | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.3.0">Release notes</a></small>
+  <small>Published: 12/19/2019 | Modules affected: cloudtrail, cloudwatch-logs-metric-filters, aws-securityhub | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.3.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -194,7 +194,7 @@ This release fixes two bugs with `terraform-update-variable`:
 ### [v0.2.1](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.2.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/18/2019 | Modules affected: custom-iam-entity | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.2.1">Release notes</a></small>
+  <small>Published: 12/17/2019 | Modules affected: custom-iam-entity | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.2.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -322,7 +322,7 @@ You can now provide lifecycle hooks to the `eks-alb-ingress-controller` module t
 ### [v0.11.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.11.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/4/2019 | Modules affected: eks-vpc-tags | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.11.0">Release notes</a></small>
+  <small>Published: 12/3/2019 | Modules affected: eks-vpc-tags | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.11.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -342,7 +342,7 @@ The VPC subnet tags generated for EKS by `eks-vpc-tags` now supports multiple EK
 ### [v0.7.1](https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.7.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/6/2019 | Modules affected: lambda, lambda-edge | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.7.1">Release notes</a></small>
+  <small>Published: 12/5/2019 | Modules affected: lambda, lambda-edge | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.7.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -433,7 +433,7 @@ Special thanks to @scottclk for the contribution!
 ### [v0.15.0](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.15.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/20/2019 | Modules affected: logs/cloudwatch-logs-metric-filters | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.15.0">Release notes</a></small>
+  <small>Published: 12/19/2019 | Modules affected: logs/cloudwatch-logs-metric-filters | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.15.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -454,7 +454,7 @@ The `cloudwatch-logs-metric-filters` module no longer configures an aws provider
 ### [v0.22.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.22.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/20/2019 | Modules affected: cloudtrail, ssh-grunt, aws-organizations, aws-organizations-config-rules | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.22.0">Release notes</a></small>
+  <small>Published: 12/19/2019 | Modules affected: cloudtrail, ssh-grunt, aws-organizations, aws-organizations-config-rules | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.22.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -531,7 +531,7 @@ The `cloudtrail` module will no longer attempt to create the server access loggi
 ### [v0.21.1](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.21.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/11/2019 | Modules affected: aws-organizations | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.21.1">Release notes</a></small>
+  <small>Published: 12/10/2019 | Modules affected: aws-organizations | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.21.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -725,6 +725,6 @@ Bump maven version to install exhibitor since 3.6.1 is no longer available
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "de5c9c10ed1ad22081bb40e78838b466"
+  "hash": "84b15cb160c3f71d3968cc3c16c4106d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-01/index.md
@@ -230,7 +230,7 @@ Here are the repos that were updated:
 
   
 
-- The modules under `iam-policies` now allow you to set the `create_resources` parameter to `false` to have the module not create any resources. This is a workaround for Terraform not supporting the `count` parameter on `module { ... }` blocks.
+- The modules under `iam-policies` now allow you to set the `create_resources` parameter to `false` to have the module not create any resources. This is a workaround for Terraform not supporting the `count` parameter on `module &#x7B; ... &#x7D;` blocks.
 
 
 </div>
@@ -288,7 +288,7 @@ Here are the repos that were updated:
   
 
 - Fixes a missing image in the documentation
-- Adds the Gruntwork License. Previously, the repository was unlicensed, thus subject to the ["all rights reserved" style default license](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/licensing-a-repository#choosing-the-right-license) which we don't want.
+- Adds the Gruntwork License. Previously, the repository was unlicensed, thus subject to the [&quot;all rights reserved&quot; style default license](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/licensing-a-repository#choosing-the-right-license) which we don&apos;t want.
 
 
 
@@ -376,7 +376,7 @@ You can now define custom metric filters in addition to the default filters requ
 
   
 
-This release exposes the [`ca_cert_identifier`](https://www.terraform.io/docs/providers/aws/r/db_instance.html#ca_cert_identifier) argument for `aws_db_instance`. This argument configures which CA certificate bundle is used by RDS. The expiration of the previous CA bundle is March 5, 2020, at which point TLS connections that haven't been updated will break. Refer to the [AWS documentation on this](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html).
+This release exposes the [`ca_cert_identifier`](https://www.terraform.io/docs/providers/aws/r/db_instance.html#ca_cert_identifier) argument for `aws_db_instance`. This argument configures which CA certificate bundle is used by RDS. The expiration of the previous CA bundle is March 5, 2020, at which point TLS connections that haven&apos;t been updated will break. Refer to the [AWS documentation on this](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html).
 
 The argument defaults to `rds-ca-2019`. Once you run `terraform apply` with this update, it will update the instance, but the change will not take effect until the next DB modification window. You can use `apply_immediately=true` to restart the instance. Until the instance is restarted, the Terraform plan will result in a perpetual diff.
 
@@ -401,14 +401,14 @@ The argument defaults to `rds-ca-2019`. Once you run `terraform apply` with this
 
 This update adds tags for ECS services and task definitions. To add a tag to a service, provide a map with the `service_tags` variable. Similar, to tag task definitions, provide a map with the `task_definition_tags` variable. For example:
 ```
-service_tags = {
-    foo = "bar"
-}
+service_tags = &#x7B;
+    foo = &quot;bar&quot;
+&#x7D;
 ```
-Use the `propagate_tags` variable to propagate tags to ECS tasks. If you set `propagate_tags` to `SERVICE`, the tags from `service_tags` will be set on tasks. If you want to propagate tags from task definitions, set `propagate_tags="TASK_DEFINITION"`. If you set `propagate_tags=null`, tasks will be created with no tags. The default is `SERVICE`.
+Use the `propagate_tags` variable to propagate tags to ECS tasks. If you set `propagate_tags` to `SERVICE`, the tags from `service_tags` will be set on tasks. If you want to propagate tags from task definitions, set `propagate_tags=&quot;TASK_DEFINITION&quot;`. If you set `propagate_tags=null`, tasks will be created with no tags. The default is `SERVICE`.
 
 **Compatibility note**
-Tag propagation requires that you adopt the [new ARN and resource ID format](https://aws.amazon.com/blogs/compute/migrating-your-amazon-ecs-deployment-to-the-new-arn-and-resource-id-format-2/). If you don't do this, you may encounter the following error:
+Tag propagation requires that you adopt the [new ARN and resource ID format](https://aws.amazon.com/blogs/compute/migrating-your-amazon-ecs-deployment-to-the-new-arn-and-resource-id-format-2/). If you don&apos;t do this, you may encounter the following error:
 
 ```
 InvalidParameterException: The new ARN and resource ID format must be enabled to propagate tags. Opt in to the new format and try again.
@@ -424,7 +424,7 @@ $ aws ecs put-account-setting-default --name serviceLongArnFormat --value enable
 
 This will set the account default, but note that the setting is per-user, per-region. The commands above should be executed within each region that uses ECS.
 
-Furthermore, you may also need to run the commands for IAM users that already exist in the account but haven't opted in to the new format. To do so, authenticate as the IAM user who will be running Terraform (such as a CI machine user), and use the `put-account-setting` variant of the command within the appropriate regions. For example:
+Furthermore, you may also need to run the commands for IAM users that already exist in the account but haven&apos;t opted in to the new format. To do so, authenticate as the IAM user who will be running Terraform (such as a CI machine user), and use the `put-account-setting` variant of the command within the appropriate regions. For example:
 
 ```
 
@@ -646,7 +646,7 @@ Bump package-zookeeper version to fix tests and fix broken links
 * **No changes to underlying modules.**
 
 
-Fix broken links in README's
+Fix broken links in README&apos;s
 
 
 
@@ -668,7 +668,7 @@ Fix broken links in README's
 
   
 
-- Fix broken links in readme's
+- Fix broken links in readme&apos;s
 - Fix wrong syntax on event metric filter pattern
 
 
@@ -897,7 +897,7 @@ The following additional fixes are also included in this release:
 
   
 
-- Fix a few broken links in README's
+- Fix a few broken links in README&apos;s
 - Update CODEOWNERS
 
 
@@ -943,7 +943,7 @@ The following additional fixes are also included in this release:
 
   
 
-- Fix broken links in README's
+- Fix broken links in README&apos;s
 
 
 
@@ -996,6 +996,6 @@ Now `vpc-app` and `vpc-mgmt` will create a single VPC endpoint for all tiers. Pr
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "8e8b6ebef302f0c3a936ba4fc89013c4"
+  "hash": "3e2e79f16f795251585d7d3e8ec72a18"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-01/index.md
@@ -500,7 +500,7 @@ The `eks-cluster-control-plane` now supports specifying a CIDR block to restrict
 ### [v0.13.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.13.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/13/2020 | Modules affected: eks-cluster-control-plane, eks-cluster-workers, eks-k8s-role-mapping, eks-k8s-external-dns | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.13.0">Release notes</a></small>
+  <small>Published: 1/14/2020 | Modules affected: eks-cluster-control-plane, eks-cluster-workers, eks-k8s-role-mapping, eks-k8s-external-dns | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.13.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -526,7 +526,7 @@ This release also includes a number of minor bug fixes:
 ### [v0.12.2: [BACKWARDS INCOMPATIBLE] Fargate](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.12.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/8/2020 | Modules affected: eks-k8s-role-mapping, eks-k8s-external-dns, eks-k8s-external-dns-iam-policy, eks-k8s-cluster-autoscaler | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.12.2">Release notes</a></small>
+  <small>Published: 1/9/2020 | Modules affected: eks-k8s-role-mapping, eks-k8s-external-dns, eks-k8s-external-dns-iam-policy, eks-k8s-cluster-autoscaler | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.12.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -551,7 +551,7 @@ Starting this release, the modules in this repo have official support for Fargat
 ### [v0.12.1: Managed Node Groups](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.12.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/6/2020 | Modules affected: eks-cluster-managed-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.12.1">Release notes</a></small>
+  <small>Published: 1/7/2020 | Modules affected: eks-cluster-managed-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.12.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -805,7 +805,7 @@ The codegen generator go library has been updated to allow rendering explicit bl
 ### [v0.23.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.23.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/24/2020 | Modules affected: guardduty-single-region, guardduty-multi-region, aws-config, aws-config-multi-region | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.23.0">Release notes</a></small>
+  <small>Published: 1/25/2020 | Modules affected: guardduty-single-region, guardduty-multi-region, aws-config, aws-config-multi-region | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.23.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -996,6 +996,6 @@ Now `vpc-app` and `vpc-mgmt` will create a single VPC endpoint for all tiers. Pr
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "7481723e61e1fc72200348c00a64ee82"
+  "hash": "8e8b6ebef302f0c3a936ba4fc89013c4"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-01/index.md
@@ -500,7 +500,7 @@ The `eks-cluster-control-plane` now supports specifying a CIDR block to restrict
 ### [v0.13.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.13.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/14/2020 | Modules affected: eks-cluster-control-plane, eks-cluster-workers, eks-k8s-role-mapping, eks-k8s-external-dns | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.13.0">Release notes</a></small>
+  <small>Published: 1/13/2020 | Modules affected: eks-cluster-control-plane, eks-cluster-workers, eks-k8s-role-mapping, eks-k8s-external-dns | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.13.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -526,7 +526,7 @@ This release also includes a number of minor bug fixes:
 ### [v0.12.2: [BACKWARDS INCOMPATIBLE] Fargate](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.12.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/9/2020 | Modules affected: eks-k8s-role-mapping, eks-k8s-external-dns, eks-k8s-external-dns-iam-policy, eks-k8s-cluster-autoscaler | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.12.2">Release notes</a></small>
+  <small>Published: 1/8/2020 | Modules affected: eks-k8s-role-mapping, eks-k8s-external-dns, eks-k8s-external-dns-iam-policy, eks-k8s-cluster-autoscaler | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.12.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -551,7 +551,7 @@ Starting this release, the modules in this repo have official support for Fargat
 ### [v0.12.1: Managed Node Groups](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.12.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/7/2020 | Modules affected: eks-cluster-managed-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.12.1">Release notes</a></small>
+  <small>Published: 1/6/2020 | Modules affected: eks-cluster-managed-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.12.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -805,7 +805,7 @@ The codegen generator go library has been updated to allow rendering explicit bl
 ### [v0.23.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.23.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/25/2020 | Modules affected: guardduty-single-region, guardduty-multi-region, aws-config, aws-config-multi-region | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.23.0">Release notes</a></small>
+  <small>Published: 1/24/2020 | Modules affected: guardduty-single-region, guardduty-multi-region, aws-config, aws-config-multi-region | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.23.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -996,6 +996,6 @@ Now `vpc-app` and `vpc-mgmt` will create a single VPC endpoint for all tiers. Pr
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "8e8b6ebef302f0c3a936ba4fc89013c4"
+  "hash": "7481723e61e1fc72200348c00a64ee82"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-02/index.md
@@ -59,7 +59,7 @@ Here are the repos that were updated:
 
 - Update CircleCi Packer from 1.3.3 to 1.5.4 
 
-The Packer template used to generate machine images now uses the `clean_resource_name` function when generating the artifact's image name (changed from `clean_ami_name`). Note that the `clean_ami_name` function was deprecated in Packer's [1.5.0 release](https://github.com/hashicorp/packer/blob/master/CHANGELOG.md#150-december-18-2019).
+The Packer template used to generate machine images now uses the `clean_resource_name` function when generating the artifact&apos;s image name (changed from `clean_ami_name`). Note that the `clean_ami_name` function was deprecated in Packer&apos;s [1.5.0 release](https://github.com/hashicorp/packer/blob/master/CHANGELOG.md#150-december-18-2019).
 
 
 
@@ -138,7 +138,7 @@ Made several updates to the `jenkins-server` module:
 
 - Expose a new `user_data_base64` input variable that allows you to pass in Base64-encoded User Data (e.g., such as a gzipped cloud-init script).
 - Fixed deprecation warnings with the ALB listener rules.
-- Updated the version of the `alb` module used under the hood. This new version no longer sets the `Environment` tag on the load balancer. Therefore, the `jenkins-server` module no longer takes an `environment_name` variable as an input variable, so if you're upgrading, you'll need to remove this variable. 
+- Updated the version of the `alb` module used under the hood. This new version no longer sets the `Environment` tag on the load balancer. Therefore, the `jenkins-server` module no longer takes an `environment_name` variable as an input variable, so if you&apos;re upgrading, you&apos;ll need to remove this variable. 
 
 
 
@@ -384,7 +384,7 @@ The `clean_up_cluster_resources` script now cleans up residual security groups f
 
   
 
-The IAM Role for Service Accounts (IRSA) input variables for the application modules (`eks-k8s-external-dns`, `eks-k8s-cluster-autoscaler`, `eks-cloudwatch-container-logs`, and `eks-alb-ingress-controller`) are now required. Previously, we defaulted `use_iam_role_for_service_accounts` to true, but this meant that you needed to provide two required variables `eks_openid_connect_provider_arn` and `eks_openid_connect_provider_url`. However, these had defaults of empty string and do not cause an error in the terraform config, which means that you would have a successful deployment even if they weren't set. This can be confusing because each of these services will silently fail since they will not have access to the AWS resources they need to manage. Starting this release the IRSA input variables have been consolidated to a single required variable `iam_role_for_service_accounts_config`.
+The IAM Role for Service Accounts (IRSA) input variables for the application modules (`eks-k8s-external-dns`, `eks-k8s-cluster-autoscaler`, `eks-cloudwatch-container-logs`, and `eks-alb-ingress-controller`) are now required. Previously, we defaulted `use_iam_role_for_service_accounts` to true, but this meant that you needed to provide two required variables `eks_openid_connect_provider_arn` and `eks_openid_connect_provider_url`. However, these had defaults of empty string and do not cause an error in the terraform config, which means that you would have a successful deployment even if they weren&apos;t set. This can be confusing because each of these services will silently fail since they will not have access to the AWS resources they need to manage. Starting this release the IRSA input variables have been consolidated to a single required variable `iam_role_for_service_accounts_config`.
 
 
 
@@ -446,9 +446,9 @@ You can now set the permissions boundary on the IAM role created for the lambda 
 - The `alb` module no longer exposes an `environment_name` input variable. This variable was solely used to set an `Environment` tag on the load balancer. To upgrade to this version, you will need to remove the `environment_name` parameter from your code. If you wish to maintain the tag for backwards compatibility, set it in the `custom_tags` parameter as follows:
 
     ```hcl
-    custom_tags = {
-      Environment = "whatever value you were setting for environment_name before"
-    } 
+    custom_tags = &#x7B;
+      Environment = &quot;whatever value you were setting for environment_name before&quot;
+    &#x7D; 
     ```
 
 
@@ -582,7 +582,7 @@ The `cloudwatch-memory-disk-metrics` module now creates and sets up a new OS use
 
   
 
-- All the modules under `alarms` now expose a `create_resources` parameter that you can set to `false` to disable the module so it creates no resources. This is a workaround for Terraform not supporting `count` or `for_each` on `module`. Note that this change is backwards incompatible solely because the `route53-health-check-alarms` module already exposed an identical `enabled` parameter, but for consistency with all our other modules and repos, we've renamed it to `create_resources`. If you were using this `enabled` parameter on the `route53-health-check-alarms` module, please rename it to `create_resources` now.
+- All the modules under `alarms` now expose a `create_resources` parameter that you can set to `false` to disable the module so it creates no resources. This is a workaround for Terraform not supporting `count` or `for_each` on `module`. Note that this change is backwards incompatible solely because the `route53-health-check-alarms` module already exposed an identical `enabled` parameter, but for consistency with all our other modules and repos, we&apos;ve renamed it to `create_resources`. If you were using this `enabled` parameter on the `route53-health-check-alarms` module, please rename it to `create_resources` now.
 
 
 
@@ -599,7 +599,7 @@ The `cloudwatch-memory-disk-metrics` module now creates and sets up a new OS use
 
   
 
-- The `run-cloudwatch-logs-agent.sh` no longer takes in a `--vpc-name` parameter, which was only used to set a log group name if `--log-group-name` was not passed in. The `--log-group-name` is now required, which is simpler and makes the intent clearer. If you wish to preserve backwards compatibility with the log group name you were using before, set `--log-group-name` to `${vpc_name}-ec2-syslog`. 
+- The `run-cloudwatch-logs-agent.sh` no longer takes in a `--vpc-name` parameter, which was only used to set a log group name if `--log-group-name` was not passed in. The `--log-group-name` is now required, which is simpler and makes the intent clearer. If you wish to preserve backwards compatibility with the log group name you were using before, set `--log-group-name` to `$&#x7B;vpc_name&#x7D;-ec2-syslog`. 
 
 
 
@@ -673,7 +673,7 @@ Previously, CloudWatch did not have the necessary permissions to deliver notific
 
   
 
-- The `kms-master-key` module now exposes a `customer_master_key_spec` variable that allows you to specify whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports. The module now also grants `kms:GetPublicKey` permissions, which is why this release was marked as "backwards incompatible."
+- The `kms-master-key` module now exposes a `customer_master_key_spec` variable that allows you to specify whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports. The module now also grants `kms:GetPublicKey` permissions, which is why this release was marked as &quot;backwards incompatible.&quot;
 
 
 </div>
@@ -722,7 +722,7 @@ This update changes the endpoint route table associates to the [`aws_vpc_endpoin
 
 - Allow not to create any resource on vpc-flow-logs
 
-Now it's possible to fully deactivate the `vpc-flow-logs` module passing the variable `create_resources = false`
+Now it&apos;s possible to fully deactivate the `vpc-flow-logs` module passing the variable `create_resources = false`
 
 
 
@@ -734,6 +734,6 @@ Now it's possible to fully deactivate the `vpc-flow-logs` module passing the var
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "40c77e94be5140f9148ca9ac73747ebf"
+  "hash": "98cc01cf8656a345dcb8c44e226cf991"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-02/index.md
@@ -196,7 +196,7 @@ incompatibilities.
 ### [02062020](https://github.com/gruntwork-io/terraform-aws-ci-pipeline-example/releases/tag/02062020)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/7/2020 | <a href="https://github.com/gruntwork-io/terraform-aws-ci-pipeline-example/releases/tag/02062020">Release notes</a></small>
+  <small>Published: 2/6/2020 | <a href="https://github.com/gruntwork-io/terraform-aws-ci-pipeline-example/releases/tag/02062020">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -213,7 +213,7 @@ incompatibilities.
 ### [v0.4.0](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.4.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/4/2020 | Modules affected: aws-securityhub, aws-config | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.4.0">Release notes</a></small>
+  <small>Published: 2/3/2020 | Modules affected: aws-securityhub, aws-config | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.4.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -360,7 +360,7 @@ The `ecs-service` module now exposes `task_role_permissions_boundary_arn` and `t
 ### [v0.15.1](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.15.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/22/2020 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.15.1">Release notes</a></small>
+  <small>Published: 2/21/2020 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.15.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -734,6 +734,6 @@ Now it's possible to fully deactivate the `vpc-flow-logs` module passing the var
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "40c77e94be5140f9148ca9ac73747ebf"
+  "hash": "9cf9a1afe08db979fbb9d51b13edfe86"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-02/index.md
@@ -196,7 +196,7 @@ incompatibilities.
 ### [02062020](https://github.com/gruntwork-io/terraform-aws-ci-pipeline-example/releases/tag/02062020)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/6/2020 | <a href="https://github.com/gruntwork-io/terraform-aws-ci-pipeline-example/releases/tag/02062020">Release notes</a></small>
+  <small>Published: 2/7/2020 | <a href="https://github.com/gruntwork-io/terraform-aws-ci-pipeline-example/releases/tag/02062020">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -213,7 +213,7 @@ incompatibilities.
 ### [v0.4.0](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.4.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/3/2020 | Modules affected: aws-securityhub, aws-config | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.4.0">Release notes</a></small>
+  <small>Published: 2/4/2020 | Modules affected: aws-securityhub, aws-config | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.4.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -360,7 +360,7 @@ The `ecs-service` module now exposes `task_role_permissions_boundary_arn` and `t
 ### [v0.15.1](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.15.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/21/2020 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.15.1">Release notes</a></small>
+  <small>Published: 2/22/2020 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.15.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -734,6 +734,6 @@ Now it's possible to fully deactivate the `vpc-flow-logs` module passing the var
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "9cf9a1afe08db979fbb9d51b13edfe86"
+  "hash": "40c77e94be5140f9148ca9ac73747ebf"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-03/index.md
@@ -192,7 +192,7 @@ Each of the manual scheduled snapshot Lambda function modules now expose an inpu
 ### [v0.12.7](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.12.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/7/2020 | Modules affected: lambda-create-snapshot | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.12.7">Release notes</a></small>
+  <small>Published: 3/6/2020 | Modules affected: lambda-create-snapshot | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.12.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -305,7 +305,7 @@ The EKS cluster creation timeout is now 60 minutes.
 ### [v0.19.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.19.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/28/2020 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.19.0">Release notes</a></small>
+  <small>Published: 3/27/2020 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.19.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -413,7 +413,7 @@ Fix an issue with the helm provider where the `stable` helm repository does not 
 ### [v0.16.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.16.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/19/2020 | Modules affected: eks-k8s-external-dns, eks-k8s-cluster-autoscaler, eks-cloudwatch-container-logs, eks-alb-ingress-controller | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.16.0">Release notes</a></small>
+  <small>Published: 3/18/2020 | Modules affected: eks-k8s-external-dns, eks-k8s-cluster-autoscaler, eks-cloudwatch-container-logs, eks-alb-ingress-controller | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.16.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -635,7 +635,7 @@ The `openvpn-server` module now accepts base64-encoded user data in the `user_da
 ### [v0.9.10](https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.10)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/6/2020 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.10">Release notes</a></small>
+  <small>Published: 3/5/2020 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.10">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -653,10 +653,27 @@ You can now restrict the CIDR blocks that are allowed to access the OpenVPN port
 ## terraform-aws-security
 
 
+### [v0.28.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.28.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 3/31/2020 | Modules affected: iam-policies, iam-groups, account-baseline-security, account-baseline-root | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.28.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Account baseline modules now support managing KMS Customer Master Keys.
+- You can now specify multiple IAM roles for managing cross account access IAM groups.
+
+
+</div>
+
+
 ### [v0.27.2](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.27.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/31/2020 | Modules affected: kms-master-key-multi-region | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.27.2">Release notes</a></small>
+  <small>Published: 3/30/2020 | Modules affected: kms-master-key-multi-region | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.27.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -727,7 +744,7 @@ This release introduces support for managing more than one KMS Customer Master K
 ### [v0.26.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.26.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/6/2020 | Modules affected: iam-groups | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.26.0">Release notes</a></small>
+  <small>Published: 3/5/2020 | Modules affected: iam-groups | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.26.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -848,7 +865,7 @@ Fix a bug in `s3-static-website` module with versions of terraform &gt;0.12.11, 
 ### [v0.8.5: Outbound NACLs between private subnets](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.8.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/27/2020 | Modules affected: vpc-app-network-acls | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.8.5">Release notes</a></small>
+  <small>Published: 3/26/2020 | Modules affected: vpc-app-network-acls | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.8.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -867,7 +884,7 @@ Thanks to @scottclk for this contribution.
 ### [v0.8.4: More control over subnet spacing](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.8.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/3/2020 | Modules affected: vpc-mgmt, vpc-app | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.8.4">Release notes</a></small>
+  <small>Published: 3/2/2020 | Modules affected: vpc-mgmt, vpc-app | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.8.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -892,6 +909,6 @@ Thanks to @mmiranda for his contribution, and to @marinalimeira for her suggesti
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "692ae5c85a2e57b8d1ba25b2375499d4"
+  "hash": "3d54c2a88005f6cc300a66913e1bb83a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-03/index.md
@@ -192,7 +192,7 @@ Each of the manual scheduled snapshot Lambda function modules now expose an inpu
 ### [v0.12.7](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.12.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/6/2020 | Modules affected: lambda-create-snapshot | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.12.7">Release notes</a></small>
+  <small>Published: 3/7/2020 | Modules affected: lambda-create-snapshot | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.12.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -305,7 +305,7 @@ The EKS cluster creation timeout is now 60 minutes.
 ### [v0.19.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.19.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/27/2020 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.19.0">Release notes</a></small>
+  <small>Published: 3/28/2020 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.19.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -413,7 +413,7 @@ Fix an issue with the helm provider where the `stable` helm repository does not 
 ### [v0.16.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.16.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/18/2020 | Modules affected: eks-k8s-external-dns, eks-k8s-cluster-autoscaler, eks-cloudwatch-container-logs, eks-alb-ingress-controller | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.16.0">Release notes</a></small>
+  <small>Published: 3/19/2020 | Modules affected: eks-k8s-external-dns, eks-k8s-cluster-autoscaler, eks-cloudwatch-container-logs, eks-alb-ingress-controller | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.16.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -635,7 +635,7 @@ The `openvpn-server` module now accepts base64-encoded user data in the `user_da
 ### [v0.9.10](https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.10)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/5/2020 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.10">Release notes</a></small>
+  <small>Published: 3/6/2020 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.10">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -656,7 +656,7 @@ You can now restrict the CIDR blocks that are allowed to access the OpenVPN port
 ### [v0.28.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.28.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/31/2020 | Modules affected: iam-policies, iam-groups, account-baseline-security, account-baseline-root | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.28.0">Release notes</a></small>
+  <small>Published: 4/1/2020 | Modules affected: iam-policies, iam-groups, account-baseline-security, account-baseline-root | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.28.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -673,7 +673,7 @@ You can now restrict the CIDR blocks that are allowed to access the OpenVPN port
 ### [v0.27.2](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.27.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/30/2020 | Modules affected: kms-master-key-multi-region | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.27.2">Release notes</a></small>
+  <small>Published: 3/31/2020 | Modules affected: kms-master-key-multi-region | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.27.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -744,7 +744,7 @@ This release introduces support for managing more than one KMS Customer Master K
 ### [v0.26.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.26.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/5/2020 | Modules affected: iam-groups | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.26.0">Release notes</a></small>
+  <small>Published: 3/6/2020 | Modules affected: iam-groups | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.26.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -865,7 +865,7 @@ Fix a bug in `s3-static-website` module with versions of terraform &gt;0.12.11, 
 ### [v0.8.5: Outbound NACLs between private subnets](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.8.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/26/2020 | Modules affected: vpc-app-network-acls | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.8.5">Release notes</a></small>
+  <small>Published: 3/27/2020 | Modules affected: vpc-app-network-acls | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.8.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -884,7 +884,7 @@ Thanks to @scottclk for this contribution.
 ### [v0.8.4: More control over subnet spacing](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.8.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/2/2020 | Modules affected: vpc-mgmt, vpc-app | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.8.4">Release notes</a></small>
+  <small>Published: 3/3/2020 | Modules affected: vpc-mgmt, vpc-app | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.8.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -909,6 +909,6 @@ Thanks to @mmiranda for his contribution, and to @marinalimeira for her suggesti
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "3d54c2a88005f6cc300a66913e1bb83a"
+  "hash": "4b135c9487294a4fb55b4ed13356e9ca"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-03/index.md
@@ -653,23 +653,6 @@ You can now restrict the CIDR blocks that are allowed to access the OpenVPN port
 ## terraform-aws-security
 
 
-### [v0.28.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.28.0)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/1/2020 | Modules affected: iam-policies, iam-groups, account-baseline-security, account-baseline-root | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.28.0">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  
-
-- Account baseline modules now support managing KMS Customer Master Keys.
-- You can now specify multiple IAM roles for managing cross account access IAM groups.
-
-
-</div>
-
-
 ### [v0.27.2](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.27.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
@@ -909,6 +892,6 @@ Thanks to @mmiranda for his contribution, and to @marinalimeira for her suggesti
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "4b135c9487294a4fb55b4ed13356e9ca"
+  "hash": "692ae5c85a2e57b8d1ba25b2375499d4"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-03/index.md
@@ -758,7 +758,7 @@ See [this blog post](https://blog.gruntwork.io/terraform-tips-tricks-loops-if-st
 
   
 
-This release exposes the [`user_data_base64`](https://www.terraform.io/docs/providers/aws/d/instance.html#user_data_base64) attribute when launching a server. We've also added [an example of using base64 user data with cloud-init](https://github.com/gruntwork-io/module-server/blob/master/examples/bastion-host/main.tf#L49).
+This release exposes the [`user_data_base64`](https://www.terraform.io/docs/providers/aws/d/instance.html#user_data_base64) attribute when launching a server. We&apos;ve also added [an example of using base64 user data with cloud-init](https://github.com/gruntwork-io/module-server/blob/master/examples/bastion-host/main.tf#L49).
 
 
 
@@ -781,7 +781,7 @@ This release exposes the [`user_data_base64`](https://www.terraform.io/docs/prov
     - `allow_ssh_from_security_group_id` has been renamed to `allow_ssh_from_security_group_ids` and is now a list of security group IDs (instead of just one) from which SSH access will be allowed.
     - `allow_rdp_from_cidr_list`: A new input variable that is a list of CIDR blocks from which RDP access will be allowed.
     - `allow_rdp_from_security_group_ids`: A new input variable that is a list of security group IDs from which RDP access will be allowed.
-- The `source_ami_filter` we were using to find the latest CentOS AMI in Packer templates started to pick up the wrong AMI, probably due to some change in the AWS Marketplace. We've updated our filter to fix this as described below.
+- The `source_ami_filter` we were using to find the latest CentOS AMI in Packer templates started to pick up the wrong AMI, probably due to some change in the AWS Marketplace. We&apos;ve updated our filter to fix this as described below.
 
 
 </div>
@@ -892,6 +892,6 @@ Thanks to @mmiranda for his contribution, and to @marinalimeira for her suggesti
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "692ae5c85a2e57b8d1ba25b2375499d4"
+  "hash": "61c40242845ce91503c8a93e071ba31e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-04/index.md
@@ -310,7 +310,7 @@ The `cloudwatch-dashboard` module now supports managing multiple dashboards in o
 
   
 
-- Added datapoints_to_alarm variable to ecs-service-alarms module:  Addresses the module 'ecs-service-alarms' didn't pass through customizations to the variable 'datapoints_to_alarm'.
+- Added datapoints_to_alarm variable to ecs-service-alarms module:  Addresses the module &apos;ecs-service-alarms&apos; didn&apos;t pass through customizations to the variable &apos;datapoints_to_alarm&apos;.
 
 
 
@@ -344,7 +344,7 @@ In the `sns-to-slack` module, resources can now be optionally created using the 
 
   
 
-- Fix a bug in the `alb-alarms` module where for "low" thresholds (e.g., low request count) it was using `GreaterThanThreshold` instead of `LessThanThreshold`.
+- Fix a bug in the `alb-alarms` module where for &quot;low&quot; thresholds (e.g., low request count) it was using `GreaterThanThreshold` instead of `LessThanThreshold`.
 
 
 </div>
@@ -468,7 +468,7 @@ The behavior has changed such that processing will now continue for all other IA
 
   
 
-- You can now grant Service Principals (e.g., "s3.amazonaws.com") access to your KMS CMKs by setting the `cmk_service_principals` parameter and specifying the actions those Service Principals will be allowed to do via a new `service_principal_actions` input variable.
+- You can now grant Service Principals (e.g., &quot;s3.amazonaws.com&quot;) access to your KMS CMKs by setting the `cmk_service_principals` parameter and specifying the actions those Service Principals will be allowed to do via a new `service_principal_actions` input variable.
 
 
 </div>
@@ -634,6 +634,6 @@ This new module allows to create a VPC Interface Endpoint to connect services wi
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "db9c18dd3d2fff32e2b226222b483056"
+  "hash": "04eadc25781212497ca19cb55c6750c8"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-04/index.md
@@ -49,7 +49,7 @@ Here are the repos that were updated:
 ### [v0.18.5](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.18.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/8/2020 | Modules affected: infrastructure-deployer, infrastructure-deploy-script, ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.18.5">Release notes</a></small>
+  <small>Published: 4/7/2020 | Modules affected: infrastructure-deployer, infrastructure-deploy-script, ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.18.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -91,7 +91,7 @@ This release adds support for specifying multiple target groups with the ECS ser
 ### [v0.19.6](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.19.6)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/11/2020 | Modules affected: eks-cluster-managed-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.19.6">Release notes</a></small>
+  <small>Published: 4/10/2020 | Modules affected: eks-cluster-managed-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.19.6">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -129,7 +129,7 @@ NOTE: This release will cause a redeploy of the `cluster-autoscaler`, but since 
 ### [v0.19.4](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.19.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/10/2020 | Modules affected: eks-cluster-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.19.4">Release notes</a></small>
+  <small>Published: 4/9/2020 | Modules affected: eks-cluster-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.19.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -246,7 +246,7 @@ See [the vars.tf file](https://github.com/gruntwork-io/module-load-balancer/blob
 ### [v0.19.1](https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.19.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/2/2020 | Modules affected: alb | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.19.1">Release notes</a></small>
+  <small>Published: 4/1/2020 | Modules affected: alb | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.19.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -373,7 +373,7 @@ In the `sns-to-slack` module, resources can now be optionally created using the 
 ### [v0.9.12](https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.12)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/3/2020 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.12">Release notes</a></small>
+  <small>Published: 4/2/2020 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.12">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -524,23 +524,6 @@ Since AWS provider 2.0, setting `num_days_after_which_delete_log_data = 0` no lo
 </div>
 
 
-### [v0.28.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.28.0)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/1/2020 | Modules affected: iam-policies, iam-groups, account-baseline-security, account-baseline-root | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.28.0">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  
-
-- Account baseline modules now support managing KMS Customer Master Keys.
-- You can now specify multiple IAM roles for managing cross account access IAM groups.
-
-
-</div>
-
-
 
 ## terraform-aws-server
 
@@ -634,6 +617,6 @@ This new module allows to create a VPC Interface Endpoint to connect services wi
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "db9c18dd3d2fff32e2b226222b483056"
+  "hash": "801072e1b1a09f273254b633a1a3e2ce"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-04/index.md
@@ -524,6 +524,23 @@ Since AWS provider 2.0, setting `num_days_after_which_delete_log_data = 0` no lo
 </div>
 
 
+### [v0.28.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.28.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/1/2020 | Modules affected: iam-policies, iam-groups, account-baseline-security, account-baseline-root | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.28.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Account baseline modules now support managing KMS Customer Master Keys.
+- You can now specify multiple IAM roles for managing cross account access IAM groups.
+
+
+</div>
+
+
 
 ## terraform-aws-server
 
@@ -617,6 +634,6 @@ This new module allows to create a VPC Interface Endpoint to connect services wi
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "ee0a65db1c25155ae63dd40ff060cfed"
+  "hash": "db9c18dd3d2fff32e2b226222b483056"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-04/index.md
@@ -49,7 +49,7 @@ Here are the repos that were updated:
 ### [v0.18.5](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.18.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/7/2020 | Modules affected: infrastructure-deployer, infrastructure-deploy-script, ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.18.5">Release notes</a></small>
+  <small>Published: 4/8/2020 | Modules affected: infrastructure-deployer, infrastructure-deploy-script, ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.18.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -91,7 +91,7 @@ This release adds support for specifying multiple target groups with the ECS ser
 ### [v0.19.6](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.19.6)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/10/2020 | Modules affected: eks-cluster-managed-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.19.6">Release notes</a></small>
+  <small>Published: 4/11/2020 | Modules affected: eks-cluster-managed-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.19.6">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -246,7 +246,7 @@ See [the vars.tf file](https://github.com/gruntwork-io/module-load-balancer/blob
 ### [v0.19.1](https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.19.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/1/2020 | Modules affected: alb | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.19.1">Release notes</a></small>
+  <small>Published: 4/2/2020 | Modules affected: alb | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.19.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -617,6 +617,6 @@ This new module allows to create a VPC Interface Endpoint to connect services wi
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "801072e1b1a09f273254b633a1a3e2ce"
+  "hash": "f9e9300782b8b2e728905877ca97378a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-04/index.md
@@ -129,7 +129,7 @@ NOTE: This release will cause a redeploy of the `cluster-autoscaler`, but since 
 ### [v0.19.4](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.19.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/9/2020 | Modules affected: eks-cluster-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.19.4">Release notes</a></small>
+  <small>Published: 4/10/2020 | Modules affected: eks-cluster-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.19.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -373,7 +373,7 @@ In the `sns-to-slack` module, resources can now be optionally created using the 
 ### [v0.9.12](https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.12)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/2/2020 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.12">Release notes</a></small>
+  <small>Published: 4/3/2020 | Modules affected: openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.9.12">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -617,6 +617,6 @@ This new module allows to create a VPC Interface Endpoint to connect services wi
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "f9e9300782b8b2e728905877ca97378a"
+  "hash": "ee0a65db1c25155ae63dd40ff060cfed"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-05/index.md
@@ -490,7 +490,7 @@ Note that previously this module output `null` for all the outputs when `create_
 ### [v0.21.2](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.21.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/28/2020 | Modules affected: alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.21.2">Release notes</a></small>
+  <small>Published: 5/29/2020 | Modules affected: alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.21.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -584,7 +584,7 @@ Note that as part of this change, the `aws_account_id` variable was removed from
 ### [v0.30.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.30.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/18/2020 | Modules affected: iam-policies, account-baseline-root | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.30.0">Release notes</a></small>
+  <small>Published: 5/19/2020 | Modules affected: iam-policies, account-baseline-root | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.30.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -699,7 +699,7 @@ For `account-baseline-app`:
 ### [v0.2.0](https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.2.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/7/2020 | Modules affected: enabled-aws-regions | <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.2.0">Release notes</a></small>
+  <small>Published: 5/8/2020 | Modules affected: enabled-aws-regions | <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.2.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -776,6 +776,6 @@ Special thanks to @jdhornsby for the fix!
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "c19c41682faaf836c75e3f6a3b9cebd3"
+  "hash": "197bc29d17eb39bf8795163db4f7bc03"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-05/index.md
@@ -87,7 +87,7 @@ Here are the repos that were updated:
 ### [v0.22.1](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.22.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/29/2020 | Modules affected: ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.22.1">Release notes</a></small>
+  <small>Published: 5/28/2020 | Modules affected: ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.22.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -125,7 +125,7 @@ The `jenkins-server` module no longer takes the `aws_account_id` variable. To up
 ### [v0.21.0](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.21.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/27/2020 | Modules affected: infrastructure-deployer, ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.21.0">Release notes</a></small>
+  <small>Published: 5/26/2020 | Modules affected: infrastructure-deployer, ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.21.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -194,7 +194,7 @@ The `infrastructure-deploy-script` now supports running `destroy`. Note that the
 ### [v0.19.0](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.19.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/7/2020 | Modules affected: infrastructure-deployer, infrastructure-deploy-script, install-jenkins | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.19.0">Release notes</a></small>
+  <small>Published: 5/6/2020 | Modules affected: infrastructure-deployer, infrastructure-deploy-script, install-jenkins | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.19.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -219,7 +219,7 @@ The `infrastructure-deploy-script` now supports running `destroy`. Note that the
 ### [v0.4.1](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.4.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/8/2020 | Modules affected: aws-securityhub | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.4.1">Release notes</a></small>
+  <small>Published: 5/7/2020 | Modules affected: aws-securityhub | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.4.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -345,7 +345,7 @@ You can now provide an existing DB subnet group to use with the RDS clusters ins
 ### [v0.19.1](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.19.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/9/2020 | Modules affected: ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.19.1">Release notes</a></small>
+  <small>Published: 5/8/2020 | Modules affected: ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.19.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -447,7 +447,7 @@ This release also includes several documentation fixes to READMEs of various mod
 ### [v0.8.0](https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.8.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/7/2020 | Modules affected: lambda | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.8.0">Release notes</a></small>
+  <small>Published: 5/6/2020 | Modules affected: lambda | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.8.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -490,7 +490,7 @@ Note that previously this module output `null` for all the outputs when `create_
 ### [v0.21.2](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.21.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/29/2020 | Modules affected: alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.21.2">Release notes</a></small>
+  <small>Published: 5/28/2020 | Modules affected: alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.21.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -584,7 +584,7 @@ Note that as part of this change, the `aws_account_id` variable was removed from
 ### [v0.30.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.30.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/19/2020 | Modules affected: iam-policies, account-baseline-root | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.30.0">Release notes</a></small>
+  <small>Published: 5/18/2020 | Modules affected: iam-policies, account-baseline-root | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.30.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -699,7 +699,7 @@ For `account-baseline-app`:
 ### [v0.2.0](https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.2.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/8/2020 | Modules affected: enabled-aws-regions | <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.2.0">Release notes</a></small>
+  <small>Published: 5/7/2020 | Modules affected: enabled-aws-regions | <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.2.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -776,6 +776,6 @@ Special thanks to @jdhornsby for the fix!
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "197bc29d17eb39bf8795163db4f7bc03"
+  "hash": "37d4245b3804b8ae19a4a5a83dd9f66a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-05/index.md
@@ -205,7 +205,7 @@ The `infrastructure-deploy-script` now supports running `destroy`. Note that the
 
 - The `infrastructure-deploy-script` no longer supports passing in the private SSH key via CLI args. You must pass it in with the environment variable `DEPLOY_SCRIPT_SSH_PRIVATE_KEY`.
 
-- `install-jenkins` will automatically disable jenkins so that it won't start on boot. This ensures that jenkins will not be started unless it has been successfully configured with `run-jenkins`. To get the previous behavior, pass in `--module-param "run-on-boot=true"`.
+- `install-jenkins` will automatically disable jenkins so that it won&apos;t start on boot. This ensures that jenkins will not be started unless it has been successfully configured with `run-jenkins`. To get the previous behavior, pass in `--module-param &quot;run-on-boot=true&quot;`.
 
 
 
@@ -379,7 +379,7 @@ This release introduces first class support for using [the EKS cluster security 
 
 - The `eks-cluster-workers` module now appends the cluster security group to the node instead of rolling out its own group by default. Note that it still creates its own group to make it easier to append rules that are only specific to the self-managed workers.
 
-This release also fixes a bug with the `eks-k8s-role-mapping` module, where previously it did not support including the Fargate execution role. If you don't include the Fargate execution role in the mapping, terraform may delete the configuration rules that enable Fargate to communicate with the Kubernetes API as workers.
+This release also fixes a bug with the `eks-k8s-role-mapping` module, where previously it did not support including the Fargate execution role. If you don&apos;t include the Fargate execution role in the mapping, terraform may delete the configuration rules that enable Fargate to communicate with the Kubernetes API as workers.
 
 
 
@@ -454,9 +454,9 @@ This release also includes several documentation fixes to READMEs of various mod
 
   
 
-The `lambda` module is now more robust to partial failures in the module. Previously you could end up in a state where you couldn't `apply` or `destroy` the module if it only partially applied the resources due to output errors. This release addresses that by changing the output logic.
+The `lambda` module is now more robust to partial failures in the module. Previously you could end up in a state where you couldn&apos;t `apply` or `destroy` the module if it only partially applied the resources due to output errors. This release addresses that by changing the output logic.
 
-Note that previously this module output `null` for all the outputs when `create_resources` was `false`. However, with this release the output is converted to `""`. If you depended on behavior of `null` outputs, you will need to adjust your code to convert `null` checks to `""`.
+Note that previously this module output `null` for all the outputs when `create_resources` was `false`. However, with this release the output is converted to `&quot;&quot;`. If you depended on behavior of `null` outputs, you will need to adjust your code to convert `null` checks to `&quot;&quot;`.
 
 
 </div>
@@ -532,7 +532,7 @@ Note that previously this module output `null` for all the outputs when `create_
 
   
 
-- The `install.sh` scripts for the `cloudwatch-log-aggregation-scripts`, `syslog`, and `cloudwatch-memory-disk-metrics-scripts` modules were unnecessarily using `eval` to execute scripts used in the install steps. This led to unexpected behavior, such as `--module-param` arguments being shell expanded. We've removed the calls to `eval` and replaced with a straight call to the underlying scripts. 
+- The `install.sh` scripts for the `cloudwatch-log-aggregation-scripts`, `syslog`, and `cloudwatch-memory-disk-metrics-scripts` modules were unnecessarily using `eval` to execute scripts used in the install steps. This led to unexpected behavior, such as `--module-param` arguments being shell expanded. We&apos;ve removed the calls to `eval` and replaced with a straight call to the underlying scripts. 
 
 _This release is marked as backwards incompatible, but this only applies if you were (intentionally or otherwise) relying on the `eval` behavior (which is not likely or recommended!)._
 
@@ -649,11 +649,11 @@ In this configuration, the central account will be configured with an S3 Bucket 
 
 **Migration guide**
 
-First, remove the now-unused regional AWS Config buckets from the terraform state so that the data remains intact. If you don't need the data, you can remove the buckets after removing them from the Terraform state. If you're using `bash`, the following loop should do the trick
+First, remove the now-unused regional AWS Config buckets from the terraform state so that the data remains intact. If you don&apos;t need the data, you can remove the buckets after removing them from the Terraform state. If you&apos;re using `bash`, the following loop should do the trick
 
 ```bash
 for region in eu_north_1 eu_west_3 ap_southeast_2 ap_southeast_1 eu_west_1 us_east_2 sa_east_1 ap_northeast_2 ca_central_1 ap_south_1 eu_central_1 ap_northeast_1 us_east_1 eu_west_2 us_west_2 us_west_1; do
-    terraform state rm "module.config.module.aws_config_${region}.aws_s3_bucket.config_bucket[0]"
+    terraform state rm &quot;module.config.module.aws_config_$&#x7B;region&#x7D;.aws_s3_bucket.config_bucket[0]&quot;
 done
 ```
 
@@ -677,14 +677,14 @@ For `aws-config-multi-region`:
 For `account-baseline-security`:
 
 * If a list of account IDs is provided in `config_linked_accounts`, those accounts will be granted access to the S3 bucket and SNS topic in the security account.
-* If the `config_s3_bucket_name` variable is provided, the S3 bucket will be created with that name. If no name is provided, the bucket will have the default name of `${var.name_prefix}-config`.
+* If the `config_s3_bucket_name` variable is provided, the S3 bucket will be created with that name. If no name is provided, the bucket will have the default name of `$&#x7B;var.name_prefix&#x7D;-config`.
 
 
 For `account-baseline-app`:
 
 * The `config_central_account_id` variable should be configured with the ID of the account that contains the S3 bucket and SNS topic. This will typically be the account that is configured with `account-baseline-security`. 
 
-* If the `config_s3_bucket_name` variable is provided, AWS Config will be configured to use that name (but the bucket will not be created within the account). If no name is provided, AWS Config will be configured to use a default name of `${var.name_prefix}-config`. This bucket must already exist and should have appropriate permissions to allow access from this account. To set up permissions, provide this account ID in the `config_linked_accounts` of the `account-baseline-security` modules.
+* If the `config_s3_bucket_name` variable is provided, AWS Config will be configured to use that name (but the bucket will not be created within the account). If no name is provided, AWS Config will be configured to use a default name of `$&#x7B;var.name_prefix&#x7D;-config`. This bucket must already exist and should have appropriate permissions to allow access from this account. To set up permissions, provide this account ID in the `config_linked_accounts` of the `account-baseline-security` modules.
 
 
 
@@ -723,7 +723,7 @@ For `account-baseline-app`:
 
   
 
-- Added a new module called `executable-dependency` that can be used to install an executable if it's not installed already. This is useful if your Terraform code depends on external dependencies, such as `terraform-aws-eks`, which depends on `kubergrunt`.
+- Added a new module called `executable-dependency` that can be used to install an executable if it&apos;s not installed already. This is useful if your Terraform code depends on external dependencies, such as `terraform-aws-eks`, which depends on `kubergrunt`.
 
 
 
@@ -776,6 +776,6 @@ Special thanks to @jdhornsby for the fix!
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "197bc29d17eb39bf8795163db4f7bc03"
+  "hash": "07bc0e05728789516b491da89191ecdc"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-05/index.md
@@ -87,7 +87,7 @@ Here are the repos that were updated:
 ### [v0.22.1](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.22.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/28/2020 | Modules affected: ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.22.1">Release notes</a></small>
+  <small>Published: 5/29/2020 | Modules affected: ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.22.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -125,7 +125,7 @@ The `jenkins-server` module no longer takes the `aws_account_id` variable. To up
 ### [v0.21.0](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.21.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/26/2020 | Modules affected: infrastructure-deployer, ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.21.0">Release notes</a></small>
+  <small>Published: 5/27/2020 | Modules affected: infrastructure-deployer, ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.21.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -194,7 +194,7 @@ The `infrastructure-deploy-script` now supports running `destroy`. Note that the
 ### [v0.19.0](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.19.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/6/2020 | Modules affected: infrastructure-deployer, infrastructure-deploy-script, install-jenkins | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.19.0">Release notes</a></small>
+  <small>Published: 5/7/2020 | Modules affected: infrastructure-deployer, infrastructure-deploy-script, install-jenkins | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.19.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -219,7 +219,7 @@ The `infrastructure-deploy-script` now supports running `destroy`. Note that the
 ### [v0.4.1](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.4.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/7/2020 | Modules affected: aws-securityhub | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.4.1">Release notes</a></small>
+  <small>Published: 5/8/2020 | Modules affected: aws-securityhub | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.4.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -345,7 +345,7 @@ You can now provide an existing DB subnet group to use with the RDS clusters ins
 ### [v0.19.1](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.19.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/8/2020 | Modules affected: ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.19.1">Release notes</a></small>
+  <small>Published: 5/9/2020 | Modules affected: ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.19.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -447,7 +447,7 @@ This release also includes several documentation fixes to READMEs of various mod
 ### [v0.8.0](https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.8.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/6/2020 | Modules affected: lambda | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.8.0">Release notes</a></small>
+  <small>Published: 5/7/2020 | Modules affected: lambda | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.8.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -776,6 +776,6 @@ Special thanks to @jdhornsby for the fix!
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "37d4245b3804b8ae19a4a5a83dd9f66a"
+  "hash": "c19c41682faaf836c75e3f6a3b9cebd3"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-06/index.md
@@ -145,7 +145,7 @@ Updates in this version:
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
   
-The variable `aws_region` was removed from the module, it's value will be retrieved from the region on the provider. When updating to this new version, make sure to remove the `aws_region` parameter to the module.
+The variable `aws_region` was removed from the module, it&apos;s value will be retrieved from the region on the provider. When updating to this new version, make sure to remove the `aws_region` parameter to the module.
 
 
 </div>
@@ -248,13 +248,13 @@ The variable `aws_region` was removed from the module, it's value will be retrie
 - The `rds` and `aurora` modules have been updated to remove redundant/duplicate resources by taking advantage of Terraform 0.12 syntax (i.e., `for_each`, `null` defaults, and `dynamic` blocks). This greatly simplifies the code and makes it more maintainable, but because many resources were renamed, this is a **backwards incompatible change**, so make sure to follow the migration guide below when upgrading!
 
 
-All input and output variables are the same, so you will not need to do any code changes. There are no changes in functionality either, so there shouldn't be anything new to `apply` (i.e., when you finish the migration, the `plan` migration should show no changes). The only thing that changed in this upgrade is that several resources were renamed in the Terraform code, so you'll need to update your Terraform state so it knows about these new names. You do this using the [state mv](https://www.terraform.io/docs/commands/state/mv.html) command (**Note**: If you're using Terragrunt, replace `terraform` with `terragrunt` in all the commands in this migration guide):
+All input and output variables are the same, so you will not need to do any code changes. There are no changes in functionality either, so there shouldn&apos;t be anything new to `apply` (i.e., when you finish the migration, the `plan` migration should show no changes). The only thing that changed in this upgrade is that several resources were renamed in the Terraform code, so you&apos;ll need to update your Terraform state so it knows about these new names. You do this using the [state mv](https://www.terraform.io/docs/commands/state/mv.html) command (**Note**: If you&apos;re using Terragrunt, replace `terraform` with `terragrunt` in all the commands in this migration guide):
 
 ```bash
 terraform state mv OLD_ADDRESS NEW_ADDRESS
 ```
 
-Where `OLD_ADDRESS` is the [resource address](https://www.terraform.io/docs/internals/resource-addressing.html) with the old resource name and `NEW_ADDRESS` is the resource address with the new name. The easiest way to get the old and new address is to upgrade to the new version of this module and run `terraform plan`. When you do so, you'll see output like this:
+Where `OLD_ADDRESS` is the [resource address](https://www.terraform.io/docs/internals/resource-addressing.html) with the old resource name and `NEW_ADDRESS` is the resource address with the new name. The easiest way to get the old and new address is to upgrade to the new version of this module and run `terraform plan`. When you do so, you&apos;ll see output like this:
 
 ```
 $ terraform plan
@@ -262,46 +262,46 @@ $ terraform plan
 [...]
 
   # module.aurora_serverless.aws_rds_cluster.cluster will be created
-  + resource "aws_rds_cluster" "cluster" {
+  + resource &quot;aws_rds_cluster&quot; &quot;cluster&quot; &#x7B;
       + apply_immediately                   = false
       + arn                                 = (known after apply)
       + availability_zones                  = (known after apply)
       + backup_retention_period             = 21
-      + cluster_identifier                  = "aurora-serverless-example"
+      + cluster_identifier                  = &quot;aurora-serverless-example&quot;
       + cluster_identifier_prefix           = (known after apply)
       + cluster_members                     = (known after apply)
 
 [...]
 
   # module.aurora_serverless.aws_rds_cluster.cluster_with_encryption_serverless[0] will be destroyed
-  - resource "aws_rds_cluster" "cluster_with_encryption_serverless" {
+  - resource &quot;aws_rds_cluster&quot; &quot;cluster_with_encryption_serverless&quot; &#x7B;
       - apply_immediately                   = false -&gt; null
-      - arn                                 = "arn:aws:rds:us-east-1:087285199408:cluster:aurora-serverless-example" -&gt; null
+      - arn                                 = &quot;arn:aws:rds:us-east-1:087285199408:cluster:aurora-serverless-example&quot; -&gt; null
       - availability_zones                  = [
-          - "us-east-1a",
-          - "us-east-1b",
-          - "us-east-1e",
+          - &quot;us-east-1a&quot;,
+          - &quot;us-east-1b&quot;,
+          - &quot;us-east-1e&quot;,
         ] -&gt; null
       - backtrack_window                    = 0 -&gt; null
       - backup_retention_period             = 21 -&gt; null
-      - cluster_identifier                  = "aurora-serverless-example" -&gt; null
+      - cluster_identifier                  = &quot;aurora-serverless-example&quot; -&gt; null
 ```
 
 The lines that show you resources being removed (with a `-` in front of them) show the old addresses in a comment above the resource:
 
 ```
   # module.aurora_serverless.aws_rds_cluster.cluster_with_encryption_serverless[0] will be destroyed
-  - resource "aws_rds_cluster" "cluster_with_encryption_serverless" {
+  - resource &quot;aws_rds_cluster&quot; &quot;cluster_with_encryption_serverless&quot; &#x7B;
 ```
 
 And the lines that show the very same resources being added (with a `+` in front of them) show the new addresses in a comment above the resource:
 
 ```
   # module.aurora_serverless.aws_rds_cluster.cluster will be created
-  + resource "aws_rds_cluster" "cluster" {
+  + resource &quot;aws_rds_cluster&quot; &quot;cluster&quot; &#x7B;
 ```
 
-You'll want to run `terraform state mv` (or `terragrunt state mv`) on each pair of these resources:
+You&apos;ll want to run `terraform state mv` (or `terragrunt state mv`) on each pair of these resources:
 
 ```
 terraform state mv \
@@ -323,7 +323,7 @@ Here are the renames that have happened:
 | `aws_db_instance.replicas_with_encryption`                 | `aws_db_instance.replicas` |
 | `aws_db_instance.replicas_without_encryption`              | `aws_db_instance.replicas` |
 
-When you've run `terraform state mv` on all the pairs of resources, you know you've done it correctly if you can run `terraform plan` and see no changes:
+When you&apos;ve run `terraform state mv` on all the pairs of resources, you know you&apos;ve done it correctly if you can run `terraform plan` and see no changes:
 
 ```
 $ terraform plan
@@ -414,7 +414,7 @@ No changes. Infrastructure is up-to-date.
 
   
 
-- Fix issue where restoring from snapshot wasn't setting `master_password`
+- Fix issue where restoring from snapshot wasn&apos;t setting `master_password`
 
 
 
@@ -452,7 +452,7 @@ No changes. Infrastructure is up-to-date.
 
   
 
-- The `ecs-cluster` module now attaches the `ecs:UpdateContainerInstancesState` permission to the ECS Cluster's IAM role. This is required for automated ECS instance draining (e.g., when receiving a spot instance termination notice).
+- The `ecs-cluster` module now attaches the `ecs:UpdateContainerInstancesState` permission to the ECS Cluster&apos;s IAM role. This is required for automated ECS instance draining (e.g., when receiving a spot instance termination notice).
 
 
 
@@ -738,6 +738,6 @@ This release adds the ability to create `tags` with the modules mentioned above.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "e34bf0493f1adf894ca7e5cc754313e8"
+  "hash": "b67c1962b15120a17e012cf2b816f233"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-06/index.md
@@ -503,7 +503,7 @@ You can now bind different containers and ports to each target group created for
 ### [v0.20.3](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.20.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/16/2020 | Modules affected: eks-k8s-external-dns, eks-alb-ingress-controller | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.20.3">Release notes</a></small>
+  <small>Published: 6/17/2020 | Modules affected: eks-k8s-external-dns, eks-alb-ingress-controller | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.20.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -522,7 +522,7 @@ You can now bind different containers and ports to each target group created for
 ### [v0.20.2](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.20.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/10/2020 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.20.2">Release notes</a></small>
+  <small>Published: 6/11/2020 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.20.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -538,7 +538,7 @@ The control plane Python PEX binaries now support long path names on Windows. Pr
 ### [v0.20.1](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.20.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/1/2020 | Modules affected: eks-cloudwatch-container-logs, eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.20.1">Release notes</a></small>
+  <small>Published: 6/2/2020 | Modules affected: eks-cloudwatch-container-logs, eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.20.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -738,6 +738,6 @@ This release adds the ability to create `tags` with the modules mentioned above.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "47b9e38062f13269320bc1d75d36f8f5"
+  "hash": "e34bf0493f1adf894ca7e5cc754313e8"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-06/index.md
@@ -503,7 +503,7 @@ You can now bind different containers and ports to each target group created for
 ### [v0.20.3](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.20.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/17/2020 | Modules affected: eks-k8s-external-dns, eks-alb-ingress-controller | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.20.3">Release notes</a></small>
+  <small>Published: 6/16/2020 | Modules affected: eks-k8s-external-dns, eks-alb-ingress-controller | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.20.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -522,7 +522,7 @@ You can now bind different containers and ports to each target group created for
 ### [v0.20.2](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.20.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/11/2020 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.20.2">Release notes</a></small>
+  <small>Published: 6/10/2020 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.20.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -538,7 +538,7 @@ The control plane Python PEX binaries now support long path names on Windows. Pr
 ### [v0.20.1](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.20.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/2/2020 | Modules affected: eks-cloudwatch-container-logs, eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.20.1">Release notes</a></small>
+  <small>Published: 6/1/2020 | Modules affected: eks-cloudwatch-container-logs, eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.20.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -738,6 +738,6 @@ This release adds the ability to create `tags` with the modules mentioned above.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "e34bf0493f1adf894ca7e5cc754313e8"
+  "hash": "47b9e38062f13269320bc1d75d36f8f5"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-07/index.md
@@ -373,7 +373,7 @@ You can now conditionally shut off the `ecs-cluster` module using the `create_re
 ### [v0.20.8](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.20.8)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/18/2020 | Modules affected: ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.20.8">Release notes</a></small>
+  <small>Published: 7/17/2020 | Modules affected: ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.20.8">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -424,7 +424,7 @@ The `roll-out-ecs-cluster-update.py` script will now directly detach the old ins
 ### [v0.20.5](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.20.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/9/2020 | Modules affected: ecs-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.20.5">Release notes</a></small>
+  <small>Published: 7/8/2020 | Modules affected: ecs-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.20.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -441,7 +441,7 @@ Fix bug where `ecs-cluster` errors out on the `aws_autoscaling_group` resource i
 ### [v0.20.4](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.20.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/2/2020 | Modules affected: ecs-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.20.4">Release notes</a></small>
+  <small>Published: 7/1/2020 | Modules affected: ecs-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.20.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -783,6 +783,28 @@ When creating a CMK using the `kms-master-key` module, you can now provide IAM c
 ## terraform-aws-server
 
 
+### [v0.8.5](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.8.5)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/31/2020 | Modules affected: ec2-backup, single-server | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.8.5">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+This release includes a fix for the `ec2-backup` module, making its tag configurations more flexible. It also fixes a few links in the `module-server` documentation.
+
+
+
+
+
+
+
+
+</div>
+
+
 ### [v0.8.4](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.8.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
@@ -933,7 +955,7 @@ This release adds subnet ARNs to the outputs for `vpc-app` and `vpc-mgmt`.
 ### [v0.8.12](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.8.12)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/2/2020 | Modules affected: vpc-interface-endpoint | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.8.12">Release notes</a></small>
+  <small>Published: 7/1/2020 | Modules affected: vpc-interface-endpoint | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.8.12">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -968,6 +990,6 @@ add glue support to vpc-interface-endpoint
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "548b7ea5ff7c73609623a5abfcb9c7d5"
+  "hash": "d655e56b1a877360422a4a3c560e0ed4"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-07/index.md
@@ -955,7 +955,7 @@ This release adds subnet ARNs to the outputs for `vpc-app` and `vpc-mgmt`.
 ### [v0.8.12](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.8.12)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/1/2020 | Modules affected: vpc-interface-endpoint | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.8.12">Release notes</a></small>
+  <small>Published: 7/2/2020 | Modules affected: vpc-interface-endpoint | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.8.12">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -990,6 +990,6 @@ add glue support to vpc-interface-endpoint
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "5a70d332c93c8fe81adec7f1ad34e9a0"
+  "hash": "81415dd50dd863d037f3c5959019d0c5"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-07/index.md
@@ -373,7 +373,7 @@ You can now conditionally shut off the `ecs-cluster` module using the `create_re
 ### [v0.20.8](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.20.8)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/17/2020 | Modules affected: ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.20.8">Release notes</a></small>
+  <small>Published: 7/18/2020 | Modules affected: ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.20.8">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -424,7 +424,7 @@ The `roll-out-ecs-cluster-update.py` script will now directly detach the old ins
 ### [v0.20.5](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.20.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/8/2020 | Modules affected: ecs-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.20.5">Release notes</a></small>
+  <small>Published: 7/9/2020 | Modules affected: ecs-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.20.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -441,7 +441,7 @@ Fix bug where `ecs-cluster` errors out on the `aws_autoscaling_group` resource i
 ### [v0.20.4](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.20.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/1/2020 | Modules affected: ecs-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.20.4">Release notes</a></small>
+  <small>Published: 7/2/2020 | Modules affected: ecs-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.20.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -786,7 +786,7 @@ When creating a CMK using the `kms-master-key` module, you can now provide IAM c
 ### [v0.8.5](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.8.5)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/31/2020 | Modules affected: ec2-backup, single-server | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.8.5">Release notes</a></small>
+  <small>Published: 8/1/2020 | Modules affected: ec2-backup, single-server | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.8.5">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -990,6 +990,6 @@ add glue support to vpc-interface-endpoint
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "d655e56b1a877360422a4a3c560e0ed4"
+  "hash": "5a70d332c93c8fe81adec7f1ad34e9a0"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-07/index.md
@@ -208,7 +208,7 @@ You can now set the `backend-config` option on the `init` call in the `ecs-deplo
 
   
 
-`infrastructure-deployer` and `infrastructure-deploy-script` now supports deploying the repo root path using `""` for `--deploy-path`. This is now the default for `--deploy-path` when it is omitted from the CLI args.
+`infrastructure-deployer` and `infrastructure-deploy-script` now supports deploying the repo root path using `&quot;&quot;` for `--deploy-path`. This is now the default for `--deploy-path` when it is omitted from the CLI args.
 
 
 </div>
@@ -658,24 +658,24 @@ This release adds a role with permissions only to access support, as required by
   
 - Updated `account-baseline-root` to allow you to turn off AWS Config and CloudTrail entirely. This is necessary 
   if you want to aggregate AWS Config and CloudTrail data in a child account (e.g., a dedicated logs account), but
-  that child account doesn't initially exist and doesn't contain S3 buckets / KMS CMKs when you first run `apply`.
+  that child account doesn&apos;t initially exist and doesn&apos;t contain S3 buckets / KMS CMKs when you first run `apply`.
   Now you can run `apply` initially with AWS Config and CloudTrail disabled, create all the child accounts, apply a
   security baseline to each child account (including creating the necessary S3 buckets and KMS CMKs), turn AWS Config
   and CloudTrail back on in the root account, and run `apply` again. Also, fixed a bug where this module will now
   use the KMS key specified via the `cloudtrail_kms_key_arn` input parameter rather than creating its own KMS master 
   key for encrypting CloudTrail data. See the Deployment Guide for the recommended configuration if deploying from 
-  scratch. See the Migration Guide if you're updating an existing deployment.
+  scratch. See the Migration Guide if you&apos;re updating an existing deployment.
 
 - Updated `account-baseline-app` so that, depending on the settings you pass in, it can either store AWS Config and
   CloudTrail data locally (e.g., if this is a dedicated account for aggregating logs) or send that data to a separate
   account (e.g., if this is an app account such a dev, stage, or prod). See the Deployment Guide for the recommended
-  configuration if deploying from scratch. See the Migration Guide if you're updating an existing deployment.
+  configuration if deploying from scratch. See the Migration Guide if you&apos;re updating an existing deployment.
 
 - Updated `account-baseline-security` to allow configuring it to send AWS Config and CloudTrail data to an external
-  account (e.g., a separate logs account). Also, fixed a bug where it wasn't setting the `config_linked_accounts`
+  account (e.g., a separate logs account). Also, fixed a bug where it wasn&apos;t setting the `config_linked_accounts`
   parameter correctly, which made AWS Config data not work correctly if trying to use the security account itself for
   aggregation.  See the Deployment Guide for the recommended configuration if deploying from scratch. See the Migration 
-  Guide if you're updating an existing deployment.
+  Guide if you&apos;re updating an existing deployment.
 
 - Updated all `account-baseline-xxx` modules to, by default, send CloudTrail data not only to an S3 bucket (e.g., for 
   aggregation in a logs account) but also CloudWatch Logs in the current account (for easy debugging).
@@ -698,7 +698,7 @@ This release adds a role with permissions only to access support, as required by
 
   
 
-Adds the `sts:TagSession` permission to the `allow_access_to_other_accounts` IAM policy. This will allow [session tags](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html). As an example, this is used with the ["Configure AWS Credentials" GitHub action](https://github.com/marketplace/actions/configure-aws-credentials-action-for-github-actions).
+Adds the `sts:TagSession` permission to the `allow_access_to_other_accounts` IAM policy. This will allow [session tags](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html). As an example, this is used with the [&quot;Configure AWS Credentials&quot; GitHub action](https://github.com/marketplace/actions/configure-aws-credentials-action-for-github-actions).
 
 
 
@@ -968,6 +968,6 @@ add glue support to vpc-interface-endpoint
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "548b7ea5ff7c73609623a5abfcb9c7d5"
+  "hash": "ac789ee1936e9507828a61a3f5c7f1ae"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-07/index.md
@@ -783,28 +783,6 @@ When creating a CMK using the `kms-master-key` module, you can now provide IAM c
 ## terraform-aws-server
 
 
-### [v0.8.5](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.8.5)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/1/2020 | Modules affected: ec2-backup, single-server | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.8.5">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  
-
-This release includes a fix for the `ec2-backup` module, making its tag configurations more flexible. It also fixes a few links in the `module-server` documentation.
-
-
-
-
-
-
-
-
-</div>
-
-
 ### [v0.8.4](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.8.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
@@ -990,6 +968,6 @@ add glue support to vpc-interface-endpoint
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "81415dd50dd863d037f3c5959019d0c5"
+  "hash": "548b7ea5ff7c73609623a5abfcb9c7d5"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-08/index.md
@@ -25,6 +25,7 @@ Here are the repos that were updated:
 - [terraform-aws-load-balancer](#terraform-aws-load-balancer)
 - [terraform-aws-openvpn](#terraform-aws-openvpn)
 - [terraform-aws-security](#terraform-aws-security)
+- [terraform-aws-server](#terraform-aws-server)
 - [terraform-aws-service-catalog](#terraform-aws-service-catalog)
 - [terraform-aws-vpc](#terraform-aws-vpc)
 
@@ -765,6 +766,32 @@ Allows an empty list of users and admins in cloudtrail-created KMS keys. Previou
 
 
 
+## terraform-aws-server
+
+
+### [v0.8.5](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.8.5)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 8/1/2020 | Modules affected: ec2-backup, single-server | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.8.5">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+This release includes a fix for the `ec2-backup` module, making its tag configurations more flexible. It also fixes a few links in the `module-server` documentation.
+
+
+
+
+
+
+
+
+</div>
+
+
+
 ## terraform-aws-service-catalog
 
 
@@ -928,6 +955,6 @@ This release introduces two changes:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "32e51d1d0bf79941f7f1474028e6eb6b"
+  "hash": "783de82cbcfde233ca8c2218b2c087f0"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-08/index.md
@@ -618,7 +618,7 @@ Resolve `shellcheck` issues in `aws-auth`.
 ### [v0.36.2](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.36.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/24/2020 | Modules affected: account-baseline-app, account-baseline-security | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.36.2">Release notes</a></small>
+  <small>Published: 8/25/2020 | Modules affected: account-baseline-app, account-baseline-security | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.36.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -635,7 +635,7 @@ You can now set the max session duration for human and machine cross account IAM
 ### [v0.36.1](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.36.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/21/2020 | Modules affected: kms-grant-multi-region, account-baseline-app, account-baseline-security, kms-master-key-multi-region | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.36.1">Release notes</a></small>
+  <small>Published: 8/22/2020 | Modules affected: kms-grant-multi-region, account-baseline-app, account-baseline-security, kms-master-key-multi-region | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.36.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -749,7 +749,7 @@ This release adds read only permissions to the `read_only` IAM policy for the [P
 ### [v0.34.3](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.34.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/11/2020 | Modules affected: cloudtrail | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.34.3">Release notes</a></small>
+  <small>Published: 8/12/2020 | Modules affected: cloudtrail | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.34.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -806,7 +806,7 @@ All packer templates now support using a custom KMS CMK for encrypting the snaps
 ### [v0.0.3](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.0.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/18/2020 | Modules affected: networking, tls-scripts, base, landingzone | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.0.3">Release notes</a></small>
+  <small>Published: 8/19/2020 | Modules affected: networking, tls-scripts, base, landingzone | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.0.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -928,6 +928,6 @@ This release introduces two changes:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "be122a1d476901be784eca3b6282fae5"
+  "hash": "b0c35156790c804b550108bb1c6f4a1a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-08/index.md
@@ -228,7 +228,7 @@ See [the updated docs](https://github.com/gruntwork-io/module-ci/tree/master/mod
 
   
 
-- Update `install-jenkins` to the latest Jenkins version (`2.235.5`), switch to `https` URLs for the APT sources, and add `DEBIAN_FRONTEND=noninteractive` to all `apt-get` calls to ensure the installs don't show interactive prompts.
+- Update `install-jenkins` to the latest Jenkins version (`2.235.5`), switch to `https` URLs for the APT sources, and add `DEBIAN_FRONTEND=noninteractive` to all `apt-get` calls to ensure the installs don&apos;t show interactive prompts.
 
 
 
@@ -408,7 +408,7 @@ Add prefix to the ECS capacity providers to support ECS cluster names that begin
 
   
 
-*Update: when doing this upgrade, we accidentally missed updating the `ecs-daemon-service` module, so it's still pinned to AWS Provider 2.x. If you're using that module, please update to release [v0.22.0](https://github.com/gruntwork-io/module-ecs/releases/tag/v0.22.0) instead.*
+*Update: when doing this upgrade, we accidentally missed updating the `ecs-daemon-service` module, so it&apos;s still pinned to AWS Provider 2.x. If you&apos;re using that module, please update to release [v0.22.0](https://github.com/gruntwork-io/module-ecs/releases/tag/v0.22.0) instead.*
 
 Starting this release, tests are run against v3.x series of the AWS provider. Note that this release is backwards compatible with v2.x of the AWS provider. However, there is no guarantee that backwards compatibility with v2.x of the AWS provider will be maintained going forward.
 
@@ -662,22 +662,22 @@ This release introduces a new module `kms-grant-multi-region` that allows you to
 
 **This release contains backwards incompatible changes. Make sure to follow the instructions in the migration guide below!**
 
-* Refactored the `account-baseline-xxx` modules to work around several chicken-and-egg problems related to AWS Config / CloudTrail. The initial deployment, as well as adding subsequent child accounts, can now be done in a single `apply` per account, rather than the previous process, which required lots of back-and-forth and multiple `apply` calls. Here's an overview of the changes:
+* Refactored the `account-baseline-xxx` modules to work around several chicken-and-egg problems related to AWS Config / CloudTrail. The initial deployment, as well as adding subsequent child accounts, can now be done in a single `apply` per account, rather than the previous process, which required lots of back-and-forth and multiple `apply` calls. Here&apos;s an overview of the changes:
 
-    * Add first-class support for marking one of the child accounts as a "logs account" that should be used for aggregating AWS Config and CloudTrail data from all accounts. The `account-baseline-root` module can now automatically create the logs account, authenticate to it, create an S3 bucket for AWS Config and an S3 bucket and KMS CMK for CloudTrail in that account, and then configure the root account to send all AWS Config and CloudTrail data to those S3 buckets. In the past, you had to disable AWS Config and CloudTrail on the very initial deployment, as the logs account did not exist, but with this release, you can leave it enabled, run `apply` once, 
-    and everything will "just work."
+    * Add first-class support for marking one of the child accounts as a &quot;logs account&quot; that should be used for aggregating AWS Config and CloudTrail data from all accounts. The `account-baseline-root` module can now automatically create the logs account, authenticate to it, create an S3 bucket for AWS Config and an S3 bucket and KMS CMK for CloudTrail in that account, and then configure the root account to send all AWS Config and CloudTrail data to those S3 buckets. In the past, you had to disable AWS Config and CloudTrail on the very initial deployment, as the logs account did not exist, but with this release, you can leave it enabled, run `apply` once, 
+    and everything will &quot;just work.&quot;
 
     * Switch from org-level AWS Config Rules to account-level AWS Config Rules. The Rules are exactly the same, but are now managed within each account, rather than solely at the root account. This is slightly less convenient / secure, but it works around a major chicken-and-egg problem when creating new child accounts. Org-level rules require every single child account to have a Config Recorder or deployment fails, so in the past, you had to initially disable Config Rules whenever you added a new child account, then create a Config Recorder in that account, and then re-enable the Rules. This process has now been reduced to a single `apply` per account.
 
 * Updated the `cloudtrail` module to: 
     * Use the `kms-master-key` module to create and manage the KMS CMK rather than custom code. This makes the code more DRY and maintainable.
-    * Properly support sharing a KMS CMK across multiple accounts. In the past, the `cloudtrail` module didn't have this ability and the `account-baseline-xxx` modules were backfilling the missing permissions, but now it's all consolidated into the `cloudtrail` module.
+    * Properly support sharing a KMS CMK across multiple accounts. In the past, the `cloudtrail` module didn&apos;t have this ability and the `account-baseline-xxx` modules were backfilling the missing permissions, but now it&apos;s all consolidated into the `cloudtrail` module.
 
 * Extracted the S3 bucket creation logic from the `aws-config` module into an `aws-config-bucket` module so it can be reused elsewhere (namely, in `account-baseline-root`).
 
 * Extracted the S3 bucket and KMS CMK creation logic from the `cloudtrail` module into an `cloudtrail-bucket` module so it can be reused elsewhere (namely, in `account-baseline-root`).
 
-* The `aws-config` and `aws-config-multi-region` modules now expose a new, required `aggregate_config_data_in_external_account` parameter that must be set to `true` if you're aggregating AWS Config data in an external account (i.e., if setting the `central_account_id` param). This redundant parameter is unfortunately necessary to work around a Terraform limitation.
+* The `aws-config` and `aws-config-multi-region` modules now expose a new, required `aggregate_config_data_in_external_account` parameter that must be set to `true` if you&apos;re aggregating AWS Config data in an external account (i.e., if setting the `central_account_id` param). This redundant parameter is unfortunately necessary to work around a Terraform limitation.
 
 * Fixed a bug in the `aws-config` module where it was not setting `s3_key_prefix` on `aws_config_delivery_channel`.
 
@@ -939,7 +939,7 @@ Service Management (`services`)
 
 This release introduces two changes:
 
-1. In the `vpc-peering-external` module, it's now possible to disable the network ACL DENY rules by setting `enable_blanket_deny=false`. This can be useful when you need to add your own ACLs and you're bumping up against the 20 rule limit.
+1. In the `vpc-peering-external` module, it&apos;s now possible to disable the network ACL DENY rules by setting `enable_blanket_deny=false`. This can be useful when you need to add your own ACLs and you&apos;re bumping up against the 20 rule limit.
 1. As outlined in the [Terraform AWS provider v3 upgrade guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_cloudwatch_log_group), CloudWatch Logs group ARNs no longer include the `:*` at the end, which caused a problem in the `vpc-flow-logs` module. This is now resolved.
 
 
@@ -955,6 +955,6 @@ This release introduces two changes:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "783de82cbcfde233ca8c2218b2c087f0"
+  "hash": "3cbc0c600a4e5e7a759d3b293afc4e97"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-08/index.md
@@ -25,7 +25,6 @@ Here are the repos that were updated:
 - [terraform-aws-load-balancer](#terraform-aws-load-balancer)
 - [terraform-aws-openvpn](#terraform-aws-openvpn)
 - [terraform-aws-security](#terraform-aws-security)
-- [terraform-aws-server](#terraform-aws-server)
 - [terraform-aws-service-catalog](#terraform-aws-service-catalog)
 - [terraform-aws-vpc](#terraform-aws-vpc)
 
@@ -87,7 +86,7 @@ Here are the repos that were updated:
 ### [v0.0.1-08112020](https://github.com/gruntwork-io/infrastructure-live-acme/releases/tag/v0.0.1-08112020)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/12/2020 | <a href="https://github.com/gruntwork-io/infrastructure-live-acme/releases/tag/v0.0.1-08112020">Release notes</a></small>
+  <small>Published: 8/11/2020 | <a href="https://github.com/gruntwork-io/infrastructure-live-acme/releases/tag/v0.0.1-08112020">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -114,7 +113,7 @@ Updates in this version:
 ### [v0.0.1-08112020](https://github.com/gruntwork-io/infrastructure-modules-acme/releases/tag/v0.0.1-08112020)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/12/2020 | <a href="https://github.com/gruntwork-io/infrastructure-modules-acme/releases/tag/v0.0.1-08112020">Release notes</a></small>
+  <small>Published: 8/11/2020 | <a href="https://github.com/gruntwork-io/infrastructure-modules-acme/releases/tag/v0.0.1-08112020">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -619,7 +618,7 @@ Resolve `shellcheck` issues in `aws-auth`.
 ### [v0.36.2](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.36.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/25/2020 | Modules affected: account-baseline-app, account-baseline-security | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.36.2">Release notes</a></small>
+  <small>Published: 8/24/2020 | Modules affected: account-baseline-app, account-baseline-security | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.36.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -636,7 +635,7 @@ You can now set the max session duration for human and machine cross account IAM
 ### [v0.36.1](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.36.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/22/2020 | Modules affected: kms-grant-multi-region, account-baseline-app, account-baseline-security, kms-master-key-multi-region | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.36.1">Release notes</a></small>
+  <small>Published: 8/21/2020 | Modules affected: kms-grant-multi-region, account-baseline-app, account-baseline-security, kms-master-key-multi-region | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.36.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -750,7 +749,7 @@ This release adds read only permissions to the `read_only` IAM policy for the [P
 ### [v0.34.3](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.34.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/12/2020 | Modules affected: cloudtrail | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.34.3">Release notes</a></small>
+  <small>Published: 8/11/2020 | Modules affected: cloudtrail | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.34.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -759,32 +758,6 @@ This release adds read only permissions to the `read_only` IAM policy for the [P
 
 
 Allows an empty list of users and admins in cloudtrail-created KMS keys. Previously, the `kms_key_user_iam_arns` and `kms_key_administrator_iam_arns` variables were required. They are now optional and default to an empty list. If they are left as empty, then `allow_cloudtrail_access_with_iam` must be `true`.
-
-
-
-</div>
-
-
-
-## terraform-aws-server
-
-
-### [v0.8.5](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.8.5)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/1/2020 | Modules affected: ec2-backup, single-server | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.8.5">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  
-
-This release includes a fix for the `ec2-backup` module, making its tag configurations more flexible. It also fixes a few links in the `module-server` documentation.
-
-
-
-
-
 
 
 
@@ -833,7 +806,7 @@ All packer templates now support using a custom KMS CMK for encrypting the snaps
 ### [v0.0.3](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.0.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/19/2020 | Modules affected: networking, tls-scripts, base, landingzone | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.0.3">Release notes</a></small>
+  <small>Published: 8/18/2020 | Modules affected: networking, tls-scripts, base, landingzone | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.0.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -955,6 +928,6 @@ This release introduces two changes:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "783de82cbcfde233ca8c2218b2c087f0"
+  "hash": "be122a1d476901be784eca3b6282fae5"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-08/index.md
@@ -86,7 +86,7 @@ Here are the repos that were updated:
 ### [v0.0.1-08112020](https://github.com/gruntwork-io/infrastructure-live-acme/releases/tag/v0.0.1-08112020)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/11/2020 | <a href="https://github.com/gruntwork-io/infrastructure-live-acme/releases/tag/v0.0.1-08112020">Release notes</a></small>
+  <small>Published: 8/12/2020 | <a href="https://github.com/gruntwork-io/infrastructure-live-acme/releases/tag/v0.0.1-08112020">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -113,7 +113,7 @@ Updates in this version:
 ### [v0.0.1-08112020](https://github.com/gruntwork-io/infrastructure-modules-acme/releases/tag/v0.0.1-08112020)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/11/2020 | <a href="https://github.com/gruntwork-io/infrastructure-modules-acme/releases/tag/v0.0.1-08112020">Release notes</a></small>
+  <small>Published: 8/12/2020 | <a href="https://github.com/gruntwork-io/infrastructure-modules-acme/releases/tag/v0.0.1-08112020">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -928,6 +928,6 @@ This release introduces two changes:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "b0c35156790c804b550108bb1c6f4a1a"
+  "hash": "32e51d1d0bf79941f7f1474028e6eb6b"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-09/index.md
@@ -122,7 +122,7 @@ This is a maintenance release that exports some test helper functions for the ec
 ### [v0.28.4](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.28.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/25/2020 | Modules affected: infrastructure-deploy-script | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.28.4">Release notes</a></small>
+  <small>Published: 9/24/2020 | Modules affected: infrastructure-deploy-script | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.28.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -774,7 +774,7 @@ This updates `install-cloudwatch-monitoring-scripts.sh` to set cache removal on 
 ### [v0.38.3](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.38.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/25/2020 | Modules affected: fail2ban | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.38.3">Release notes</a></small>
+  <small>Published: 9/24/2020 | Modules affected: fail2ban | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.38.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1081,7 +1081,7 @@ replace ssm role with new best practice
 ### [v0.3.2](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.3.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/30/2020 | Modules affected: data-stores | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.3.2">Release notes</a></small>
+  <small>Published: 9/29/2020 | Modules affected: data-stores | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.3.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1152,7 +1152,7 @@ You can now configure the `--search-domain` option on the OpenVPN server. Note t
 ### [v0.2.8](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.2.8)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/25/2020 | Modules affected: services/k8s-service | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.2.8">Release notes</a></small>
+  <small>Published: 9/24/2020 | Modules affected: services/k8s-service | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.2.8">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1285,7 +1285,7 @@ Updated documentation and tests:
 ### [v0.2.2](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.2.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/9/2020 | Modules affected: base, data-stores, landingzone, mgmt | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.2.2">Release notes</a></small>
+  <small>Published: 9/8/2020 | Modules affected: base, data-stores, landingzone, mgmt | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.2.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1524,6 +1524,6 @@ This is a minor update that fixes a perpetual diff in the `vpc-flow-logs` module
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "015880c0de9494eb14d146a96a4873d8"
+  "hash": "12b8390bf21f6098b8f69113f800a8fd"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-09/index.md
@@ -122,7 +122,7 @@ This is a maintenance release that exports some test helper functions for the ec
 ### [v0.28.4](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.28.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/24/2020 | Modules affected: infrastructure-deploy-script | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.28.4">Release notes</a></small>
+  <small>Published: 9/25/2020 | Modules affected: infrastructure-deploy-script | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.28.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -774,7 +774,7 @@ This updates `install-cloudwatch-monitoring-scripts.sh` to set cache removal on 
 ### [v0.38.3](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.38.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/24/2020 | Modules affected: fail2ban | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.38.3">Release notes</a></small>
+  <small>Published: 9/25/2020 | Modules affected: fail2ban | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.38.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1081,7 +1081,7 @@ replace ssm role with new best practice
 ### [v0.3.2](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.3.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/29/2020 | Modules affected: data-stores | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.3.2">Release notes</a></small>
+  <small>Published: 9/30/2020 | Modules affected: data-stores | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.3.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1152,7 +1152,7 @@ You can now configure the `--search-domain` option on the OpenVPN server. Note t
 ### [v0.2.8](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.2.8)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/24/2020 | Modules affected: services/k8s-service | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.2.8">Release notes</a></small>
+  <small>Published: 9/25/2020 | Modules affected: services/k8s-service | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.2.8">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1524,6 +1524,6 @@ This is a minor update that fixes a perpetual diff in the `vpc-flow-logs` module
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "12b8390bf21f6098b8f69113f800a8fd"
+  "hash": "08f3383985e1c3e34966b11ac5acd257"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-09/index.md
@@ -1285,7 +1285,7 @@ Updated documentation and tests:
 ### [v0.2.2](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.2.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/8/2020 | Modules affected: base, data-stores, landingzone, mgmt | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.2.2">Release notes</a></small>
+  <small>Published: 9/9/2020 | Modules affected: base, data-stores, landingzone, mgmt | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.2.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1524,6 +1524,6 @@ This is a minor update that fixes a perpetual diff in the `vpc-flow-logs` module
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "08f3383985e1c3e34966b11ac5acd257"
+  "hash": "015880c0de9494eb14d146a96a4873d8"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-09/index.md
@@ -167,7 +167,7 @@ This is a maintenance release that exports some test helper functions for the ec
 
 Adds a new flag, `--idempotent`, to the [`build-docker-image` tool](https://github.com/gruntwork-io/module-ci/blob/6af8f6928af612b04c816ac84016d2b7fd689067/modules/ecs-deploy-runner/docker/kaniko/build_docker_image.go) in the Kaniko image of the ecs-deploy-runner. Invoking the build-docker-image tool with the flag will cause it to check for the existence of an image before building and pushing.
 
-Also adds an optional `route53_tags` to the Jenkins example code, making the example more portable and less specific to Gruntwork's testing processes.
+Also adds an optional `route53_tags` to the Jenkins example code, making the example more portable and less specific to Gruntwork&apos;s testing processes.
 
 
 
@@ -221,7 +221,7 @@ You can now specify repo restrictions as regex using `allowed_repos_regex` and `
 
   
 
-Add `lifecycle` block to ignore changes to `snapshot_identifier` so that restored DB clusters won't get destroyed during updates.
+Add `lifecycle` block to ignore changes to `snapshot_identifier` so that restored DB clusters won&apos;t get destroyed during updates.
 
 
 
@@ -1411,7 +1411,7 @@ Fix OS permissions that are set on the downloaded binary from the `executable-de
 
   
 
-- Add DynamoDB VPC endpoints to the `vpc-mgmt` module. We already had these endpoints in `vpc-app`, but somehow must've forgotten to add them to `vpc-mgmt`. 
+- Add DynamoDB VPC endpoints to the `vpc-mgmt` module. We already had these endpoints in `vpc-app`, but somehow must&apos;ve forgotten to add them to `vpc-mgmt`. 
 - Propagate the tags from the `custom_tags` input variable in `vpc-app` and `vpc-mgmt` to all VPC endpoints. This ensures more consistent tagging for all resources created by these modules.
 
 
@@ -1524,6 +1524,6 @@ This is a minor update that fixes a perpetual diff in the `vpc-flow-logs` module
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "015880c0de9494eb14d146a96a4873d8"
+  "hash": "1645f4c6570831c580d6b2f105f9a8dc"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-10/index.md
@@ -315,7 +315,7 @@ Updates the `custom-iam-entity` module to use the latest version in `module-secu
 ### [v0.7.1](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.7.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/14/2020 | Modules affected: cloudtrail | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.7.1">Release notes</a></small>
+  <small>Published: 10/15/2020 | Modules affected: cloudtrail | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.7.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -806,7 +806,7 @@ This release bumps the `terraform-aws-eks` module up to the latest version, incl
 ### [v0.4.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.4.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/19/2020 | Modules affected: data-stores/rds, services/package-static-assets, mgmt/bastion-host, base/ec2-baseline | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.4.0">Release notes</a></small>
+  <small>Published: 10/20/2020 | Modules affected: data-stores/rds, services/package-static-assets, mgmt/bastion-host, base/ec2-baseline | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.4.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -882,7 +882,7 @@ This release updates the following modules to the latest releases of their respe
 ### [v0.7.1](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.7.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/27/2020 | Modules affected: zookeeper-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.7.1">Release notes</a></small>
+  <small>Published: 10/28/2020 | Modules affected: zookeeper-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.7.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -924,6 +924,6 @@ This release updates the following modules to the latest releases of their respe
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "5a5d8cc04d26be8b536485e7a87ed27b"
+  "hash": "58d4b04963a9d98f486738227f651054"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-10/index.md
@@ -279,7 +279,7 @@ You can now configure the ECS deploy runner with repository credentials for pull
 ### [v0.8.1](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.8.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/22/2020 | Modules affected: custom-iam-entity | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.8.1">Release notes</a></small>
+  <small>Published: 10/21/2020 | Modules affected: custom-iam-entity | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.8.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -315,7 +315,7 @@ Updates the `custom-iam-entity` module to use the latest version in `module-secu
 ### [v0.7.1](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.7.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/15/2020 | Modules affected: cloudtrail | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.7.1">Release notes</a></small>
+  <small>Published: 10/14/2020 | Modules affected: cloudtrail | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.7.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -806,7 +806,7 @@ This release bumps the `terraform-aws-eks` module up to the latest version, incl
 ### [v0.4.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.4.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/20/2020 | Modules affected: data-stores/rds, services/package-static-assets, mgmt/bastion-host, base/ec2-baseline | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.4.0">Release notes</a></small>
+  <small>Published: 10/19/2020 | Modules affected: data-stores/rds, services/package-static-assets, mgmt/bastion-host, base/ec2-baseline | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.4.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -882,7 +882,7 @@ This release updates the following modules to the latest releases of their respe
 ### [v0.7.1](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.7.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/28/2020 | Modules affected: zookeeper-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.7.1">Release notes</a></small>
+  <small>Published: 10/27/2020 | Modules affected: zookeeper-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.7.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -924,6 +924,6 @@ This release updates the following modules to the latest releases of their respe
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "e4a76fcaf53091beddcc267aa6ff7b63"
+  "hash": "5a5d8cc04d26be8b536485e7a87ed27b"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-10/index.md
@@ -279,7 +279,7 @@ You can now configure the ECS deploy runner with repository credentials for pull
 ### [v0.8.1](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.8.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/21/2020 | Modules affected: custom-iam-entity | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.8.1">Release notes</a></small>
+  <small>Published: 10/22/2020 | Modules affected: custom-iam-entity | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.8.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -924,6 +924,6 @@ This release updates the following modules to the latest releases of their respe
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "58d4b04963a9d98f486738227f651054"
+  "hash": "e4a76fcaf53091beddcc267aa6ff7b63"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-10/index.md
@@ -41,7 +41,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  This release fixes an issue with using [`toJson` and related sprig functions](https://masterminds.github.io/sprig/) within Boilerplate templates. It's now possible to read variable inputs from Boilerplate YML files and render those to JSON.
+  This release fixes an issue with using [`toJson` and related sprig functions](https://masterminds.github.io/sprig/) within Boilerplate templates. It&apos;s now possible to read variable inputs from Boilerplate YML files and render those to JSON.
 
 See [related PR](https://github.com/gruntwork-io/boilerplate/pull/67).
 
@@ -343,7 +343,7 @@ Expose ability to specify an existing KMS key for encrypting cloudtrail logs.
 
   
 
-- You can now enable the HTTP endpoint for the Data API on Aurora Serverless using the new 'enable_http_endpoint' input variable.
+- You can now enable the HTTP endpoint for the Data API on Aurora Serverless using the new &apos;enable_http_endpoint&apos; input variable.
 
 
 
@@ -519,7 +519,7 @@ All other functionality is preserved. To update to this version, replace usage o
 
   
 
-This release adds the option to create an outbound "allow all" rule in the Lambda security group that will allow it to communicate with external services. To enable this, set `should_create_outbound_rule=true` when calling the `lambda` module. Defaults to false.
+This release adds the option to create an outbound &quot;allow all&quot; rule in the Lambda security group that will allow it to communicate with external services. To enable this, set `should_create_outbound_rule=true` when calling the `lambda` module. Defaults to false.
 
 
 
@@ -569,7 +569,7 @@ This release adds the option to create an outbound "allow all" rule in the Lambd
 
   
 
-- Fix a bug in the `alb-target-group-alarms` module, switching the module to use `"Seconds"` instead of `"Count"` as the proper unit for the `TargetResponseTime` alarm. 
+- Fix a bug in the `alb-target-group-alarms` module, switching the module to use `&quot;Seconds&quot;` instead of `&quot;Count&quot;` as the proper unit for the `TargetResponseTime` alarm. 
 
 
 
@@ -590,7 +590,7 @@ This release adds the option to create an outbound "allow all" rule in the Lambd
 
   
 
-- Added the `create_before_destroy = true` lifecycle setting to the `aws_api_gateway_deployment` resource to work around intermittent "BadRequestException: Active stages pointing to this deployment must be moved or deleted" errors.
+- Added the `create_before_destroy = true` lifecycle setting to the `aws_api_gateway_deployment` resource to work around intermittent &quot;BadRequestException: Active stages pointing to this deployment must be moved or deleted&quot; errors.
 
 
 
@@ -723,7 +723,7 @@ __This release contains backwards incompatible changes. Make sure to follow the 
 
   
 
-- You can now specify the principals that will be allowed to assume the IAM role created by the `single-server` module. This can be useful, for example, to override the default from `["ec2.amazonaws.com"]` to `["ec2.amazonaws.com.cn"]` when using the AWS China region.
+- You can now specify the principals that will be allowed to assume the IAM role created by the `single-server` module. This can be useful, for example, to override the default from `[&quot;ec2.amazonaws.com&quot;]` to `[&quot;ec2.amazonaws.com.cn&quot;]` when using the AWS China region.
 
 
 
@@ -744,7 +744,7 @@ __This release contains backwards incompatible changes. Make sure to follow the 
 
   
 
-- Bump all underlying module version numbers and require Terraform `0.12.26` _or above_, which means you can now use the Service Catalog with Terraform `0.13.x` as well! The only exception are the Kubernetes / EKS services, as the underlying modules do not support Terraform `0.13.x` yet; we are working on that now and will do a new release when that's ready.
+- Bump all underlying module version numbers and require Terraform `0.12.26` _or above_, which means you can now use the Service Catalog with Terraform `0.13.x` as well! The only exception are the Kubernetes / EKS services, as the underlying modules do not support Terraform `0.13.x` yet; we are working on that now and will do a new release when that&apos;s ready.
 
 
 
@@ -787,7 +787,7 @@ This release adds the following features to the catalog:
 - The alb module now allows you to pass an existing S3 bucket for ALB access logs. This is useful for sending ALB logs to a central log account
 - For EKS, you can now provide a list of CIDR ranges or security groups that are permitted to access the private EKS API endpoint.
 
-We've also caught up to the latest release of the [module-security](https://github.com/gruntwork-io/module-security/) and [terraform-aws-eks](https://github.com/gruntwork-io/terraform-aws-eks) repositories.
+We&apos;ve also caught up to the latest release of the [module-security](https://github.com/gruntwork-io/module-security/) and [terraform-aws-eks](https://github.com/gruntwork-io/terraform-aws-eks) repositories.
 
 
 **Migration guide for eks-cluster**
@@ -924,6 +924,6 @@ This release updates the following modules to the latest releases of their respe
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "e4a76fcaf53091beddcc267aa6ff7b63"
+  "hash": "6870feea7aeadd599a8b69392a32ae68"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-11/index.md
@@ -417,7 +417,7 @@ __This release contains backwards incompatible changes. Make sure to follow the 
 ### [v0.42.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.42.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/24/2020 | Modules affected: ebs-encryption-multi-region, ebs-encryption | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.42.0">Release notes</a></small>
+  <small>Published: 11/23/2020 | Modules affected: ebs-encryption-multi-region, ebs-encryption | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.42.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -554,7 +554,7 @@ This release adds a new module, `ebs-encryption`, which allows you to control wh
 ### [v0.9.2](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.9.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/5/2020 | Modules affected: attach-eni | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.9.2">Release notes</a></small>
+  <small>Published: 11/4/2020 | Modules affected: attach-eni | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.9.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -615,7 +615,7 @@ This release adds a new module, `ebs-encryption`, which allows you to control wh
 ### [v0.10.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.10.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/24/2020 | Modules affected: services/terraform-aws-eks, networking, base, data-stores | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.10.0">Release notes</a></small>
+  <small>Published: 11/23/2020 | Modules affected: services/terraform-aws-eks, networking, base, data-stores | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.10.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -882,6 +882,6 @@ This release updates the default names set for the VPC DNS resolvers. The names 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "e0a9792eeac901a50030cf2fb40f4d29"
+  "hash": "f4c31fd0bcaa3b3e42fc22bf3d0e66f3"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-11/index.md
@@ -253,7 +253,7 @@ This release updates the `eks-alb-ingress-controller` to use the new chart locat
 
   
 
-- You can now configure a custom assume role policy for the IAM role in the `lambda` module using the new `assume_role_policy` input variable. This is useful in a few special cases when the default assume role policy won't work, such as using Lambda functions to rotate secrets in AWS Secrets Manager.
+- You can now configure a custom assume role policy for the IAM role in the `lambda` module using the new `assume_role_policy` input variable. This is useful in a few special cases when the default assume role policy won&apos;t work, such as using Lambda functions to rotate secrets in AWS Secrets Manager.
 
 
 
@@ -363,8 +363,8 @@ This release updates the `eks-alb-ingress-controller` to use the new chart locat
        - Code execution or elevation of privilege via NTP command line stack-based buffer overflow
    - [CVE-2019-7306  - 20.04 is not affected](https://people.canonical.com/~ubuntu-security/cve/2019/CVE-2019-7306.html)
        - Byobu Apport uploads .screenrc with diagnostics
-- We're using `easy-rsa v2.x` on Ubuntu 20.04 - allows for continuity between the Ubuntu 16.04, 18.04, or 20.04 implementations of `package-openvpn`. There's an issue raised to follow up on this and upgrade to using `easy-rsa v3.x` 
-- By adding support for Ubuntu 20.04, we're ensuring:
+- We&apos;re using `easy-rsa v2.x` on Ubuntu 20.04 - allows for continuity between the Ubuntu 16.04, 18.04, or 20.04 implementations of `package-openvpn`. There&apos;s an issue raised to follow up on this and upgrade to using `easy-rsa v3.x` 
+- By adding support for Ubuntu 20.04, we&apos;re ensuring:
     - this package can work on the latest LTS distro and has been tested with it
     - users can use a more secure implementation of openVPN
     - users can reuse the `/examples/packer/build.json` to build an AMI with Ubuntu 20.04.
@@ -481,7 +481,7 @@ New module: `secrets-manager-resource-policies`. This module manages the [resour
 
   
 
-Fix bug where the default value for `ebs_kms_key_name` must be `""`, not `null` for the `account-baseline-security` module.
+Fix bug where the default value for `ebs_kms_key_name` must be `&quot;&quot;`, not `null` for the `account-baseline-security` module.
 
 
 
@@ -586,7 +586,7 @@ This release adds a new module, `ebs-encryption`, which allows you to control wh
 
 - EKS cluster now supports the aws-auth-merger functionality introduced in [terraform-aws-eks v0.23.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.23.0).
 - Sets default values for the ssh-grunt group name in the ECS cluster
-- Updates Aurora & RDS modules to restore-from-snapshot using the snapshot's identifier
+- Updates Aurora &amp; RDS modules to restore-from-snapshot using the snapshot&apos;s identifier
 
 
 
@@ -882,6 +882,6 @@ This release updates the default names set for the VPC DNS resolvers. The names 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "e0a9792eeac901a50030cf2fb40f4d29"
+  "hash": "bdbd05cd5b13ffc17f8924425bedf087"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-11/index.md
@@ -417,7 +417,7 @@ __This release contains backwards incompatible changes. Make sure to follow the 
 ### [v0.42.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.42.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/23/2020 | Modules affected: ebs-encryption-multi-region, ebs-encryption | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.42.0">Release notes</a></small>
+  <small>Published: 11/24/2020 | Modules affected: ebs-encryption-multi-region, ebs-encryption | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.42.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -554,7 +554,7 @@ This release adds a new module, `ebs-encryption`, which allows you to control wh
 ### [v0.9.2](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.9.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/4/2020 | Modules affected: attach-eni | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.9.2">Release notes</a></small>
+  <small>Published: 11/5/2020 | Modules affected: attach-eni | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.9.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -615,7 +615,7 @@ This release adds a new module, `ebs-encryption`, which allows you to control wh
 ### [v0.10.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.10.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/23/2020 | Modules affected: services/terraform-aws-eks, networking, base, data-stores | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.10.0">Release notes</a></small>
+  <small>Published: 11/24/2020 | Modules affected: services/terraform-aws-eks, networking, base, data-stores | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.10.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -882,6 +882,6 @@ This release updates the default names set for the VPC DNS resolvers. The names 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "f4c31fd0bcaa3b3e42fc22bf3d0e66f3"
+  "hash": "e0a9792eeac901a50030cf2fb40f4d29"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-12/index.md
@@ -333,7 +333,7 @@ You can now enable container insights on the ECS cluster deployed with the `ecs-
 ### [v0.31.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.31.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/14/2020 | Modules affected: eks-cluster-control-plane, eks-cluster-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.31.0">Release notes</a></small>
+  <small>Published: 12/15/2020 | Modules affected: eks-cluster-control-plane, eks-cluster-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.31.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -968,6 +968,6 @@ The `exhibitor-shared-config` module has been refactored to use the `private-s3-
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "731ea0c1f30dddfa81dcda6d72f8a9a3"
+  "hash": "bc97a2bb4736f83c0947197982f4f041"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-12/index.md
@@ -333,7 +333,7 @@ You can now enable container insights on the ECS cluster deployed with the `ecs-
 ### [v0.31.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.31.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/15/2020 | Modules affected: eks-cluster-control-plane, eks-cluster-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.31.0">Release notes</a></small>
+  <small>Published: 12/14/2020 | Modules affected: eks-cluster-control-plane, eks-cluster-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.31.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -968,6 +968,6 @@ The `exhibitor-shared-config` module has been refactored to use the `private-s3-
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "bc97a2bb4736f83c0947197982f4f041"
+  "hash": "731ea0c1f30dddfa81dcda6d72f8a9a3"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-01/index.md
@@ -137,7 +137,7 @@ https://github.com/gruntwork-io/repo-copier/pull/45: Optimize Go module processi
 ### [v0.0.1](https://github.com/gruntwork-io/repo-copier/releases/tag/v0.0.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/16/2021 | <a href="https://github.com/gruntwork-io/repo-copier/releases/tag/v0.0.1">Release notes</a></small>
+  <small>Published: 1/15/2021 | <a href="https://github.com/gruntwork-io/repo-copier/releases/tag/v0.0.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -418,7 +418,7 @@ We are publishing soon a migration guide from CIS 1.2.0 to 1.3.0!
 ### [v0.32.2](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.32.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/29/2021 | Modules affected: eks-cluster-control-plane, eks-cluster-managed-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.32.2">Release notes</a></small>
+  <small>Published: 1/28/2021 | Modules affected: eks-cluster-control-plane, eks-cluster-managed-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.32.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -493,7 +493,7 @@ The core services modules are now compatible with helm provider 2.x. Note that s
 ### [v0.7.1](https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.7.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/27/2021 | Modules affected: (none) | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.7.1">Release notes</a></small>
+  <small>Published: 1/26/2021 | Modules affected: (none) | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.7.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -881,6 +881,6 @@ In this release, we have updated the behavior to not explicitly apply the defaul
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "8b1b908417a369c8b041b96d3d5c8973"
+  "hash": "3399a0f38f6ed606a57d5f6ee5a789ad"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-01/index.md
@@ -184,7 +184,7 @@ https://github.com/gruntwork-io/repo-copier/pull/45: Optimize Go module processi
 
   
 
-- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we've updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
+- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we&apos;ve updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
 
 
 
@@ -224,7 +224,7 @@ https://github.com/gruntwork-io/repo-copier/pull/45: Optimize Go module processi
 
   
 
-- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we've updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
+- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we&apos;ve updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
 
 
 
@@ -344,7 +344,7 @@ We are publishing soon a migration guide from CIS 1.2.0 to 1.3.0!
 
   
 
-- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we've updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
+- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we&apos;ve updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
 
 
 
@@ -367,7 +367,7 @@ We are publishing soon a migration guide from CIS 1.2.0 to 1.3.0!
 
   
 
-- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we've updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
+- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we&apos;ve updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
 
 
 
@@ -546,7 +546,7 @@ The core services modules are now compatible with helm provider 2.x. Note that s
 
   
 
-- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we've updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
+- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we&apos;ve updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
 
 
 
@@ -570,7 +570,7 @@ The core services modules are now compatible with helm provider 2.x. Note that s
   
 
 - We have added support for Ubuntu 20.04 in testing and dropped support for Ubuntu 16.04
-- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we've updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
+- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we&apos;ve updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
 
 
 
@@ -633,7 +633,7 @@ The core services modules are now compatible with helm provider 2.x. Note that s
 
   
 
-- Fixes broken links on the website's repo browser by using root-relative links for README & LICENSE file references.
+- Fixes broken links on the website&apos;s repo browser by using root-relative links for README &amp; LICENSE file references.
 
 
 </div>
@@ -696,7 +696,7 @@ NOTE: Starting this release, the `attach-eni` module no longer works with Ubuntu
 
   
 
-- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we've updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
+- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we&apos;ve updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
 
 
 
@@ -718,7 +718,7 @@ NOTE: Starting this release, the `attach-eni` module no longer works with Ubuntu
 
 - You can now configure the update timeout for the `elasticsearch` module using the new `update_timeout` input variable. The default timeout has been increased from 60m to 90m, as we were seeing some intermittent timeouts on creation.
 - Bumped the `terraform-aws-ci` version number in the `mgmt` modules. This is mainly to pick up a fix for the `jenkins` module related to the default `snapshot_id` value.
-- Removed a `depends_on` clause from the `ecs-cluster` module which was causing recent Terraform versions to exit with an error. This `depends_on` wasn't necessary in the first place.
+- Removed a `depends_on` clause from the `ecs-cluster` module which was causing recent Terraform versions to exit with an error. This `depends_on` wasn&apos;t necessary in the first place.
 - Updated the `eks-core-services` module to the 2.x version of the Helm provider. This is a backwards incompatible change. See the migration guide below.
 - Updated the `required_version` constraint on the `k8s-namepsace` to `&gt;= 0.12.26`. This was missed during the Terraform 0.13 upgrade.
 
@@ -765,7 +765,7 @@ NOTE: Starting this release, the `attach-eni` module no longer works with Ubuntu
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
   
-- Updated the `landingzone/account-baseline-root` & `landingzone/account-baseline-security` modules to include the new `iam-access-analyzer` module in order to be compliant with CIS 1.3.0. The additional `iam-access-analyzer` module is disabled by default to aid consistency and backwards compatibility between versions of the `landingzone`. 
+- Updated the `landingzone/account-baseline-root` &amp; `landingzone/account-baseline-security` modules to include the new `iam-access-analyzer` module in order to be compliant with CIS 1.3.0. The additional `iam-access-analyzer` module is disabled by default to aid consistency and backwards compatibility between versions of the `landingzone`. 
 - Updated the related examples to showcase how the `landingzone` module could use the `iam-access-analyzer` module. To enable the use of this feature, users will need to set `enable_iam_access_analyzer` to true in the variables.tf for each of these modules or examples.
 - Once all our libraries are upgraded and tested to be compatible with CIS 1.3.0 we’ll publish a migration guide to help you update.
 
@@ -866,7 +866,7 @@ In this release, we have updated the behavior to not explicitly apply the defaul
 
   
 
-- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we've updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
+- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we&apos;ve updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
 
 
 
@@ -881,6 +881,6 @@ In this release, we have updated the behavior to not explicitly apply the defaul
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "8b1b908417a369c8b041b96d3d5c8973"
+  "hash": "b09f779d4b4e1150132a9f1bc715d68c"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-01/index.md
@@ -137,7 +137,7 @@ https://github.com/gruntwork-io/repo-copier/pull/45: Optimize Go module processi
 ### [v0.0.1](https://github.com/gruntwork-io/repo-copier/releases/tag/v0.0.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/15/2021 | <a href="https://github.com/gruntwork-io/repo-copier/releases/tag/v0.0.1">Release notes</a></small>
+  <small>Published: 1/16/2021 | <a href="https://github.com/gruntwork-io/repo-copier/releases/tag/v0.0.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -418,7 +418,7 @@ We are publishing soon a migration guide from CIS 1.2.0 to 1.3.0!
 ### [v0.32.2](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.32.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/28/2021 | Modules affected: eks-cluster-control-plane, eks-cluster-managed-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.32.2">Release notes</a></small>
+  <small>Published: 1/29/2021 | Modules affected: eks-cluster-control-plane, eks-cluster-managed-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.32.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -493,7 +493,7 @@ The core services modules are now compatible with helm provider 2.x. Note that s
 ### [v0.7.1](https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.7.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 1/26/2021 | Modules affected: (none) | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.7.1">Release notes</a></small>
+  <small>Published: 1/27/2021 | Modules affected: (none) | <a href="https://github.com/gruntwork-io/terraform-aws-elk/releases/tag/v0.7.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -881,6 +881,6 @@ In this release, we have updated the behavior to not explicitly apply the defaul
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "3399a0f38f6ed606a57d5f6ee5a789ad"
+  "hash": "8b1b908417a369c8b041b96d3d5c8973"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-02/index.md
@@ -34,7 +34,7 @@ Here are the repos that were updated:
 ### [v0.0.3](https://github.com/gruntwork-io/aws-sample-app/releases/tag/v0.0.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/9/2021 | <a href="https://github.com/gruntwork-io/aws-sample-app/releases/tag/v0.0.3">Release notes</a></small>
+  <small>Published: 2/8/2021 | <a href="https://github.com/gruntwork-io/aws-sample-app/releases/tag/v0.0.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -722,7 +722,7 @@ Fixes a bug in the `ecs-cluster` module to allow SSH from CIDR blocks to work co
 ### [v0.18.4](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.18.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/12/2021 | Modules affected: mgmt/jenkins | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.18.4">Release notes</a></small>
+  <small>Published: 2/11/2021 | Modules affected: mgmt/jenkins | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.18.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -920,6 +920,6 @@ Fixes a bug in the `ecs-cluster` module to allow SSH from CIDR blocks to work co
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "394e768013c3288ce631aa50fb6bc5e8"
+  "hash": "8c4ba49fd75078ae28bf2c623c83f2ce"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-02/index.md
@@ -34,7 +34,7 @@ Here are the repos that were updated:
 ### [v0.0.3](https://github.com/gruntwork-io/aws-sample-app/releases/tag/v0.0.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/8/2021 | <a href="https://github.com/gruntwork-io/aws-sample-app/releases/tag/v0.0.3">Release notes</a></small>
+  <small>Published: 2/9/2021 | <a href="https://github.com/gruntwork-io/aws-sample-app/releases/tag/v0.0.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -722,7 +722,7 @@ Fixes a bug in the `ecs-cluster` module to allow SSH from CIDR blocks to work co
 ### [v0.18.4](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.18.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/11/2021 | Modules affected: mgmt/jenkins | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.18.4">Release notes</a></small>
+  <small>Published: 2/12/2021 | Modules affected: mgmt/jenkins | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.18.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -920,6 +920,6 @@ Fixes a bug in the `ecs-cluster` module to allow SSH from CIDR blocks to work co
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "8c4ba49fd75078ae28bf2c623c83f2ce"
+  "hash": "394e768013c3288ce631aa50fb6bc5e8"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-02/index.md
@@ -62,7 +62,7 @@ Here are the repos that were updated:
 Updated all module versions to the latest. Most of these were backwards compatible changes, except for the EKS / Helm updates, as we have switched to Helm provider v2.  Refer to the Migration Guide down below for details.
 
 
-Most modules solely require a version number bump. The one exception is that if you're using EKS and Helm, Helm provider version 2 has come out, and some minor code changes are required to use it. See the [`terraform-aws-eks` v0.32.0 release notes](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.32.0) for instructions.
+Most modules solely require a version number bump. The one exception is that if you&apos;re using EKS and Helm, Helm provider version 2 has come out, and some minor code changes are required to use it. See the [`terraform-aws-eks` v0.32.0 release notes](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.32.0) for instructions.
 
 
 * https://github.com/gruntwork-io/infrastructure-modules-multi-account-acme/pull/51
@@ -129,7 +129,7 @@ https://github.com/gruntwork-io/repo-copier/pull/71: Add more unit tests.
 
   https://github.com/gruntwork-io/repo-copier/pull/64: Fix bug with how assets were packaged that caused an error when running `repo-copier`.
 
-https://github.com/gruntwork-io/repo-copier/pull/60: Add support for a GitHub connector, which allows you to copy code directly from GitHub, so you don't need S3 as an intermediary.
+https://github.com/gruntwork-io/repo-copier/pull/60: Add support for a GitHub connector, which allows you to copy code directly from GitHub, so you don&apos;t need S3 as an intermediary.
 
 https://github.com/gruntwork-io/repo-copier/pull/65: Add support for specifying proxies for each connector via `--proxy-url` params.
 
@@ -150,7 +150,7 @@ https://github.com/gruntwork-io/repo-copier/pull/65: Add support for specifying 
 
   
 
-- AWS ElastiCache, and the Terraform AWS provider, have changed how reader endpoints work ([context](https://aws.amazon.com/about-aws/whats-new/2019/06/amazon-elasticache-launches-reader-endpoint-for-redis/)), which broke the `read_endpoints` output variable in the `redis` module. In this release, we've fixed this issue, and updated to use the new terminology and type from AWS / Terraform: the output variable is now called `reader_endpoint` and is a single value instead of a list. 
+- AWS ElastiCache, and the Terraform AWS provider, have changed how reader endpoints work ([context](https://aws.amazon.com/about-aws/whats-new/2019/06/amazon-elasticache-launches-reader-endpoint-for-redis/)), which broke the `read_endpoints` output variable in the `redis` module. In this release, we&apos;ve fixed this issue, and updated to use the new terminology and type from AWS / Terraform: the output variable is now called `reader_endpoint` and is a single value instead of a list. 
 
 
 </div>
@@ -166,7 +166,7 @@ https://github.com/gruntwork-io/repo-copier/pull/65: Add support for specifying 
 
   
 
-- Several months ago, AWS made a backward-incompatible change related to the Elasticache Replication Group Multi-AZ behavior, introducing a new [`MultiAZEnabled` toggle](https://awsapichanges.info/archive/changes/db86f9-elasticache.html#CreateReplicationGroup). This means that, the last several months, if you deployed Redis with with `enable_automatic_failover` set to `true`, but did not have this `MultiAZEnabled` flag—which wasn't exposed in Terraform's AWS provider—Redis would be deployed into only a single AZ. This issue was fixed in [AWS provider 3.26](https://github.com/hashicorp/terraform-provider-aws/pull/17320), and in this release, we now expose a new `enable_multi_az` variable in the `redis` module so that you can configure this property. This is a backwards incompatible change, so please see the migration guide below.
+- Several months ago, AWS made a backward-incompatible change related to the Elasticache Replication Group Multi-AZ behavior, introducing a new [`MultiAZEnabled` toggle](https://awsapichanges.info/archive/changes/db86f9-elasticache.html#CreateReplicationGroup). This means that, the last several months, if you deployed Redis with with `enable_automatic_failover` set to `true`, but did not have this `MultiAZEnabled` flag—which wasn&apos;t exposed in Terraform&apos;s AWS provider—Redis would be deployed into only a single AZ. This issue was fixed in [AWS provider 3.26](https://github.com/hashicorp/terraform-provider-aws/pull/17320), and in this release, we now expose a new `enable_multi_az` variable in the `redis` module so that you can configure this property. This is a backwards incompatible change, so please see the migration guide below.
 
 
 </div>
@@ -225,7 +225,7 @@ The default version of tools installed in the deploy runner has been updated:
 
   
 
-- You can now configure IOPS for the Jenkins EBS volume by setting the new `ebs_volume_iops`  input parameter. Note that you'll also need to set the `ebs_volume_type` input parameter (which existed before) to `io1`.
+- You can now configure IOPS for the Jenkins EBS volume by setting the new `ebs_volume_iops`  input parameter. Note that you&apos;ll also need to set the `ebs_volume_type` input parameter (which existed before) to `io1`.
 
 
 
@@ -280,7 +280,7 @@ The default version of tools installed in the deploy runner has been updated:
 
   
 
-- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we've updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
+- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we&apos;ve updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
 - Update the default `Dockerfile` in `ecs-deploy-runner` to use Kubergrunt `v0.6.9`.
 
 
@@ -380,7 +380,7 @@ This release removes the `service_autoscaling_iam_role_arn` output from the `ecs
 
   
 
-Bump default k8s version to 1.19. If you wish to use Kubernetes version 1.19 with EKS, you must update `kubergrunt` to version `0.6.10` or newer. Note that If you were using the default (that is, you were not passing in `kubernetes_version`), you will need to explicitly pass in `kubernetes_version = "1.18"` to avoid inadvertently upgrading the EKS cluster.
+Bump default k8s version to 1.19. If you wish to use Kubernetes version 1.19 with EKS, you must update `kubergrunt` to version `0.6.10` or newer. Note that If you were using the default (that is, you were not passing in `kubernetes_version`), you will need to explicitly pass in `kubernetes_version = &quot;1.18&quot;` to avoid inadvertently upgrading the EKS cluster.
 
 
 
@@ -503,7 +503,7 @@ Bump default k8s version to 1.19. If you wish to use Kubernetes version 1.19 wit
 
   
 
-- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we've updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
+- We recently renamed most of our repos to follow the Terraform Registry convention of `terraform-&lt;cloud&gt;-&lt;name&gt;` (e.g., `terraform-aws-vpc`. In this release, we&apos;ve updated all cross-references and links from the old names to the new names. There should be no change in behavior, and GitHub redirects old names to new names anyway, but using the up-to-date names will help reduce confusion.
 
 
 
@@ -817,7 +817,7 @@ Fixes a bug in the `ecs-cluster` module to allow SSH from CIDR blocks to work co
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  All nested module dependencies have been updated to the latest upstream versions. We've also resolved warnings related to deprecated variable interpolation syntax.
+  All nested module dependencies have been updated to the latest upstream versions. We&apos;ve also resolved warnings related to deprecated variable interpolation syntax.
 
 
 - Updated dependency gruntwork-io/terraform-aws-vpc to v0.13.0
@@ -864,7 +864,7 @@ Fixes a bug in the `ecs-cluster` module to allow SSH from CIDR blocks to work co
     - Once all Gruntwork repos have been upgrade to work with `0.14.x`, we will publish a migration guide with a version compatibility table and announce it all via the Gruntwork Newsletter.
 - Remove docker key from machine config
 - Add placeholder.tf for TFC/TFE/PMR
-- Lock PIP's version to be smaller than 21.0
+- Lock PIP&apos;s version to be smaller than 21.0
 
 
 
@@ -920,6 +920,6 @@ Fixes a bug in the `ecs-cluster` module to allow SSH from CIDR blocks to work co
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "394e768013c3288ce631aa50fb6bc5e8"
+  "hash": "0b0199fc7090073fe4850f30768bd8df"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-03/index.md
@@ -921,7 +921,7 @@ For more details, please refer to the release notes from Terraform 0.14 [release
 ### [v0.45.6](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.45.6)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/24/2021 | Modules affected: account-baseline-root | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.45.6">Release notes</a></small>
+  <small>Published: 3/23/2021 | Modules affected: account-baseline-root | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.45.6">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1212,7 +1212,7 @@ Variables affected: `aws_region`, `vpc_name`, `cidr_block`, `num_nat_gateways`.
 ### [v0.22.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.22.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/12/2021 | Modules affected: mgmt/jenkins | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.22.0">Release notes</a></small>
+  <small>Published: 3/11/2021 | Modules affected: mgmt/jenkins | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.22.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1489,7 +1489,7 @@ Support for optional resource creation via the `create_resources` parameter was 
 ### [v0.9.0](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.9.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/25/2021 | Modules affected: exhibitor-shared-config, zookeeper-cluster, zookeeper-iam-permissions, zookeeper-security-group-rules | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.9.0">Release notes</a></small>
+  <small>Published: 3/24/2021 | Modules affected: exhibitor-shared-config, zookeeper-cluster, zookeeper-iam-permissions, zookeeper-security-group-rules | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.9.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1513,6 +1513,6 @@ Support for optional resource creation via the `create_resources` parameter was 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "3e33c11671eb0d1713b0858144d3dcb2"
+  "hash": "ed45ccee4e9c3e53e09e45d03088c7b8"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-03/index.md
@@ -921,7 +921,7 @@ For more details, please refer to the release notes from Terraform 0.14 [release
 ### [v0.45.6](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.45.6)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/23/2021 | Modules affected: account-baseline-root | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.45.6">Release notes</a></small>
+  <small>Published: 3/24/2021 | Modules affected: account-baseline-root | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.45.6">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1212,7 +1212,7 @@ Variables affected: `aws_region`, `vpc_name`, `cidr_block`, `num_nat_gateways`.
 ### [v0.22.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.22.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/11/2021 | Modules affected: mgmt/jenkins | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.22.0">Release notes</a></small>
+  <small>Published: 3/12/2021 | Modules affected: mgmt/jenkins | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.22.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1489,7 +1489,7 @@ Support for optional resource creation via the `create_resources` parameter was 
 ### [v0.9.0](https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.9.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/24/2021 | Modules affected: exhibitor-shared-config, zookeeper-cluster, zookeeper-iam-permissions, zookeeper-security-group-rules | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.9.0">Release notes</a></small>
+  <small>Published: 3/25/2021 | Modules affected: exhibitor-shared-config, zookeeper-cluster, zookeeper-iam-permissions, zookeeper-security-group-rules | <a href="https://github.com/gruntwork-io/terraform-aws-zookeeper/releases/tag/v0.9.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1513,6 +1513,6 @@ Support for optional resource creation via the `create_resources` parameter was 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "ed45ccee4e9c3e53e09e45d03088c7b8"
+  "hash": "3e33c11671eb0d1713b0858144d3dcb2"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-03/index.md
@@ -51,7 +51,7 @@ Here are the repos that were updated:
 - Drop support for creating GitHub repos (this is now handled in the gruntwork-clients org)
 - Adds support for creating secrets for the VCS tokens
 
-Also undergoes a sort of rebranding of a "generic gruntwork CLI tool" to being specific to the ref arch. The README is updated with all the details.
+Also undergoes a sort of rebranding of a &quot;generic gruntwork CLI tool&quot; to being specific to the ref arch. The README is updated with all the details.
 
 </div>
 
@@ -81,7 +81,7 @@ Also undergoes a sort of rebranding of a "generic gruntwork CLI tool" to being s
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/repo-copier/pull/88: Fix a bug where the `--disable-pull-request-protection` and `--disable-fast-forward-protection` arguments didn't work properly if BitBucket was configured with a custom context path.
+  https://github.com/gruntwork-io/repo-copier/pull/88: Fix a bug where the `--disable-pull-request-protection` and `--disable-fast-forward-protection` arguments didn&apos;t work properly if BitBucket was configured with a custom context path.
 
 </div>
 
@@ -274,7 +274,7 @@ Also undergoes a sort of rebranding of a "generic gruntwork CLI tool" to being s
 From this release onward, this repo will be running tests with Terraform 0.14.x, so **we recommend updating to 0.14.x soon**!
 **All modules still support Terraform 0.12.26** and above (by using features like `required_providers` and `source` URLs).
 
-Once all Gruntwork repositories have been updated to support Terraform 0.14.x, a newsletter announcement will be published via the Gruntwork Newsletter & a migration guide will be published on our website.
+Once all Gruntwork repositories have been updated to support Terraform 0.14.x, a newsletter announcement will be published via the Gruntwork Newsletter &amp; a migration guide will be published on our website.
 
 
 
@@ -496,7 +496,7 @@ From this release onward, this repo will be running tests with Terraform 0.14.x,
 
 **All modules still support Terraform 0.12.26** and above (by using features like `required_providers` and `source` URLs)
 
-Once all Gruntwork repositories have been updated to support Terraform 0.14.x, a newsletter announcement will be published via the Gruntwork Newsletter & a migration guide will be published on our website
+Once all Gruntwork repositories have been updated to support Terraform 0.14.x, a newsletter announcement will be published via the Gruntwork Newsletter &amp; a migration guide will be published on our website
 
 
 
@@ -728,7 +728,7 @@ From this release onward, this repo will be running tests with Terraform 0.14.x,
 
 **All modules still support Terraform 0.12.26** and above (by using features like `required_providers` and `source` URLs).
 
-Once all Gruntwork repositories have been updated to support Terraform 0.14.x, a newsletter announcement will be published via the Gruntwork Newsletter & a migration guide will be published on our website.
+Once all Gruntwork repositories have been updated to support Terraform 0.14.x, a newsletter announcement will be published via the Gruntwork Newsletter &amp; a migration guide will be published on our website.
 
 
 
@@ -791,7 +791,7 @@ Releasing a new minor version for this repo to mark **forward-only compatibility
 From release `v0.24.2`, this repo will be running tests with Terraform 0.14.x, so **we recommend updating to 0.14.x soon**!
 **All modules still support Terraform 0.12.26** and above (by using features like `required_providers` and `source` URLs).
 
-Once all Gruntwork repositories have been updated to support Terraform 0.14.x, a newsletter announcement will be published via the Gruntwork Newsletter & a migration guide will be published on our website.
+Once all Gruntwork repositories have been updated to support Terraform 0.14.x, a newsletter announcement will be published via the Gruntwork Newsletter &amp; a migration guide will be published on our website.
 
 For more details, please refer to the release notes from Terraform 0.14 [release](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.24.2)
 
@@ -814,7 +814,7 @@ For more details, please refer to the release notes from Terraform 0.14 [release
 
     **All modules still support Terraform 0.12.26** and above (by using features like `required_providers` and `source` URLs).
 
-    Once all Gruntwork repositories have been updated to support Terraform 0.14.x, a newsletter announcement will be published via the Gruntwork Newsletter & a migration guide will be published on our website.
+    Once all Gruntwork repositories have been updated to support Terraform 0.14.x, a newsletter announcement will be published via the Gruntwork Newsletter &amp; a migration guide will be published on our website.
 
 - SNS topics can now be encrypted in `cloudwatch-logs-metric-filters` by providing a `sns_topic_kms_master_key_id` variable.
 
@@ -894,7 +894,7 @@ For more details, please refer to the release notes from Terraform 0.14 [release
 
   
 
-- Update the billing IAM policy to use the AWS-managed billing policy under the hood (so it's always up to date), but still layer the MFA requirement on top. This will also affect the modules that use this policy under the hood, including the billing IAM group in the `iam-groups` module and the billing IAM role in the `cross-account-iam-roles` module.
+- Update the billing IAM policy to use the AWS-managed billing policy under the hood (so it&apos;s always up to date), but still layer the MFA requirement on top. This will also affect the modules that use this policy under the hood, including the billing IAM group in the `iam-groups` module and the billing IAM role in the `cross-account-iam-roles` module.
 - - **NOTE: Using `account-baseline-root` with this release results in insufficient permissions on the CloudTrail S3 bucket. Use [v0.48.1](https://github.com/gruntwork-io/terraform-aws-security/releases/v0.48.1) or later instead.** The `cloudtrail-bucket`, `cloudtrail`, and `account-baseline-root` modules now all expose a new `cloudtrail_organization_id` input variable that you can use to configure an organization-wide CloudTrail.
 
 
@@ -1115,7 +1115,7 @@ Variables affected: `aws_region`, `vpc_name`, `cidr_block`, `num_nat_gateways`.
 
   
 
-- The `s3-bucket` now sets the `access_logging_bucket` param to `null` by default. This makes it easier to use the module with Terragrunt. This is a backwards incompatible change because, if you don't set `access_logging_bucket` any more, this module will no longer create an access logging bucket by default.
+- The `s3-bucket` now sets the `access_logging_bucket` param to `null` by default. This makes it easier to use the module with Terragrunt. This is a backwards incompatible change because, if you don&apos;t set `access_logging_bucket` any more, this module will no longer create an access logging bucket by default.
 
 
 
@@ -1199,7 +1199,7 @@ Variables affected: `aws_region`, `vpc_name`, `cidr_block`, `num_nat_gateways`.
 
   
 
-- Update dependency gruntwork-io/terraform-aws-cache to v0.11.0. Several months ago, AWS made a backward-incompatible change related to the Elasticache Replication Group Multi-AZ behavior, introducing a new `MultiAZEnabled` toggle. This means that, the last several months, if you deployed Redis with with `enable_automatic_failover` set to true, but did not have this `MultiAZEnabled` flag—which wasn't exposed in Terraform's AWS provider—Redis would be deployed into only a single AZ. This issue was fixed in AWS provider 3.26, and in this release, we now expose a new `enable_multi_az` variable in the redis module so that you can configure this property. This change is **backwards incompatible**: you must pass in `enable_multi_az`. To avoid a rebuild of your cluster, you can set it to `null`.
+- Update dependency gruntwork-io/terraform-aws-cache to v0.11.0. Several months ago, AWS made a backward-incompatible change related to the Elasticache Replication Group Multi-AZ behavior, introducing a new `MultiAZEnabled` toggle. This means that, the last several months, if you deployed Redis with with `enable_automatic_failover` set to true, but did not have this `MultiAZEnabled` flag—which wasn&apos;t exposed in Terraform&apos;s AWS provider—Redis would be deployed into only a single AZ. This issue was fixed in AWS provider 3.26, and in this release, we now expose a new `enable_multi_az` variable in the redis module so that you can configure this property. This change is **backwards incompatible**: you must pass in `enable_multi_az`. To avoid a rebuild of your cluster, you can set it to `null`.
 - Creation of network ACLs is now optional in both `vpc` and `vpc-mgmt` services.
 - Update dependency gruntwork-io/terraform-aws-load-balancer to v0.22.0
 - Update default version of  gruntwork-io/terragrunt installed on CI servers to v0.28.11
@@ -1349,7 +1349,7 @@ You can now configure multiple domain names to route to the ALB. This is useful 
 - Allow specifying custom tags with RDS and Aurora.
 - Allow specifying custom database parameters for RDS and Aurora.
 - Add ability to manage service linked role for elasticsearch in the module
-- Disable 'data' when not using config or cloudtrail in `account-baseline-root`
+- Disable &apos;data&apos; when not using config or cloudtrail in `account-baseline-root`
 - Add ability to configure encryption at rest and custom tags on elasticsearch
 
 
@@ -1376,7 +1376,7 @@ You can now configure multiple domain names to route to the ALB. This is useful 
 From this release onward, this repo will be running tests with Terraform 0.14.x, so **we recommend updating to 0.14.x soon**!
 **All modules still support Terraform 0.12.26** and above (by using features like `required_providers` and `source` URLs).
 
-Once all Gruntwork repositories have been updated to support Terraform 0.14.x, a newsletter announcement will be published via the Gruntwork Newsletter & a migration guide will be published on our website.
+Once all Gruntwork repositories have been updated to support Terraform 0.14.x, a newsletter announcement will be published via the Gruntwork Newsletter &amp; a migration guide will be published on our website.
 
 
 
@@ -1416,7 +1416,7 @@ If `create_resources` was set to `false` in the `vpc-mgmt-network-acls` module, 
 
   
 
-* Older versions of Terraform could not use lists with ternary syntax, so we had to use `split` and `join` to work around it. This should not be a problem in current Terraform versions, so we've removed the workaround in this release. There should be no change in behavior, other than, as a nice side effect, `plan` output should work better now for NAT Gateways.
+* Older versions of Terraform could not use lists with ternary syntax, so we had to use `split` and `join` to work around it. This should not be a problem in current Terraform versions, so we&apos;ve removed the workaround in this release. There should be no change in behavior, other than, as a nice side effect, `plan` output should work better now for NAT Gateways.
 
 
 
@@ -1513,6 +1513,6 @@ Support for optional resource creation via the `create_resources` parameter was 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "3e33c11671eb0d1713b0858144d3dcb2"
+  "hash": "7a91989eff5fb7a59c7982051e14a066"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-04/index.md
@@ -90,7 +90,7 @@ In addition, there are many other bug fixes and updates, including:
     - Once all Gruntwork repos have been upgrade to work with `0.14.x`, we will publish a migration guide with a version compatibility table and announce it all via the Gruntwork Newsletter.
 - Many other bug fixes and improvements, including:
     - Bump to latest Service Catalog version
-    - Enable encryption by default in a few places where it wasn't enabled already
+    - Enable encryption by default in a few places where it wasn&apos;t enabled already
     - A number of CI / CD and Jenkins fixes
     - Switch to `main` branch from `master`
     - Update internal references to the new repo naming scheme
@@ -334,7 +334,7 @@ This releases enable encryption by default for the Jenkins EBS volume. Previousl
 
   
 
-- Use account's name as key for for_each instead of account_id in SecurityHub **[BACKWARDS INCOMPATIBLE]**
+- Use account&apos;s name as key for for_each instead of account_id in SecurityHub **[BACKWARDS INCOMPATIBLE]**
 
 
 </div>
@@ -477,7 +477,7 @@ This release updates versions of several underlying modules, including several b
   
 
 - You can now enable Amazon ECS Exec for your Tasks by setting the new `enable_execute_command` input variable to `true`.
-- Fixed a couple "interpolation only" warnings.
+- Fixed a couple &quot;interpolation only&quot; warnings.
 
 
 
@@ -494,7 +494,7 @@ This release updates versions of several underlying modules, including several b
 
   
 
-- Fixes an "interpolation-only expressions" deprecation warning in `ecs-service`.
+- Fixes an &quot;interpolation-only expressions&quot; deprecation warning in `ecs-service`.
 
 
 
@@ -533,7 +533,7 @@ This release updates versions of several underlying modules, including several b
 
   
 
-- Fix health check and timeout settings for the target groups created by `ecs-service`. Depending on the protocol you're using (e.g., TCP, UDP, TLS, etc), only certain values are permitted. The AWS docs are unclear on this, but we've done our best to implement the required rules.
+- Fix health check and timeout settings for the target groups created by `ecs-service`. Depending on the protocol you&apos;re using (e.g., TCP, UDP, TLS, etc), only certain values are permitted. The AWS docs are unclear on this, but we&apos;ve done our best to implement the required rules.
 
 
 
@@ -811,7 +811,7 @@ Refer to the migration guide to avoid recreating the IAM roles when updating to 
   
 
 - You can now use Docker images with the `lambda` module by specifying the new input variables `image_uri`, `entry_point`, `command`, and `working_directory`.
-- We renamed all our repos to use HashiCorp's naming convention (`terraform-&lt;cloud&gt;-&lt;name&gt;`, e.g., `terraform-aws-vpc`), so we went through each repo and updated all the internal references. This should not affect functionality.
+- We renamed all our repos to use HashiCorp&apos;s naming convention (`terraform-&lt;cloud&gt;-&lt;name&gt;`, e.g., `terraform-aws-vpc`), so we went through each repo and updated all the internal references. This should not affect functionality.
 
 
 
@@ -1003,7 +1003,7 @@ You can now customize the `mssfix` value used in the openvpn config that is down
     - From this release onward, we will only be running tests with Terraform `0.14.x` against this repo, so we recommend updating to `0.14.x` soon! 
     - To give you more time to upgrade, for the time being, all modules will still support Terraform `0.12.26` and above, as that version has several features in it (`required_providers` with `source` URLs) that make it more forwards compatible with `0.14.x`. 
     - Once all Gruntwork repos have been upgrade to work with `0.14.x`, we will publish a migration guide with a version compatibility table and announce it all via the Gruntwork Newsletter.
-- Add `gox` to the test's README.md
+- Add `gox` to the test&apos;s README.md
 - Add note for partial Ubuntu20 support 
 
 
@@ -1142,8 +1142,8 @@ The `dev_permitted_services` variable in the `iam-policies` module now allows fi
 
 ```
 dev_permitted_services = [
-    "sns",
-    "s3:PutObject"
+    &quot;sns&quot;,
+    &quot;s3:PutObject&quot;
 ]
 ```
 
@@ -1350,7 +1350,7 @@ This change is backward compatible, but you will notice a new `sid` for the poli
 
   
 
-- Fix a bug in the output variables of the `route53` module that, depending on the inputs you passed in, could lead to an "Inconsistent conditional result types" error.
+- Fix a bug in the output variables of the `route53` module that, depending on the inputs you passed in, could lead to an &quot;Inconsistent conditional result types&quot; error.
 
 
 
@@ -1394,20 +1394,20 @@ This change is backward compatible, but you will notice a new `sid` for the poli
 Allows wildcard domains to be passed in the `subject_alternative_names`, making it easier to request a single ACM certificate that protects both the apex domain (`example.com`) AND the first level of subdomains (`*.example.com`). To achieve this, request `example.com` in the key of your `var.public_zones` map and pass `*.example.com` in the `subject_alternative_names` list for the same entry: 
 
 ```
-public_zones = {
-       "example.com" = {
-           comment = "You can add arbitrary text here"
-           tags = {
-              Foo = "bar"
-           }
+public_zones = &#x7B;
+       &quot;example.com&quot; = &#x7B;
+           comment = &quot;You can add arbitrary text here&quot;
+           tags = &#x7B;
+              Foo = &quot;bar&quot;
+           &#x7D;
            force_destroy = true
-           subject_alternative_names = ["*.example.com"]
+           subject_alternative_names = [&quot;*.example.com&quot;]
            created_outside_terraform = true
-           base_domain_name_tags = {
+           base_domain_name_tags = &#x7B;
                original = true
-           }
-       }
-  }
+           &#x7D;
+       &#x7D;
+  &#x7D;
 ```
 
 **NOTE**: Starting this release, it is no longer possible to disable the creation of ACM certificates on the domains that are managed by the module. We introduced back the ability to disable ACM certificate creation in [v0.44.5](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.44.5). It is advised to upgrade to at least that version if you want to avoid managing ACM certificates in this module.
@@ -1800,6 +1800,6 @@ adds a number of conditional variables to the App Account Baseline in order to o
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "698621c183a6e83cd809ed09851e6938"
+  "hash": "fa00d39328dadb09ae6251671dbe48c0"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-04/index.md
@@ -269,7 +269,7 @@ Fix regression bug where we no longer can download golang from the old location 
 ### [v0.33.1: Upgrade ecs runner terraform to 0.13.6](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.33.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/14/2021 | Modules affected: ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.33.1">Release notes</a></small>
+  <small>Published: 4/13/2021 | Modules affected: ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.33.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1461,7 +1461,7 @@ public_zones = {
 ### [v0.30.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.30.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/14/2021 | Modules affected: mgmt/jenkins, mgmt/openvpn-server, data-stores, services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.30.0">Release notes</a></small>
+  <small>Published: 4/13/2021 | Modules affected: mgmt/jenkins, mgmt/openvpn-server, data-stores, services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.30.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1800,6 +1800,6 @@ adds a number of conditional variables to the App Account Baseline in order to o
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "698621c183a6e83cd809ed09851e6938"
+  "hash": "37a8489720d3a7c3f5cd350cbe9110e7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-04/index.md
@@ -269,7 +269,7 @@ Fix regression bug where we no longer can download golang from the old location 
 ### [v0.33.1: Upgrade ecs runner terraform to 0.13.6](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.33.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/13/2021 | Modules affected: ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.33.1">Release notes</a></small>
+  <small>Published: 4/14/2021 | Modules affected: ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.33.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1461,7 +1461,7 @@ public_zones = {
 ### [v0.30.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.30.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/13/2021 | Modules affected: mgmt/jenkins, mgmt/openvpn-server, data-stores, services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.30.0">Release notes</a></small>
+  <small>Published: 4/14/2021 | Modules affected: mgmt/jenkins, mgmt/openvpn-server, data-stores, services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.30.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1800,6 +1800,6 @@ adds a number of conditional variables to the App Account Baseline in order to o
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "37a8489720d3a7c3f5cd350cbe9110e7"
+  "hash": "698621c183a6e83cd809ed09851e6938"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-05/index.md
@@ -556,7 +556,7 @@ You can now customize the helm release name and the service account annotations 
 ### [v0.11.1](https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.11.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/20/2021 | Modules affected: lambda | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.11.1">Release notes</a></small>
+  <small>Published: 5/19/2021 | Modules affected: lambda | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.11.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1158,6 +1158,6 @@ Add support for exposing client access directly in the nacls for the private app
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "a3de521495fe7e198fd28b9520bb5002"
+  "hash": "5475133ccddf329da38707c0bdca528a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-05/index.md
@@ -556,7 +556,7 @@ You can now customize the helm release name and the service account annotations 
 ### [v0.11.1](https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.11.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/19/2021 | Modules affected: lambda | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.11.1">Release notes</a></small>
+  <small>Published: 5/20/2021 | Modules affected: lambda | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.11.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1158,6 +1158,6 @@ Add support for exposing client access directly in the nacls for the private app
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "5475133ccddf329da38707c0bdca528a"
+  "hash": "a3de521495fe7e198fd28b9520bb5002"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-05/index.md
@@ -147,7 +147,7 @@ Since this repo is solely used for examples/demonstrations, and NOT meant for di
     - From this release onward, we will only be running tests with Terraform `0.15.x` against this repo, so we recommend updating to `0.15.x` soon! 
     - To give you more time to upgrade, for the time being, all modules will still support Terraform `0.12.26` and above, as that version has several features in it (`required_providers` with `source` URLs) that make it more forwards compatible with `0.15.x`. 
     - Once all Gruntwork repos have been upgrade to work with `0.15.x`, we will publish a migration guide with a version compatibility table and announce it all via the Gruntwork Newsletter.
-- Note that as part of the Terraform 0.15 upgrade, we've updated the `Dockerfile` for the `ecs-deploy-runner` to install Terraform 0.15.1 and Terragrunt v0.29.0 by default. **This is a backwards incompatible change**. See the migration guide below for upgrade instructions.
+- Note that as part of the Terraform 0.15 upgrade, we&apos;ve updated the `Dockerfile` for the `ecs-deploy-runner` to install Terraform 0.15.1 and Terragrunt v0.29.0 by default. **This is a backwards incompatible change**. See the migration guide below for upgrade instructions.
 
 
 </div>
@@ -263,7 +263,7 @@ Update the underlying versions of the following modules:
 
   
 
-- Update example `landingzone` READMEs to mention parallelism when running applying with `terraform apply` (see [here](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/blob/a5b42067f853bb6bc8657ba4772c76bbbc418f45/examples/for-learning-and-testing/landingzone/account-baseline-app/README.md) & [here](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/blob/a5b42067f853bb6bc8657ba4772c76bbbc418f45/examples/for-learning-and-testing/landingzone/account-baseline-security/README.md))
+- Update example `landingzone` READMEs to mention parallelism when running applying with `terraform apply` (see [here](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/blob/a5b42067f853bb6bc8657ba4772c76bbbc418f45/examples/for-learning-and-testing/landingzone/account-baseline-app/README.md) &amp; [here](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/blob/a5b42067f853bb6bc8657ba4772c76bbbc418f45/examples/for-learning-and-testing/landingzone/account-baseline-security/README.md))
 - Update `account-baseline-security` and `account-baseline-app` to expose and name the variables consistently across submodules
 
 
@@ -918,7 +918,7 @@ The `account-baseline-app`, `account-baseline-security`, and `account-baseline-r
   
 
 - Add Lambda README
-- Make route53 ACM certificate validation optional. It is now possible to request ACM certificates without having DNS verification records created for them or having them pass AWS's programmatic validation process. You can request certs that will not require verification by setting the variables: 
+- Make route53 ACM certificate validation optional. It is now possible to request ACM certificates without having DNS verification records created for them or having them pass AWS&apos;s programmatic validation process. You can request certs that will not require verification by setting the variables: 
 
   * `create_verification_record`
   * `verify_certificate` 
@@ -1158,6 +1158,6 @@ Add support for exposing client access directly in the nacls for the private app
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "a3de521495fe7e198fd28b9520bb5002"
+  "hash": "2e6f91939cce0767cf9b43d22e92f8ec"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-06/index.md
@@ -34,7 +34,7 @@ Here are the repos that were updated:
 ### [v0.2.2](https://github.com/gruntwork-io/gruntwork/releases/tag/v0.2.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/11/2021 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.2.2">Release notes</a></small>
+  <small>Published: 6/12/2021 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.2.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -768,7 +768,7 @@ Adds a new feature to the `custom-iam-entity` module to make it easier to create
 ### [v0.44.7](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.44.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/29/2021 | Modules affected: services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.44.7">Release notes</a></small>
+  <small>Published: 6/30/2021 | Modules affected: services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.44.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1242,6 +1242,6 @@ Adds support for tags to the redis module.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "b5412da56adb17e470e4ce0255e73d48"
+  "hash": "0aa2a6bf8021abbc9bff10e1736514ca"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-06/index.md
@@ -34,7 +34,7 @@ Here are the repos that were updated:
 ### [v0.2.2](https://github.com/gruntwork-io/gruntwork/releases/tag/v0.2.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/12/2021 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.2.2">Release notes</a></small>
+  <small>Published: 6/11/2021 | <a href="https://github.com/gruntwork-io/gruntwork/releases/tag/v0.2.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -768,7 +768,7 @@ Adds a new feature to the `custom-iam-entity` module to make it easier to create
 ### [v0.44.7](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.44.7)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/30/2021 | Modules affected: services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.44.7">Release notes</a></small>
+  <small>Published: 6/29/2021 | Modules affected: services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.44.7">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1242,6 +1242,6 @@ Adds support for tags to the redis module.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "0aa2a6bf8021abbc9bff10e1736514ca"
+  "hash": "b5412da56adb17e470e4ce0255e73d48"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-06/index.md
@@ -370,7 +370,7 @@ Update underlying dependencies:
 
 - Adds a locking mechanism to Securityhub tests, to prevent a race condition that happened during concurrent runs of these tests. 
 - Adds `for-production` examples.
-- Updates variable description for the Security Hub's email.
+- Updates variable description for the Security Hub&apos;s email.
 - Cleans up unused variables in `account-baseline-root`.
 - Updates log filters to meet CIS 1.4 recommendations.
 - Updates version references from v1.3 to v1.4 throughout the codebase.
@@ -1168,7 +1168,7 @@ Adds support for tags to the redis module.
   
 
 - You can now configure whether image tags are mutable or not in the `ecr-repos` module using the new `image_tag_mutability` field in the `repositories` input variable.
-- Fix a bug in the `rds` module where it would create a new KMS key, but wasn't actually using it, and was using the default RDS key instead. The API has changed now: to create and use a custom KMS key, set `create_custom_kms_key` to `true`; to use an existing KMS key, set `create_custom_kms_key` to `false` and pass in the KMS key to use via `kms_key_arn`. If `create_custom_kms_key` is `false` and you don't pass in a custom KMS key, the module will use the default RDS key.
+- Fix a bug in the `rds` module where it would create a new KMS key, but wasn&apos;t actually using it, and was using the default RDS key instead. The API has changed now: to create and use a custom KMS key, set `create_custom_kms_key` to `true`; to use an existing KMS key, set `create_custom_kms_key` to `false` and pass in the KMS key to use via `kms_key_arn`. If `create_custom_kms_key` is `false` and you don&apos;t pass in a custom KMS key, the module will use the default RDS key.
 
 
 
@@ -1242,6 +1242,6 @@ Adds support for tags to the redis module.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "0aa2a6bf8021abbc9bff10e1736514ca"
+  "hash": "03ee6480a406606590c61d24560b244e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-07/index.md
@@ -629,7 +629,7 @@ The `apply_immediately` flag now propagates to the replica instances for the `rd
 
   
 
-- Fix RBAC permissions for `aws-auth-merger` so that it can create a new `aws-auth` ConfigMap when it doesn't exist.
+- Fix RBAC permissions for `aws-auth-merger` so that it can create a new `aws-auth` ConfigMap when it doesn&apos;t exist.
 
 
 
@@ -651,29 +651,29 @@ Fix undocumented variable `multi_instance_overrides` so you can also set `weight
 Note that this introduces a format change - if you were using `multi_instance_overrides` before, you will need to update your code to use the new format. If you had:
 
 ```hcl
-  autoscaling_group_configurations = {
-    asg = {
+  autoscaling_group_configurations = &#x7B;
+    asg = &#x7B;
       use_multi_instances_policy = true
-      spot_allocation_strategy   = "capacity-optimized"
-      multi_instance_overrides   = ["t3.micro", "t2.micro"]
+      spot_allocation_strategy   = &quot;capacity-optimized&quot;
+      multi_instance_overrides   = [&quot;t3.micro&quot;, &quot;t2.micro&quot;]
 
       # other fields omitted for brevity
-    }
-  }
+    &#x7D;
+  &#x7D;
 ```
 
 Update the `multi_instance_overrides` field to:
 
 ```hcl
-  autoscaling_group_configurations = {
-    asg = {
+  autoscaling_group_configurations = &#x7B;
+    asg = &#x7B;
       use_multi_instances_policy = true
-      spot_allocation_strategy   = "capacity-optimized"
-      multi_instance_overrides   = [{ instance_type = "t3.micro" }, { instance_type = "t2.micro" }]
+      spot_allocation_strategy   = &quot;capacity-optimized&quot;
+      multi_instance_overrides   = [&#x7B; instance_type = &quot;t3.micro&quot; &#x7D;, &#x7B; instance_type = &quot;t2.micro&quot; &#x7D;]
 
       # other fields omitted for brevity
-    }
-  }
+    &#x7D;
+  &#x7D;
 ```
 
 
@@ -1230,7 +1230,7 @@ Refer to the [module docs](https://github.com/gruntwork-io/terraform-aws-lambda/
 
 - We have refactored all our multi-region modules (the ones that have `-multi-region` in the name) to no longer create nested `provider` blocks. Instead, providers must be passed in now via the `providers` map. This reduces the number of providers that Terraform must instantiate, making the multi-region modules much faster and more stable to use. It also gives you full control over how to authenticate to your various AWS accounts. However, **this is a backwards incompatible change**, so make sure to [read the migration guide below](#migration-guide-for-multi-region-modules).
 - To update the multi-region modules, we updated the Golang `generator` code too. It no longer creates nested `provider` blocks or the `local.all_regions` variable and no longer supports a `SeedRegion` param. However, it does support new params to configure Terraform and AWS provider version constraints. **These changes are also backwards incompatible**, so make sure to [read the migration guide below](#migration-guide-for-the-golang-generator-code).
-- We've fixed small bugs in the `aws-config`, `aws-config-bucket`, and `kms-master-key` modules so they no longer create `data` sources when `create_resources` is set to `false`.
+- We&apos;ve fixed small bugs in the `aws-config`, `aws-config-bucket`, and `kms-master-key` modules so they no longer create `data` sources when `create_resources` is set to `false`.
 
 
 </div>
@@ -1497,7 +1497,7 @@ Exposes the ability to pass through volumes (including EFS volumes) to the wrapp
   
 
 - We made it easier to pass in EC2 instance type for the ECS packer template.
-- We lightly refactored test_helpers.go, so that changes to test_helpers.go doesn't trigger so many full-suite test runs in the future.
+- We lightly refactored test_helpers.go, so that changes to test_helpers.go doesn&apos;t trigger so many full-suite test runs in the future.
 - In the modules/data-stores/elasticsearch, we added support for custom endpoints.
 
 
@@ -1914,6 +1914,6 @@ Fixed bug with configuring default NACLs, where default NACLs were applied and c
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "097f7a79a08f976498607f461d3b55da"
+  "hash": "64e45c6da093f5a15734b5765be2b41f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-08/index.md
@@ -229,7 +229,7 @@ Here are the repos that were updated:
 ### [v0.38.6](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.38.6)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/20/2021 | Modules affected: ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.38.6">Release notes</a></small>
+  <small>Published: 8/19/2021 | Modules affected: ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.38.6">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -537,7 +537,7 @@ This release also configures the RenovateBot not to update this repo itself, as 
 ### [v0.30.4](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.30.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/25/2021 | Modules affected: ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.30.4">Release notes</a></small>
+  <small>Published: 8/24/2021 | Modules affected: ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.30.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -554,7 +554,7 @@ This release also configures the RenovateBot not to update this repo itself, as 
 ### [v0.30.3](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.30.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/18/2021 | Modules affected: ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.30.3">Release notes</a></small>
+  <small>Published: 8/17/2021 | Modules affected: ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.30.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -933,7 +933,7 @@ This release also configures the RenovateBot not to update this repo itself, as 
 ### [v0.53.4](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.53.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/11/2021 | Modules affected: cloudtrail-bucket, cloudtrail, aws-config-multi-region, aws-config | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.53.4">Release notes</a></small>
+  <small>Published: 8/10/2021 | Modules affected: cloudtrail-bucket, cloudtrail, aws-config-multi-region, aws-config | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.53.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1265,7 +1265,7 @@ Optionally create service-linked roles for security account using `var.service_l
 ### [v0.56.2](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.56.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/12/2021 | Modules affected: services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.56.2">Release notes</a></small>
+  <small>Published: 8/11/2021 | Modules affected: services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.56.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1338,7 +1338,7 @@ Optionally create service-linked roles for security account using `var.service_l
 ### [v0.55.2](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.55.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/6/2021 | Modules affected: mgmt | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.55.2">Release notes</a></small>
+  <small>Published: 8/5/2021 | Modules affected: mgmt | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.55.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1486,6 +1486,6 @@ Updated the `s3-cloudfront` module to create the S3 bucket for access logs using
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "618b30b9d83f409d35cf579c7a56ade2"
+  "hash": "1f46b9e1cbc8e615148df7de172f3caf"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-08/index.md
@@ -229,7 +229,7 @@ Here are the repos that were updated:
 ### [v0.38.6](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.38.6)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/19/2021 | Modules affected: ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.38.6">Release notes</a></small>
+  <small>Published: 8/20/2021 | Modules affected: ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.38.6">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1265,7 +1265,7 @@ Optionally create service-linked roles for security account using `var.service_l
 ### [v0.56.2](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.56.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/11/2021 | Modules affected: services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.56.2">Release notes</a></small>
+  <small>Published: 8/12/2021 | Modules affected: services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.56.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1486,6 +1486,6 @@ Updated the `s3-cloudfront` module to create the S3 bucket for access logs using
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "1f46b9e1cbc8e615148df7de172f3caf"
+  "hash": "3ecf526a244356ae08e56efd82ff077b"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-08/index.md
@@ -483,7 +483,7 @@ This release also configures the RenovateBot not to update this repo itself, as 
 
   
 
-- Override renovate.json ignorePaths so that it won't ignore examples or tests
+- Override renovate.json ignorePaths so that it won&apos;t ignore examples or tests
 - vpc: Expose default security group ID in outputs
 
 
@@ -580,7 +580,7 @@ This release also configures the RenovateBot not to update this repo itself, as 
 
   
 
-- You can now enable the ECS "circuit breaker" feature via the new `deployment_circuit_breaker` input variable.
+- You can now enable the ECS &quot;circuit breaker&quot; feature via the new `deployment_circuit_breaker` input variable.
 
 
 
@@ -730,7 +730,7 @@ This release also configures the RenovateBot not to update this repo itself, as 
 
   
 
-- You can now have the `lambda` module use an existing IAM role, rather than creating a new one, by passing in the IAM role's ARN via the new `existing_role_arn` input variable.
+- You can now have the `lambda` module use an existing IAM role, rather than creating a new one, by passing in the IAM role&apos;s ARN via the new `existing_role_arn` input variable.
 
 
 
@@ -1486,6 +1486,6 @@ Updated the `s3-cloudfront` module to create the S3 bucket for access logs using
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "618b30b9d83f409d35cf579c7a56ade2"
+  "hash": "73b93bf8f641160f37dfca1f64ab310a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-08/index.md
@@ -537,7 +537,7 @@ This release also configures the RenovateBot not to update this repo itself, as 
 ### [v0.30.4](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.30.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/24/2021 | Modules affected: ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.30.4">Release notes</a></small>
+  <small>Published: 8/25/2021 | Modules affected: ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.30.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -554,7 +554,7 @@ This release also configures the RenovateBot not to update this repo itself, as 
 ### [v0.30.3](https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.30.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/17/2021 | Modules affected: ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.30.3">Release notes</a></small>
+  <small>Published: 8/18/2021 | Modules affected: ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.30.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -933,7 +933,7 @@ This release also configures the RenovateBot not to update this repo itself, as 
 ### [v0.53.4](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.53.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/10/2021 | Modules affected: cloudtrail-bucket, cloudtrail, aws-config-multi-region, aws-config | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.53.4">Release notes</a></small>
+  <small>Published: 8/11/2021 | Modules affected: cloudtrail-bucket, cloudtrail, aws-config-multi-region, aws-config | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.53.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1338,7 +1338,7 @@ Optionally create service-linked roles for security account using `var.service_l
 ### [v0.55.2](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.55.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 8/5/2021 | Modules affected: mgmt | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.55.2">Release notes</a></small>
+  <small>Published: 8/6/2021 | Modules affected: mgmt | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.55.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1486,6 +1486,6 @@ Updated the `s3-cloudfront` module to create the S3 bucket for access logs using
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "3ecf526a244356ae08e56efd82ff077b"
+  "hash": "618b30b9d83f409d35cf579c7a56ade2"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-09/index.md
@@ -655,7 +655,7 @@ This release also adds a script to enable MFA Delete for the `private-s3-bucket`
 ### [v0.62.1](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.62.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/26/2021 | Modules affected: services/eks-core-services, services/ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.62.1">Release notes</a></small>
+  <small>Published: 9/25/2021 | Modules affected: services/eks-core-services, services/ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.62.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -674,7 +674,7 @@ This release also adds a script to enable MFA Delete for the `private-s3-bucket`
 ### [v0.62.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.62.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/18/2021 | Modules affected: services/eks-core-services, mgmt, networking | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.62.0">Release notes</a></small>
+  <small>Published: 9/17/2021 | Modules affected: services/eks-core-services, mgmt, networking | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.62.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -867,6 +867,6 @@ This release also adds a script to enable MFA Delete for the `private-s3-bucket`
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "01cdfc06c685bb16b3133720fcdefb42"
+  "hash": "0149359cd0470a435a527712c8e9f574"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-09/index.md
@@ -325,13 +325,13 @@ This release introduces a change to the CI / CD pipeline (Gruntwork Pipelines) t
 To update your existing Gruntwork Reference Architecture to have this new support, make the following changes:
 
 
-The destroy feature was added in [`terraform-aws-ci v0.38.5`](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.38.5). So as long as you update your Ref Arch to point to this version or newer, you're good. In the steps below, we'll be using **`v0.38.9`**, but you can use the latest version as well.
+The destroy feature was added in [`terraform-aws-ci v0.38.5`](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.38.5). So as long as you update your Ref Arch to point to this version or newer, you&apos;re good. In the steps below, we&apos;ll be using **`v0.38.9`**, but you can use the latest version as well.
 
 1. Update your `infrastructure-live` repo:
     - Pull in changes to:
         - `.circleci/config.yml` (if using CircleCI) from [example config](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/blob/e9ec3c7d4a126afb41fba551b1b0af4a3c2fef6f/examples/for-production/infrastructure-live/.circleci/config.yml). View the [diff](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/pull/238/files#diff-d4e24a34d392c9288702b33b1ebf2127786e91650e59ed5652583313aaec1215).
         - `_ci/scripts/deploy-infra.sh` from [example deploy-infra.sh](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/blob/e9ec3c7d4a126afb41fba551b1b0af4a3c2fef6f/examples/for-production/infrastructure-live/_ci/scripts/deploy-infra.sh). View the [diff](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/pull/238/files#diff-4ac1abb2a2d4274b92a12b1ed02aefc3d87e4344a2718eaea6d7834bdb0a1a34).
-            - NOTE: Line 120 is wrong and should be: `command_args="$([[ "$command" == "destroy" ]] && echo "" || echo "-destroy")"`
+            - NOTE: Line 120 is wrong and should be: `command_args=&quot;$([[ &quot;$command&quot; == &quot;destroy&quot; ]] &amp;&amp; echo &quot;&quot; || echo &quot;-destroy&quot;)&quot;`
     - Modify the 2 container image files:
         - Bump `DOCKERFILE_REPO_REF` to point to &gt;= `v0.38.9` of `terraform-aws-ci` in `shared/&lt;AWS_REGION&gt;/_regional/container_images/build_deploy_runner_image.sh`. View the [diff](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/pull/238/files#diff-b276e6dcf0807843c5d4bab2e59b02810c02da29fec1aaa3574ebc71aa889d66).
         - Bump `DOCKERFILE_REPO_REF` to point to &gt;= `v0.38.9` of `terraform-aws-ci` in `shared/&lt;AWS_REGION&gt;/_regional/container_images/build_kaniko_image.sh`. View the [diff](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/pull/238/files#diff-65a8e9beccac1053c7d2767edc27d520820cd77d354d4bfe1c270a9b153dd077).
@@ -701,7 +701,7 @@ This release also adds a script to enable MFA Delete for the `private-s3-bucket`
   
 
 - Update dependency gruntwork-io/terraform-aws-vpc to v0.17.5
-- Extend Elasticsearch to support Multi AZ & Master Accounts
+- Extend Elasticsearch to support Multi AZ &amp; Master Accounts
 - Expose `security_group_tags` for App  VPCs.
 
 
@@ -816,7 +816,7 @@ This release also adds a script to enable MFA Delete for the `private-s3-bucket`
 
   
 
-- You can now disable access logging in the `s3-cloudfront` module using the new `disable_logging` input variable. This is useful in regions where CloudFront access logging isn't supported.
+- You can now disable access logging in the `s3-cloudfront` module using the new `disable_logging` input variable. This is useful in regions where CloudFront access logging isn&apos;t supported.
 
 
 
@@ -867,6 +867,6 @@ This release also adds a script to enable MFA Delete for the `private-s3-bucket`
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "01cdfc06c685bb16b3133720fcdefb42"
+  "hash": "54ca2160fab8397467fb075a03477ed4"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-09/index.md
@@ -655,7 +655,7 @@ This release also adds a script to enable MFA Delete for the `private-s3-bucket`
 ### [v0.62.1](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.62.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/25/2021 | Modules affected: services/eks-core-services, services/ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.62.1">Release notes</a></small>
+  <small>Published: 9/26/2021 | Modules affected: services/eks-core-services, services/ecs-service | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.62.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -674,7 +674,7 @@ This release also adds a script to enable MFA Delete for the `private-s3-bucket`
 ### [v0.62.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.62.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/17/2021 | Modules affected: services/eks-core-services, mgmt, networking | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.62.0">Release notes</a></small>
+  <small>Published: 9/18/2021 | Modules affected: services/eks-core-services, mgmt, networking | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.62.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -867,6 +867,6 @@ This release also adds a script to enable MFA Delete for the `private-s3-bucket`
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "0149359cd0470a435a527712c8e9f574"
+  "hash": "01cdfc06c685bb16b3133720fcdefb42"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-10/index.md
@@ -695,7 +695,7 @@ With this release, we are improving the documentation around how to best use thi
 ### [v0.63.1](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.63.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/13/2021 | Modules affected: base, data-stores, mgmt, networking | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.63.1">Release notes</a></small>
+  <small>Published: 10/12/2021 | Modules affected: base, data-stores, mgmt, networking | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.63.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -882,6 +882,6 @@ With this release, we are improving the documentation around how to best use thi
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "89c8462dcee2d37b21f2e400a8385b37"
+  "hash": "973bdc08c02da359c84a47e480cefff1"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-10/index.md
@@ -170,7 +170,7 @@ Bumped the default versions of various tools in ECS Deploy Runner. The following
 - Kubergrunt: `v0.7.7` =&gt; `v0.7.10`
 - `terraform-aws-ci`: `v0.38.4` =&gt; `v0.38.14`
 
-If you wish to keep the old version, pass in the respective variables as build args when building the container. E.g., to revert to the older terraform version, pass in `--build-arg 'terraform_version=0.15.5` to the `docker build` command.
+If you wish to keep the old version, pass in the respective variables as build args when building the container. E.g., to revert to the older terraform version, pass in `--build-arg &apos;terraform_version=0.15.5` to the `docker build` command.
 
 
 
@@ -437,11 +437,11 @@ This release also updates the following dependency version:
 - Fix line break in middle of paragraph
 - Fix typo: lamda -&gt; lambda **[BACKWARD INCOMPATIBLE].** 
 
-This release fixes a typo in the aws_iam_role_policy resource, changing the name from "network_interfaces_for_lamda" to "network_interfaces_for_lambda". This is a backward incompatible change, requiring re-creation of the aws_iam_role_policy.
+This release fixes a typo in the aws_iam_role_policy resource, changing the name from &quot;network_interfaces_for_lamda&quot; to &quot;network_interfaces_for_lambda&quot;. This is a backward incompatible change, requiring re-creation of the aws_iam_role_policy.
 
 However, the downtime incurred by this operation should be so brief as to be negligible, because the policy will be removed and immediately added back at apply time.
 
-If you wish to avoid this brief downtime, you can use the terraform state mv operation to move your aws_iam_role_policy resource's state via the following command:
+If you wish to avoid this brief downtime, you can use the terraform state mv operation to move your aws_iam_role_policy resource&apos;s state via the following command:
 
 `terraform state mv aws_iam_role_policy.network_interfaces_for_lamda aws_iam_role_policy.network_interfaces_for_lambda`
 
@@ -882,6 +882,6 @@ With this release, we are improving the documentation around how to best use thi
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "89c8462dcee2d37b21f2e400a8385b37"
+  "hash": "644c6935c91d12a12769a213f4ed8e94"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-10/index.md
@@ -695,7 +695,7 @@ With this release, we are improving the documentation around how to best use thi
 ### [v0.63.1](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.63.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/12/2021 | Modules affected: base, data-stores, mgmt, networking | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.63.1">Release notes</a></small>
+  <small>Published: 10/13/2021 | Modules affected: base, data-stores, mgmt, networking | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.63.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -882,6 +882,6 @@ With this release, we are improving the documentation around how to best use thi
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "973bdc08c02da359c84a47e480cefff1"
+  "hash": "89c8462dcee2d37b21f2e400a8385b37"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-11/index.md
@@ -196,7 +196,7 @@ Added `delete_automated_backups` variable and respective handling to rds module.
 ### [v0.46.4](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.46.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/13/2021 | Modules affected: eks-cluster-managed-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.46.4">Release notes</a></small>
+  <small>Published: 11/12/2021 | Modules affected: eks-cluster-managed-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.46.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -568,6 +568,6 @@ This release also updates versions of underlying dependencies:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "6e5189f31ad7478e3ae66ffc2a891369"
+  "hash": "5b0e7d2ceba90fbbd97f90f00369d7b4"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-11/index.md
@@ -384,7 +384,7 @@ Added support to AWS Managed Node Groups to pass in taints. This adds the variab
 
   
 
-- RDS: Added support for  "backup_window" variable to specify when backups should run
+- RDS: Added support for  &quot;backup_window&quot; variable to specify when backups should run
 
 
 
@@ -470,7 +470,7 @@ Added support to AWS Managed Node Groups to pass in taints. This adds the variab
 
   
 
-- Updated `ingress_group` input to support setting `priority = null`, so that you can have ingress resources with no group order. This is useful in situations where you have dynamic environments where the priority doesn't matter, as you can only have one ingress per group order.
+- Updated `ingress_group` input to support setting `priority = null`, so that you can have ingress resources with no group order. This is useful in situations where you have dynamic environments where the priority doesn&apos;t matter, as you can only have one ingress per group order.
 
 
 
@@ -568,6 +568,6 @@ This release also updates versions of underlying dependencies:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "6e5189f31ad7478e3ae66ffc2a891369"
+  "hash": "08a10060aa40085424487e42bf8038f1"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-11/index.md
@@ -196,7 +196,7 @@ Added `delete_automated_backups` variable and respective handling to rds module.
 ### [v0.46.4](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.46.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/12/2021 | Modules affected: eks-cluster-managed-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.46.4">Release notes</a></small>
+  <small>Published: 11/13/2021 | Modules affected: eks-cluster-managed-workers | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.46.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -568,6 +568,6 @@ This release also updates versions of underlying dependencies:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "5b0e7d2ceba90fbbd97f90f00369d7b4"
+  "hash": "6e5189f31ad7478e3ae66ffc2a891369"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-12/index.md
@@ -375,7 +375,7 @@ For terragrunt, add `ap-southeast-3` to the `all_aws_regions` local variable.
 ### [v0.56.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.56.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/16/2021 | Modules affected: private-s3-bucket, iam-access-analyzer-multi-region, iam-users | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.56.0">Release notes</a></small>
+  <small>Published: 12/15/2021 | Modules affected: private-s3-bucket, iam-access-analyzer-multi-region, iam-users | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.56.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -652,6 +652,6 @@ For terragrunt, add `ap-southeast-3` to the `all_aws_regions` local variable.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "6badfa9eda217cb3b4b83bc3e01c873f"
+  "hash": "568d84bcaab7c6e3722cca21b2d577a4"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-12/index.md
@@ -375,7 +375,7 @@ For terragrunt, add `ap-southeast-3` to the `all_aws_regions` local variable.
 ### [v0.56.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.56.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 12/15/2021 | Modules affected: private-s3-bucket, iam-access-analyzer-multi-region, iam-users | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.56.0">Release notes</a></small>
+  <small>Published: 12/16/2021 | Modules affected: private-s3-bucket, iam-access-analyzer-multi-region, iam-users | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.56.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -652,6 +652,6 @@ For terragrunt, add `ap-southeast-3` to the `all_aws_regions` local variable.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "568d84bcaab7c6e3722cca21b2d577a4"
+  "hash": "6badfa9eda217cb3b4b83bc3e01c873f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-12/index.md
@@ -54,7 +54,7 @@ Here are the repos that were updated:
 
   https://github.com/gruntwork-io/repo-copier/pull/111: 
 
-* Fix "no commit found for SHA" error that would come up in certain cases when copying repos.
+* Fix &quot;no commit found for SHA&quot; error that would come up in certain cases when copying repos.
 * The default behavior of `--force-overwrite` is now to overwrite Git history in the existing repo instead of deleting the repo entirely and recreating it. If you wish to delete and recreate, you now also need to pass `--force-recreate`.
 
 </div>
@@ -68,7 +68,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  https://github.com/gruntwork-io/repo-copier/pull/108: Remove `--copy-deps` flag, as it had performance issues and bugs, and with little-to-no usage, wasn't worth fixing.
+  https://github.com/gruntwork-io/repo-copier/pull/108: Remove `--copy-deps` flag, as it had performance issues and bugs, and with little-to-no usage, wasn&apos;t worth fixing.
 
 </div>
 
@@ -87,7 +87,7 @@ Here are the repos that were updated:
 
   
 
-- We've updated the version of the boto library used in the `asg-rolling-deploy` module from 1.7.10 to 1.20.24 to fix a compatibility issue with python 3.10 (while still maintaining backwards compatibility with older python 3.7+ releases). However, this new version of boto **DOES NOT WORK WITH PYTHON 2**. Python 2 was sunsetted on January 1, 2020, so hopefully, you've already migrated off of it, but if you haven't, you will now need to to use this version of the `asg-rolling-deploy` module.
+- We&apos;ve updated the version of the boto library used in the `asg-rolling-deploy` module from 1.7.10 to 1.20.24 to fix a compatibility issue with python 3.10 (while still maintaining backwards compatibility with older python 3.7+ releases). However, this new version of boto **DOES NOT WORK WITH PYTHON 2**. Python 2 was sunsetted on January 1, 2020, so hopefully, you&apos;ve already migrated off of it, but if you haven&apos;t, you will now need to to use this version of the `asg-rolling-deploy` module.
 
 
 
@@ -354,14 +354,14 @@ Add the following to your `providers.tf` for terraform:
 
 ```hcl
 
-provider "aws" {
-  region = "ap-southeast-3"
-  alias  = "ap_southeast_3"
+provider &quot;aws&quot; &#x7B;
+  region = &quot;ap-southeast-3&quot;
+  alias  = &quot;ap_southeast_3&quot;
 
   # Skip credential validation and account ID retrieval for disabled or restricted regions
-  skip_credentials_validation = contains(coalesce(var.opt_in_regions, []), "ap-southeast-3") ? false : true
-  skip_requesting_account_id  = contains(coalesce(var.opt_in_regions, []), "ap-southeast-3") ? false : true
-}
+  skip_credentials_validation = contains(coalesce(var.opt_in_regions, []), &quot;ap-southeast-3&quot;) ? false : true
+  skip_requesting_account_id  = contains(coalesce(var.opt_in_regions, []), &quot;ap-southeast-3&quot;) ? false : true
+&#x7D;
 ```
 
 For terragrunt, add `ap-southeast-3` to the `all_aws_regions` local variable.
@@ -652,6 +652,6 @@ For terragrunt, add `ap-southeast-3` to the `all_aws_regions` local variable.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "6badfa9eda217cb3b4b83bc3e01c873f"
+  "hash": "fb45763298a06bf36916cd308d505fd4"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-01/index.md
@@ -40,7 +40,7 @@ Here are the repos that were updated:
 
   https://github.com/gruntwork-io/repo-copier/pull/112: 
 
-* You can now have `repo-copier` append a suffix to the name of each copied repo using the new `--repo-name-suffix` parameter. This is useful to ensure each repo name is unique and doesn't conflict with any repos you already have.
+* You can now have `repo-copier` append a suffix to the name of each copied repo using the new `--repo-name-suffix` parameter. This is useful to ensure each repo name is unique and doesn&apos;t conflict with any repos you already have.
 * Improve error handling on GitLab repos to make it clearer you must specify a group in the URL, not a repo or user.
 
 </div>
@@ -58,7 +58,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  What's Changed
+  What&apos;s Changed
 ====================
 - f73b8cb Documentation for tfenv and upgrading terraform. (#555)
 
@@ -87,7 +87,7 @@ Here are the repos that were updated:
 * Update python circleci docker image to nextgen by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/506
 * Update QUICK_START.md by @bwhaley in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/509
 * Allow generating code as part of parseform command by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/510
-* Add GitHub PR & Issue Templates by @robmorgan in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/493
+* Add GitHub PR &amp; Issue Templates by @robmorgan in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/493
 * Add ed25519 and ecdsa ssh key to known hosts for testing by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/512
 * Clarify docs in 06-adding-a-new-account.md by @rhoboat in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/515
 * [FEATURE BRANCH] Multiple include based DRY Terragrunt by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/438
@@ -104,14 +104,14 @@ Here are the repos that were updated:
 * Configure allow_ssh_from_security_group_ids in eks cluster module by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/526
 * Give EDR permissions to manage itself by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/530
 * Fix to handle data files in _envcommon folder by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/532
-* Fix bug where envcommon detector doesn't handle nochange well by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/533
+* Fix bug where envcommon detector doesn&apos;t handle nochange well by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/533
 * Fix the infrastructure live repo URL to use https when using gitlab or github actions for CI by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/534
 * macie2:Describe* is necessary for CIS by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/544
 * Enable cloudwatch logs exports and deletion protection by @zackproser in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/548
 * Avoid ECR repo name collisions during tests by @bwhaley in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/547
 * Access logging on the Terraform state bucket by @bwhaley in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/546
 * [skip ci] Update codeowners to reflect current owners by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/550
-* Replace 'renovate.json' with 'patcher' in comments by @infraredgirl in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/549
+* Replace &apos;renovate.json&apos; with &apos;patcher&apos; in comments by @infraredgirl in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/549
 * Combine renovate bot updates by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/551
 * Plumb through custom VCS endpoints for GitLab by @bwhaley in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/462
 * More renovatebot PRs by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/552
@@ -185,7 +185,7 @@ Added `permissions_boundary` to `ecs-deploy-runner` ECS Task IAM role and ECS Ta
     - This also necessitated a change to `gruntwork-module-circieci-helpers` module in the script `configure-environment-for-gruntwork-module`, which configures the CI build environment for typical Gruntwork modules. It now installs `tfenv` and includes a new configuration option `--tfenv-version`, which is enabled by default. If also configured to install `terraform`, this script will use `tfenv` to install and manage that `terraform` version. Because this change is backard incompatible, please see the migration guide below.
 
 
-Most users will not be affected by the change to `configure-environment-for-gruntwork-module`. If you do not need terraform installed in your environment you would pass in `--terraform-version NONE`, and now you also must pass in `--tfenv-version NONE`. If you don't pass in `--tfenv-version NONE`, it will install the latest version of `tfenv`. Note: if you want to install terraform without tfenv, you would only set `--tfenv-version NONE`, and it will still install terraform as usual.
+Most users will not be affected by the change to `configure-environment-for-gruntwork-module`. If you do not need terraform installed in your environment you would pass in `--terraform-version NONE`, and now you also must pass in `--tfenv-version NONE`. If you don&apos;t pass in `--tfenv-version NONE`, it will install the latest version of `tfenv`. Note: if you want to install terraform without tfenv, you would only set `--tfenv-version NONE`, and it will still install terraform as usual.
 
 
 - https://github.com/gruntwork-io/terraform-aws-ci/pull/386
@@ -349,7 +349,7 @@ Updated dependency `gruntwork-io/terraform-aws-service-catalog` to `v0.70.1`. As
 
   
 
-- Updated `aws` provider version constraints to ensure Terraform doesn't use one with a bug around launch templates.
+- Updated `aws` provider version constraints to ensure Terraform doesn&apos;t use one with a bug around launch templates.
 - Added support for configuring prefix delegation mode on AWS VPC CNI. Prefix delegation mode increases the number of secondary IPs that can be provisioned to an EC2 instance, greatly expanding the number of Pods that can be scheduled on a node. Refer to [the updated documentation](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-control-plane#how-do-i-increase-the-number-of-pods-for-my-worker-nodes) for more details.
 
 Note that this change is functionally backward compatible, but due to complexities around Kubernetes versioning, some of the settings may not be available across all Kubernetes versions, and therefore this release is marked as backward incompatible out of caution. If you run into errors, or have issues with the AWS VPC CNI as a result of upgrading to this release, you can disable the prefix delegation management in the module by setting `var.use_vpc_cni_customize_script` input variable to `false`.
@@ -492,7 +492,7 @@ Note that this is **a backward incompatible change**: a naive update to this ver
 
   
 
-- `cloudwatch-custom-metrics-iam-policy`: Added comment explaining why "ec2:DescribeTags" is needed
+- `cloudwatch-custom-metrics-iam-policy`: Added comment explaining why &quot;ec2:DescribeTags&quot; is needed
 - Updated `sns-to-slack` module to use python 3.7 instead of 2.7.
 
 
@@ -514,7 +514,7 @@ Note that this is **a backward incompatible change**: a naive update to this ver
 
   
 
-- openvpn-admin: Fixes a bug that was causing `openvpn-admin` to return the instance's private IPv4 address. `openvpn-admin` now correctly returns the instance's public IPv4 address.
+- openvpn-admin: Fixes a bug that was causing `openvpn-admin` to return the instance&apos;s private IPv4 address. `openvpn-admin` now correctly returns the instance&apos;s public IPv4 address.
 
 
 
@@ -533,11 +533,11 @@ Note that this is **a backward incompatible change**: a naive update to this ver
 
   
 
-- Require IMDSv2 in aws_launch_configuration. This release allows you to configure the AWS Instance Metadata Service's (IMDS) state (enabled or disabled) and which versions of this endpoint to allow the use of via Terraform and these new variables: 
+- Require IMDSv2 in aws_launch_configuration. This release allows you to configure the AWS Instance Metadata Service&apos;s (IMDS) state (enabled or disabled) and which versions of this endpoint to allow the use of via Terraform and these new variables: 
 - `var.enable_imds`
 - `var.use_imdsv1`
 
-In addition, `var.use_imdsv1` defaults to `false` to enforce use of the preferred IMDSv2 endpoint. If you don't need to also use IMDSv1, we recommend leaving this variable set to `false`, and updating your `start-openvpn-admin` script to this release tag. 
+In addition, `var.use_imdsv1` defaults to `false` to enforce use of the preferred IMDSv2 endpoint. If you don&apos;t need to also use IMDSv1, we recommend leaving this variable set to `false`, and updating your `start-openvpn-admin` script to this release tag. 
 
 Note that if you: 
 1. are upgrading to this tag 
@@ -669,7 +669,7 @@ Updated to generate DSA-like Diffie-Hellman parameters (uses weak prime). The we
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
   
-**NOTE: This release is functionally backward compatible, but requires an updated aws provider version to work (&gt;= 3.64.0). For most users, this won't be an issue and Terraform will automatically update to the required provider version, but if you have wrapper modules that depend on an older aws provider version, you will need to update your wrapper module to be compatible with the newer provider before you can bump to this version.**
+**NOTE: This release is functionally backward compatible, but requires an updated aws provider version to work (&gt;= 3.64.0). For most users, this won&apos;t be an issue and Terraform will automatically update to the required provider version, but if you have wrapper modules that depend on an older aws provider version, you will need to update your wrapper module to be compatible with the newer provider before you can bump to this version.**
 
 
 - Added support for replicating a key cross region. Refer to [the updated documentation](https://github.com/gruntwork-io/terraform-aws-security/blob/master/modules/kms-master-key-multi-region/core-concepts.md#what-is-the-difference-between-creating-one-key-in-all-regions-and-creating-a-single-all-region-key) of `kms-master-key-multi-region` for more information.
@@ -992,7 +992,7 @@ Update various dependencies.
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
   
-- Now the creation of the Internet Gateway is optional. We can have public subnets and still disable the IGW by setting the variable `enable_igw` to `false` (it's `true` by default). This fixes #150.
+- Now the creation of the Internet Gateway is optional. We can have public subnets and still disable the IGW by setting the variable `enable_igw` to `false` (it&apos;s `true` by default). This fixes #150.
 
 
 
@@ -1032,6 +1032,6 @@ route_table_deletion_timeout
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "5863697853b2f2adac6487d5ba309ecb"
+  "hash": "be0b72d65e49a2b027c8ed65afa16089"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-02/index.md
@@ -168,7 +168,7 @@ https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/574
 
   
 
-- Housekeeping: Updated CODEOWNERS, Added GitHub PR & Issue Templates, and whitespace changes.
+- Housekeeping: Updated CODEOWNERS, Added GitHub PR &amp; Issue Templates, and whitespace changes.
 - Restricted provider version to &lt; 4.0 due to breaking changes in new provider
 
 
@@ -559,7 +559,7 @@ Default value is still `true`.
 
   
 
-- Updated provider versioning to restrict to `&lt; 4.0`. AWS Provider 4.x series introduced a number of backward incompatible changes and these modules haven't been updated to work with them yet.
+- Updated provider versioning to restrict to `&lt; 4.0`. AWS Provider 4.x series introduced a number of backward incompatible changes and these modules haven&apos;t been updated to work with them yet.
 - Exposed the ability to configure copy-on-write cloning for Aurora DB cluster.
 
 
@@ -1030,7 +1030,7 @@ Default value is still `true`.
   
 
 - Rename vars.tf to more canonical variables.tf
-- Install CloudWatch Script: Whether you're using amd64 or am64, the cloudwatch agent download script will download the architecture-specific agent.
+- Install CloudWatch Script: Whether you&apos;re using amd64 or am64, the cloudwatch agent download script will download the architecture-specific agent.
 
 
 
@@ -1683,7 +1683,7 @@ Hard expiry requires an administrator to reset the password, which greatly degra
 
   
 
-- Updated default EKS disallowed availability zones list to include a new AZ for `ca-central-1` that doesn't support EKS Fargate
+- Updated default EKS disallowed availability zones list to include a new AZ for `ca-central-1` that doesn&apos;t support EKS Fargate
 - Updated dependency `terraform-aws-vpc` to v0.18.12
 - Exposed the following new functionality in the `vpc` module:
     - Added support for making Internet Gateway creation optional.
@@ -1767,7 +1767,7 @@ Hard expiry requires an administrator to reset the password, which greatly degra
 
   
 
-- Add GitHub PR & Issue Templates
+- Add GitHub PR &amp; Issue Templates
 - Add gruntwork-io/maintenance-tier-3-orion to CODEOWNERS
 - Restricted provider version to &lt; 4.0 due to breaking changes in new provider
 
@@ -1948,6 +1948,6 @@ Exposed `icmp_type` and `icmp_code` in `var.private_app_allow_inbound_ports_from
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "77cb3f5554c41881172c1529bdab66b1"
+  "hash": "e29b127072e5f605a52fd793d0437a77"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-02/index.md
@@ -752,7 +752,7 @@ Default value is still `true`.
 ### [v0.17.2](https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.17.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/24/2022 | Modules affected: lambda-edge, lambda | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.17.2">Release notes</a></small>
+  <small>Published: 2/25/2022 | Modules affected: lambda-edge, lambda | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.17.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1562,7 +1562,7 @@ Hard expiry requires an administrator to reset the password, which greatly degra
 ### [v0.75.3](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.75.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/15/2022 | Modules affected: landingzone | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.75.3">Release notes</a></small>
+  <small>Published: 2/16/2022 | Modules affected: landingzone | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.75.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1718,7 +1718,7 @@ Hard expiry requires an administrator to reset the password, which greatly degra
 ### [v0.72.1](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.72.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/2/2022 | Modules affected: networking/vpc | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.72.1">Release notes</a></small>
+  <small>Published: 2/3/2022 | Modules affected: networking/vpc | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.72.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1948,6 +1948,6 @@ Exposed `icmp_type` and `icmp_code` in `var.private_app_allow_inbound_ports_from
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "dfcaa1a0b5ef2e76c98c70d1426030d2"
+  "hash": "77cb3f5554c41881172c1529bdab66b1"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-02/index.md
@@ -752,7 +752,7 @@ Default value is still `true`.
 ### [v0.17.2](https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.17.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/25/2022 | Modules affected: lambda-edge, lambda | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.17.2">Release notes</a></small>
+  <small>Published: 2/24/2022 | Modules affected: lambda-edge, lambda | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.17.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1562,7 +1562,7 @@ Hard expiry requires an administrator to reset the password, which greatly degra
 ### [v0.75.3](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.75.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/16/2022 | Modules affected: landingzone | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.75.3">Release notes</a></small>
+  <small>Published: 2/15/2022 | Modules affected: landingzone | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.75.3">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1718,7 +1718,7 @@ Hard expiry requires an administrator to reset the password, which greatly degra
 ### [v0.72.1](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.72.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 2/3/2022 | Modules affected: networking/vpc | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.72.1">Release notes</a></small>
+  <small>Published: 2/2/2022 | Modules affected: networking/vpc | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.72.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1948,6 +1948,6 @@ Exposed `icmp_type` and `icmp_code` in `var.private_app_allow_inbound_ports_from
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "77cb3f5554c41881172c1529bdab66b1"
+  "hash": "dfcaa1a0b5ef2e76c98c70d1426030d2"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-03/index.md
@@ -97,7 +97,7 @@ required_version: "~&gt; 0.4.3"
 ### [v0.0.28](https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v0.0.28)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/4/2022 | <a href="https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v0.0.28">Release notes</a></small>
+  <small>Published: 3/5/2022 | <a href="https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v0.0.28">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -483,7 +483,7 @@ Updated the `macie` module to allow configuring and managing the Macie CloudWatc
 ### [v0.50.2](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.50.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/22/2022 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.50.2">Release notes</a></small>
+  <small>Published: 3/23/2022 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.50.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -619,7 +619,7 @@ Updated the `macie` module to allow configuring and managing the Macie CloudWatc
 ### [v0.32.1](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.32.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/10/2022 | Modules affected: alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.32.1">Release notes</a></small>
+  <small>Published: 3/11/2022 | Modules affected: alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.32.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -708,7 +708,7 @@ The `openvpn-server` module has been updated to support the recently changed `pr
 ### [v0.63.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.63.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/23/2022 | Modules affected: private-s3-bucket, aws-config-bucket, aws-config-multi-region, aws-config-rules | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.63.0">Release notes</a></small>
+  <small>Published: 3/24/2022 | Modules affected: private-s3-bucket, aws-config-bucket, aws-config-multi-region, aws-config-rules | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.63.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -822,7 +822,7 @@ This release updates the `private-s3-bucket` module and other modules in this re
 ### [v0.85.1](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.85.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/23/2022 | Modules affected: services/lambda, data-stores/ecr-repos | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.85.1">Release notes</a></small>
+  <small>Published: 3/24/2022 | Modules affected: services/lambda, data-stores/ecr-repos | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.85.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -898,7 +898,7 @@ This release updates the `private-s3-bucket` module and other modules in this re
 ### [v0.84.2](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.84.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/9/2022 | Modules affected: services/lambda | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.84.2">Release notes</a></small>
+  <small>Published: 3/10/2022 | Modules affected: services/lambda | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.84.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -933,7 +933,7 @@ This release updates the `private-s3-bucket` module and other modules in this re
 ### [v0.84.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.84.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/8/2022 | Modules affected: services/lambda, mgmt/openvpn-server, services/eks-workers, services/eks-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.84.0">Release notes</a></small>
+  <small>Published: 3/9/2022 | Modules affected: services/lambda, mgmt/openvpn-server, services/eks-workers, services/eks-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.84.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -963,7 +963,7 @@ This release updates the `private-s3-bucket` module and other modules in this re
 ### [v0.83.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.83.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/4/2022 | Modules affected: mgmt/bastion-host, services/ec2-instance, base/ec2-baseline, mgmt/ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.83.0">Release notes</a></small>
+  <small>Published: 3/5/2022 | Modules affected: mgmt/bastion-host, services/ec2-instance, base/ec2-baseline, mgmt/ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.83.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1186,6 +1186,6 @@ You can bump the provider by running `terraform init` with the `-upgrade` flag, 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "efe3374aba8a58999c19e85d4cf8ead7"
+  "hash": "fa84adb2a036b360286e0ea2ed481d5d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-03/index.md
@@ -45,7 +45,7 @@ Here are the repos that were updated:
 E.g.:
 
 ```
-required_version: "~&gt; 0.4.3"
+required_version: &quot;~&gt; 0.4.3&quot;
 ```
 
 </div>
@@ -166,7 +166,7 @@ required_version: "~&gt; 0.4.3"
 
   
 
-- Allows attaching permission boundaries to the role attached to the server's group role.
+- Allows attaching permission boundaries to the role attached to the server&apos;s group role.
 
 
 
@@ -313,7 +313,7 @@ required_version: "~&gt; 0.4.3"
 
   
 
-- Updated the `ecs-deploy-runner-standard-configuration` module to not define a `required_providers` block, since it doesn't have any provider resources.
+- Updated the `ecs-deploy-runner-standard-configuration` module to not define a `required_providers` block, since it doesn&apos;t have any provider resources.
 - Updated the standard configuration of `ecs-deploy-runner` to allow calling `--help` without option args on scripts within EDR
 - Added the ability to pass through additional flags to go test command when using `run-go-tests`
 
@@ -749,7 +749,7 @@ This release updates the `private-s3-bucket` module and other modules in this re
 
   
 
-- Fixed bug where setting `replica_regions = ["*"]` in a conditional did not have the intended effect.
+- Fixed bug where setting `replica_regions = [&quot;*&quot;]` in a conditional did not have the intended effect.
 
 
 
@@ -870,7 +870,7 @@ This release updates the `private-s3-bucket` module and other modules in this re
 
   
 
-- Exposed the 'auth_token' parameter in `redis` module to allow configuring password protected redis instances.
+- Exposed the &apos;auth_token&apos; parameter in `redis` module to allow configuring password protected redis instances.
 - Update dependency `terraform-aws-server` to `v0.14.2`
 
 
@@ -1114,7 +1114,7 @@ This is a **functionally backward compatible upgrade**, verified with partially 
 - No configuration changes are required.
 - The AWS provider version must be bumped to at least `3.75.0`.
 
-You can bump the provider by running `terraform init` with the `-upgrade` flag, as in `terraform init -upgrade`. See [HashiCorp's guide on upgrading providers](https://www.terraform.io/language/files/dependency-lock#new-version-of-an-existing-provider) for more details.
+You can bump the provider by running `terraform init` with the `-upgrade` flag, as in `terraform init -upgrade`. See [HashiCorp&apos;s guide on upgrading providers](https://www.terraform.io/language/files/dependency-lock#new-version-of-an-existing-provider) for more details.
 
 
 - https://github.com/gruntwork-io/terraform-aws-vpc/pull/264
@@ -1186,6 +1186,6 @@ You can bump the provider by running `terraform init` with the `-upgrade` flag, 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "fa84adb2a036b360286e0ea2ed481d5d"
+  "hash": "5c124e1abac09a77fc8c94ffc449fca7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-03/index.md
@@ -97,7 +97,7 @@ required_version: "~&gt; 0.4.3"
 ### [v0.0.28](https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v0.0.28)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/5/2022 | <a href="https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v0.0.28">Release notes</a></small>
+  <small>Published: 3/4/2022 | <a href="https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v0.0.28">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -483,7 +483,7 @@ Updated the `macie` module to allow configuring and managing the Macie CloudWatc
 ### [v0.50.2](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.50.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/23/2022 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.50.2">Release notes</a></small>
+  <small>Published: 3/22/2022 | Modules affected: eks-cluster-control-plane | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.50.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -619,7 +619,7 @@ Updated the `macie` module to allow configuring and managing the Macie CloudWatc
 ### [v0.32.1](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.32.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/11/2022 | Modules affected: alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.32.1">Release notes</a></small>
+  <small>Published: 3/10/2022 | Modules affected: alarms | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.32.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -708,7 +708,7 @@ The `openvpn-server` module has been updated to support the recently changed `pr
 ### [v0.63.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.63.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/24/2022 | Modules affected: private-s3-bucket, aws-config-bucket, aws-config-multi-region, aws-config-rules | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.63.0">Release notes</a></small>
+  <small>Published: 3/23/2022 | Modules affected: private-s3-bucket, aws-config-bucket, aws-config-multi-region, aws-config-rules | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.63.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -822,7 +822,7 @@ This release updates the `private-s3-bucket` module and other modules in this re
 ### [v0.85.1](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.85.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/24/2022 | Modules affected: services/lambda, data-stores/ecr-repos | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.85.1">Release notes</a></small>
+  <small>Published: 3/23/2022 | Modules affected: services/lambda, data-stores/ecr-repos | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.85.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -898,7 +898,7 @@ This release updates the `private-s3-bucket` module and other modules in this re
 ### [v0.84.2](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.84.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/10/2022 | Modules affected: services/lambda | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.84.2">Release notes</a></small>
+  <small>Published: 3/9/2022 | Modules affected: services/lambda | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.84.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -933,7 +933,7 @@ This release updates the `private-s3-bucket` module and other modules in this re
 ### [v0.84.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.84.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/9/2022 | Modules affected: services/lambda, mgmt/openvpn-server, services/eks-workers, services/eks-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.84.0">Release notes</a></small>
+  <small>Published: 3/8/2022 | Modules affected: services/lambda, mgmt/openvpn-server, services/eks-workers, services/eks-cluster | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.84.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -963,7 +963,7 @@ This release updates the `private-s3-bucket` module and other modules in this re
 ### [v0.83.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.83.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/5/2022 | Modules affected: mgmt/bastion-host, services/ec2-instance, base/ec2-baseline, mgmt/ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.83.0">Release notes</a></small>
+  <small>Published: 3/4/2022 | Modules affected: mgmt/bastion-host, services/ec2-instance, base/ec2-baseline, mgmt/ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.83.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1186,6 +1186,6 @@ You can bump the provider by running `terraform init` with the `-upgrade` flag, 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "fa84adb2a036b360286e0ea2ed481d5d"
+  "hash": "efe3374aba8a58999c19e85d4cf8ead7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-04/index.md
@@ -64,7 +64,7 @@ Here are the repos that were updated:
 * Run go mod tidy to ensure go.sum is correct for linux by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/592
 * Make sure account_id is included in account-baseline-security by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/595
 * 12.5 rolled off available RDS versions list so bump to latest by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/597
-* 14.1 is too new and our sample app doesn't support it by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/598
+* 14.1 is too new and our sample app doesn&apos;t support it by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/598
 * Implement preflight check for GitHub PAT validity by @zackproser in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/596
 * Implement preflight check for repo URLs validity by @zackproser in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/600
 * Update deprecated circleci images to latest by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/601
@@ -80,7 +80,7 @@ Here are the repos that were updated:
 * Swap Ref Arch docs 03 and 04 position per customer feedback by @zackproser in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/633
 * Update CI base images to ubuntu:20.04 by @zackproser in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/632
 * Update quick start to point to knowledge base by @brikis98 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/617
-* Write machine user's public SSH key to infra live by @zackproser in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/634
+* Write machine user&apos;s public SSH key to infra live by @zackproser in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/634
 * Always write Admin IAM user credentials to a password file committed to VCS by @zackproser in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/636
 * Harmonize QUICK_START footer with service catalog by @zackproser in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/640
 * Use InfraLiveRepoURL in favor of get_git_origin_url. Deprecate latter by @zackproser in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/641
@@ -804,52 +804,52 @@ When you run `terraform apply` there should be no destroyed or recreated resourc
 For example, you are currently passing in a JSON string such as:
 ```hcl
 routing_rules = &lt;&lt;EOF
-[{
-    "Condition": {
-        "KeyPrefixEquals": "docs/"
-    },
-    "Redirect": {
-        "ReplaceKeyPrefixWith": "documents/"
-    }
-}]
+[&#x7B;
+    &quot;Condition&quot;: &#x7B;
+        &quot;KeyPrefixEquals&quot;: &quot;docs/&quot;
+    &#x7D;,
+    &quot;Redirect&quot;: &#x7B;
+        &quot;ReplaceKeyPrefixWith&quot;: &quot;documents/&quot;
+    &#x7D;
+&#x7D;]
 EOF
 ```
 
 You may be able to use [json2hcl](https://github.com/kvz/json2hcl) to convert this into a map. Then you should also convert the CamelCase to snake_case.
 ```bash
-$ echo '{
-    "Condition": {
-        "KeyPrefixEquals": "docs/"
-    },
-    "Redirect": {
-        "ReplaceKeyPrefixWith": "documents/"
-    }
-}' | json2hcl
+$ echo &apos;&#x7B;
+    &quot;Condition&quot;: &#x7B;
+        &quot;KeyPrefixEquals&quot;: &quot;docs/&quot;
+    &#x7D;,
+    &quot;Redirect&quot;: &#x7B;
+        &quot;ReplaceKeyPrefixWith&quot;: &quot;documents/&quot;
+    &#x7D;
+&#x7D;&apos; | json2hcl
 
-"Condition" = {
-  "KeyPrefixEquals" = "docs/"
-}
+&quot;Condition&quot; = &#x7B;
+  &quot;KeyPrefixEquals&quot; = &quot;docs/&quot;
+&#x7D;
 
-"Redirect" = {
-  "ReplaceKeyPrefixWith" = "documents/"
-}
+&quot;Redirect&quot; = &#x7B;
+  &quot;ReplaceKeyPrefixWith&quot; = &quot;documents/&quot;
+&#x7D;
 ```
 
 Finally:
 ```hcl
-routing_rule = {
-  condition = {
-    key_prefix_equals = "docs/"
-  }
-  redirect = {
-    replace_key_prefix_with = "documents/"
-  }
-}
+routing_rule = &#x7B;
+  condition = &#x7B;
+    key_prefix_equals = &quot;docs/&quot;
+  &#x7D;
+  redirect = &#x7B;
+    replace_key_prefix_with = &quot;documents/&quot;
+  &#x7D;
+&#x7D;
 ```
 
 Please note: The AWS provider only supports one (1) rule in the `routing_rule`.
 
-Alas we had no choice but to drop support for the AWS Provider 3.x style of `routing_rules` for an S3 bucket's website configuration. The AWS Provider 4.x style is called `routing_rule` and has a different format. Previously you could pass in a JSON string which would get interpreted by the provider. Now, you must pass in a map to this `s3-static-website` module, which will appropriately funnel values from that map into the block format expected by the provider. See the [variable definition](https://github.com/gruntwork-io/terraform-aws-static-assets/blob/135ce97b6334248bf12a393ccf36c662504674ea/modules/s3-static-website/variables.tf#L62-L114) for more.
+Alas we had no choice but to drop support for the AWS Provider 3.x style of `routing_rules` for an S3 bucket&apos;s website configuration. The AWS Provider 4.x style is called `routing_rule` and has a different format. Previously you could pass in a JSON string which would get interpreted by the provider. Now, you must pass in a map to this `s3-static-website` module, which will appropriately funnel values from that map into the block format expected by the provider. See the [variable definition](https://github.com/gruntwork-io/terraform-aws-static-assets/blob/135ce97b6334248bf12a393ccf36c662504674ea/modules/s3-static-website/variables.tf#L62-L114) for more.
 
 
 If you are not using routing rules, you have no backward incompatibilities with this upgrade. In this case, it is a **functionally backward compatible upgrade**, verified with partially automated upgrade testing. Upgrade testing was done to ensure that running init/plan/apply on pre-existing resources created by `s3-static-website` will not run into issues when you upgrade to this version of the module. 
@@ -859,7 +859,7 @@ If you are not using routing rules, you have no backward incompatibilities with 
  - However, you do need to bump the provider when upgrading. Read on.
 
 
-Modules calling `s3-static-website` and `s3-cloudfront` have to bump the provider to at least 3.75.0 (`&gt;= 3.75.0`). You will need to rerun `apply` to add the new S3 bucket resources created by the AWS 4.x provider. Note that because `s3-static-website` and `s3-cloudfront` now require a minimum AWS provider version of `3.75.0`, you will need to run `terraform init` with `-upgrade` to pull the new provider version. See [HashiCorp's guide on upgrading providers](https://www.terraform.io/language/files/dependency-lock#new-version-of-an-existing-provider) for more details. 
+Modules calling `s3-static-website` and `s3-cloudfront` have to bump the provider to at least 3.75.0 (`&gt;= 3.75.0`). You will need to rerun `apply` to add the new S3 bucket resources created by the AWS 4.x provider. Note that because `s3-static-website` and `s3-cloudfront` now require a minimum AWS provider version of `3.75.0`, you will need to run `terraform init` with `-upgrade` to pull the new provider version. See [HashiCorp&apos;s guide on upgrading providers](https://www.terraform.io/language/files/dependency-lock#new-version-of-an-existing-provider) for more details. 
 
 
 - [Bump dependency terraform-aws-security to v0.63.1](https://github.com/gruntwork-io/terraform-aws-static-assets/pull/94)
@@ -894,6 +894,6 @@ Modules calling `s3-static-website` and `s3-cloudfront` have to bump the provide
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "9e1cfb0a82aed52c39deff47a15b5f3e"
+  "hash": "151d9185b36b61ef7bce88d2eeb5e056"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-04/index.md
@@ -875,7 +875,7 @@ Modules calling `s3-static-website` and `s3-cloudfront` have to bump the provide
 ### [v0.21.1](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.21.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/16/2022 | Modules affected: vpc-app | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.21.1">Release notes</a></small>
+  <small>Published: 4/17/2022 | Modules affected: vpc-app | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.21.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -894,6 +894,6 @@ Modules calling `s3-static-website` and `s3-cloudfront` have to bump the provide
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "27ef98ef9e7a3196b2cecfaff750c18e"
+  "hash": "9e1cfb0a82aed52c39deff47a15b5f3e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-04/index.md
@@ -875,7 +875,7 @@ Modules calling `s3-static-website` and `s3-cloudfront` have to bump the provide
 ### [v0.21.1](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.21.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 4/17/2022 | Modules affected: vpc-app | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.21.1">Release notes</a></small>
+  <small>Published: 4/16/2022 | Modules affected: vpc-app | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.21.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -894,6 +894,6 @@ Modules calling `s3-static-website` and `s3-cloudfront` have to bump the provide
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "9e1cfb0a82aed52c39deff47a15b5f3e"
+  "hash": "27ef98ef9e7a3196b2cecfaff750c18e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-05/index.md
@@ -96,7 +96,7 @@ Here are the repos that were updated:
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
-  This release updates the `boilerplate` references for the special branch we're using for the updated Gruntwork wizard experience
+  This release updates the `boilerplate` references for the special branch we&apos;re using for the updated Gruntwork wizard experience
 
 
 
@@ -177,7 +177,7 @@ Note that IAM users in the Gruntwork AWS Account are required to have MFA to ass
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
 
   
-Minor update, all related to testing module upgrades to make our builds more stable across Gruntwork's IaC library.
+Minor update, all related to testing module upgrades to make our builds more stable across Gruntwork&apos;s IaC library.
 
 - Remove dead code from upgrade test.
 - Update PR Template
@@ -276,7 +276,7 @@ Updated the default version of Steampipe that is installed in the `steampipe-run
 
   
 - Updated `vpc`, `vpc-mgmt` modules to support tagging of route tables.
-    - If you'd like to configure tagging, set `public_route_table_custom_tags`, `private_app_route_table_custom_tags`, and `private_persistence_route_table_custom_tags`.
+    - If you&apos;d like to configure tagging, set `public_route_table_custom_tags`, `private_app_route_table_custom_tags`, and `private_persistence_route_table_custom_tags`.
 - These dependencies were updated:
     - `terraform-aws-service-catalog` `v0.85.2` =&gt; `v0.86.1`.
         - [`v0.86.0`](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.86.0) requires minimum AWS provider version 3.75.0 for several modules.
@@ -392,7 +392,7 @@ Updated the default version of Steampipe that is installed in the `steampipe-run
   
 
 - Added a new module (`lambda-http-api-gateway`) for configuring an AWS HTTP (V2) API Gateway hooked up to different Lambda functions. Unlike `api-gateway-proxy`, this allows you to configure various HTTP requests to invoke different lambda functions (e.g., `GET` request on `/hello` can invoke the `foo` lambda function, while `POST` request on `/hello` can invoke the `bar` lambda function. Refer to [the module documentation](https://github.com/gruntwork-io/terraform-aws-lambda/tree/master/modules/lambda-http-api-gateway) for more information.
-- Added a new module (`run-lambda-entrypoint`) that can be used as an entrypoint for container image based Lambda function to expose AWS Secrets Manager secrets as environment variables to the Lambda function. This is useful if you don't want to leak the Secrets Manager entries into the Lambda function metadata which most traditional integrations will do as they rely on standard Lambda settings like Environment Variables. Refer to [the module documentation](https://github.com/gruntwork-io/terraform-aws-lambda/tree/master/modules/run-lambda-entrypoint) for more information.
+- Added a new module (`run-lambda-entrypoint`) that can be used as an entrypoint for container image based Lambda function to expose AWS Secrets Manager secrets as environment variables to the Lambda function. This is useful if you don&apos;t want to leak the Secrets Manager entries into the Lambda function metadata which most traditional integrations will do as they rely on standard Lambda settings like Environment Variables. Refer to [the module documentation](https://github.com/gruntwork-io/terraform-aws-lambda/tree/master/modules/run-lambda-entrypoint) for more information.
 
 
 
@@ -473,7 +473,7 @@ Updated the default version of Steampipe that is installed in the `steampipe-run
 
   
 
-- **Ignore changes to various S3 configuration**: A bug was introduced in our `v0.63.0` release of this repo. When upgrading the `private-s3-bucket` module, a race condition in the plan could leave your S3 bucket in a state where configurations were actually removed. The plan would show in-place updates, but depending on execution order and completion of the AWS API calls, the update to remove the configuration could happen last, thereby removing the configuration on the bucket. While not ideal, you could work around this issue by running `apply` a second time, picking up the discrepancy and adding the configurations back to the bucket, but this update makes it so you don't have to run `apply` a second time. When upgrading your modules, including making them AWS Provider v4 compatible, we recommend using this `v0.65.1` version. See the PR and associated issue for more details.
+- **Ignore changes to various S3 configuration**: A bug was introduced in our `v0.63.0` release of this repo. When upgrading the `private-s3-bucket` module, a race condition in the plan could leave your S3 bucket in a state where configurations were actually removed. The plan would show in-place updates, but depending on execution order and completion of the AWS API calls, the update to remove the configuration could happen last, thereby removing the configuration on the bucket. While not ideal, you could work around this issue by running `apply` a second time, picking up the discrepancy and adding the configurations back to the bucket, but this update makes it so you don&apos;t have to run `apply` a second time. When upgrading your modules, including making them AWS Provider v4 compatible, we recommend using this `v0.65.1` version. See the PR and associated issue for more details.
 
 
 
@@ -731,6 +731,6 @@ Support for python2 has been dropped. All modules that depend on python now requ
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "bc20357fa261490cd533fc0f16b375a3"
+  "hash": "27e625ae6ff0126d6d5fb054b94a3ca4"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-05/index.md
@@ -483,7 +483,7 @@ Updated the default version of Steampipe that is installed in the `steampipe-run
 ### [v0.65.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.65.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/19/2022 | Modules affected: aws-config-bucket, aws-config-multi-region, aws-config-rules, aws-config | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.65.0">Release notes</a></small>
+  <small>Published: 5/20/2022 | Modules affected: aws-config-bucket, aws-config-multi-region, aws-config-rules, aws-config | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.65.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -576,7 +576,7 @@ The modules list above makes it look like a scary update; however, this should b
 ### [v0.88.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.88.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/17/2022 | Modules affected: mgmt/tailscale-subnet-router | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.88.0">Release notes</a></small>
+  <small>Published: 5/18/2022 | Modules affected: mgmt/tailscale-subnet-router | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.88.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -670,7 +670,7 @@ The modules list above makes it look like a scary update; however, this should b
 ### [v0.85.11](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.85.11)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/2/2022 | Modules affected: mgmt/tailscale-subnet-router | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.85.11">Release notes</a></small>
+  <small>Published: 5/3/2022 | Modules affected: mgmt/tailscale-subnet-router | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.85.11">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -731,6 +731,6 @@ Support for python2 has been dropped. All modules that depend on python now requ
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "908b356b6757102f67ea2cdfe2d60dc8"
+  "hash": "bc20357fa261490cd533fc0f16b375a3"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-05/index.md
@@ -483,7 +483,7 @@ Updated the default version of Steampipe that is installed in the `steampipe-run
 ### [v0.65.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.65.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/20/2022 | Modules affected: aws-config-bucket, aws-config-multi-region, aws-config-rules, aws-config | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.65.0">Release notes</a></small>
+  <small>Published: 5/19/2022 | Modules affected: aws-config-bucket, aws-config-multi-region, aws-config-rules, aws-config | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.65.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -576,7 +576,7 @@ The modules list above makes it look like a scary update; however, this should b
 ### [v0.88.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.88.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/18/2022 | Modules affected: mgmt/tailscale-subnet-router | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.88.0">Release notes</a></small>
+  <small>Published: 5/17/2022 | Modules affected: mgmt/tailscale-subnet-router | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.88.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -670,7 +670,7 @@ The modules list above makes it look like a scary update; however, this should b
 ### [v0.85.11](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.85.11)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 5/3/2022 | Modules affected: mgmt/tailscale-subnet-router | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.85.11">Release notes</a></small>
+  <small>Published: 5/2/2022 | Modules affected: mgmt/tailscale-subnet-router | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.85.11">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -731,6 +731,6 @@ Support for python2 has been dropped. All modules that depend on python now requ
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "bc20357fa261490cd533fc0f16b375a3"
+  "hash": "908b356b6757102f67ea2cdfe2d60dc8"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-06/index.md
@@ -305,22 +305,6 @@ This release is functionally equivalent and backward compatible with the previou
 ## terraform-aws-cis-service-catalog
 
 
-### [v0.35.4](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.35.4)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/1/2022 | Modules affected: landingzone/account-baseline-security | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.35.4">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  
-
-- Exposed the ability to configure `max_password_age` and password `hard_expiry` for the IAM Password Policy from `account-baseline-security`.
-
-
-</div>
-
-
 ### [v0.35.3](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.35.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
@@ -1311,6 +1295,6 @@ Updated dependency `terraform-aws-security` to `v0.65.2`.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "2e29752e6c3ae0a3fd0ca7da4afbb931"
+  "hash": "3ae6c5850bd9d48811eb1eb51a1225a3"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-06/index.md
@@ -308,7 +308,7 @@ This release is functionally equivalent and backward compatible with the previou
 ### [v0.35.4](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.35.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/30/2022 | Modules affected: landingzone/account-baseline-security | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.35.4">Release notes</a></small>
+  <small>Published: 7/1/2022 | Modules affected: landingzone/account-baseline-security | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.35.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -514,7 +514,7 @@ NOTE: Many dependencies were updated across backward incompatible versions, but 
 ### [v0.19.2](https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.19.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/9/2022 | Modules affected: lambda | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.19.2">Release notes</a></small>
+  <small>Published: 6/10/2022 | Modules affected: lambda | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.19.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -849,7 +849,7 @@ Updated release pipeline to build and publish `run-lambda-entrypoint`.
 ### [v0.91.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.91.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/27/2022 | Modules affected: services/eks-cluster, services/eks-workers, services/eks-core-services, services/k8s-service | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.91.0">Release notes</a></small>
+  <small>Published: 6/28/2022 | Modules affected: services/eks-cluster, services/eks-workers, services/eks-core-services, services/k8s-service | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.91.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -940,7 +940,7 @@ Updated release pipeline to build and publish `run-lambda-entrypoint`.
 ### [v0.90.4](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.90.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/16/2022 | Modules affected: services/ecs-cluster, services/ecs-service, services/eks-cluster, services/public-static-website | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.90.4">Release notes</a></small>
+  <small>Published: 6/17/2022 | Modules affected: services/ecs-cluster, services/ecs-service, services/eks-cluster, services/public-static-website | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.90.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1099,7 +1099,7 @@ Updated release pipeline to build and publish `run-lambda-entrypoint`.
 ### [v0.89.1](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.89.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/6/2022 | Modules affected: services/ecs-cluster, services/public-static-website, mgmt/openvpn-server, data-stores/ecr-repos | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.89.1">Release notes</a></small>
+  <small>Published: 6/7/2022 | Modules affected: services/ecs-cluster, services/public-static-website, mgmt/openvpn-server, data-stores/ecr-repos | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.89.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1311,6 +1311,6 @@ Updated dependency `terraform-aws-security` to `v0.65.2`.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "a9b1999ecdb051e3b0e133d22afbfb9a"
+  "hash": "61ee5f34f8fe30eeeae79148197be474"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-06/index.md
@@ -54,7 +54,7 @@ Here are the repos that were updated:
 ### [v0.1.0](https://github.com/gruntwork-io/repo-copier/releases/tag/v0.1.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/2/2022 | <a href="https://github.com/gruntwork-io/repo-copier/releases/tag/v0.1.0">Release notes</a></small>
+  <small>Published: 6/1/2022 | <a href="https://github.com/gruntwork-io/repo-copier/releases/tag/v0.1.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -305,6 +305,22 @@ This release is functionally equivalent and backward compatible with the previou
 ## terraform-aws-cis-service-catalog
 
 
+### [v0.35.4](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.35.4)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/30/2022 | Modules affected: landingzone/account-baseline-security | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.35.4">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Exposed the ability to configure `max_password_age` and password `hard_expiry` for the IAM Password Policy from `account-baseline-security`.
+
+
+</div>
+
+
 ### [v0.35.3](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.35.3)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
@@ -498,7 +514,7 @@ NOTE: Many dependencies were updated across backward incompatible versions, but 
 ### [v0.19.2](https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.19.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/10/2022 | Modules affected: lambda | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.19.2">Release notes</a></small>
+  <small>Published: 6/9/2022 | Modules affected: lambda | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.19.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -833,7 +849,7 @@ Updated release pipeline to build and publish `run-lambda-entrypoint`.
 ### [v0.91.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.91.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/28/2022 | Modules affected: services/eks-cluster, services/eks-workers, services/eks-core-services, services/k8s-service | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.91.0">Release notes</a></small>
+  <small>Published: 6/27/2022 | Modules affected: services/eks-cluster, services/eks-workers, services/eks-core-services, services/k8s-service | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.91.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -924,7 +940,7 @@ Updated release pipeline to build and publish `run-lambda-entrypoint`.
 ### [v0.90.4](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.90.4)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/17/2022 | Modules affected: services/ecs-cluster, services/ecs-service, services/eks-cluster, services/public-static-website | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.90.4">Release notes</a></small>
+  <small>Published: 6/16/2022 | Modules affected: services/ecs-cluster, services/ecs-service, services/eks-cluster, services/public-static-website | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.90.4">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -963,7 +979,7 @@ Updated release pipeline to build and publish `run-lambda-entrypoint`.
 ### [v0.90.2](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.90.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/16/2022 | Modules affected: networking/vpc, services/eks-cluster, services/eks-core-services, services/eks-workers | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.90.2">Release notes</a></small>
+  <small>Published: 6/15/2022 | Modules affected: networking/vpc, services/eks-cluster, services/eks-core-services, services/eks-workers | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.90.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1083,7 +1099,7 @@ Updated release pipeline to build and publish `run-lambda-entrypoint`.
 ### [v0.89.1](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.89.1)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/7/2022 | Modules affected: services/ecs-cluster, services/public-static-website, mgmt/openvpn-server, data-stores/ecr-repos | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.89.1">Release notes</a></small>
+  <small>Published: 6/6/2022 | Modules affected: services/ecs-cluster, services/public-static-website, mgmt/openvpn-server, data-stores/ecr-repos | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.89.1">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1295,6 +1311,6 @@ Updated dependency `terraform-aws-security` to `v0.65.2`.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "3ae6c5850bd9d48811eb1eb51a1225a3"
+  "hash": "a9b1999ecdb051e3b0e133d22afbfb9a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-06/index.md
@@ -54,7 +54,7 @@ Here are the repos that were updated:
 ### [v0.1.0](https://github.com/gruntwork-io/repo-copier/releases/tag/v0.1.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/1/2022 | <a href="https://github.com/gruntwork-io/repo-copier/releases/tag/v0.1.0">Release notes</a></small>
+  <small>Published: 6/2/2022 | <a href="https://github.com/gruntwork-io/repo-copier/releases/tag/v0.1.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -979,7 +979,7 @@ Updated release pipeline to build and publish `run-lambda-entrypoint`.
 ### [v0.90.2](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.90.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/15/2022 | Modules affected: networking/vpc, services/eks-cluster, services/eks-core-services, services/eks-workers | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.90.2">Release notes</a></small>
+  <small>Published: 6/16/2022 | Modules affected: networking/vpc, services/eks-cluster, services/eks-core-services, services/eks-workers | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.90.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -1311,6 +1311,6 @@ Updated dependency `terraform-aws-security` to `v0.65.2`.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "61ee5f34f8fe30eeeae79148197be474"
+  "hash": "2e29752e6c3ae0a3fd0ca7da4afbb931"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-07/index.md
@@ -148,7 +148,7 @@ If you were relying on either of these behaviors, please file a GitHub issue wit
 ### [v0.50.2](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.50.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/6/2022 | Modules affected: ecs-deploy-runner-standard-configuration, ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.50.2">Release notes</a></small>
+  <small>Published: 7/5/2022 | Modules affected: ecs-deploy-runner-standard-configuration, ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.50.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -435,22 +435,6 @@ https://github.com/gruntwork-io/terraform-aws-ci-steampipe/pull/28
 - Added the ability to disable private SSH and RDP access at the NACL level, using the new `enable_administrative_remote_access_private_subnets_from_self` (for mgmt VPC), `enable_administrative_remote_access_private_app_subnets_from_self` and `enable_administrative_remote_access_private_persistence_subnets_from_self` (for app VPC) variables.
 - Added the ability to configure the remote administrative ports for the NACLs from the VPC layer using the new `remote_administrative_ports` variable.
 
-
-
-</div>
-
-
-### [v0.35.4](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.35.4)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/1/2022 | Modules affected: landingzone/account-baseline-security | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.35.4">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  
-
-- Exposed the ability to configure `max_password_age` and password `hard_expiry` for the IAM Password Policy from `account-baseline-security`.
 
 
 </div>
@@ -869,6 +853,6 @@ https://github.com/gruntwork-io/terraform-aws-ci-steampipe/pull/28
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "e4268e3180c0dc1da599faee0b1f1658"
+  "hash": "3d64f8dbb2c4e9cd929fda4f590db618"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-07/index.md
@@ -148,7 +148,7 @@ If you were relying on either of these behaviors, please file a GitHub issue wit
 ### [v0.50.2](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.50.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 7/5/2022 | Modules affected: ecs-deploy-runner-standard-configuration, ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.50.2">Release notes</a></small>
+  <small>Published: 7/6/2022 | Modules affected: ecs-deploy-runner-standard-configuration, ecs-deploy-runner | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.50.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -853,6 +853,6 @@ https://github.com/gruntwork-io/terraform-aws-ci-steampipe/pull/28
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "3d64f8dbb2c4e9cd929fda4f590db618"
+  "hash": "5cdccd08c3250654aa536f4b47d7bbf8"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-07/index.md
@@ -440,6 +440,22 @@ https://github.com/gruntwork-io/terraform-aws-ci-steampipe/pull/28
 </div>
 
 
+### [v0.35.4](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.35.4)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/1/2022 | Modules affected: landingzone/account-baseline-security | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.35.4">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Exposed the ability to configure `max_password_age` and password `hard_expiry` for the IAM Password Policy from `account-baseline-security`.
+
+
+</div>
+
+
 
 ## terraform-aws-data-storage
 
@@ -853,6 +869,6 @@ https://github.com/gruntwork-io/terraform-aws-ci-steampipe/pull/28
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "5cdccd08c3250654aa536f4b47d7bbf8"
+  "hash": "e4268e3180c0dc1da599faee0b1f1658"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-07/index.md
@@ -506,8 +506,8 @@ https://github.com/gruntwork-io/terraform-aws-ci-steampipe/pull/28
   
 
 - **Unlock AWS provider v4. Require minimum 3.75.1.** This update includes a few tests that make sure upgrading to this module from the last release is easy. However, you may need to bump your AWS provider version. See the migration guide notes below for more.
-    - Fixed a perpetual diff problem in `examples/rds-mysql-with-cross-region-replica`. If you've used this example, you've probably already noticed this in your own code when re-running apply. We've updated the example to include the `var.storage_encrypted` setting in all example code that references the `modules/rds` module.
-    - Uncovered an undocumented (as of this release) backward incompatibility in the AWS Provider v4 upgrade from v3.75. We've handled this within the `modules/rds` logic so you don't have to update your code.
+    - Fixed a perpetual diff problem in `examples/rds-mysql-with-cross-region-replica`. If you&apos;ve used this example, you&apos;ve probably already noticed this in your own code when re-running apply. We&apos;ve updated the example to include the `var.storage_encrypted` setting in all example code that references the `modules/rds` module.
+    - Uncovered an undocumented (as of this release) backward incompatibility in the AWS Provider v4 upgrade from v3.75. We&apos;ve handled this within the `modules/rds` logic so you don&apos;t have to update your code.
 
 
 </div>
@@ -869,6 +869,6 @@ https://github.com/gruntwork-io/terraform-aws-ci-steampipe/pull/28
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "e4268e3180c0dc1da599faee0b1f1658"
+  "hash": "888f9d7e007d5303918d161d10651e02"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-08/index.md
@@ -152,7 +152,7 @@ These commands are intended to be used in conjunction with the `gruntwork vault 
 * Send deployment finished email by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/686
 * Cleanup more preflight checks by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/687
 * Commit code after generating by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/692
-* New error: PrimaryRegion and secret ARN region don't match by @zackproser in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/694
+* New error: PrimaryRegion and secret ARN region don&apos;t match by @zackproser in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/694
 * If on AWS hardware, hardcode the mssfix value to use by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/693
 * Add skip_get_ec2_platforms by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/700
 * Add a link to the deployer infra documentation by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/701
@@ -167,7 +167,7 @@ These commands are intended to be used in conjunction with the `gruntwork vault 
 * Fix bug where the wrong repo was linked to ami build scripts by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/716
 * Make sure to set desired_capacity when min_size is adjusted by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/717
 * Return all preflight errors instead of err directly by @yorinasub17 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/718
-* Grant GW Ref Arch deployer's CIDR access to shared VPC mgmt by @zackproser in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/719
+* Grant GW Ref Arch deployer&apos;s CIDR access to shared VPC mgmt by @zackproser in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/719
 * Enhance preflight access errors with remediation info by @zackproser in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/721
 * Update PR Template by @rhoboat in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/722
 * Catch CACertFields whose length exceeds 40 by @zackproser in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/734
@@ -355,7 +355,7 @@ https://github.com/gruntwork-io/terraform-aws-ci-steampipe/pull/31
 - **Unlocked AWS provider v4. Require minimum 3.75.1.**
     - In [v0.39.0](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.39.0), we missed several module updates in the underlying `terraform-aws-service-catalog` dependency of this repo. 
     - That has been remedied in [gruntwork-io/terraform-aws-service-catalog@v0.96.1 (release)](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.96.1). 
-    - Now we've updated all references in `terraform-aws-cis-service-catalog` to point to the latest, AWS Provider v4 unlocked, version of `terraform-aws-service-catalog`. 
+    - Now we&apos;ve updated all references in `terraform-aws-cis-service-catalog` to point to the latest, AWS Provider v4 unlocked, version of `terraform-aws-service-catalog`. 
     - No configuration changes are required by you. Please see the migration guide below.
 
 
@@ -594,7 +594,7 @@ https://github.com/gruntwork-io/terraform-aws-ci-steampipe/pull/31
 
   
 
-- `modules/logs` updated to only install logrotate from source if the RPM isn't already installed
+- `modules/logs` updated to only install logrotate from source if the RPM isn&apos;t already installed
 
 
 
@@ -733,7 +733,7 @@ https://github.com/gruntwork-io/terraform-aws-ci-steampipe/pull/31
 
   
 
-- Exposed the `cleanup_on_fail` parameter in `k8s-service` module's `helm_release` resource.
+- Exposed the `cleanup_on_fail` parameter in `k8s-service` module&apos;s `helm_release` resource.
 - Updated `landingzone/account-baseline-root` to expose `advanced_event_selectors` for Cloudtrail as `cloudtrail_advanced_event_selectors`.
 - Updated `rds` module to make the `option_group_name` parameter configurable.
 - Updated `jenkins` to allow configuring without a Route53 entry.
@@ -894,6 +894,6 @@ Special thanks to @lorelei-rupp-imprivata for catching this issue!
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "6406670d9f995af1b0ba7b13fd3d254f"
+  "hash": "39e9aa4d181dc140eeca0b4bc3eaa487"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-09/index.md
@@ -137,7 +137,7 @@ Here are the repos that were updated:
 ### [v0.35.6](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.35.6)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/23/2022 | Modules affected: alarms, logs | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.35.6">Release notes</a></small>
+  <small>Published: 9/24/2022 | Modules affected: alarms, logs | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.35.6">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -156,6 +156,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "27bc407e76fe27be2664d4694b4dc678"
+  "hash": "fbd624f17c5844ab9adc5d3615a3f1c6"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-09/index.md
@@ -137,7 +137,7 @@ Here are the repos that were updated:
 ### [v0.35.6](https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.35.6)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 9/24/2022 | Modules affected: alarms, logs | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.35.6">Release notes</a></small>
+  <small>Published: 9/23/2022 | Modules affected: alarms, logs | <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.35.6">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -156,6 +156,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "fbd624f17c5844ab9adc5d3615a3f1c6"
+  "hash": "27bc407e76fe27be2664d4694b4dc678"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-10/index.md
@@ -164,7 +164,7 @@ Here are the repos that were updated:
 ### [v0.41.2](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.41.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/27/2022 | Modules affected: data-stores/rds | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.41.2">Release notes</a></small>
+  <small>Published: 10/28/2022 | Modules affected: data-stores/rds | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.41.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -440,6 +440,6 @@ Due to the Cluster Autoscaler version bump, additional IAM Permissions have been
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "07566d7466aad7d2dae156899c60387a"
+  "hash": "ee6c07901f6235f9070ed9a618818996"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-10/index.md
@@ -164,7 +164,7 @@ Here are the repos that were updated:
 ### [v0.41.2](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.41.2)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 10/28/2022 | Modules affected: data-stores/rds | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.41.2">Release notes</a></small>
+  <small>Published: 10/27/2022 | Modules affected: data-stores/rds | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.41.2">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -440,6 +440,6 @@ Due to the Cluster Autoscaler version bump, additional IAM Permissions have been
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "ee6c07901f6235f9070ed9a618818996"
+  "hash": "07566d7466aad7d2dae156899c60387a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-10/index.md
@@ -152,7 +152,7 @@ Here are the repos that were updated:
 - Organize upgrade tests better. (https://github.com/gruntwork-io/terraform-aws-ci/pull/480)
 - Update additional refs to main (https://github.com/gruntwork-io/terraform-aws-ci/pull/482)
 - Update CODEOWNERS (https://github.com/gruntwork-io/terraform-aws-ci/pull/485)
-- Fix the issue where --skip-fmt didn't actually do anything. (https://github.com/gruntwork-io/terraform-aws-ci/pull/487)
+- Fix the issue where --skip-fmt didn&apos;t actually do anything. (https://github.com/gruntwork-io/terraform-aws-ci/pull/487)
 
 </div>
 
@@ -237,9 +237,9 @@ The default version of Kubernetes installed by the module has been updated to 1.
 Due to the Cluster Autoscaler version bump, additional IAM Permissions have been added to `eks-k8s-cluster-autoscaler-iam-policy`:
 
 ```
-        "ec2:DescribeImages",
-        "ec2:GetInstanceTypesFromInstanceRequirements",
-        "eks:DescribeNodegroup"
+        &quot;ec2:DescribeImages&quot;,
+        &quot;ec2:GetInstanceTypesFromInstanceRequirements&quot;,
+        &quot;eks:DescribeNodegroup&quot;
 ```
 
 
@@ -440,6 +440,6 @@ Due to the Cluster Autoscaler version bump, additional IAM Permissions have been
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "ee6c07901f6235f9070ed9a618818996"
+  "hash": "3536807f086094723c6cc5acd2f7709f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-11/index.md
@@ -35,7 +35,7 @@ Here are the repos that were updated:
 
   * Fix unit tests by @yorinasub17 in https://github.com/gruntwork-io/aws-sample-app/pull/33
 * Bump redis from 3.0.2 to 3.1.1 by @dependabot in https://github.com/gruntwork-io/aws-sample-app/pull/27
-* Add GitHub PR & Issue Templates by @robmorgan in https://github.com/gruntwork-io/aws-sample-app/pull/32
+* Add GitHub PR &amp; Issue Templates by @robmorgan in https://github.com/gruntwork-io/aws-sample-app/pull/32
 * [skip ci] Update codeowners to reflect current owners by @yorinasub17 in https://github.com/gruntwork-io/aws-sample-app/pull/35
 * Update deprecated circleci images to latest by @yorinasub17 in https://github.com/gruntwork-io/aws-sample-app/pull/36
 * Data source: use aws_subnets over aws_subnet_ids by @rhoboat in https://github.com/gruntwork-io/aws-sample-app/pull/39
@@ -73,7 +73,7 @@ Here are the repos that were updated:
   
 
 - Update Centos 7 image used in examples
-- Replace 'local readonly' with 'local -r' in bash scripts
+- Replace &apos;local readonly&apos; with &apos;local -r&apos; in bash scripts
 
 
 
@@ -443,6 +443,6 @@ Note: Previously, importing aws_iam_user_login_profiles would trigger a password
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "f180324c01695c6099bd5f2dac3e8da3"
+  "hash": "97210b9a047d414110644d4b90d86433"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-11/index.md
@@ -11,11 +11,14 @@ documentation](/guides/working-with-code/using-modules#updating).
 Here are the repos that were updated:
 
 - [aws-sample-app](#aws-sample-app)
+- [repo-copier](#repo-copier)
 - [terraform-aws-ci](#terraform-aws-ci)
+- [terraform-aws-cis-service-catalog](#terraform-aws-cis-service-catalog)
 - [terraform-aws-ecs](#terraform-aws-ecs)
 - [terraform-aws-eks](#terraform-aws-eks)
 - [terraform-aws-lambda](#terraform-aws-lambda)
 - [terraform-aws-security](#terraform-aws-security)
+- [terraform-aws-server](#terraform-aws-server)
 - [terraform-aws-service-catalog](#terraform-aws-service-catalog)
 - [terraform-aws-static-assets](#terraform-aws-static-assets)
 
@@ -52,6 +55,29 @@ Here are the repos that were updated:
 * @hongil0316 made their first contribution in https://github.com/gruntwork-io/aws-sample-app/pull/53
 
 **Full Changelog**: https://github.com/gruntwork-io/aws-sample-app/compare/v0.0.5...v0.0.6
+
+</div>
+
+
+
+## repo-copier
+
+
+### [v0.1.1](https://github.com/gruntwork-io/repo-copier/releases/tag/v0.1.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 11/25/2022 | <a href="https://github.com/gruntwork-io/repo-copier/releases/tag/v0.1.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+* Update Golang version. Fix tests. by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/126
+* Fix stack overflow error by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/127
+* Configure visibility for repositories by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/130
+* Fix stack overflow error (merge to master) by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/129
+
+**Full Changelog**: https://github.com/gruntwork-io/repo-copier/compare/v0.1.0...v0.1.1
 
 </div>
 
@@ -99,6 +125,35 @@ Here are the repos that were updated:
 
 
 
+## terraform-aws-cis-service-catalog
+
+
+### [v0.42.0](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.42.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 11/24/2022 | Modules affected: data-stores/rds, landingzone/account-baseline-app, landingzone/account-baseline-root, landingzone/account-baseline-security | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.42.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Update References to CIS v1.5
+- Added support for new AWS region (`me-central-1` UAE) to multiregion modules
+- Updated `terraform-aws-security` versions to `v0.66.0`
+- Updated `terraform-aws-service-catalog` versions to `v0.98.0`
+- Use BuildKit pattern for passing secrets
+- Make changes to deprecate set-output command in Github action
+- Update dependencies to the latest versions.
+
+
+
+
+
+</div>
+
+
+
 ## terraform-aws-ecs
 
 
@@ -124,6 +179,22 @@ Here are the repos that were updated:
 
 
 ## terraform-aws-eks
+
+
+### [v0.55.2](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.55.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 11/23/2022 | Modules affected: eks-scripts | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.55.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Install Python libraries as part of install process in `eks-scripts`
+
+
+</div>
 
 
 ### [v0.55.1](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.55.1)
@@ -183,6 +254,21 @@ Here are the repos that were updated:
 ## terraform-aws-security
 
 
+### [v0.67.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.67.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 11/29/2022 | Modules affected: ntp | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.67.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+- Switching NTP to chrony and configuring
+
+
+</div>
+
+
 ### [v0.66.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.66.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
@@ -221,13 +307,71 @@ Note: Previously, importing aws_iam_user_login_profiles would trigger a password
 
 
 
+## terraform-aws-server
+
+
+### [v0.15.3](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.15.3)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 11/28/2022 | Modules affected: attach-eni, persistent-ebs-volume | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.15.3">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Converted Packer examples from json to hcl
+
+
+
+
+</div>
+
+
+### [v0.15.2](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.15.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 11/23/2022 | Modules affected: single-server | <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.15.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Added `user_data_replace_on_change` var to allow for enabling or disabling the EC2 auto-replace when a change is made to user-data
+
+
+
+</div>
+
+
+
 ## terraform-aws-service-catalog
+
+
+### [v0.99.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.99.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 11/24/2022 | Modules affected: services/k8s-service, services/eks-cluster, services/eks-core-services, services/eks-workers | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.99.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Add subPath processing for ConfigMaps and Secrets
+- Update `terraform-aws-eks` to `v0.55.2` - fix Python dependency issue with new AWS EKS optimized AMIs
+- Add patch for CIS RDS module
+
+
+
+</div>
 
 
 ### [v0.98.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.98.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/22/2022 | Modules affected: base/ec2-baseline, data-stores/rds, data-stores/s3-bucket, landingzone/account-baseline-app | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.98.0">Release notes</a></small>
+  <small>Published: 11/21/2022 | Modules affected: base/ec2-baseline, data-stores/rds, data-stores/s3-bucket, landingzone/account-baseline-app | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.98.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -323,6 +467,6 @@ Note: Previously, importing aws_iam_user_login_profiles would trigger a password
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "62d11e8a16c238815561a4f6348aa902"
+  "hash": "82905f1ddc2422d4a7c924072db4fb9c"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-11/index.md
@@ -11,7 +11,6 @@ documentation](/guides/working-with-code/using-modules#updating).
 Here are the repos that were updated:
 
 - [aws-sample-app](#aws-sample-app)
-- [repo-copier](#repo-copier)
 - [terraform-aws-ci](#terraform-aws-ci)
 - [terraform-aws-cis-service-catalog](#terraform-aws-cis-service-catalog)
 - [terraform-aws-ecs](#terraform-aws-ecs)
@@ -55,29 +54,6 @@ Here are the repos that were updated:
 * @hongil0316 made their first contribution in https://github.com/gruntwork-io/aws-sample-app/pull/53
 
 **Full Changelog**: https://github.com/gruntwork-io/aws-sample-app/compare/v0.0.5...v0.0.6
-
-</div>
-
-
-
-## repo-copier
-
-
-### [v0.1.1](https://github.com/gruntwork-io/repo-copier/releases/tag/v0.1.1)
-
-<p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/25/2022 | <a href="https://github.com/gruntwork-io/repo-copier/releases/tag/v0.1.1">Release notes</a></small>
-</p>
-
-<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
-
-  
-* Update Golang version. Fix tests. by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/126
-* Fix stack overflow error by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/127
-* Configure visibility for repositories by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/130
-* Fix stack overflow error (merge to master) by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/129
-
-**Full Changelog**: https://github.com/gruntwork-io/repo-copier/compare/v0.1.0...v0.1.1
 
 </div>
 
@@ -371,7 +347,7 @@ Note: Previously, importing aws_iam_user_login_profiles would trigger a password
 ### [v0.98.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.98.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 11/21/2022 | Modules affected: base/ec2-baseline, data-stores/rds, data-stores/s3-bucket, landingzone/account-baseline-app | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.98.0">Release notes</a></small>
+  <small>Published: 11/22/2022 | Modules affected: base/ec2-baseline, data-stores/rds, data-stores/s3-bucket, landingzone/account-baseline-app | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.98.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -467,6 +443,6 @@ Note: Previously, importing aws_iam_user_login_profiles would trigger a password
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "82905f1ddc2422d4a7c924072db4fb9c"
+  "hash": "f180324c01695c6099bd5f2dac3e8da3"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-12/index.md
@@ -1,0 +1,70 @@
+
+# Gruntwork release 2022-12
+
+<p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2022-12</small></p>
+
+This page is lists all the updates to the [Gruntwork Infrastructure as Code 
+Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-12. For instructions 
+on how to use these updates in your code, check out the [updating 
+documentation](/guides/working-with-code/using-modules#updating).
+
+Here are the repos that were updated:
+
+- [terraform-aws-ci](#terraform-aws-ci)
+- [terraform-aws-load-balancer](#terraform-aws-load-balancer)
+
+
+## terraform-aws-ci
+
+
+### [v0.50.12](https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.50.12)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 12/1/2022 | Modules affected: ecs-deploy-runner, gruntwork-module-circleci-helpers | <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.50.12">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Use BuildKit pattern for passing secrets in the CircleCI build
+- Fix intermittent test failure
+- Use main branch in deploy-runner docker image
+- Fix installing `gox` in Go 1.17 and newer
+
+
+
+
+
+</div>
+
+
+
+## terraform-aws-load-balancer
+
+
+### [v0.29.3](https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.29.3)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 12/1/2022 | Modules affected: alb | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.29.3">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Deprecate `vpc_id` variable
+
+
+
+</div>
+
+
+
+
+<!-- ##DOCS-SOURCER-START
+{
+  "sourcePlugin": "releases",
+  "hash": "e60e8ecf9e0395256fb8b57a7e33624b"
+}
+##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-12/index.md
@@ -10,8 +10,39 @@ documentation](/guides/working-with-code/using-modules#updating).
 
 Here are the repos that were updated:
 
+- [repo-copier](#repo-copier)
 - [terraform-aws-ci](#terraform-aws-ci)
 - [terraform-aws-load-balancer](#terraform-aws-load-balancer)
+
+
+## repo-copier
+
+
+### [v0.1.1](https://github.com/gruntwork-io/repo-copier/releases/tag/v0.1.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 12/1/2022 | <a href="https://github.com/gruntwork-io/repo-copier/releases/tag/v0.1.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+* Create CODEOWNERS by @rhoboat in https://github.com/gruntwork-io/repo-copier/pull/120
+* Use terratest_log_parser to summarize test results in circleci by @yorinasub17 in https://github.com/gruntwork-io/repo-copier/pull/119
+* Update CODEOWNERS by @yorinasub17 in https://github.com/gruntwork-io/repo-copier/pull/121
+* Use BuildKit pattern for passing secrets by @hongil0316 in https://github.com/gruntwork-io/repo-copier/pull/122
+* Update Golang version. Fix tests. by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/126
+* Fix stack overflow error by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/127
+* Configure visibility for repositories by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/130
+* Fix stack overflow error (merge to master) by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/129
+* Configure visibility for repositories, additional option "internal" by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/132
+* Add --repo-name-prefix option by @edgeb1-roche in https://github.com/gruntwork-io/repo-copier/pull/128
+* Fix build failure by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/136
+
+**Full Changelog**: https://github.com/gruntwork-io/repo-copier/compare/v0.1.0...v0.1.1
+
+</div>
+
 
 
 ## terraform-aws-ci
@@ -65,6 +96,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "e60e8ecf9e0395256fb8b57a7e33624b"
+  "hash": "c5a14153ef69ad85ccd99fd2d495b553"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-12/index.md
@@ -35,7 +35,7 @@ Here are the repos that were updated:
 * Fix stack overflow error by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/127
 * Configure visibility for repositories by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/130
 * Fix stack overflow error (merge to master) by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/129
-* Configure visibility for repositories, additional option "internal" by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/132
+* Configure visibility for repositories, additional option &quot;internal&quot; by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/132
 * Add --repo-name-prefix option by @edgeb1-roche in https://github.com/gruntwork-io/repo-copier/pull/128
 * Fix build failure by @levkoburburas in https://github.com/gruntwork-io/repo-copier/pull/136
 
@@ -96,6 +96,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "c5a14153ef69ad85ccd99fd2d495b553"
+  "hash": "79a2d68965faabae13c415c6c06264b7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/index.md
+++ b/docs/guides/stay-up-to-date/releases/index.md
@@ -11,7 +11,8 @@ Library](https://gruntwork.io/infrastructure-as-code-library/), grouped by month
 updates in your code, check out the [updating documentation](/guides/working-with-code/using-modules#updating).
 
 <CardGroup cols={1} gap="1rem" stacked equalHeightRows={false} commonCardProps={{padding: "1.25rem"}}>
-  <Card title="Gruntwork Release 2022-11" href="/guides/stay-up-to-date/releases/2022-11" />
+  <Card title="Gruntwork Release 2022-12" href="/guides/stay-up-to-date/releases/2022-12" />
+<Card title="Gruntwork Release 2022-11" href="/guides/stay-up-to-date/releases/2022-11" />
 <Card title="Gruntwork Release 2022-10" href="/guides/stay-up-to-date/releases/2022-10" />
 <Card title="Gruntwork Release 2022-09" href="/guides/stay-up-to-date/releases/2022-09" />
 <Card title="Gruntwork Release 2022-08" href="/guides/stay-up-to-date/releases/2022-08" />
@@ -95,6 +96,6 @@ updates in your code, check out the [updating documentation](/guides/working-wit
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "cfef2db98d485bf2e3f67039788cea02"
+  "hash": "2f6060863cba9c5de0851e6e3eba4f47"
 }
 ##DOCS-SOURCER-END -->


### PR DESCRIPTION
Re-run releases plugin in `docs-sourcer`.

Direct link to preview: https://deploy-preview-595--pensive-meitner-faaeee.netlify.app/guides/stay-up-to-date/

**Update**: based on PR feedback in https://github.com/gruntwork-io/docs-sourcer/pull/93, I switched the `docs-sourcer` to a different HTML escape function, so now far more characters get escaped. This is good... but it means almost every single release file changed, so this PR is now rather large.