### PR TITLE
Update callout to point to new Gruntwork Pipelines example

### DIFF
--- a/_docs-sources/guides/build-it-yourself/pipelines/index.md
+++ b/_docs-sources/guides/build-it-yourself/pipelines/index.md
@@ -7,24 +7,23 @@ import { CardList } from "/src/components/CardGroup"
 
 # Set Up an Infrastructure CI/CD Pipeline
 
-:::caution
+:::info
 
-This guide hasn’t been updated in the past 6 months. If you find any inaccuracies, please share with us at feedback@gruntwork.io.
+This document is an excellent resource for understanding the problem space of CI/CD and the design choices that Gruntwork Pipelines makes.  
+
+If you are looking to get hands-on with Gruntwork Pipelines and deploy it yourself, see [the official examples in our service catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/master/examples/for-production/gruntwork-pipelines)
 
 :::
 
 ## Overview
 
-This is a comprehensive guide of how to design, configure, and implement a Continuous Integration and Continuous
-Delivery pipeline for your infrastructure code. This guide will walk you through the steps to set up a secure CI/CD
-pipeline for your favorite infrastructure as code tools (e.g., Terraform) using your favorite CI/CD platform (e.g.,
-Jenkins, Circle, GitLab, etc).
-
-TLDR: If you follow this guide, you’ll be able to set up a pipeline that works like this:
-
-![For an extended version with audio commentary, see <https://youtu.be/iYXghJK7YdU>](/img/guides/build-it-yourself/pipelines/walkthrough.gif)
+This is a comprehensive guide explaining the problem space of CI/CD, its threat vectors, and the design decisions that Gruntwork Pipelines 
+makes in order to keep your sensitive credentials secure. 
 
 ## What this guide will not cover
+
+This guide is not hands-on! If you're looking to explore and play around with Gruntwork Pipelines, you should instead view and deploy [our official 
+examples in our service catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/master/examples/for-production/gruntwork-pipelines).
 
 CI/CD for infrastructure code is a large topic and a single guide cannot cover everything. There
 are several items that this guide will not cover, including:

--- a/docs/courses.mdx
+++ b/docs/courses.mdx
@@ -58,8 +58,5 @@ Courses are offered through Teachable. Access is included with every Gruntwork s
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "22fb47e1f56898c89c3c4eb09358374f"
-}
+{"sourcePlugin":"local-copier","hash":"22fb47e1f56898c89c3c4eb09358374f"}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/devops-general/index.md
+++ b/docs/faq/devops-general/index.md
@@ -10,8 +10,5 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "edc21b0a2f48bdf03447da1c1cb9ac21"
-}
+{"sourcePlugin":"local-copier","hash":"edc21b0a2f48bdf03447da1c1cb9ac21"}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/eks/index.md
+++ b/docs/faq/eks/index.md
@@ -14,8 +14,5 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "d95f4a0a70695a6733735a2c67f6bd4e"
-}
+{"sourcePlugin":"local-copier","hash":"d95f4a0a70695a6733735a2c67f6bd4e"}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/iac-general/index.md
+++ b/docs/faq/iac-general/index.md
@@ -6,8 +6,5 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "36bb7ec496d13c871b1259ef31ea7b1f"
-}
+{"sourcePlugin":"local-copier","hash":"36bb7ec496d13c871b1259ef31ea7b1f"}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -69,8 +69,5 @@ Get answers to frequently asked questions, organized by category.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "dbdf6417d65b463c42d8decdbed70717"
-}
+{"sourcePlugin":"local-copier","hash":"dbdf6417d65b463c42d8decdbed70717"}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/pipelines/index.md
+++ b/docs/faq/pipelines/index.md
@@ -13,8 +13,5 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "a07af15175a16401cffba58d7eb21ef0"
-}
+{"sourcePlugin":"local-copier","hash":"a07af15175a16401cffba58d7eb21ef0"}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/ref-arch-predeployment/index.md
+++ b/docs/faq/ref-arch-predeployment/index.md
@@ -26,8 +26,5 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "dc57285f55e7caced69fdb4052fa6264"
-}
+{"sourcePlugin":"local-copier","hash":"dc57285f55e7caced69fdb4052fa6264"}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/ref-arch/index.md
+++ b/docs/faq/ref-arch/index.md
@@ -32,8 +32,5 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "613ecde6c13ca14adbc92aac692f90bf"
-}
+{"sourcePlugin":"local-copier","hash":"613ecde6c13ca14adbc92aac692f90bf"}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/service-catalog/index.md
+++ b/docs/faq/service-catalog/index.md
@@ -10,8 +10,5 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "1ab393265d039a3821716343f10c0e0b"
-}
+{"sourcePlugin":"local-copier","hash":"1ab393265d039a3821716343f10c0e0b"}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/terragrunt/index.md
+++ b/docs/faq/terragrunt/index.md
@@ -16,8 +16,5 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "98df4b23885f621d3307a6112f2c6c9b"
-}
+{"sourcePlugin":"local-copier","hash":"98df4b23885f621d3307a6112f2c6c9b"}
 ##DOCS-SOURCER-END -->

--- a/docs/faq/terratest/index.md
+++ b/docs/faq/terratest/index.md
@@ -12,8 +12,5 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "6d88bf0ee938daacc5ee3c6547d45d3d"
-}
+{"sourcePlugin":"local-copier","hash":"6d88bf0ee938daacc5ee3c6547d45d3d"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/core-concepts/intro.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/core-concepts/intro.md
@@ -51,8 +51,5 @@ controls.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "306ddcbed0920339735b69c9f1a73219"
-}
+{"sourcePlugin":"local-copier","hash":"306ddcbed0920339735b69c9f1a73219"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/core-concepts/recommendation-sections.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/core-concepts/recommendation-sections.md
@@ -58,8 +58,5 @@ suggest limiting routing for VPC peering connections based on [the principle of 
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "9c5ed024400994bf3693d1340382dfbf"
-}
+{"sourcePlugin":"local-copier","hash":"9c5ed024400994bf3693d1340382dfbf"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/create-an-iam-user-in-the-root-account.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/create-an-iam-user-in-the-root-account.md
@@ -14,8 +14,5 @@ IAM user manually by
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "4d6487d6c1c3be7d2da2e166f24c93e0"
-}
+{"sourcePlugin":"local-copier","hash":"4d6487d6c1c3be7d2da2e166f24c93e0"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/create-the-root-account.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/create-the-root-account.md
@@ -9,8 +9,5 @@ The first step is to create your root account. This account will be the parent o
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "1a99aa01895f6501a3b02d3c2c087c59"
-}
+{"sourcePlugin":"local-copier","hash":"1a99aa01895f6501a3b02d3c2c087c59"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/create-vpc-flow-logs.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/create-vpc-flow-logs.md
@@ -155,8 +155,5 @@ default security groups from all VPCs in all regions.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "8312868084cd9973395eb4fd0af2d900"
-}
+{"sourcePlugin":"local-copier","hash":"8312868084cd9973395eb4fd0af2d900"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-app-to-logs-account.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-app-to-logs-account.md
@@ -271,8 +271,5 @@ On some operating systems, such as MacOS, you may also need to increase your ope
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "4b5387c63b27de9f1446fe439d6438af"
-}
+{"sourcePlugin":"local-copier","hash":"4b5387c63b27de9f1446fe439d6438af"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-app-to-other-child-accounts.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-app-to-other-child-accounts.md
@@ -309,8 +309,5 @@ the benchmark, v1.3.0; the AWS Security Hub does not support this version at the
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "33d01518a80c1b75e1bbe137ef4763ff"
-}
+{"sourcePlugin":"local-copier","hash":"33d01518a80c1b75e1bbe137ef4763ff"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-root-to-root-account.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-root-to-root-account.md
@@ -587,8 +587,5 @@ those root users again.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "16a777737a8d6c48de0fe2f6ca292c5a"
-}
+{"sourcePlugin":"local-copier","hash":"16a777737a8d6c48de0fe2f6ca292c5a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-security-to-security-account.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/apply-account-baseline-security-to-security-account.md
@@ -330,8 +330,5 @@ echo "<PASSWORD>" | base64 --decode | keybase pgp decrypt
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "defd1dc9d6c10d7c36b4bf207bfe074f"
-}
+{"sourcePlugin":"local-copier","hash":"defd1dc9d6c10d7c36b4bf207bfe074f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/enable-key-rotation-for-kms-keys.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/enable-key-rotation-for-kms-keys.md
@@ -6,8 +6,5 @@ to create KMS keys with key rotation enabled by default.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "61d36e4a905478a070114a1cb7e9cd4e"
-}
+{"sourcePlugin":"local-copier","hash":"61d36e4a905478a070114a1cb7e9cd4e"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/maintain-compliance-by-following-iam-best-practices.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/maintain-compliance-by-following-iam-best-practices.md
@@ -19,8 +19,5 @@ We conclude the IAM section with a few parting words of wisdom for maintaining c
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "eb60c65580aa8aea2e2209212c54e24f"
-}
+{"sourcePlugin":"local-copier","hash":"eb60c65580aa8aea2e2209212c54e24f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/maintain-compliance-by-following-logging-best-practices.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/maintain-compliance-by-following-logging-best-practices.md
@@ -4,8 +4,5 @@ The logging section of the Benchmark includes configurations for CloudTrail, AWS
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "39456528af509fa05ddd582fa6983d8f"
-}
+{"sourcePlugin":"local-copier","hash":"39456528af509fa05ddd582fa6983d8f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/maintain-compliance-by-following-storage-best-practices.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/maintain-compliance-by-following-storage-best-practices.md
@@ -18,8 +18,5 @@ the hood.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "b2f8907a2b4273753794fb96e9f89ffe"
-}
+{"sourcePlugin":"local-copier","hash":"b2f8907a2b4273753794fb96e9f89ffe"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/use-iam-roles-for-ec2-instances.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deploy-landing-zone-solution/use-iam-roles-for-ec2-instances.md
@@ -23,8 +23,5 @@ access to the AWS API. Using static API credentials should be avoided whenever p
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "af99b295cc0bfa675cbfdf671eb033a7"
-}
+{"sourcePlugin":"local-copier","hash":"af99b295cc0bfa675cbfdf671eb033a7"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deployment-approach.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/deployment-approach.md
@@ -9,8 +9,5 @@ The standalone modules will follow the pattern of referencing the module and pro
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "a9dde76d161304ab0b3185f97436ca20"
-}
+{"sourcePlugin":"local-copier","hash":"a9dde76d161304ab0b3185f97436ca20"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/lock-down-the-root-account-iam-users.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/lock-down-the-root-account-iam-users.md
@@ -32,8 +32,5 @@ so using a virtual or hardware MFA device is preferable; that said, MFA with SMS
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "e0e6d5a424416b59aff4c05e685cc5e9"
-}
+{"sourcePlugin":"local-copier","hash":"e0e6d5a424416b59aff4c05e685cc5e9"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/lock-down-the-root-user.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/lock-down-the-root-user.md
@@ -62,8 +62,5 @@ your credentials) or for the
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "a5b9b812a92ff9ac762947e49a73ce40"
-}
+{"sourcePlugin":"local-copier","hash":"a5b9b812a92ff9ac762947e49a73ce40"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
@@ -139,8 +139,5 @@ Example:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "402d73f62a8fa3b89d18d1decb3ebeba"
-}
+{"sourcePlugin":"local-copier","hash":"402d73f62a8fa3b89d18d1decb3ebeba"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/pre-requisites.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/pre-requisites.md
@@ -55,8 +55,5 @@ automatically.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "cfc6e23713c964098ba9f49dbe2a448f"
-}
+{"sourcePlugin":"local-copier","hash":"cfc6e23713c964098ba9f49dbe2a448f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/prepare-your-infrastructure-live-repository.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/prepare-your-infrastructure-live-repository.md
@@ -9,8 +9,5 @@ We’ve previously described exactly how to prepare your repository in the
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "b8d57689504020947c3b27c055920715"
-}
+{"sourcePlugin":"local-copier","hash":"b8d57689504020947c3b27c055920715"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/the-gruntwork-solution.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/the-gruntwork-solution.md
@@ -59,8 +59,5 @@ our [Introduction to Gruntwork](/intro/overview/intro-to-gruntwork) section.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "81acd02dda18bf32fb8caa79c4628c3c"
-}
+{"sourcePlugin":"local-copier","hash":"81acd02dda18bf32fb8caa79c4628c3c"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/index.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/index.md
@@ -69,8 +69,5 @@ walkthrough.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "62afd671cf06da950d577fe88796bfe0"
-}
+{"sourcePlugin":"local-copier","hash":"62afd671cf06da950d577fe88796bfe0"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/next-steps.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/next-steps.md
@@ -13,8 +13,5 @@ Now it’s time to confirm that your configurations are correct and you didn’t
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "da234b67eaac211be828271e9d5a4a40"
-}
+{"sourcePlugin":"local-copier","hash":"da234b67eaac211be828271e9d5a4a40"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/identity-and-access-management.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/identity-and-access-management.md
@@ -336,8 +336,5 @@ For further detail, follow the manual steps outlined in the CIS Benchmark docume
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "0cbf46af308ab524cdd1f839d41ad6fb"
-}
+{"sourcePlugin":"local-copier","hash":"0cbf46af308ab524cdd1f839d41ad6fb"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/intro.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/intro.md
@@ -18,8 +18,5 @@ edition of Terraform Up & Running](https://medium.com/gruntwork/terraform-up-run
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "b16df89a913536dd1269166a711b6434"
-}
+{"sourcePlugin":"local-copier","hash":"b16df89a913536dd1269166a711b6434"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/logging.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/logging.md
@@ -148,8 +148,5 @@ the default VPCs which exist in all regions of the account. You can use the
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "fa7e59351da6b6e1fadfd62d09cf2c27"
-}
+{"sourcePlugin":"local-copier","hash":"fa7e59351da6b6e1fadfd62d09cf2c27"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/monitoring.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/monitoring.md
@@ -12,8 +12,5 @@ Terraform resources.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "6f13f1638eebe902e46fb2759688903f"
-}
+{"sourcePlugin":"local-copier","hash":"6f13f1638eebe902e46fb2759688903f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/networking.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/networking.md
@@ -21,8 +21,5 @@ on the services running on those subnets. This can help to avoid exposing servic
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "eea45ba729cc31d9d27d7266188b3a58"
-}
+{"sourcePlugin":"local-copier","hash":"eea45ba729cc31d9d27d7266188b3a58"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/storage.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/production-grade-design/storage.md
@@ -138,8 +138,5 @@ explicit list of buckets per region, namely in the variable `buckets_to_analyze`
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "a42545420e9759182b9a7727a91aab4a"
-}
+{"sourcePlugin":"local-copier","hash":"a42545420e9759182b9a7727a91aab4a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/traceability-matrix.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/traceability-matrix.md
@@ -734,8 +734,5 @@ sections above.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "deda90311b36e4b300a2d13b43d04817"
-}
+{"sourcePlugin":"local-copier","hash":"deda90311b36e4b300a2d13b43d04817"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/index.md
+++ b/docs/guides/build-it-yourself/index.md
@@ -63,8 +63,5 @@ The Gruntwork IaC library empowers you to construct your own bespoke architectur
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "9e81132b36c74657d6bce6895ca8e817"
-}
+{"sourcePlugin":"local-copier","hash":"9e81132b36c74657d6bce6895ca8e817"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/interacting-with-kubernetes.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/interacting-with-kubernetes.md
@@ -59,8 +59,5 @@ Terraform code anyway (e.g., execute a script).
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "ede0867c6736ce962649a05fe05c141f"
-}
+{"sourcePlugin":"local-copier","hash":"ede0867c6736ce962649a05fe05c141f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/kubernetes-access-control.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/kubernetes-access-control.md
@@ -42,8 +42,5 @@ namespace), and associate those roles with the specific user and service account
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "d29f803c93ab0f3d203614b9f0e15d33"
-}
+{"sourcePlugin":"local-copier","hash":"d29f803c93ab0f3d203614b9f0e15d33"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/kubernetes-architecture.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/kubernetes-architecture.md
@@ -106,8 +106,5 @@ used for Service Discovery within Kubernetes, a topic we’ll discuss later.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "42caae9827cb7b64f4c5e0b6e9d7c00d"
-}
+{"sourcePlugin":"local-copier","hash":"42caae9827cb7b64f4c5e0b6e9d7c00d"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/kubernetes-resources.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/kubernetes-resources.md
@@ -123,8 +123,5 @@ secrets unencrypted!).
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "515b338cb8b99a1ad5127df1aa98c187"
-}
+{"sourcePlugin":"local-copier","hash":"515b338cb8b99a1ad5127df1aa98c187"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/options-for-running-kubernetes-in-aws.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/options-for-running-kubernetes-in-aws.md
@@ -36,8 +36,5 @@ still fairly new, so some functionality is missing or more complicated to use th
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "014ad817a0f78576ebd997277ebec6a2"
-}
+{"sourcePlugin":"local-copier","hash":"014ad817a0f78576ebd997277ebec6a2"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/what-is-kubernetes.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/what-is-kubernetes.md
@@ -41,8 +41,5 @@ Provide containers with environment-specific configuration data and secrets.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "90e5f0b5e2067db1b348484f5df12685"
-}
+{"sourcePlugin":"local-copier","hash":"90e5f0b5e2067db1b348484f5df12685"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/why-kubernetes.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/core-concepts/why-kubernetes.md
@@ -38,8 +38,5 @@ continuously getting better.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "87ef2e892443e7eb5ba94d715722233f"
-}
+{"sourcePlugin":"local-copier","hash":"87ef2e892443e7eb5ba94d715722233f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/10-try-out-the-cluster.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/10-try-out-the-cluster.md
@@ -19,8 +19,5 @@ kubectl get nodes
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "ce3e3dd28d904805638be7b3e6cf7bd9"
-}
+{"sourcePlugin":"local-copier","hash":"ce3e3dd28d904805638be7b3e6cf7bd9"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/11-updating-the-worker-nodes.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/11-updating-the-worker-nodes.md
@@ -41,8 +41,5 @@ kubergrunt eks deploy --region <AWS_REGION> --asg-name <AUTO_SCALING_GROUP_NAME>
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "7e4f6f3320632a138f9f4eb9d05b2385"
-}
+{"sourcePlugin":"local-copier","hash":"7e4f6f3320632a138f9f4eb9d05b2385"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-access-to-the-control-plane-and-worker-nodes.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-access-to-the-control-plane-and-worker-nodes.md
@@ -103,8 +103,5 @@ resource "aws_iam_role_policy" "ssh_grunt_permissions" {
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "985bfb828a22c317d6b029d2afb50f13"
-}
+{"sourcePlugin":"local-copier","hash":"985bfb828a22c317d6b029d2afb50f13"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-logging-metrics-and-alarms-for-the-worker-nodes.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-logging-metrics-and-alarms-for-the-worker-nodes.md
@@ -95,8 +95,5 @@ data "terraform_remote_state" "sns_region" {
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "89574f3a5a0644f6cc08c0ac71026395"
-}
+{"sourcePlugin":"local-copier","hash":"89574f3a5a0644f6cc08c0ac71026395"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-role-mapping.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-role-mapping.md
@@ -76,8 +76,5 @@ data "aws_eks_cluster_auth" "kubernetes_token" {
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "b38a1e8d5a91d55332bd4b3507773920"
-}
+{"sourcePlugin":"local-copier","hash":"b38a1e8d5a91d55332bd4b3507773920"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-the-control-plane.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-the-control-plane.md
@@ -129,8 +129,5 @@ variable "terraform_state_s3_bucket" {
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "c117b6c75e7609d24e95b51029946518"
-}
+{"sourcePlugin":"local-copier","hash":"c117b6c75e7609d24e95b51029946518"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-the-worker-node-user-data-script.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-the-worker-node-user-data-script.md
@@ -105,8 +105,5 @@ data "template_file" "user_data" {
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "f6e4c30ad255804535b49152c8f38011"
-}
+{"sourcePlugin":"local-copier","hash":"f6e4c30ad255804535b49152c8f38011"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-the-worker-nodes.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/configure-the-worker-nodes.md
@@ -74,8 +74,5 @@ variable "cluster_instance_keypair_name" {
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "5e5c32c3eb4bb045778d6baa48588f63"
-}
+{"sourcePlugin":"local-copier","hash":"5e5c32c3eb4bb045778d6baa48588f63"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/create-the-worker-node-ami.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/create-the-worker-node-ami.md
@@ -137,8 +137,5 @@ guide.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "e5f9d652cc31940ba66f4a28616a859c"
-}
+{"sourcePlugin":"local-copier","hash":"e5f9d652cc31940ba66f4a28616a859c"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/deploy-the-eks-cluster.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/deploy-the-eks-cluster.md
@@ -124,8 +124,5 @@ terragrunt apply
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "583d7ce531dae4a139a6d2a9be293e1d"
-}
+{"sourcePlugin":"local-copier","hash":"583d7ce531dae4a139a6d2a9be293e1d"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/deploy-the-vpc.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/deploy-the-vpc.md
@@ -149,8 +149,5 @@ terragrunt apply
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "58b8f9e6fdf484fe77a7af365a0b1d52"
-}
+{"sourcePlugin":"local-copier","hash":"58b8f9e6fdf484fe77a7af365a0b1d52"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/pre-requisites.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/deployment-walkthrough/pre-requisites.md
@@ -58,8 +58,5 @@ for instructions.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "bb604626b168b80f098c1e9b7153e517"
-}
+{"sourcePlugin":"local-copier","hash":"bb604626b168b80f098c1e9b7153e517"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/index.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/index.md
@@ -50,8 +50,5 @@ This guide will walk you through the process of configuring a production-grade K
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "5403ac4c228d55992995c2be7039a52f"
-}
+{"sourcePlugin":"local-copier","hash":"5403ac4c228d55992995c2be7039a52f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/next-steps.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/next-steps.md
@@ -9,8 +9,5 @@ any data stores they depend on by using the following guides:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "643cf72893cefb9b09e6294e3290486f"
-}
+{"sourcePlugin":"local-copier","hash":"643cf72893cefb9b09e6294e3290486f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/authenticate.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/authenticate.md
@@ -71,8 +71,5 @@ this tool separately, so we are just recording this here for historical reasons.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "5d6b9747b406cb6ddc44edd9134b8364"
-}
+{"sourcePlugin":"local-copier","hash":"5d6b9747b406cb6ddc44edd9134b8364"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/control-plane.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/control-plane.md
@@ -54,8 +54,5 @@ CloudWatch.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "33906f19517c426da30c4b4055e951d5"
-}
+{"sourcePlugin":"local-copier","hash":"33906f19517c426da30c4b4055e951d5"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/iam-role-mapping-and-rbac.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/iam-role-mapping-and-rbac.md
@@ -45,8 +45,5 @@ assume those roles.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "ff384b3108de45dc98d77a4b652db03c"
-}
+{"sourcePlugin":"local-copier","hash":"ff384b3108de45dc98d77a4b652db03c"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/intro.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/intro.md
@@ -11,8 +11,5 @@ that looks something like this:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "c88f426a734a69c8fb4fe700b67ac612"
-}
+{"sourcePlugin":"local-copier","hash":"c88f426a734a69c8fb4fe700b67ac612"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/logging.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/logging.md
@@ -27,8 +27,5 @@ the logs from the worker nodes (including all the pods on them) to CloudWatch.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "345e40c904372f680deb43eb3be26cd4"
-}
+{"sourcePlugin":"local-copier","hash":"345e40c904372f680deb43eb3be26cd4"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/protecting-pods.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/protecting-pods.md
@@ -34,8 +34,5 @@ gives it permissions to talk solely to the other pods it should be able to acces
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "c3d9ad836a5f25fa94a9454107f65885"
-}
+{"sourcePlugin":"local-copier","hash":"c3d9ad836a5f25fa94a9454107f65885"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/use-eks.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/use-eks.md
@@ -8,8 +8,5 @@ solutions will most likely be eclipsed very quickly by future EKS releases.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "5c1d0eaffbf00b57e330e9a2dc9dc150"
-}
+{"sourcePlugin":"local-copier","hash":"5c1d0eaffbf00b57e330e9a2dc9dc150"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/vpc-configuration.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/vpc-configuration.md
@@ -30,8 +30,5 @@ sure that remote VPC DNS resolution is enabled on both accepter and requester si
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "13fa4dbe8f473c8e7d1a69075e8b8332"
-}
+{"sourcePlugin":"local-copier","hash":"13fa4dbe8f473c8e7d1a69075e8b8332"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/worker-nodes.md
+++ b/docs/guides/build-it-yourself/kubernetes-cluster/production-grade-design/worker-nodes.md
@@ -66,8 +66,5 @@ a secure base image (e.g., CIS hardened images), intrusion prevention (e.g., `fa
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "a43f6ca97de73dd352c53ef2b9c67447"
-}
+{"sourcePlugin":"local-copier","hash":"a43f6ca97de73dd352c53ef2b9c67447"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/aws-account.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/aws-account.md
@@ -12,8 +12,5 @@ to share it publicly on the Internet), and you will be logged into your new AWS 
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "a26a34b590ddc29e228b8a54169fe46f"
-}
+{"sourcePlugin":"local-copier","hash":"a26a34b590ddc29e228b8a54169fe46f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/aws-config.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/aws-config.md
@@ -19,8 +19,5 @@ but you can also author your own [custom rules](https://docs.aws.amazon.com/conf
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "c0738bbc3e7e12844bba76062de1f2d3"
-}
+{"sourcePlugin":"local-copier","hash":"c0738bbc3e7e12844bba76062de1f2d3"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/aws-organizations.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/aws-organizations.md
@@ -47,8 +47,5 @@ those regions or services do not meet your company’s compliance requirements (
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "82ac4c70419f79af31d32ad9d227017f"
-}
+{"sourcePlugin":"local-copier","hash":"82ac4c70419f79af31d32ad9d227017f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/cloud-trail.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/cloud-trail.md
@@ -14,8 +14,5 @@ incidents, and maintaining audit logs for compliance.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "a50f2d65b0b6df3c41b2ac3f06978253"
-}
+{"sourcePlugin":"local-copier","hash":"a50f2d65b0b6df3c41b2ac3f06978253"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/federated-authentication.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/federated-authentication.md
@@ -34,8 +34,5 @@ requires multiple steps, including manually copy/pasting credentials.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "ce9789097213ecbf3283dc36a00de4c0"
-}
+{"sourcePlugin":"local-copier","hash":"ce9789097213ecbf3283dc36a00de4c0"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/guard-duty.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/guard-duty.md
@@ -11,8 +11,5 @@ intelligence to identify and prioritize potential threats.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "9cb49659918b9b4e5dd2a2d286b0e06e"
-}
+{"sourcePlugin":"local-copier","hash":"9cb49659918b9b4e5dd2a2d286b0e06e"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/iam-groups.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/iam-groups.md
@@ -13,8 +13,5 @@ and assign each IAM user to the appropriate IAM groups.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "6ed6987baac0556cbd72538586818a92"
-}
+{"sourcePlugin":"local-copier","hash":"6ed6987baac0556cbd72538586818a92"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/iam-policies.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/iam-policies.md
@@ -70,8 +70,5 @@ S3 bucket.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "a4908e782e751d52c4e94bd29c054a42"
-}
+{"sourcePlugin":"local-copier","hash":"a4908e782e751d52c4e94bd29c054a42"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/iam-roles.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/iam-roles.md
@@ -125,8 +125,5 @@ services permissions to access specific resources in your AWS account.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "4665d08042eeca71ae65dd366edfc6b6"
-}
+{"sourcePlugin":"local-copier","hash":"4665d08042eeca71ae65dd366edfc6b6"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/iam-users.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/iam-users.md
@@ -70,8 +70,5 @@ user permissions, you will need to use IAM policies, which are the topic of the 
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "17f37d79f888c3473e9bb0d065d07342"
-}
+{"sourcePlugin":"local-copier","hash":"17f37d79f888c3473e9bb0d065d07342"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/root-user.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/root-user.md
@@ -60,8 +60,5 @@ more limited permissions, and then you’ll likely never touch the root user acc
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "0ea3d2d2cf61de3dc23190489c4ec9d5"
-}
+{"sourcePlugin":"local-copier","hash":"0ea3d2d2cf61de3dc23190489c4ec9d5"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/core-concepts/what-is-an-aws-account-structure.md
+++ b/docs/guides/build-it-yourself/landing-zone/core-concepts/what-is-an-aws-account-structure.md
@@ -35,8 +35,5 @@ breakdowns by account, service, tag, etc.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "362ad001515117c47bdd32c727dda5cb"
-}
+{"sourcePlugin":"local-copier","hash":"362ad001515117c47bdd32c727dda5cb"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/apply-the-security-baseline-to-the-logs-account.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/apply-the-security-baseline-to-the-logs-account.md
@@ -153,8 +153,5 @@ On some operating systems, such as MacOS, you may also need to increase your ope
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "5897f14941f18912553be9b56c315a44"
-}
+{"sourcePlugin":"local-copier","hash":"5897f14941f18912553be9b56c315a44"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/apply-the-security-baseline-to-the-other-child-accounts.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/apply-the-security-baseline-to-the-other-child-accounts.md
@@ -163,8 +163,5 @@ Remember to repeat this process in the other child accounts too (i.e., dev, prod
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "45173e5da3f7dee7be00b3a1817b2ba5"
-}
+{"sourcePlugin":"local-copier","hash":"45173e5da3f7dee7be00b3a1817b2ba5"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/apply-the-security-baseline-to-the-root-account.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/apply-the-security-baseline-to-the-root-account.md
@@ -81,8 +81,5 @@ echo "<PASSWORD>" | base64 --decode | keybase pgp decrypt
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "73e0abc5a85b7eed2ade8902177ee939"
-}
+{"sourcePlugin":"local-copier","hash":"73e0abc5a85b7eed2ade8902177ee939"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/apply-the-security-baseline-to-the-security-account.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/apply-the-security-baseline-to-the-security-account.md
@@ -203,8 +203,5 @@ echo "<PASSWORD>" | base64 --decode | keybase pgp decrypt
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "6bb19e643b3460a03224cc1c7959407b"
-}
+{"sourcePlugin":"local-copier","hash":"6bb19e643b3460a03224cc1c7959407b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/configure-the-security-baseline-for-the-root-account.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/configure-the-security-baseline-for-the-root-account.md
@@ -173,8 +173,5 @@ and any other existing resources.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "30683ab11accc62e34aedda01ae175a3"
-}
+{"sourcePlugin":"local-copier","hash":"30683ab11accc62e34aedda01ae175a3"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/create-an-iam-user-in-the-root-account.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/create-an-iam-user-in-the-root-account.md
@@ -18,8 +18,5 @@ IAM user manually by
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "a101684204db60a27bcace52b801c84b"
-}
+{"sourcePlugin":"local-copier","hash":"a101684204db60a27bcace52b801c84b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/create-the-root-account.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/create-the-root-account.md
@@ -14,8 +14,5 @@ the central place where you manage billing. You create this initial account manu
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "429cdfbcd62cd69e8a3eebd428aff6a6"
-}
+{"sourcePlugin":"local-copier","hash":"429cdfbcd62cd69e8a3eebd428aff6a6"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/import-existing-resources-from-the-root-account-into-terraform-state.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/import-existing-resources-from-the-root-account-into-terraform-state.md
@@ -145,8 +145,5 @@ rm -rf .terragrunt-cache
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "d9f7dfdde4944b7cc694380b1de97f3b"
-}
+{"sourcePlugin":"local-copier","hash":"d9f7dfdde4944b7cc694380b1de97f3b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/lock-down-the-root-account-iam-users.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/lock-down-the-root-account-iam-users.md
@@ -35,8 +35,5 @@ so using a virtual or hardware MFA device is preferable; that said, MFA with SMS
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "32a5dce3ef592eceb9dde972c55c3488"
-}
+{"sourcePlugin":"local-copier","hash":"32a5dce3ef592eceb9dde972c55c3488"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/lock-down-the-root-user-in-the-child-accounts.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/lock-down-the-root-user-in-the-child-accounts.md
@@ -6,8 +6,5 @@ those root users again.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "c85c9033ffe3883e37dd273344e69c93"
-}
+{"sourcePlugin":"local-copier","hash":"c85c9033ffe3883e37dd273344e69c93"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/lock-down-the-root-user.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/lock-down-the-root-user.md
@@ -45,8 +45,5 @@ your credentials) or for the
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "7a79f34d25438e5b383ac8ba0284b60f"
-}
+{"sourcePlugin":"local-copier","hash":"7a79f34d25438e5b383ac8ba0284b60f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/pre-requisites.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/pre-requisites.md
@@ -56,8 +56,5 @@ automatically.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "236b0439a1fea830fcd050c5a4b2bbbf"
-}
+{"sourcePlugin":"local-copier","hash":"236b0439a1fea830fcd050c5a4b2bbbf"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/prepare-your-infrastructure-live-repository.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/prepare-your-infrastructure-live-repository.md
@@ -176,8 +176,5 @@ locals {
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "35887123ab1bc3a011216db14a532073"
-}
+{"sourcePlugin":"local-copier","hash":"35887123ab1bc3a011216db14a532073"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/reset-the-root-user-password-in-each-child-account.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/reset-the-root-user-password-in-each-child-account.md
@@ -13,8 +13,5 @@ Use this process to reset the password for the root user of each child account y
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "15ed745884720a8772c22f6a45107605"
-}
+{"sourcePlugin":"local-copier","hash":"15ed745884720a8772c22f6a45107605"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/try-authenticating-as-an-iam-user-to-the-child-accounts.md
+++ b/docs/guides/build-it-yourself/landing-zone/deployment-walkthrough/try-authenticating-as-an-iam-user-to-the-child-accounts.md
@@ -25,8 +25,5 @@ authenticating:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "35cbebd2ff2edeb050efe3fdeb75a877"
-}
+{"sourcePlugin":"local-copier","hash":"35cbebd2ff2edeb050efe3fdeb75a877"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/index.md
+++ b/docs/guides/build-it-yourself/landing-zone/index.md
@@ -97,8 +97,5 @@ Feel free to read this guide from start to finish or skip around to whatever sec
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "752e6d34077e9e0dc32fc210b7f4e60c"
-}
+{"sourcePlugin":"local-copier","hash":"752e6d34077e9e0dc32fc210b7f4e60c"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/next-steps.md
+++ b/docs/guides/build-it-yourself/landing-zone/next-steps.md
@@ -6,8 +6,5 @@ accounts! Usually, the best starting point is to configure your network topology
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "5b9f8101edad02a62a1b7fb5f75275e6"
-}
+{"sourcePlugin":"local-copier","hash":"5b9f8101edad02a62a1b7fb5f75275e6"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/aws-config.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/aws-config.md
@@ -17,8 +17,5 @@ We typically recommend that you aggregate AWS Config data in the logs account. T
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "fe326f40c8b8ed46a200d6adef9a1f2b"
-}
+{"sourcePlugin":"local-copier","hash":"fe326f40c8b8ed46a200d6adef9a1f2b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/child-accounts.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/child-accounts.md
@@ -68,8 +68,5 @@ for large organizations to have dozens or even hundreds of AWS accounts.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "3e830de18a177052333745fb4918957c"
-}
+{"sourcePlugin":"local-copier","hash":"3e830de18a177052333745fb4918957c"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/cloud-trail.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/cloud-trail.md
@@ -18,8 +18,5 @@ happening in the account. We typically recommend that you aggregate these logs i
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "4ef96ebe041d1549530790269f1c7dff"
-}
+{"sourcePlugin":"local-copier","hash":"4ef96ebe041d1549530790269f1c7dff"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/federated-auth.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/federated-auth.md
@@ -52,8 +52,5 @@ so if you want to require MFA, you need to do that in the IdP itself (i.e., in G
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "faac25bb0d3743a5cbbacf88bd4a50de"
-}
+{"sourcePlugin":"local-copier","hash":"faac25bb0d3743a5cbbacf88bd4a50de"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/guard-duty.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/guard-duty.md
@@ -8,8 +8,5 @@ publishing GuardDuty’s findings to a dedicated Amazon SNS topic.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "f8a2464c61fa3e9f9f138b75d8cc477d"
-}
+{"sourcePlugin":"local-copier","hash":"f8a2464c61fa3e9f9f138b75d8cc477d"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/iam-roles-for-services.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/iam-roles-for-services.md
@@ -136,8 +136,5 @@ sensitive machine user access keys.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "6a6f172c3ecdc65911aeb1e7770e05e6"
-}
+{"sourcePlugin":"local-copier","hash":"6a6f172c3ecdc65911aeb1e7770e05e6"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/iam-roles-for-users.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/iam-roles-for-users.md
@@ -56,8 +56,5 @@ server and allows developers with access to these IAM roles to request VPN certi
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "f159d5c23afaa110863cab6ea08681f6"
-}
+{"sourcePlugin":"local-copier","hash":"f159d5c23afaa110863cab6ea08681f6"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/iam-users-and-groups.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/iam-users-and-groups.md
@@ -45,8 +45,5 @@ You must be a <span className="js-subscribe-cta">Gruntwork subscriber</span> to 
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "99eaa2fe1ef9ded6186b0122c1e886b1"
-}
+{"sourcePlugin":"local-copier","hash":"99eaa2fe1ef9ded6186b0122c1e886b1"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/intro.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/intro.md
@@ -13,8 +13,5 @@ we'll break it down piece by piece in the next few sections.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "cba12c0619ad568620c14ecef35e7318"
-}
+{"sourcePlugin":"local-copier","hash":"cba12c0619ad568620c14ecef35e7318"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/mfa-policy.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/mfa-policy.md
@@ -35,8 +35,5 @@ place.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "9b3c7722e10bbb324ab1ada41fea5587"
-}
+{"sourcePlugin":"local-copier","hash":"9b3c7722e10bbb324ab1ada41fea5587"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/password-policy.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/password-policy.md
@@ -7,8 +7,5 @@ certain compliance requirements may force you to use a specific password policy)
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "a73f3b1d9fcf38b8631f4cf2f9b054e6"
-}
+{"sourcePlugin":"local-copier","hash":"a73f3b1d9fcf38b8631f4cf2f9b054e6"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/landing-zone/production-grade-design/the-root-account.md
+++ b/docs/guides/build-it-yourself/landing-zone/production-grade-design/the-root-account.md
@@ -12,8 +12,5 @@ IAM group that gives the finance team access to the billing details.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "1121dc71681544ba526d79d51610b718"
-}
+{"sourcePlugin":"local-copier","hash":"1121dc71681544ba526d79d51610b718"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/core-concepts/ci-cd-platforms.md
+++ b/docs/guides/build-it-yourself/pipelines/core-concepts/ci-cd-platforms.md
@@ -131,8 +131,5 @@ provides, as well as how they mitigate the threat model that we cover:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "bd71d5ce0506580b993cb8087e03824a"
-}
+{"sourcePlugin":"local-copier","hash":"bd71d5ce0506580b993cb8087e03824a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/core-concepts/ci-cd-workflows.md
+++ b/docs/guides/build-it-yourself/pipelines/core-concepts/ci-cd-workflows.md
@@ -440,8 +440,5 @@ for this type of workflow.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "284f183e734e92f7edc7feef7d0fc603"
-}
+{"sourcePlugin":"local-copier","hash":"284f183e734e92f7edc7feef7d0fc603"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/core-concepts/threat-model-of-ci-cd.md
+++ b/docs/guides/build-it-yourself/pipelines/core-concepts/threat-model-of-ci-cd.md
@@ -48,8 +48,5 @@ With this threat model in mind, let’s take a look at the different CI/CD platf
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "0405627489307382892291a16e5ecc7b"
-}
+{"sourcePlugin":"local-copier","hash":"0405627489307382892291a16e5ecc7b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/core-concepts/trunk-based-development-model.md
+++ b/docs/guides/build-it-yourself/pipelines/core-concepts/trunk-based-development-model.md
@@ -56,8 +56,5 @@ infrastructure code.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "7e5794c67b0a6291110316f83cf3ec40"
-}
+{"sourcePlugin":"local-copier","hash":"7e5794c67b0a6291110316f83cf3ec40"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/core-concepts/types-of-infrastructure-code.md
+++ b/docs/guides/build-it-yourself/pipelines/core-concepts/types-of-infrastructure-code.md
@@ -36,8 +36,5 @@ infrastructure modules, and live infrastructure configuration.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "c2807b3ca886f83c5a5bbab1b46bbdf3"
-}
+{"sourcePlugin":"local-copier","hash":"c2807b3ca886f83c5a5bbab1b46bbdf3"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/core-concepts/what-is-continuous-integration-and-continuous-delivery.md
+++ b/docs/guides/build-it-yourself/pipelines/core-concepts/what-is-continuous-integration-and-continuous-delivery.md
@@ -14,8 +14,5 @@ of a production-ready CI/CD pipeline for infrastructure code.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "055f3cc7ce91e5b026c8544984db2953"
-}
+{"sourcePlugin":"local-copier","hash":"055f3cc7ce91e5b026c8544984db2953"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/core-concepts/why-is-it-important-to-have-ci-cd.md
+++ b/docs/guides/build-it-yourself/pipelines/core-concepts/why-is-it-important-to-have-ci-cd.md
@@ -38,8 +38,5 @@ ensuring that there is ample time for improvements and corrections.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "a6ab72f0c256b45899a32fc4d7da617f"
-}
+{"sourcePlugin":"local-copier","hash":"a6ab72f0c256b45899a32fc4d7da617f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/configure-ci-server.md
+++ b/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/configure-ci-server.md
@@ -39,8 +39,5 @@ events!
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "80db423fbd3342a56695e95ad0398426"
-}
+{"sourcePlugin":"local-copier","hash":"80db423fbd3342a56695e95ad0398426"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/define-pipeline-as-code.md
+++ b/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/define-pipeline-as-code.md
@@ -473,8 +473,5 @@ jobs:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "5e170f18736a77f9cef786d57bde6f1e"
-}
+{"sourcePlugin":"local-copier","hash":"5e170f18736a77f9cef786d57bde6f1e"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/deploy-a-vpc.md
+++ b/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/deploy-a-vpc.md
@@ -37,8 +37,5 @@ infrastructure-live
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "717d3f161c59cb4de6dce9c9af8d5f46"
-}
+{"sourcePlugin":"local-copier","hash":"717d3f161c59cb4de6dce9c9af8d5f46"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/deploy-the-ecs-deploy-runner.md
+++ b/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/deploy-the-ecs-deploy-runner.md
@@ -751,8 +751,5 @@ Repeat for each environment that you want to support the ECS Deploy Runner stack
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "8029084fb854ab63c9abd3a29140edc0"
-}
+{"sourcePlugin":"local-copier","hash":"8029084fb854ab63c9abd3a29140edc0"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/pre-requisites.md
+++ b/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/pre-requisites.md
@@ -67,8 +67,5 @@ on alternative options, such as how to
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "791cc3285e6008466de5d18f80dec125"
-}
+{"sourcePlugin":"local-copier","hash":"791cc3285e6008466de5d18f80dec125"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/try-out-the-ecs-deploy-runner.md
+++ b/docs/guides/build-it-yourself/pipelines/deployment-walkthrough/try-out-the-ecs-deploy-runner.md
@@ -50,8 +50,5 @@ Running this command will provide output similar to below:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "dd6544d11642b0f43fdddbeea03cb5ba"
-}
+{"sourcePlugin":"local-copier","hash":"dd6544d11642b0f43fdddbeea03cb5ba"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/index.md
+++ b/docs/guides/build-it-yourself/pipelines/index.md
@@ -7,24 +7,23 @@ import { CardList } from "/src/components/CardGroup"
 
 # Set Up an Infrastructure CI/CD Pipeline
 
-:::caution
+:::info
 
-This guide hasn’t been updated in the past 6 months. If you find any inaccuracies, please share with us at feedback@gruntwork.io.
+This document is an excellent resource for understanding the problem space of CI/CD and the design choices that Gruntwork Pipelines makes.  
+
+If you are looking to get hands-on with Gruntwork Pipelines and deploy it yourself, see [the official examples in our service catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/master/examples/for-production/gruntwork-pipelines)
 
 :::
 
 ## Overview
 
-This is a comprehensive guide of how to design, configure, and implement a Continuous Integration and Continuous
-Delivery pipeline for your infrastructure code. This guide will walk you through the steps to set up a secure CI/CD
-pipeline for your favorite infrastructure as code tools (e.g., Terraform) using your favorite CI/CD platform (e.g.,
-Jenkins, Circle, GitLab, etc).
-
-TLDR: If you follow this guide, you’ll be able to set up a pipeline that works like this:
-
-![For an extended version with audio commentary, see <https://youtu.be/iYXghJK7YdU>](/img/guides/build-it-yourself/pipelines/walkthrough.gif)
+This is a comprehensive guide explaining the problem space of CI/CD, its threat vectors, and the design decisions that Gruntwork Pipelines 
+makes in order to keep your sensitive credentials secure. 
 
 ## What this guide will not cover
+
+This guide is not hands-on! If you're looking to explore and play around with Gruntwork Pipelines, you should instead view and deploy [our official 
+examples in our service catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/master/examples/for-production/gruntwork-pipelines).
 
 CI/CD for infrastructure code is a large topic and a single guide cannot cover everything. There
 are several items that this guide will not cover, including:
@@ -90,8 +89,5 @@ Feel free to read this guide from start to finish or skip around to whatever sec
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "3130cb825c605b438694546804a4f87c"
-}
+{"sourcePlugin":"local-copier","hash":"0d4a701ecaf6b15a54896e84ee9673cf"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/next-steps.md
+++ b/docs/guides/build-it-yourself/pipelines/next-steps.md
@@ -9,8 +9,5 @@ Now that you have a CI/CD pipeline for your infrastructure code, test it out by 
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "e60b6909a25e315724ca19125d51f4d4"
-}
+{"sourcePlugin":"local-copier","hash":"e60b6909a25e315724ca19125d51f4d4"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/intro.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/intro.md
@@ -12,8 +12,5 @@ infrastructure code, using a platform that looks something like this:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "85dfc1646a1dc0b0f306a424397fcb8f"
-}
+{"sourcePlugin":"local-copier","hash":"85dfc1646a1dc0b0f306a424397fcb8f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/limit-triggers-for-deploy-server.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/limit-triggers-for-deploy-server.md
@@ -19,8 +19,5 @@ You can find similar mechanisms for limiting deployments in the various deploy s
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "e9c3158c4440a350fd13f6bcee185874"
-}
+{"sourcePlugin":"local-copier","hash":"e9c3158c4440a350fd13f6bcee185874"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/lock-down-vcs-systems.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/lock-down-vcs-systems.md
@@ -38,8 +38,5 @@ internal environment variables or show infrastructure secrets using external dat
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "cd626b695d8951028daebd4a888f0a6b"
-}
+{"sourcePlugin":"local-copier","hash":"cd626b695d8951028daebd4a888f0a6b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/options-for-deploy-server.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/options-for-deploy-server.md
@@ -38,8 +38,5 @@ cover it, the design is compatible with using Terraform Enterprise as the deploy
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "b9eefadd3f55d13a074ac0ef37224cbf"
-}
+{"sourcePlugin":"local-copier","hash":"b9eefadd3f55d13a074ac0ef37224cbf"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/summary-of-deployment-sequence.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/summary-of-deployment-sequence.md
@@ -6,8 +6,5 @@ To put it all together, the following sequence diagram shows how all the various
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "83e40872165416269a4b09b4a858fd52"
-}
+{"sourcePlugin":"local-copier","hash":"83e40872165416269a4b09b4a858fd52"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/summary-of-mitigations.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/summary-of-mitigations.md
@@ -94,8 +94,5 @@ with the `sensitive` keyword so that terraform will mask the outputs.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "a11ceab4a04a9730d22dad8113b22d42"
-}
+{"sourcePlugin":"local-copier","hash":"a11ceab4a04a9730d22dad8113b22d42"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/use-a-vpc-to-lock-down-deploy-server.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/use-a-vpc-to-lock-down-deploy-server.md
@@ -7,8 +7,5 @@ outbound access except for the minimum required (e.g, allow access to AWS APIs).
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "31fee0a9bffad6966be2e1ab2870904e"
-}
+{"sourcePlugin":"local-copier","hash":"31fee0a9bffad6966be2e1ab2870904e"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/use-approval-flows.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/use-approval-flows.md
@@ -12,8 +12,5 @@ can approve the workflow.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "cb8b5eba89e7858826984e3f326a831c"
-}
+{"sourcePlugin":"local-copier","hash":"cb8b5eba89e7858826984e3f326a831c"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/use-generic-ci-cd-platforms-as-a-workflow-engine-but-run-infrastructure-deployments-from-within-your-account.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/use-generic-ci-cd-platforms-as-a-workflow-engine-but-run-infrastructure-deployments-from-within-your-account.md
@@ -28,8 +28,5 @@ builds on existing code, but they don’t get arbitrary admin access.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "9688f7f6bd80fec2188af6893093859e"
-}
+{"sourcePlugin":"local-copier","hash":"9688f7f6bd80fec2188af6893093859e"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/pipelines/production-grade-design/use-minimal-iam-permissions-for-a-deployment.md
+++ b/docs/guides/build-it-yourself/pipelines/production-grade-design/use-minimal-iam-permissions-for-a-deployment.md
@@ -9,8 +9,5 @@ which has more access to the environments.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "a4cd5ed3be343c5f6bce08340047756b"
-}
+{"sourcePlugin":"local-copier","hash":"a4cd5ed3be343c5f6bce08340047756b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/cidr-notation.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/cidr-notation.md
@@ -42,8 +42,5 @@ CIDR notation for just one IP, `4.4.4.4`.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "7b2b8b88ad17636beedfea22b23770f8"
-}
+{"sourcePlugin":"local-copier","hash":"7b2b8b88ad17636beedfea22b23770f8"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/default-vp-cs-and-custom-vp-cs.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/default-vp-cs-and-custom-vp-cs.md
@@ -54,8 +54,5 @@ over how to configure a VPC with the kind of security, scalability, and high ava
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "6590a3524e17c9eb1805818e98c04514"
-}
+{"sourcePlugin":"local-copier","hash":"6590a3524e17c9eb1805818e98c04514"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/internet-gateways-public-subnets-and-private-subnets.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/internet-gateways-public-subnets-and-private-subnets.md
@@ -11,8 +11,5 @@ the VPC.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "d47dde0089191a4a4707e0f5c050d2dd"
-}
+{"sourcePlugin":"local-copier","hash":"d47dde0089191a4a4707e0f5c050d2dd"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/nat-gateways.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/nat-gateways.md
@@ -37,8 +37,5 @@ the traffic for all other IPs, `0.0.0.0/0`, to a NAT Gateway with ID `nat-67890`
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "15d7ee1da61bdf479f662a44cee6c79a"
-}
+{"sourcePlugin":"local-copier","hash":"15d7ee1da61bdf479f662a44cee6c79a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/network-ac-ls.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/network-ac-ls.md
@@ -37,8 +37,5 @@ locking down source/destination IP addresses.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "7d0ca667894b24e72340105224933c82"
-}
+{"sourcePlugin":"local-copier","hash":"7d0ca667894b24e72340105224933c82"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/regions-and-availability-zones.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/regions-and-availability-zones.md
@@ -22,8 +22,5 @@ as starting points.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "b9de64a86c71d7442fc242dad729d910"
-}
+{"sourcePlugin":"local-copier","hash":"b9de64a86c71d7442fc242dad729d910"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/route-tables.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/route-tables.md
@@ -34,8 +34,5 @@ will be automatically routed within the subnet by AWS. This table then adds a fa
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "d8ec27c10689e15775980056dfec5918"
-}
+{"sourcePlugin":"local-copier","hash":"d8ec27c10689e15775980056dfec5918"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/security-groups.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/security-groups.md
@@ -76,8 +76,5 @@ custom security group with rules that exactly match your use case, rather than r
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "596687737b7eef31327fd9ca1202ac12"
-}
+{"sourcePlugin":"local-copier","hash":"596687737b7eef31327fd9ca1202ac12"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/subnets.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/subnets.md
@@ -11,8 +11,5 @@ ranges.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "9d8faa2989a62412f9b7b87826e4abea"
-}
+{"sourcePlugin":"local-copier","hash":"9d8faa2989a62412f9b7b87826e4abea"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/vpc-endpoints.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/vpc-endpoints.md
@@ -33,8 +33,5 @@ a paid service, and includes support for CloudTrail, Secrets Manager, EC2, SNS, 
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "6ce6ec81a6a21c99701e06df1b1aa301"
-}
+{"sourcePlugin":"local-copier","hash":"6ce6ec81a6a21c99701e06df1b1aa301"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/vpc-ip-addresses.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/vpc-ip-addresses.md
@@ -31,8 +31,5 @@ while another instance might get the private IP address `172.31.5.3` and the pub
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "9bbf0955ec269211f268d40559149a83"
-}
+{"sourcePlugin":"local-copier","hash":"9bbf0955ec269211f268d40559149a83"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/vpc-peering.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/vpc-peering.md
@@ -26,8 +26,5 @@ connections total) can quickly become impractical. In this case, you should look
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "29e8ed8c5281f7822258c6df63ce1abf"
-}
+{"sourcePlugin":"local-copier","hash":"29e8ed8c5281f7822258c6df63ce1abf"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/core-concepts/what-is-a-vpc.md
+++ b/docs/guides/build-it-yourself/vpc/core-concepts/what-is-a-vpc.md
@@ -31,8 +31,5 @@ your office and all the resources in your AWS account can access the same IPs an
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "6c8bc96902491a81cc29d838b18a4226"
-}
+{"sourcePlugin":"local-copier","hash":"6c8bc96902491a81cc29d838b18a4226"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/deployment-walkthrough/clean-up-default-vp-cs-and-security-groups.md
+++ b/docs/guides/build-it-yourself/vpc/deployment-walkthrough/clean-up-default-vp-cs-and-security-groups.md
@@ -9,8 +9,5 @@ cloud-nuke defaults-aws
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "f24a4c59eb7b0e53a6b225dd9c83ac9c"
-}
+{"sourcePlugin":"local-copier","hash":"f24a4c59eb7b0e53a6b225dd9c83ac9c"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-a-bastion-host.md
+++ b/docs/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-a-bastion-host.md
@@ -4,8 +4,5 @@ Please check out our [Bastion Host](https://github.com/gruntwork-io/terraform-aw
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "f7a9be2aa12f7a05ca7c8cf17a38192e"
-}
+{"sourcePlugin":"local-copier","hash":"f7a9be2aa12f7a05ca7c8cf17a38192e"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-a-management-vpc.md
+++ b/docs/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-a-management-vpc.md
@@ -214,8 +214,5 @@ terragrunt apply
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "8a19045805626f1cc39de968f2bb0727"
-}
+{"sourcePlugin":"local-copier","hash":"8a19045805626f1cc39de968f2bb0727"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-application-vp-cs.md
+++ b/docs/guides/build-it-yourself/vpc/deployment-walkthrough/deploy-application-vp-cs.md
@@ -245,8 +245,5 @@ terragrunt apply
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "a324250d5ea77e813734245029fd8ea3"
-}
+{"sourcePlugin":"local-copier","hash":"a324250d5ea77e813734245029fd8ea3"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/deployment-walkthrough/pre-requisites.md
+++ b/docs/guides/build-it-yourself/vpc/deployment-walkthrough/pre-requisites.md
@@ -43,8 +43,5 @@ for instructions.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "897a81f742761a069a69b560cd27a435"
-}
+{"sourcePlugin":"local-copier","hash":"897a81f742761a069a69b560cd27a435"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/index.md
+++ b/docs/guides/build-it-yourself/vpc/index.md
@@ -47,8 +47,5 @@ Feel free to read this guide from start to finish or skip around to whatever sec
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "b18c2f59aca7f95a28b40f641a9824bc"
-}
+{"sourcePlugin":"local-copier","hash":"b18c2f59aca7f95a28b40f641a9824bc"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/next-steps.md
+++ b/docs/guides/build-it-yourself/vpc/next-steps.md
@@ -13,8 +13,5 @@ If you’re not sure which of these options to use, check out the `Server Cluste
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "77586324e67a96b2d83aa7d115ab4a1a"
-}
+{"sourcePlugin":"local-copier","hash":"77586324e67a96b2d83aa7d115ab4a1a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/production-grade-design/bastion-host.md
+++ b/docs/guides/build-it-yourself/vpc/production-grade-design/bastion-host.md
@@ -20,8 +20,5 @@ allow you to manage and connect to EC2 Instances via a custom protocol managed b
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "ced5f0444b037cc4e6f71ffacb6f4fdb"
-}
+{"sourcePlugin":"local-copier","hash":"ced5f0444b037cc4e6f71ffacb6f4fdb"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/production-grade-design/defense-in-depth.md
+++ b/docs/guides/build-it-yourself/vpc/production-grade-design/defense-in-depth.md
@@ -15,8 +15,5 @@ described in the next few sections.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "241d7669f0872b5219798ddc187be0b9"
-}
+{"sourcePlugin":"local-copier","hash":"241d7669f0872b5219798ddc187be0b9"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/production-grade-design/internet-gateways-and-nat-gateways.md
+++ b/docs/guides/build-it-yourself/vpc/production-grade-design/internet-gateways-and-nat-gateways.md
@@ -27,8 +27,5 @@ availability zone as the subnet itself).
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "22caf29ab8296f42141d487cc067867e"
-}
+{"sourcePlugin":"local-copier","hash":"22caf29ab8296f42141d487cc067867e"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/production-grade-design/intro.md
+++ b/docs/guides/build-it-yourself/vpc/production-grade-design/intro.md
@@ -11,8 +11,5 @@ something like this:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "3f015395ed57051b605f4d66bd4e29e6"
-}
+{"sourcePlugin":"local-copier","hash":"3f015395ed57051b605f4d66bd4e29e6"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/production-grade-design/multiple-aws-accounts.md
+++ b/docs/guides/build-it-yourself/vpc/production-grade-design/multiple-aws-accounts.md
@@ -16,8 +16,5 @@ guide for instructions.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "c17c05c07c1d9b5d5a89d0d4b54bee60"
-}
+{"sourcePlugin":"local-copier","hash":"c17c05c07c1d9b5d5a89d0d4b54bee60"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/production-grade-design/multiple-subnet-tiers.md
+++ b/docs/guides/build-it-yourself/vpc/production-grade-design/multiple-subnet-tiers.md
@@ -37,8 +37,5 @@ discussed in the next section.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "82d0988a700d0886134f55402940d47a"
-}
+{"sourcePlugin":"local-copier","hash":"82d0988a700d0886134f55402940d47a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/production-grade-design/multiple-vp-cs.md
+++ b/docs/guides/build-it-yourself/vpc/production-grade-design/multiple-vp-cs.md
@@ -54,8 +54,5 @@ your corporate intranet via site-to-site VPN connections.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "784b8265b51b59059718a34b68ea4339"
-}
+{"sourcePlugin":"local-copier","hash":"784b8265b51b59059718a34b68ea4339"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/vpc/production-grade-design/security-groups-and-nac-ls.md
+++ b/docs/guides/build-it-yourself/vpc/production-grade-design/security-groups-and-nac-ls.md
@@ -33,8 +33,5 @@ environment.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "6c6ba79465b3a5149489da3d2c535cf1"
-}
+{"sourcePlugin":"local-copier","hash":"6c6ba79465b3a5149489da3d2c535cf1"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -22,8 +22,5 @@ We present a comprehensive model to help you establish a robust infrastructure p
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "e4a74979df7a616ab9e0822a3da5e42f"
-}
+{"sourcePlugin":"local-copier","hash":"e4a74979df7a616ab9e0822a3da5e42f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/gruntwork-solutions/index.md
+++ b/docs/guides/production-framework/gruntwork-solutions/index.md
@@ -42,8 +42,5 @@ questions, please [contact sales](https://gruntwork.io/contact/).
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "680b0acbfc7763840216253afa6e2a17"
-}
+{"sourcePlugin":"local-copier","hash":"680b0acbfc7763840216253afa6e2a17"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/index.md
+++ b/docs/guides/production-framework/index.md
@@ -187,8 +187,5 @@ Gruntwork to help you implement this framework.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "807e76130e6f37725f946587a4c8ff0e"
-}
+{"sourcePlugin":"local-copier","hash":"807e76130e6f37725f946587a4c8ff0e"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/automatic-updates/auto-update-features.md
+++ b/docs/guides/production-framework/ingredients/automatic-updates/auto-update-features.md
@@ -19,8 +19,5 @@ Your auto update solution should automatically check that none of your dependenc
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "9e7dfaaa99b9a027ed3e3f05ffad33e0"
-}
+{"sourcePlugin":"local-copier","hash":"9e7dfaaa99b9a027ed3e3f05ffad33e0"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/automatic-updates/how-auto-update-should-work.md
+++ b/docs/guides/production-framework/ingredients/automatic-updates/how-auto-update-should-work.md
@@ -19,8 +19,5 @@ Once the update is merged, the CI / CD pipeline again kicks in, and automaticall
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "1d9283d627bcec9be8c17049eab3ad3a"
-}
+{"sourcePlugin":"local-copier","hash":"1d9283d627bcec9be8c17049eab3ad3a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/automatic-updates/index.md
+++ b/docs/guides/production-framework/ingredients/automatic-updates/index.md
@@ -13,8 +13,5 @@ everything up-to-date, so that all your hard work doesn't turn into tech debt.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "b1f78cbc1cf2063fa44c3a3b09932c0a"
-}
+{"sourcePlugin":"local-copier","hash":"b1f78cbc1cf2063fa44c3a3b09932c0a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/ci-cd-pipeline/ci-cd-features.md
+++ b/docs/guides/production-framework/ingredients/ci-cd-pipeline/ci-cd-features.md
@@ -39,8 +39,5 @@ AWS](https://docs.gruntwork.io/docs/guides/build-it-yourself/landing-zone/).
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "52893974c9e95ad383ac61f7e2d718e5"
-}
+{"sourcePlugin":"local-copier","hash":"52893974c9e95ad383ac61f7e2d718e5"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/ci-cd-pipeline/ci-cd-only-path-to-prod.md
+++ b/docs/guides/production-framework/ingredients/ci-cd-pipeline/ci-cd-only-path-to-prod.md
@@ -16,8 +16,5 @@ It's a bad idea to have give your CI server (e.g., Jenkins)—which your entire 
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "184306807d3afdf76391109109b4fe83"
-}
+{"sourcePlugin":"local-copier","hash":"184306807d3afdf76391109109b4fe83"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/ci-cd-pipeline/index.md
+++ b/docs/guides/production-framework/ingredients/ci-cd-pipeline/index.md
@@ -8,8 +8,5 @@ pipeline) to automate their build, test, and deployment processes.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "ba6270b591efb22fbe6b9b5adb930269"
-}
+{"sourcePlugin":"local-copier","hash":"ba6270b591efb22fbe6b9b5adb930269"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/index.md
+++ b/docs/guides/production-framework/ingredients/index.md
@@ -8,8 +8,5 @@ cloud effectively.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "dd43f8507970ba12e96d6951c5c123d3"
-}
+{"sourcePlugin":"local-copier","hash":"dd43f8507970ba12e96d6951c5c123d3"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/landing-zone/account-vending-machine.md
+++ b/docs/guides/production-framework/ingredients/landing-zone/account-vending-machine.md
@@ -22,8 +22,5 @@ As part of the account provisioning process, the Account Vending Machine should 
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "bb70e6c37087cc1b297644eb6bccdf6e"
-}
+{"sourcePlugin":"local-copier","hash":"bb70e6c37087cc1b297644eb6bccdf6e"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/landing-zone/index.md
+++ b/docs/guides/production-framework/ingredients/landing-zone/index.md
@@ -13,8 +13,5 @@ harder than setting up the proper controls in the first place.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "638abda85660525852f391f9d2e1a759"
-}
+{"sourcePlugin":"local-copier","hash":"638abda85660525852f391f9d2e1a759"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/landing-zone/what-landing-zone-should-include.md
+++ b/docs/guides/production-framework/ingredients/landing-zone/what-landing-zone-should-include.md
@@ -26,8 +26,5 @@ Zone](https://docs.gruntwork.io/docs/guides/build-it-yourself/landing-zone/).
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "48f58cc321f48e30db0584fad30d84ed"
-}
+{"sourcePlugin":"local-copier","hash":"48f58cc321f48e30db0584fad30d84ed"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/other-ingredients/index.md
+++ b/docs/guides/production-framework/ingredients/other-ingredients/index.md
@@ -22,8 +22,5 @@ Performance optimization, cost optimization, and capacity optimization ("rightsi
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "cd9b72d0289fcb3677281df788691d87"
-}
+{"sourcePlugin":"local-copier","hash":"cd9b72d0289fcb3677281df788691d87"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/self-service/common-self-service-use-cases.md
+++ b/docs/guides/production-framework/ingredients/self-service/common-self-service-use-cases.md
@@ -17,8 +17,5 @@ Deploy a new app: that is, a web service written in a general purpose programmin
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "9c13d0c788f2295456c702e6c7da82be"
-}
+{"sourcePlugin":"local-copier","hash":"9c13d0c788f2295456c702e6c7da82be"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/self-service/how-self-service-should-work.md
+++ b/docs/guides/production-framework/ingredients/self-service/how-self-service-should-work.md
@@ -19,8 +19,5 @@ Many Ops teams get nervous with the idea of self-service: what if the developers
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "77f527c693abd32b67e88ea9a77fe6f4"
-}
+{"sourcePlugin":"local-copier","hash":"77f527c693abd32b67e88ea9a77fe6f4"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/self-service/index.md
+++ b/docs/guides/production-framework/ingredients/self-service/index.md
@@ -10,8 +10,5 @@ infrastructure those apps depend on.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "0d1779ee5564dd35f8deaa3ae48d81ec"
-}
+{"sourcePlugin":"local-copier","hash":"0d1779ee5564dd35f8deaa3ae48d81ec"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/service-catalog/application-templates.md
+++ b/docs/guides/production-framework/ingredients/service-catalog/application-templates.md
@@ -72,8 +72,5 @@ You'll want to make it as simple as possible for new apps to be integrated into 
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "8fe39d263edd56aa3da7b053063169eb"
-}
+{"sourcePlugin":"local-copier","hash":"8fe39d263edd56aa3da7b053063169eb"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/service-catalog/index.md
+++ b/docs/guides/production-framework/ingredients/service-catalog/index.md
@@ -23,8 +23,5 @@ mean by "Service Catalog" in this guide, and what a modern Service Catalog looks
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "9724455defe23434547b2c1433c89445"
-}
+{"sourcePlugin":"local-copier","hash":"9724455defe23434547b2c1433c89445"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/service-catalog/infrastructure-templates.md
+++ b/docs/guides/production-framework/ingredients/service-catalog/infrastructure-templates.md
@@ -82,8 +82,5 @@ We'll discuss CI / CD more in a dedicated section later on.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "8453ef57b74100d6a6b9f64658b14dc3"
-}
+{"sourcePlugin":"local-copier","hash":"8453ef57b74100d6a6b9f64658b14dc3"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/ingredients/service-catalog/modern-service-catalog.md
+++ b/docs/guides/production-framework/ingredients/service-catalog/modern-service-catalog.md
@@ -48,8 +48,5 @@ For a concrete example of a Service Catalog for AWS, see the [Gruntwork Service 
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "d2c8c16c221d43b0989eeec08a273e3a"
-}
+{"sourcePlugin":"local-copier","hash":"d2c8c16c221d43b0989eeec08a273e3a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/recipes/dev-team-experience.md
+++ b/docs/guides/production-framework/recipes/dev-team-experience.md
@@ -94,8 +94,5 @@ Let's imagine that you've started a team with two developers, Ann and Bob. The t
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "6f688e879fc6b7981c52a0c651d4781a"
-}
+{"sourcePlugin":"local-copier","hash":"6f688e879fc6b7981c52a0c651d4781a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/recipes/index.md
+++ b/docs/guides/production-framework/recipes/index.md
@@ -10,8 +10,5 @@ how all these pieces can work together.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "cc18e09055167ce9e85d6ce57d2a82b7"
-}
+{"sourcePlugin":"local-copier","hash":"cc18e09055167ce9e85d6ce57d2a82b7"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/production-framework/recipes/ops-team-experience.md
+++ b/docs/guides/production-framework/recipes/ops-team-experience.md
@@ -29,8 +29,5 @@ On the Ops side, Carol and Daniel are responsible for maintaining your Service C
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "33c46b2d11c76043adf77f0a05c3c622"
-}
+{"sourcePlugin":"local-copier","hash":"33c46b2d11c76043adf77f0a05c3c622"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/configuration-guide/index.md
+++ b/docs/guides/reference-architecture/configuration-guide/index.md
@@ -257,8 +257,5 @@ In the ref arch form, `VCSPATSecretsManagerARN` is where you enter this ARN.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "3cfd9930ece7baaa5154d8565fcb6ae4"
-}
+{"sourcePlugin":"local-copier","hash":"3cfd9930ece7baaa5154d8565fcb6ae4"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/02-authenticate/01-intro.md
+++ b/docs/guides/reference-architecture/example-usage-guide/02-authenticate/01-intro.md
@@ -29,8 +29,5 @@ and connecting to all the resources in your AWS accounts:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "f851b2325036a5c724b6ad10ce9bba81"
-}
+{"sourcePlugin":"local-copier","hash":"f851b2325036a5c724b6ad10ce9bba81"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/02-authenticate/02-setting-up-initial-access.md
+++ b/docs/guides/reference-architecture/example-usage-guide/02-authenticate/02-setting-up-initial-access.md
@@ -139,8 +139,5 @@ To deploy this new code and create the new IAM users, you will need to:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "471a3233265134ad05fc2dc635a9e664"
-}
+{"sourcePlugin":"local-copier","hash":"471a3233265134ad05fc2dc635a9e664"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/02-authenticate/03-authenticate-to-the-aws-web-console.md
+++ b/docs/guides/reference-architecture/example-usage-guide/02-authenticate/03-authenticate-to-the-aws-web-console.md
@@ -32,8 +32,5 @@ To authenticate to any other account (e.g., dev, stage, prod), you need to:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "979ec28e782e43d075a0a2ffc0e492c6"
-}
+{"sourcePlugin":"local-copier","hash":"979ec28e782e43d075a0a2ffc0e492c6"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/02-authenticate/04-authenticate-to-aws-via-the-cli.md
+++ b/docs/guides/reference-architecture/example-usage-guide/02-authenticate/04-authenticate-to-aws-via-the-cli.md
@@ -100,8 +100,5 @@ Be sure to read [`USAGE.md`](https://github.com/99designs/aws-vault/blob/master/
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "18111d9a15431ff8db544e24d26c278d"
-}
+{"sourcePlugin":"local-copier","hash":"18111d9a15431ff8db544e24d26c278d"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/02-authenticate/05-authenticate-to-ec2-instances-via-ssh.md
+++ b/docs/guides/reference-architecture/example-usage-guide/02-authenticate/05-authenticate-to-ec2-instances-via-ssh.md
@@ -74,8 +74,5 @@ Key Pairs.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "7c0ac42ce4c59251e14f2f2515cde419"
-}
+{"sourcePlugin":"local-copier","hash":"7c0ac42ce4c59251e14f2f2515cde419"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/02-authenticate/06-authenticate-to-the-vpn-server.md
+++ b/docs/guides/reference-architecture/example-usage-guide/02-authenticate/06-authenticate-to-the-vpn-server.md
@@ -62,8 +62,5 @@ network (e.g., SSH to EC2 instances in private subnets) as if you were "in" the 
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "9701399b662535fea1aae6071601c987"
-}
+{"sourcePlugin":"local-copier","hash":"9701399b662535fea1aae6071601c987"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/01-intro.md
+++ b/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/01-intro.md
@@ -16,8 +16,5 @@ Architecture.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "aa44de3dbcbfce8dd6c85a400d5b48c4"
-}
+{"sourcePlugin":"local-copier","hash":"aa44de3dbcbfce8dd6c85a400d5b48c4"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/02-what-is-already-deployed.md
+++ b/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/02-what-is-already-deployed.md
@@ -15,8 +15,5 @@ practices from [aws-sample-app](https://github.com/gruntwork-io/aws-sample-app/)
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "825877259e74045470098650457e418f"
-}
+{"sourcePlugin":"local-copier","hash":"825877259e74045470098650457e418f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/03-the-app.md
+++ b/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/03-the-app.md
@@ -40,8 +40,5 @@ Since we need to pull in the dependencies to run this app, we will also need a c
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "6e307243ed73a07a528949ca977e651b"
-}
+{"sourcePlugin":"local-copier","hash":"6e307243ed73a07a528949ca977e651b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/04-dockerizing.md
+++ b/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/04-dockerizing.md
@@ -65,8 +65,5 @@ Some things to note when writing up your `Dockerfile` and building your app:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "2d6fc8ba4c4927f850bd052ab8189738"
-}
+{"sourcePlugin":"local-copier","hash":"2d6fc8ba4c4927f850bd052ab8189738"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/05-publish-docker-image.md
+++ b/docs/guides/reference-architecture/example-usage-guide/03-deploy-apps/05-publish-docker-image.md
@@ -62,8 +62,5 @@ docker push 234567890123.dkr.ecr.us-west-2.amazonaws.com/simple-web-app:v1
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "4847ef3d9ebb1415b0f6a8ce36bfdb28"
-}
+{"sourcePlugin":"local-copier","hash":"4847ef3d9ebb1415b0f6a8ce36bfdb28"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/04-configure-gw-pipelines/01-intro.md
+++ b/docs/guides/reference-architecture/example-usage-guide/04-configure-gw-pipelines/01-intro.md
@@ -23,8 +23,5 @@ code](https://gruntwork.io/guides/automations/how-to-configure-a-production-grad
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "ebe11d1c8039bdcaf654a54e2a779a21"
-}
+{"sourcePlugin":"local-copier","hash":"ebe11d1c8039bdcaf654a54e2a779a21"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/04-configure-gw-pipelines/02-ci--cd-pipeline-for-infrastructure-code.md
+++ b/docs/guides/reference-architecture/example-usage-guide/04-configure-gw-pipelines/02-ci--cd-pipeline-for-infrastructure-code.md
@@ -99,8 +99,5 @@ For instructions on how to destroy infrastructure, see the [Undeploy guide](../0
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "b214054a49f7368da435d1d80d42ab81"
-}
+{"sourcePlugin":"local-copier","hash":"b214054a49f7368da435d1d80d42ab81"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/04-configure-gw-pipelines/03-ci--cd-pipeline-for-app-code.md
+++ b/docs/guides/reference-architecture/example-usage-guide/04-configure-gw-pipelines/03-ci--cd-pipeline-for-app-code.md
@@ -64,8 +64,5 @@ Once the branch is merged, updates to the `main` branch will trigger a build job
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "1c2c536bc8e48c128e3d338349e0f46a"
-}
+{"sourcePlugin":"local-copier","hash":"1c2c536bc8e48c128e3d338349e0f46a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/04-configure-gw-pipelines/04-update-the-ci--cd-pipeline-itself.md
+++ b/docs/guides/reference-architecture/example-usage-guide/04-configure-gw-pipelines/04-update-the-ci--cd-pipeline-itself.md
@@ -70,8 +70,5 @@ pull request as your changes to the `ecs-deploy-runner` module configuration.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "6457637d554e50c34b0c4e2e1785d09b"
-}
+{"sourcePlugin":"local-copier","hash":"6457637d554e50c34b0c4e2e1785d09b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/05-monitoring-alerting-logging/01-intro.md
+++ b/docs/guides/reference-architecture/example-usage-guide/05-monitoring-alerting-logging/01-intro.md
@@ -14,8 +14,5 @@ and deploy your code, you'll want to see what's happening in your AWS account:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "4bf00ab56efc3404d9b7686ebc2efe7f"
-}
+{"sourcePlugin":"local-copier","hash":"4bf00ab56efc3404d9b7686ebc2efe7f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/05-monitoring-alerting-logging/02-metrics.md
+++ b/docs/guides/reference-architecture/example-usage-guide/05-monitoring-alerting-logging/02-metrics.md
@@ -15,8 +15,5 @@ with the most useful metrics for your services and have that open on a big scree
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "5f2fa1a102144ef3da979c801ded2487"
-}
+{"sourcePlugin":"local-copier","hash":"5f2fa1a102144ef3da979c801ded2487"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/05-monitoring-alerting-logging/03-alerts.md
+++ b/docs/guides/reference-architecture/example-usage-guide/05-monitoring-alerting-logging/03-alerts.md
@@ -20,8 +20,5 @@ module](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/master/mod
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "584b4a2ae80caff18e9aabc951d9878d"
-}
+{"sourcePlugin":"local-copier","hash":"584b4a2ae80caff18e9aabc951d9878d"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/05-monitoring-alerting-logging/04-logs.md
+++ b/docs/guides/reference-architecture/example-usage-guide/05-monitoring-alerting-logging/04-logs.md
@@ -9,8 +9,5 @@ your servers in near-real-time.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "25e86ad1c431db7ea9afe1ebe3fbdb3a"
-}
+{"sourcePlugin":"local-copier","hash":"25e86ad1c431db7ea9afe1ebe3fbdb3a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/01-intro.md
+++ b/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/01-intro.md
@@ -15,8 +15,5 @@ need to expand the Reference Architecture with more accounts, like a test or san
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "4642c93de8e8463703cbd58048a53b80"
-}
+{"sourcePlugin":"local-copier","hash":"4642c93de8e8463703cbd58048a53b80"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/02-create-new-account-in-your-aws-org.md
+++ b/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/02-create-new-account-in-your-aws-org.md
@@ -24,8 +24,5 @@ At this point, you won't need to use the root credentials again until you are re
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "ce81ca7d4a533a62629db83aa91e9910"
-}
+{"sourcePlugin":"local-copier","hash":"ce81ca7d4a533a62629db83aa91e9910"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/03-update-logs-security-shared-accounts-to-allow-cross-account-access.md
+++ b/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/03-update-logs-security-shared-accounts-to-allow-cross-account-access.md
@@ -38,8 +38,5 @@ approve it to apply the updated cross account permissions.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "5bff1b351c15013c2c899f19817071e4"
-}
+{"sourcePlugin":"local-copier","hash":"5bff1b351c15013c2c899f19817071e4"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/04-deploy-the-security-baseline.md
+++ b/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/04-deploy-the-security-baseline.md
@@ -66,8 +66,5 @@ Once you confirm you have access to the new account from the `security` account,
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "6b2971383476a10a88bcaa6c38599547"
-}
+{"sourcePlugin":"local-copier","hash":"6b2971383476a10a88bcaa6c38599547"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/05-deploy-the-ecs-deploy-runner.md
+++ b/docs/guides/reference-architecture/example-usage-guide/06-adding-a-new-account/05-deploy-the-ecs-deploy-runner.md
@@ -37,8 +37,5 @@ to provision new infrastructure in the account.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "f383a1b3ce7b725423c02c57370d347b"
-}
+{"sourcePlugin":"local-copier","hash":"f383a1b3ce7b725423c02c57370d347b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/01-intro.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/01-intro.md
@@ -20,8 +20,5 @@ this section, we'll walk you through how to undeploy parts or all of the Referen
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "827378c8b6b828091bb9ce0adf1f8588"
-}
+{"sourcePlugin":"local-copier","hash":"827378c8b6b828091bb9ce0adf1f8588"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/02-before-you-get-started.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/02-before-you-get-started.md
@@ -9,8 +9,5 @@ accidentally shooting yourself in the foot.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "29615744ecd8587257bae2b0a7a24773"
-}
+{"sourcePlugin":"local-copier","hash":"29615744ecd8587257bae2b0a7a24773"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/03-pre-requisite-force-destroy-on-s3-buckets.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/03-pre-requisite-force-destroy-on-s3-buckets.md
@@ -21,8 +21,5 @@ services that expose this variable (note, you may not have all of these in your 
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "ee44dc198c327e0255356257c89b1b77"
-}
+{"sourcePlugin":"local-copier","hash":"ee44dc198c327e0255356257c89b1b77"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/04-pre-requisite-understand-module-dependencies.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/04-pre-requisite-understand-module-dependencies.md
@@ -21,8 +21,5 @@ You can check the module dependency tree with `graph-dependencies` and GraphViz:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "9157fe8a4406021c41bd8b94cb73d04b"
-}
+{"sourcePlugin":"local-copier","hash":"9157fe8a4406021c41bd8b94cb73d04b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/05-undeploying-modules-using-gruntwork-pipelines.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/05-undeploying-modules-using-gruntwork-pipelines.md
@@ -35,8 +35,5 @@ modules that have no existing downstream dependencies.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "8b72dc69092ed45097995a27428b543d"
-}
+{"sourcePlugin":"local-copier","hash":"8b72dc69092ed45097995a27428b543d"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/06-manually-undeploying-a-single-module.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/06-manually-undeploying-a-single-module.md
@@ -9,8 +9,5 @@ terragrunt destroy
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "611be9e2302e61959431d8e5512fd72c"
-}
+{"sourcePlugin":"local-copier","hash":"611be9e2302e61959431d8e5512fd72c"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/07-manually-undeploying-multiple-modules-or-an-entire-environment.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/07-manually-undeploying-multiple-modules-or-an-entire-environment.md
@@ -30,8 +30,5 @@ terragrunt destroy-all \
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "aba0a579f1326a57f833dba058bbbc67"
-}
+{"sourcePlugin":"local-copier","hash":"aba0a579f1326a57f833dba058bbbc67"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/08-removing-the-terraform-state.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/08-removing-the-terraform-state.md
@@ -14,8 +14,5 @@ destroyed successfully**.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "9c3adf3f67ede26bb4c92a2567125676"
-}
+{"sourcePlugin":"local-copier","hash":"9c3adf3f67ede26bb4c92a2567125676"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/09-useful-tips.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/09-useful-tips.md
@@ -25,8 +25,5 @@
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "86b46c82511aa42dadcb6a5f347ba164"
-}
+{"sourcePlugin":"local-copier","hash":"86b46c82511aa42dadcb6a5f347ba164"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/07-undeploy/10-known-errors.md
+++ b/docs/guides/reference-architecture/example-usage-guide/07-undeploy/10-known-errors.md
@@ -24,8 +24,5 @@ There are a few reasons your call to `destroy` may fail:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "33d1173bfb40293642e364d45877e81b"
-}
+{"sourcePlugin":"local-copier","hash":"33d1173bfb40293642e364d45877e81b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/example-usage-guide/index.md
+++ b/docs/guides/reference-architecture/example-usage-guide/index.md
@@ -161,8 +161,5 @@ Next up, let's have a look at [how to authenticate](02-authenticate/01-intro.md)
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "16a73da5e040233872dddede948a3e66"
-}
+{"sourcePlugin":"local-copier","hash":"16a73da5e040233872dddede948a3e66"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/index.md
+++ b/docs/guides/reference-architecture/index.md
@@ -29,8 +29,5 @@ Modernize your legacy Reference Architecture to use our new Service Catalog patt
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "675db72e2d75cc00ff5d3ec1a5407f0a"
-}
+{"sourcePlugin":"local-copier","hash":"675db72e2d75cc00ff5d3ec1a5407f0a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/reference-architecture/update-to-service-catalog.md
+++ b/docs/guides/reference-architecture/update-to-service-catalog.md
@@ -602,8 +602,5 @@ The following modules require a different version of the Service Catalog than `v
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "43a73701aef385b0281b0d77ec14dd2a"
-}
+{"sourcePlugin":"local-copier","hash":"43a73701aef385b0281b0d77ec14dd2a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.3.0/core-concepts.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.3.0/core-concepts.md
@@ -52,8 +52,5 @@ configure the newly created modules.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "43e5a48a98d74f7993a9e6a02c7570df"
-}
+{"sourcePlugin":"local-copier","hash":"43e5a48a98d74f7993a9e6a02c7570df"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.3.0/deployment-walkthrough/step-1-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.3.0/deployment-walkthrough/step-1-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -187,8 +187,5 @@ compatible with CIS AWS v1.3.0:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "5d834f1ec7d61ca84a6b9c44079b4a27"
-}
+{"sourcePlugin":"local-copier","hash":"5d834f1ec7d61ca84a6b9c44079b4a27"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.3.0/deployment-walkthrough/step-2-manual-steps.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.3.0/deployment-walkthrough/step-2-manual-steps.md
@@ -11,8 +11,5 @@ on the AWS website for detailed instructions.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "8f30fea3c56323b9c5c0ce3cd5fa1841"
-}
+{"sourcePlugin":"local-copier","hash":"8f30fea3c56323b9c5c0ce3cd5fa1841"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.3.0/deployment-walkthrough/step-3-deploy-new-modules.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.3.0/deployment-walkthrough/step-3-deploy-new-modules.md
@@ -88,8 +88,5 @@ docs](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/tree/v0.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "6270eb0777685afb4bf98586be2e994f"
-}
+{"sourcePlugin":"local-copier","hash":"6270eb0777685afb4bf98586be2e994f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.3.0/index.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.3.0/index.md
@@ -23,8 +23,5 @@ tag is compatible with CIS AWS v1.3.0, as well as the manuals step you need to p
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "c2c87981bea218be1a10832343a9863b"
-}
+{"sourcePlugin":"local-copier","hash":"c2c87981bea218be1a10832343a9863b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.4.0/core-concepts.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.4.0/core-concepts.md
@@ -38,8 +38,5 @@ necessary manual steps.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "d2e11fe53ce1dd113f0a0d8ecc1e8f11"
-}
+{"sourcePlugin":"local-copier","hash":"d2e11fe53ce1dd113f0a0d8ecc1e8f11"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.4.0/deployment-walkthrough/step-1-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.4.0/deployment-walkthrough/step-1-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -82,8 +82,5 @@ compatible with CIS AWS v1.4.0:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "a05d8f4802daa27e86b50cb1724ac7e8"
-}
+{"sourcePlugin":"local-copier","hash":"a05d8f4802daa27e86b50cb1724ac7e8"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.4.0/deployment-walkthrough/step-2-update-the-account-baseline-modules.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.4.0/deployment-walkthrough/step-2-update-the-account-baseline-modules.md
@@ -116,8 +116,5 @@ All the other child accounts (logs, stage, prod, etc) need the same configuratio
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "cb0578642a724e3749d66a16916e7194"
-}
+{"sourcePlugin":"local-copier","hash":"cb0578642a724e3749d66a16916e7194"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.4.0/deployment-walkthrough/step-3-manual-steps.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.4.0/deployment-walkthrough/step-3-manual-steps.md
@@ -117,8 +117,5 @@ You may be using a region that doesn’t properly support AWS Config (e.g: `ap-n
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "339270287018e92e149b0be448340c4d"
-}
+{"sourcePlugin":"local-copier","hash":"339270287018e92e149b0be448340c4d"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.4.0/finally.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.4.0/finally.md
@@ -8,8 +8,5 @@ If you’ve got any feedback or you think something’s missing from the guide, 
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "0467d5d25c74d981f3263fbe92df4204"
-}
+{"sourcePlugin":"local-copier","hash":"0467d5d25c74d981f3263fbe92df4204"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/cis/cis-1.4.0/index.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.4.0/index.md
@@ -23,8 +23,5 @@ CIS AWS Foundations Benchmark.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "8c0f9be6013feef70b809f0778c9116f"
-}
+{"sourcePlugin":"local-copier","hash":"8c0f9be6013feef70b809f0778c9116f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/index.md
+++ b/docs/guides/stay-up-to-date/index.md
@@ -16,22 +16,7 @@ import CardGroup from "/src/components/CardGroup"
 
 <CardGroup cols={1} gap="1rem" stacked equalHeightRows={false} commonCardProps={{padding: "1.25rem"}}>
 
-<Card title="Update to 2023-01" href="/guides/stay-up-to-date/releases/2023-01" />
-<Card title="Update to 2022-12" href="/guides/stay-up-to-date/releases/2022-12" />
-<Card title="Update to 2022-11" href="/guides/stay-up-to-date/releases/2022-11" />
-<Card title="Update to 2022-10" href="/guides/stay-up-to-date/releases/2022-10" />
-<Card title="Update to 2022-09" href="/guides/stay-up-to-date/releases/2022-09" />
-<Card title="Update to 2022-08" href="/guides/stay-up-to-date/releases/2022-08" />
-<Card title="Update to 2022-07" href="/guides/stay-up-to-date/releases/2022-07" />
-<Card title="Update to 2022-06" href="/guides/stay-up-to-date/releases/2022-06" />
-<Card title="Update to 2022-05" href="/guides/stay-up-to-date/releases/2022-05" />
-<Card title="Update to 2022-04" href="/guides/stay-up-to-date/releases/2022-04" />
-<Card title="Update to 2022-03" href="/guides/stay-up-to-date/releases/2022-03" />
-<Card title="Update to 2022-02" href="/guides/stay-up-to-date/releases/2022-02" />
-<Card title="Update to 2022-01" href="/guides/stay-up-to-date/releases/2022-01" />
-<Card title="Update to 2021-12" href="/guides/stay-up-to-date/releases/2021-12" />
-<Card title="Update to 2021-11" href="/guides/stay-up-to-date/releases/2021-11" />
-<Card title="See older releases" href="/guides/stay-up-to-date/releases" />
+<!-- replaced-by-docs-sourcer-automatically-do-not-edit -->
 
 </CardGroup>
 
@@ -107,8 +92,5 @@ href="/guides/stay-up-to-date/terraform/terraform-1.1"
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "releases",
-  "hash": "7ea35831433ed92507132ae0bae19621"
-}
+{"sourcePlugin":"local-copier","hash":"ed1e8236458bdd340ad49fba5f4f0855"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/core-concepts.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/core-concepts.md
@@ -44,8 +44,5 @@ documentation](https://terragrunt.gruntwork.io/docs/features/keep-your-terragrun
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "29aa2eab851b8a4a259acf265a6c2315"
-}
+{"sourcePlugin":"local-copier","hash":"29aa2eab851b8a4a259acf265a6c2315"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/deployment-walkthrough/intro.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/deployment-walkthrough/intro.md
@@ -41,8 +41,5 @@ include "envcommon" {
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "05542d29c57c912a1c745fa10f80a326"
-}
+{"sourcePlugin":"local-copier","hash":"05542d29c57c912a1c745fa10f80a326"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/deployment-walkthrough/optional-even-dryer-configuration.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/deployment-walkthrough/optional-even-dryer-configuration.md
@@ -182,8 +182,5 @@ the `inputs` attribute even if it references `dependency` blocks.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "9c88b007237c084a93910cc7da9b2bad"
-}
+{"sourcePlugin":"local-copier","hash":"9c88b007237c084a93910cc7da9b2bad"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/deployment-walkthrough/refactoring-common-configurations-for-a-component.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/deployment-walkthrough/refactoring-common-configurations-for-a-component.md
@@ -277,8 +277,5 @@ moved to the common component configuration.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "3b740cb5844fe232f5ac8126887b90d6"
-}
+{"sourcePlugin":"local-copier","hash":"3b740cb5844fe232f5ac8126887b90d6"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/deployment-walkthrough/update-to-the-service-catalog-based-reference-architecture.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/deployment-walkthrough/update-to-the-service-catalog-based-reference-architecture.md
@@ -28,8 +28,5 @@ fully supported by Gruntwork.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "0375aad45a4e44290040bdf324035ce2"
-}
+{"sourcePlugin":"local-copier","hash":"0375aad45a4e44290040bdf324035ce2"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/index.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-dry-your-reference-architecture/index.md
@@ -24,8 +24,5 @@ The steps you need to take to update your code to use multi-include to avoid dup
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "e6b78a8b5feffb8c40a83d5aeab2ae0b"
-}
+{"sourcePlugin":"local-copier","hash":"e6b78a8b5feffb8c40a83d5aeab2ae0b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3/core-concepts.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3/core-concepts.md
@@ -22,8 +22,5 @@ Architecture to be compatible with AWS provider version 3.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "56d01e92f2d0efef79e79bee9f272d89"
-}
+{"sourcePlugin":"local-copier","hash":"56d01e92f2d0efef79e79bee9f272d89"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3/deployment-walkthrough.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3/deployment-walkthrough.md
@@ -182,8 +182,5 @@ on how to update your components to be compatible with AWS provider v3.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "ab6bc780e5dab16724fdb9635ba78a15"
-}
+{"sourcePlugin":"local-copier","hash":"ab6bc780e5dab16724fdb9635ba78a15"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3/index.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v3/index.md
@@ -29,8 +29,5 @@ which Gruntwork Repo version tag is compatible with AWS provider v3.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "d893235577f4c44c0b19f7f0eed0a15d"
-}
+{"sourcePlugin":"local-copier","hash":"d893235577f4c44c0b19f7f0eed0a15d"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v4/core-concepts.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v4/core-concepts.md
@@ -14,8 +14,5 @@ modules and the Gruntwork Reference Architecture to be compatible with AWS provi
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "3f08159b93c4188b5accd6a4c66f4345"
-}
+{"sourcePlugin":"local-copier","hash":"3f08159b93c4188b5accd6a4c66f4345"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v4/deployment-walkthrough.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v4/deployment-walkthrough.md
@@ -141,8 +141,5 @@ If you have any questions, we'd love to hear them. Please reach out to <a href="
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "6c00387c2495618b8e214128440b9ab8"
-}
+{"sourcePlugin":"local-copier","hash":"6c00387c2495618b8e214128440b9ab8"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v4/index.md
+++ b/docs/guides/stay-up-to-date/terraform/how-to-update-to-aws-provider-v4/index.md
@@ -27,8 +27,5 @@ which Gruntwork Repo version tag is compatible with AWS provider v4.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "fc690bcf3f52e1125b2279310bd37b45"
-}
+{"sourcePlugin":"local-copier","hash":"fc690bcf3f52e1125b2279310bd37b45"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.1/core-concepts.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.1/core-concepts.md
@@ -13,8 +13,5 @@ post](https://www.hashicorp.com/blog/terraform-1-1-improves-refactoring-and-the-
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "49defa1819542396936b1f0481640f93"
-}
+{"sourcePlugin":"local-copier","hash":"49defa1819542396936b1f0481640f93"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.1/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-1-x.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.1/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-1-x.md
@@ -30,8 +30,5 @@ If you haven’t already, you need to:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "901f5f12726f3f8ebba1f5058c1e957a"
-}
+{"sourcePlugin":"local-copier","hash":"901f5f12726f3f8ebba1f5058c1e957a"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.1/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.1/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -140,8 +140,5 @@ and the respective versions that are compatible with Terraform 1.1:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "2b2b98d7e75d84cb9b1df09cf54a734e"
-}
+{"sourcePlugin":"local-copier","hash":"2b2b98d7e75d84cb9b1df09cf54a734e"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.1/index.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.1/index.md
@@ -27,8 +27,5 @@ tag is compatible with Terraform 1.1.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "de75607ce00354136cfc3f917a2f047b"
-}
+{"sourcePlugin":"local-copier","hash":"de75607ce00354136cfc3f917a2f047b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.x/core-concepts.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.x/core-concepts.md
@@ -21,8 +21,5 @@ notes](https://github.com/hashicorp/terraform/releases/tag/v1.0.0):
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "ee2c203478dfbf3301d71f56df87cb65"
-}
+{"sourcePlugin":"local-copier","hash":"ee2c203478dfbf3301d71f56df87cb65"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-15.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-15.md
@@ -27,8 +27,5 @@ If you haven’t already, you need to:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "79d751e6f54ffaa62190769a98e3b402"
-}
+{"sourcePlugin":"local-copier","hash":"79d751e6f54ffaa62190769a98e3b402"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.x/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -174,8 +174,5 @@ and the respective versions that are compatible with Terraform 1.x:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "5de71c86b2c7405e338748eee98f96ce"
-}
+{"sourcePlugin":"local-copier","hash":"5de71c86b2c7405e338748eee98f96ce"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-1.x/index.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-1.x/index.md
@@ -29,8 +29,5 @@ tag is compatible with Terraform 1.x.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "b902a9ed1b8a8c7ee812f8b2588235fa"
-}
+{"sourcePlugin":"local-copier","hash":"b902a9ed1b8a8c7ee812f8b2588235fa"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-12/deployment-walkthrough.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-12/deployment-walkthrough.md
@@ -430,8 +430,5 @@ At the end of this, you should be able to run `terragrunt plan` cleanly.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "1133a6f06da0e83fa0be975301931929"
-}
+{"sourcePlugin":"local-copier","hash":"1133a6f06da0e83fa0be975301931929"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-12/index.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-12/index.md
@@ -34,8 +34,5 @@ This means that both the modules and the live config need to be updated in order
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "18301a838452f27f0c74540894001124"
-}
+{"sourcePlugin":"local-copier","hash":"18301a838452f27f0c74540894001124"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-12/version-compatibility-table.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-12/version-compatibility-table.md
@@ -41,8 +41,5 @@ The following lists our Terraform packages and their compatibility with Terrafor
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "3aac38d34fa5070df5bd4d9e0f13ca77"
-}
+{"sourcePlugin":"local-copier","hash":"3aac38d34fa5070df5bd4d9e0f13ca77"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-13/core-concepts.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-13/core-concepts.md
@@ -18,8 +18,5 @@ update to these new versions and make other changes to your code, as described i
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "38ed9039f3be3645c5202dc00a7aa30b"
-}
+{"sourcePlugin":"local-copier","hash":"38ed9039f3be3645c5202dc00a7aa30b"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-12.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-12.md
@@ -16,8 +16,5 @@ If you haven’t already, you need to:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "4dd0c2fb042ce6d83b7a5f20404f6b75"
-}
+{"sourcePlugin":"local-copier","hash":"4dd0c2fb042ce6d83b7a5f20404f6b75"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-2-update-your-code-to-be-compatible-with-terraform-0-13.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-2-update-your-code-to-be-compatible-with-terraform-0-13.md
@@ -10,8 +10,5 @@ Upgrade Guide](https://www.terraform.io/upgrade-guides/0-13.html).
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "b92f87fe0e1cbc75dedb55878f8e449e"
-}
+{"sourcePlugin":"local-copier","hash":"b92f87fe0e1cbc75dedb55878f8e449e"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -171,8 +171,5 @@ compatible with Terraform 0.13:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "df2574e2ef9ba51262631488b3dc0ae2"
-}
+{"sourcePlugin":"local-copier","hash":"df2574e2ef9ba51262631488b3dc0ae2"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-4-update-provider-sources.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/step-4-update-provider-sources.md
@@ -34,8 +34,5 @@ terraform state replace-provider -- -/aws registry.terraform.io/hashicorp/aws
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "0c5aa574c82b473c254f163ea660dffa"
-}
+{"sourcePlugin":"local-copier","hash":"0c5aa574c82b473c254f163ea660dffa"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/updating-the-gruntwork-reference-architecture-to-terraform-0-13.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-13/deployment-walkthrough/updating-the-gruntwork-reference-architecture-to-terraform-0-13.md
@@ -40,8 +40,5 @@ refer to PRs in the Standard Reference Architecture section above.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "32d87de726919474b48d92e47af026b9"
-}
+{"sourcePlugin":"local-copier","hash":"32d87de726919474b48d92e47af026b9"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-13/index.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-13/index.md
@@ -27,8 +27,5 @@ tag is compatible with Terraform 0.13.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "be501a70cd0f8c6716015ad5523e3a3e"
-}
+{"sourcePlugin":"local-copier","hash":"be501a70cd0f8c6716015ad5523e3a3e"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-14/core-concepts.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-14/core-concepts.md
@@ -19,8 +19,5 @@ update to these new versions and make other changes to your code, as described i
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "742b88aaf1e35809a26ab436a9804eea"
-}
+{"sourcePlugin":"local-copier","hash":"742b88aaf1e35809a26ab436a9804eea"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-13.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-13.md
@@ -21,8 +21,5 @@ If you haven’t already, you need to:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "78154acff2abc82aa789869751dc1a07"
-}
+{"sourcePlugin":"local-copier","hash":"78154acff2abc82aa789869751dc1a07"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-2-update-your-code-to-be-compatible-with-terraform-0-14.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-2-update-your-code-to-be-compatible-with-terraform-0-14.md
@@ -10,8 +10,5 @@ Upgrade Guide](https://www.terraform.io/upgrade-guides/0-14.html).
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "bcf8113ea4cfc97a8df30908df187cb7"
-}
+{"sourcePlugin":"local-copier","hash":"bcf8113ea4cfc97a8df30908df187cb7"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -170,8 +170,5 @@ compatible with Terraform 0.14:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "fe5c67ca172107229a89899b73efc1ce"
-}
+{"sourcePlugin":"local-copier","hash":"fe5c67ca172107229a89899b73efc1ce"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-4-start-using-lock-files.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-14/deployment-walkthrough/step-4-start-using-lock-files.md
@@ -17,8 +17,5 @@ to version control.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "a8737cd633b12986e72317de6dde4a3c"
-}
+{"sourcePlugin":"local-copier","hash":"a8737cd633b12986e72317de6dde4a3c"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-14/index.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-14/index.md
@@ -28,8 +28,5 @@ tag is compatible with Terraform 0.14.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "203575611078979267a82cc2be69911c"
-}
+{"sourcePlugin":"local-copier","hash":"203575611078979267a82cc2be69911c"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-15/core-concepts.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-15/core-concepts.md
@@ -27,8 +27,5 @@ following section.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "11dd054fc7d70bce30badb6f78ce6f46"
-}
+{"sourcePlugin":"local-copier","hash":"11dd054fc7d70bce30badb6f78ce6f46"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-15/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-14.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-15/deployment-walkthrough/step-1-update-your-code-to-be-compatible-with-terraform-0-14.md
@@ -24,8 +24,5 @@ If you haven’t already, you need to:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "23d3ea3ca81c703609b2f3704f330b34"
-}
+{"sourcePlugin":"local-copier","hash":"23d3ea3ca81c703609b2f3704f330b34"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-15/deployment-walkthrough/step-2-update-your-code-to-be-compatible-with-terraform-0-15.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-15/deployment-walkthrough/step-2-update-your-code-to-be-compatible-with-terraform-0-15.md
@@ -10,8 +10,5 @@ Upgrade Guide](https://www.terraform.io/upgrade-guides/0-15.html).
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "54113b1e4b9c28fa1060a88404ff7a2f"
-}
+{"sourcePlugin":"local-copier","hash":"54113b1e4b9c28fa1060a88404ff7a2f"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-15/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-15/deployment-walkthrough/step-3-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -170,8 +170,5 @@ compatible with Terraform 0.15:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "358211de8f59ad73100aa258a90b9d32"
-}
+{"sourcePlugin":"local-copier","hash":"358211de8f59ad73100aa258a90b9d32"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/terraform/terraform-15/index.md
+++ b/docs/guides/stay-up-to-date/terraform/terraform-15/index.md
@@ -30,8 +30,5 @@ compatible with Terraform 0.15.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "5e53cb16df16edff97b8cf973cb022ac"
-}
+{"sourcePlugin":"local-copier","hash":"5e53cb16df16edff97b8cf973cb022ac"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/style/golang-style-guide.md
+++ b/docs/guides/style/golang-style-guide.md
@@ -262,8 +262,5 @@ suffix `E` return an error as the last return value; methods without `E` mark th
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "e3576d96a0cb8b02e8913e36d63bbf90"
-}
+{"sourcePlugin":"local-copier","hash":"e3576d96a0cb8b02e8913e36d63bbf90"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/style/index.md
+++ b/docs/guides/style/index.md
@@ -31,8 +31,5 @@ Gruntwork follows Google's shell style guide for Bash scripts.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "a2e7a4dcf7d1eb2a24102927805a2a5d"
-}
+{"sourcePlugin":"local-copier","hash":"a2e7a4dcf7d1eb2a24102927805a2a5d"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/style/markdown-style-guide.md
+++ b/docs/guides/style/markdown-style-guide.md
@@ -823,8 +823,5 @@ This Markdown style guide is adapted from [one provided by Google](https://googl
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "3b3cc134306552881bc83ebc8cbe9531"
-}
+{"sourcePlugin":"local-copier","hash":"3b3cc134306552881bc83ebc8cbe9531"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/style/terraform-style-guide.md
+++ b/docs/guides/style/terraform-style-guide.md
@@ -395,8 +395,5 @@ func TestECS(t *testing.T) {
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "ebf33215ca11bf62867a076882927304"
-}
+{"sourcePlugin":"local-copier","hash":"ebf33215ca11bf62867a076882927304"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/working-with-code/contributing.md
+++ b/docs/guides/working-with-code/contributing.md
@@ -52,8 +52,5 @@ code and release a new version.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "14f13b5f634ced6a221c0a69fd2fe79d"
-}
+{"sourcePlugin":"local-copier","hash":"14f13b5f634ced6a221c0a69fd2fe79d"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/working-with-code/forking.md
+++ b/docs/guides/working-with-code/forking.md
@@ -62,8 +62,5 @@ bans all outside sources, then follow the instructions above to fork the code, a
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "4e5e16c72ceec51847a5322cda7d5bda"
-}
+{"sourcePlugin":"local-copier","hash":"4e5e16c72ceec51847a5322cda7d5bda"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/working-with-code/tfc-integration.md
+++ b/docs/guides/working-with-code/tfc-integration.md
@@ -460,8 +460,5 @@ Happy Terragrunting!
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "5b20d6a539da0fdb344d84384fccbe9c"
-}
+{"sourcePlugin":"local-copier","hash":"5b20d6a539da0fdb344d84384fccbe9c"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/working-with-code/using-modules.md
+++ b/docs/guides/working-with-code/using-modules.md
@@ -768,8 +768,5 @@ Now that you have your Terraform module deployed, you can pull in updates as fol
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "51856e814c4a4bc50bdbcab6b0aaf2ce"
-}
+{"sourcePlugin":"local-copier","hash":"51856e814c4a4bc50bdbcab6b0aaf2ce"}
 ##DOCS-SOURCER-END -->

--- a/docs/guides/working-with-code/versioning.md
+++ b/docs/guides/working-with-code/versioning.md
@@ -118,8 +118,5 @@ Follow the steps below to keep your code up to date:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "e6b205742fd86b90d4b9c4d01efb2853"
-}
+{"sourcePlugin":"local-copier","hash":"e6b205742fd86b90d4b9c4d01efb2853"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,0 +1,40 @@
+---
+sidebar_position: 1
+---
+
+# Tutorial Intro (Home Page)
+
+Let's discover **Docusaurus in less than 5 minutes**.
+
+## Getting Started
+
+Get started by **creating a new site**.
+
+Or **try Docusaurus immediately** with **[docusaurus.new](https://docusaurus.new)**.
+
+## Generate a new site
+
+Generate a new Docusaurus site using the **classic template**:
+
+```shell
+npm init docusaurus@latest my-website classic
+```
+
+## Start your site
+
+Run the development server:
+
+```shell
+cd my-website
+
+npx docusaurus start
+```
+
+Your site starts at `http://localhost:3000`.
+
+Open `docs/intro.md` and edit some lines: the site **reloads automatically** and display your changes.
+
+
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"local-copier","hash":"9a76adceeb3958af906263551c8dc0c4"}
+##DOCS-SOURCER-END -->

--- a/docs/intro/core-concepts/immutable-infrastructure.md
+++ b/docs/intro/core-concepts/immutable-infrastructure.md
@@ -35,8 +35,5 @@ longer work, e.g., if certain packages have been removed from APT or YUM).
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "159cda91c449de4ffd9bc29a10116c09"
-}
+{"sourcePlugin":"local-copier","hash":"159cda91c449de4ffd9bc29a10116c09"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/core-concepts/infrastructure-as-code.md
+++ b/docs/intro/core-concepts/infrastructure-as-code.md
@@ -60,8 +60,5 @@ Packer, Docker, and Helm, each of which we’ll discuss in the next several sect
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "e29d1b09112e97f7f9908267a676c308"
-}
+{"sourcePlugin":"local-copier","hash":"e29d1b09112e97f7f9908267a676c308"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/core-concepts/production-framework.md
+++ b/docs/intro/core-concepts/production-framework.md
@@ -16,8 +16,5 @@ Guide](/guides/production-framework) for the full details.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "4dda35c027cc8ed707d9bf946d096d9a"
-}
+{"sourcePlugin":"local-copier","hash":"4dda35c027cc8ed707d9bf946d096d9a"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/dev-portal/create-account.md
+++ b/docs/intro/dev-portal/create-account.md
@@ -33,8 +33,5 @@ If you are the admin for your organization, you'll be prompted to confirm detail
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "01375ec9b14d989af4af205eba101d88"
-}
+{"sourcePlugin":"local-copier","hash":"01375ec9b14d989af4af205eba101d88"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/dev-portal/invite-team.md
+++ b/docs/intro/dev-portal/invite-team.md
@@ -42,8 +42,5 @@ The number of licenses available depends on the level of your subscription. You 
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "702a33b934d092e229bc9c8d17e92387"
-}
+{"sourcePlugin":"local-copier","hash":"702a33b934d092e229bc9c8d17e92387"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/dev-portal/link-github-id.md
+++ b/docs/intro/dev-portal/link-github-id.md
@@ -23,8 +23,5 @@ To link a new GitHub ID, you’ll first have to unlink the current one. Although
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "83dd05d2370300a2388662fd39dc39a8"
-}
+{"sourcePlugin":"local-copier","hash":"83dd05d2370300a2388662fd39dc39a8"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/environment-setup/recommended_tools.md
+++ b/docs/intro/environment-setup/recommended_tools.md
@@ -90,8 +90,5 @@ docker run -it -v $(pwd):/work gruntwork /bin/bash
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "7f188f772b0e347ce8651e40270ce141"
-}
+{"sourcePlugin":"local-copier","hash":"7f188f772b0e347ce8651e40270ce141"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/first-deployment/deploy.md
+++ b/docs/intro/first-deployment/deploy.md
@@ -261,8 +261,5 @@ terragrunt apply-all
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "7203857858fed888b41d453b81b3e12b"
-}
+{"sourcePlugin":"local-copier","hash":"7203857858fed888b41d453b81b3e12b"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/first-deployment/testing.md
+++ b/docs/intro/first-deployment/testing.md
@@ -213,8 +213,5 @@ For a lot more information on writing automated tests for Terraform code, see:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "5ab7f3dbd4aa0424b2e7611b1a4036e7"
-}
+{"sourcePlugin":"local-copier","hash":"5ab7f3dbd4aa0424b2e7611b1a4036e7"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/first-deployment/using-terraform-modules.md
+++ b/docs/intro/first-deployment/using-terraform-modules.md
@@ -238,8 +238,5 @@ output "private_persistence_subnet_ids" {
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "22ca9d71da618bade6675c2eabc553f5"
-}
+{"sourcePlugin":"local-copier","hash":"22ca9d71da618bade6675c2eabc553f5"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/next-steps.mdx
+++ b/docs/intro/next-steps.mdx
@@ -28,8 +28,5 @@ Now that your foundational knowledge is in place and your workspace is configure
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "096674fca64983f45542f73cc4fc7e9b"
-}
+{"sourcePlugin":"local-copier","hash":"096674fca64983f45542f73cc4fc7e9b"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/overview/getting-started.mdx
+++ b/docs/intro/overview/getting-started.mdx
@@ -30,8 +30,5 @@ In this introductory guide we’ll cover the fundamentals you'll need in order t
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "2c594f2c6b6c5ab9e1c211a3475fa279"
-}
+{"sourcePlugin":"local-copier","hash":"2c594f2c6b6c5ab9e1c211a3475fa279"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/overview/gruntwork-production-framework.md
+++ b/docs/intro/overview/gruntwork-production-framework.md
@@ -1,0 +1,37 @@
+# Gruntwork Production Framework
+
+The Gruntwork Production Framework is our opinionated, step-by-step framework for achieving a world-class DevOps setup. At Gruntwork, we've had the privilege to work with software teams from tiny startups to massive Fortune 50 companies to some of the world's largest government agencies, and this framework captures the common patterns we've seen that actually worked.
+
+This document is a high-level summary of the Gruntwork Production Framework. We will post and link to the full version in the future.
+
+## The ingredients of success
+
+There are a core set of raw primitives your company will need to put in place to achieve a world-class DevOps setup. We consider these the ingredients of success:
+
+1. Service catalog
+1. Application catalog
+1. CI/CD pipeline
+1. Developer self-service
+
+### How Gruntwork helps
+
+The Gruntwork product is designed to help customers implement this framework. For more information, see [how it works](how-it-works).
+
+## Ingredient #1: Service catalog
+
+This is an overloaded term, so let's dive into the details of what we mean by a Service Catalog in this guide.
+
+## Ingredient #2: Application catalog
+...
+
+## Ingredient #3: CI/CD pipeline
+...
+
+## Ingredient #4: Developer self-service 
+...
+
+
+
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"local-copier","hash":"ebca2e605787776f91971e9c55972a74"}
+##DOCS-SOURCER-END -->

--- a/docs/intro/overview/gruntwork-vs-other.md
+++ b/docs/intro/overview/gruntwork-vs-other.md
@@ -1,0 +1,6 @@
+# Grunwork vs. other
+
+
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"local-copier","hash":"c8aeff437ffbf0d5134c70daf339a109"}
+##DOCS-SOURCER-END -->

--- a/docs/intro/overview/how-it-works.md
+++ b/docs/intro/overview/how-it-works.md
@@ -48,8 +48,5 @@ Gruntwork products strike a balance between opinionatedness and configurability.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "ccd70a8cadb3be5f8e2501cd80a7482c"
-}
+{"sourcePlugin":"local-copier","hash":"ccd70a8cadb3be5f8e2501cd80a7482c"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/overview/intro-to-gruntwork.md
+++ b/docs/intro/overview/intro-to-gruntwork.md
@@ -18,8 +18,5 @@ All Gruntwork products are built on and fully compatible with [open source Terra
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "1b5fc69a4dbe2b64db10761645dece1b"
-}
+{"sourcePlugin":"local-copier","hash":"1b5fc69a4dbe2b64db10761645dece1b"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/overview/reference-architecture-prerequisites-guide.md
+++ b/docs/intro/overview/reference-architecture-prerequisites-guide.md
@@ -85,8 +85,5 @@ Gruntwork accelerates you down the road towards having your entire AWS cloud inf
 </details>
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "7b610a770e16d34aaddb3760cbfc5639"
-}
+{"sourcePlugin":"local-copier","hash":"7b610a770e16d34aaddb3760cbfc5639"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/overview/use-cases.md
+++ b/docs/intro/overview/use-cases.md
@@ -1,0 +1,6 @@
+# Use cases
+
+
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"local-copier","hash":"9e449ec8d34b49b98c1c2e301378c065"}
+##DOCS-SOURCER-END -->

--- a/docs/intro/tool-fundamentals/docker.md
+++ b/docs/intro/tool-fundamentals/docker.md
@@ -21,8 +21,5 @@ Nomad that you can use to deploy and manage Docker images.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "ac4aef92859a42de2010069751aa1766"
-}
+{"sourcePlugin":"local-copier","hash":"ac4aef92859a42de2010069751aa1766"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/tool-fundamentals/packer.md
+++ b/docs/intro/tool-fundamentals/packer.md
@@ -52,8 +52,5 @@ its opinionated tools.
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "1d077cb69e254937c2472634a22eff5d"
-}
+{"sourcePlugin":"local-copier","hash":"1d077cb69e254937c2472634a22eff5d"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/tool-fundamentals/terraform.md
+++ b/docs/intro/tool-fundamentals/terraform.md
@@ -39,8 +39,5 @@ The Gruntwork module library and open source tools are compatible with Terraform
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "5e3e898ec4ed802c2b91154b6a9e8fad"
-}
+{"sourcePlugin":"local-copier","hash":"5e3e898ec4ed802c2b91154b6a9e8fad"}
 ##DOCS-SOURCER-END -->

--- a/docs/intro/tool-fundamentals/terragrunt.md
+++ b/docs/intro/tool-fundamentals/terragrunt.md
@@ -32,8 +32,5 @@ Infrastructure as Code Library with plain Terraform, Terraform Enterprise, Atlan
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "66b4546e1b2cacd7b6bdb6db216d5bf9"
-}
+{"sourcePlugin":"local-copier","hash":"66b4546e1b2cacd7b6bdb6db216d5bf9"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/intro.md
+++ b/docs/reference/intro.md
@@ -1,0 +1,12 @@
+---
+'title': 'Overview'
+---
+
+# Gruntwork Service Catalog API Reference
+
+This section introduces what's found in the reference area.
+
+
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"local-copier","hash":"7d8cca66029815dd0e83044962ad5bbd"}
+##DOCS-SOURCER-END -->

--- a/docs/reference/modules/stub.md
+++ b/docs/reference/modules/stub.md
@@ -1,0 +1,10 @@
+---
+'title': 'Module'
+---
+
+# Module
+
+
+<!-- ##DOCS-SOURCER-START
+{"sourcePlugin":"local-copier","hash":"c49fe59e5436e774d662dd58b36e767c"}
+##DOCS-SOURCER-END -->

--- a/docs/reference/services/intro/create-your-own-service-catalog.md
+++ b/docs/reference/services/intro/create-your-own-service-catalog.md
@@ -187,8 +187,5 @@ inputs = {
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "1f4ef9cbba76e05f0cc247508e82dc54"
-}
+{"sourcePlugin":"local-copier","hash":"1f4ef9cbba76e05f0cc247508e82dc54"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/intro/deploy-new-infrastructure.md
+++ b/docs/reference/services/intro/deploy-new-infrastructure.md
@@ -396,8 +396,5 @@ most commonly used filters will be:
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "d9f703f17d3e41684bef2ab8f2fae2a1"
-}
+{"sourcePlugin":"local-copier","hash":"d9f703f17d3e41684bef2ab8f2fae2a1"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/intro/make-changes-to-your-infrastructure.md
+++ b/docs/reference/services/intro/make-changes-to-your-infrastructure.md
@@ -191,8 +191,5 @@ _(Documentation coming soon. If you need help with this ASAP, please contact [su
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "1da75fa30f9ba0e374e7d4940d56e9a5"
-}
+{"sourcePlugin":"local-copier","hash":"1da75fa30f9ba0e374e7d4940d56e9a5"}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/intro/overview.md
+++ b/docs/reference/services/intro/overview.md
@@ -98,8 +98,5 @@ Makes sure to ALWAYS read the release notes and migration instructions (if any) 
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "750a36ba2c3ba2455d2eba763802109d"
-}
+{"sourcePlugin":"local-copier","hash":"750a36ba2c3ba2455d2eba763802109d"}
 ##DOCS-SOURCER-END -->

--- a/docs/support.mdx
+++ b/docs/support.mdx
@@ -166,8 +166,5 @@ You can access the Gruntwork billing portal using the primary billing email asso
 To protect the security of your account, this link will expire after 5 minutes. You can generate a new access link anytime. If you need further assistance with billing questions, contact support@gruntwork.io.
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "f9b976b73520cf5642486199cdf9b362"
-}
+{"sourcePlugin":"local-copier","hash":"f9b976b73520cf5642486199cdf9b362"}
 ##DOCS-SOURCER-END -->

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -48,8 +48,5 @@ Repo Copier is a CLI tool to copy repository data (including code, issues, PRs, 
 
 
 <!-- ##DOCS-SOURCER-START
-{
-  "sourcePlugin": "local-copier",
-  "hash": "9163aa4a6f27ddea984ff8f78e22e44b"
-}
+{"sourcePlugin":"local-copier","hash":"9163aa4a6f27ddea984ff8f78e22e44b"}
 ##DOCS-SOURCER-END -->


### PR DESCRIPTION
![Set-Up-an-Infrastructure-CI-CD-Pipeline-Gruntwork-Docs](https://user-images.githubusercontent.com/1769996/220812709-de074695-ff7a-43e1-b1e5-a2c9043e0298.png)

These changes update the callout on our DIY Pipelines guide to reflect: 
1.The fact that the DIY Pipelines guide on the docs site is more of a high level design document 
2. We have an official Pipelines example in the service catalog now that is intended to be deployed

The callout also links to the official example in our service catalog.

Questions for reviewers:
1. Have I missed anything that would be good to update in light of the example? 
2. Are all the auto-generated hash updates in this PR expected? I was running the local dev server while editing `docs_sources`.

It should hopefully be a welcome change!