### PR TITLE
Update manual steps for Macie: create a new classification job

### DIFF
--- a/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
+++ b/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
@@ -81,7 +81,7 @@ To set up Macie to analyze the desired S3 buckets, you’ll need to create a **M
 in the [terraform-provider-aws](https://github.com/hashicorp/terraform-provider-aws/issues/20726), where the `aws_macie2_classification_job`
 can't be updated. Therefore, we ask you to manually create a new Classification Job and add all desired buckets.
 
-:::
+:::note
 
 If you are using Steampipe for checking your Compliance status, you should create the job by selecting a list of buckets,
 and **not** by bucket criterea. Steampipe fetchs the bucket list that's being analyzed by Macie, so if you specify critereas

--- a/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
+++ b/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
@@ -92,6 +92,23 @@ query for finding the buckets analyzed by Macie](https://github.com/turbot/steam
 
 You can use either the [AWS Console](https://docs.aws.amazon.com/macie/latest/user/discovery-jobs-create.html), or the
 [AWS CLI](https://docs.aws.amazon.com/de_de/cli/latest/reference/macie2/create-classification-job.html#create-classification-job) to make the change.
+The script below will fetch a list of all buckets in an AWS account and create a new classification job for them to be weekly
+analyzed. The script needs to be executed while authenticated in AWS.
+
+```bash
+#!/bin/bash
+
+# Get Account ID
+ACCOUNT_ID=$(aws sts get-caller-identity --output json | jq '.Account')
+echo "Creating classification job for account $ACCOUNT_ID"
+
+# Get the full list of buckets
+BUCKETS_LIST=$(aws s3api list-buckets --output json | jq '[.Buckets[] | .Name]')
+echo "Creating classification job for list of buckets $BUCKETS_LIST"
+
+# Create a job in Macie that will analyze all buckets once per week, on Mondays
+aws macie2 create-classification-job --name "weekly-analyzis" --job-type "SCHEDULED" --schedule-frequency "{ \"weeklySchedule\": {\"dayOfWeek\": \"MONDAY\" } }" --s3-job-definition "{\"bucketDefinitions\":[{\"accountId\":$ACCOUNT_ID, \"buckets\":$BUCKETS_LIST}]}"
+```
 
 
 ## 7. Enable MFA Delete for all S3 buckets

--- a/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
+++ b/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
@@ -73,7 +73,7 @@ You can also configure an automated system integration if you have a third party
 Follow the steps in the [AWS
 docs](https://docs.aws.amazon.com/sns/latest/dg/sns-http-https-endpoint-as-subscriber.html) on how to add an HTTPS endpoint as a subscriber to the alerts.
 
-## 6. Add existing buckets to a new Macie classification job.
+## 6. Add existing buckets to a new Macie classification job
 
 Macie is a new AWS service that uses machine learning (ML) and pattern matching to discover and help protect your sensitive
 data. The Landing Zone solution already configured Macie in all deployed accounts. The last step is to specify the S3 buckets to be analyzed.

--- a/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
+++ b/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
@@ -73,28 +73,24 @@ You can also configure an automated system integration if you have a third party
 Follow the steps in the [AWS
 docs](https://docs.aws.amazon.com/sns/latest/dg/sns-http-https-endpoint-as-subscriber.html) on how to add an HTTPS endpoint as a subscriber to the alerts.
 
-## 6. Manually maintain buckets to analyze in the `buckets_to_analyze` variable
+## 6. Add existing buckets to a new Macie classification job.
 
 Macie is a new AWS service that uses machine learning (ML) and pattern matching to discover and help protect your sensitive
-data. To set up Macie to analyze the desired S3 buckets, you’ll need to create a **Macie classification job**. Typically,
-you’ll want it to analyze all the buckets in the region. However, the terraform AWS provider does not support specifying
-all the buckets in a region - it requires that an explicit list of buckets be provided. Therefore, you’ll
-need to maintain an explicit list of buckets per region, namely in the variable `buckets_to_analyze`. This list of buckets needs to be maintained in the future as new buckets are created in the account. Please read the
-[documentation](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/blob/master/modules/security/macie/variables.tf#L21-L30)
-for this variable in order to understand how to structure the list of buckets per region.
+data. The Landing Zone solution already configured Macie in all deployed accounts. The last step is to setup S3 buckets to be analyzed.
+To set up Macie to analyze the desired S3 buckets, you’ll need to create a **Macie classification job**. There is a bug
+in the [terraform-provider-aws](https://github.com/hashicorp/terraform-provider-aws/issues/20726), where the `aws_macie2_classification_job`
+can't be updated. Therefore, we ask you to manually create a new Classification Job and add all desired buckets.
 
-On each account, you can get a full list of existing S3 buckets using the AWS CLI:
+:::
 
-```
-aws s3 ls
-```
+If you are using Steampipe for checking your Compliance status, you should create the job by selecting a list of buckets,
+and **not** by bucket criterea. Steampipe fetchs the bucket list that's being analyzed by Macie, so if you specify critereas
+for the job, Steampipe will not match that the bucket is indeed being analyzed.
 
-For each bucket, the region can also be retrieved using the AWS CLI:
+:::
 
-
-```
-aws s3api get-bucket-location --bucket <BUCKET_NAME>
-```
+You can use either the [AWS Console](https://docs.aws.amazon.com/macie/latest/user/discovery-jobs-create.html), or the
+[AWS CLI](https://docs.aws.amazon.com/de_de/cli/latest/reference/macie2/create-classification-job.html#create-classification-job) to make the change.
 
 
 ## 7. Enable MFA Delete for all S3 buckets

--- a/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
+++ b/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
@@ -76,16 +76,17 @@ docs](https://docs.aws.amazon.com/sns/latest/dg/sns-http-https-endpoint-as-subsc
 ## 6. Add existing buckets to a new Macie classification job.
 
 Macie is a new AWS service that uses machine learning (ML) and pattern matching to discover and help protect your sensitive
-data. The Landing Zone solution already configured Macie in all deployed accounts. The last step is to setup S3 buckets to be analyzed.
+data. The Landing Zone solution already configured Macie in all deployed accounts. The last step is to specify the S3 buckets to be analyzed.
 To set up Macie to analyze the desired S3 buckets, you’ll need to create a **Macie classification job**. There is a bug
 in the [terraform-provider-aws](https://github.com/hashicorp/terraform-provider-aws/issues/20726), where the `aws_macie2_classification_job`
-can't be updated. Therefore, we ask you to manually create a new Classification Job and add all desired buckets.
+can't be updated. Therefore, until that bug is fixed (it has been open more than 2 years), we ask you to manually create a new Classification Job and add all buckets that might contain sensitive information, across **all accounts**.
 
 :::note
 
-If you are using Steampipe for checking your Compliance status, you should create the job by selecting a list of buckets,
-and **not** by bucket criterea. Steampipe fetchs the bucket list that's being analyzed by Macie, so if you specify critereas
-for the job, Steampipe will not match that the bucket is indeed being analyzed.
+If you are using Steampipe for checking your Compliance status, you should create the job by "selecting specific buckets",
+and **not** by "specifying bucket criteria". Steampipe fetches the bucket list that's being analyzed by Macie, so if you
+specify a filter for finding the buckets, Steampipe will not match which bucket are being analyzed. [See Steampipe's
+query for finding the buckets analyzed by Macie](https://github.com/turbot/steampipe-mod-aws-compliance/blob/c7cea47662c03f4cc4a84a17e41872e8ace611dc/query/s3/s3_bucket_protected_by_macie.sql#L6-L7).
 
 :::
 

--- a/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
+++ b/_docs-sources/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
@@ -92,8 +92,10 @@ query for finding the buckets analyzed by Macie](https://github.com/turbot/steam
 
 You can use either the [AWS Console](https://docs.aws.amazon.com/macie/latest/user/discovery-jobs-create.html), or the
 [AWS CLI](https://docs.aws.amazon.com/de_de/cli/latest/reference/macie2/create-classification-job.html#create-classification-job) to make the change.
+
+
 The script below will fetch a list of all buckets in an AWS account and create a new classification job for them to be weekly
-analyzed. The script needs to be executed while authenticated in AWS.
+analyzed. The script needs to be executed while authenticated to each account (shared, security, dev, prod etc), and `aws` CLI and `jq` should be available.
 
 ```bash
 #!/bin/bash

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
@@ -76,16 +76,17 @@ docs](https://docs.aws.amazon.com/sns/latest/dg/sns-http-https-endpoint-as-subsc
 ## 6. Add existing buckets to a new Macie classification job.
 
 Macie is a new AWS service that uses machine learning (ML) and pattern matching to discover and help protect your sensitive
-data. The Landing Zone solution already configured Macie in all deployed accounts. The last step is to setup S3 buckets to be analyzed.
+data. The Landing Zone solution already configured Macie in all deployed accounts. The last step is to specify the S3 buckets to be analyzed.
 To set up Macie to analyze the desired S3 buckets, you’ll need to create a **Macie classification job**. There is a bug
 in the [terraform-provider-aws](https://github.com/hashicorp/terraform-provider-aws/issues/20726), where the `aws_macie2_classification_job`
-can't be updated. Therefore, we ask you to manually create a new Classification Job and add all desired buckets.
+can't be updated. Therefore, until that bug is fixed (it has been open more than 2 years), we ask you to manually create a new Classification Job and add all buckets that might contain sensitive information, across **all accounts**.
 
 :::note
 
-If you are using Steampipe for checking your Compliance status, you should create the job by selecting a list of buckets,
-and **not** by bucket criterea. Steampipe fetchs the bucket list that's being analyzed by Macie, so if you specify critereas
-for the job, Steampipe will not match that the bucket is indeed being analyzed.
+If you are using Steampipe for checking your Compliance status, you should create the job by "selecting specific buckets",
+and **not** by "specifying bucket criteria". Steampipe fetches the bucket list that's being analyzed by Macie, so if you
+specify a filter for finding the buckets, Steampipe will not match which bucket are being analyzed. [See Steampipe's
+query for finding the buckets analyzed by Macie](https://github.com/turbot/steampipe-mod-aws-compliance/blob/c7cea47662c03f4cc4a84a17e41872e8ace611dc/query/s3/s3_bucket_protected_by_macie.sql#L6-L7).
 
 :::
 
@@ -137,6 +138,6 @@ Example:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "097e94fdf92a51a0d66541c023b2eece"
+  "hash": "ce2b91bfd56b1180d1a9593d9d670721"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
@@ -81,7 +81,7 @@ To set up Macie to analyze the desired S3 buckets, you’ll need to create a **M
 in the [terraform-provider-aws](https://github.com/hashicorp/terraform-provider-aws/issues/20726), where the `aws_macie2_classification_job`
 can't be updated. Therefore, we ask you to manually create a new Classification Job and add all desired buckets.
 
-:::
+:::note
 
 If you are using Steampipe for checking your Compliance status, you should create the job by selecting a list of buckets,
 and **not** by bucket criterea. Steampipe fetchs the bucket list that's being analyzed by Macie, so if you specify critereas
@@ -137,6 +137,6 @@ Example:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "55c33e942915fa7a73d6a2c74329fa04"
+  "hash": "097e94fdf92a51a0d66541c023b2eece"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
@@ -92,6 +92,23 @@ query for finding the buckets analyzed by Macie](https://github.com/turbot/steam
 
 You can use either the [AWS Console](https://docs.aws.amazon.com/macie/latest/user/discovery-jobs-create.html), or the
 [AWS CLI](https://docs.aws.amazon.com/de_de/cli/latest/reference/macie2/create-classification-job.html#create-classification-job) to make the change.
+The script below will fetch a list of all buckets in an AWS account and create a new classification job for them to be weekly
+analyzed. The script needs to be executed while authenticated in AWS.
+
+```bash
+#!/bin/bash
+
+# Get Account ID
+ACCOUNT_ID=$(aws sts get-caller-identity --output json | jq '.Account')
+echo "Creating classification job for account $ACCOUNT_ID"
+
+# Get the full list of buckets
+BUCKETS_LIST=$(aws s3api list-buckets --output json | jq '[.Buckets[] | .Name]')
+echo "Creating classification job for list of buckets $BUCKETS_LIST"
+
+# Create a job in Macie that will analyze all buckets once per week, on Mondays
+aws macie2 create-classification-job --name "weekly-analyzis" --job-type "SCHEDULED" --schedule-frequency "{ \"weeklySchedule\": {\"dayOfWeek\": \"MONDAY\" } }" --s3-job-definition "{\"bucketDefinitions\":[{\"accountId\":$ACCOUNT_ID, \"buckets\":$BUCKETS_LIST}]}"
+```
 
 
 ## 7. Enable MFA Delete for all S3 buckets
@@ -138,6 +155,6 @@ Example:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "2a04133c19a941e49653787d6877206c"
+  "hash": "0bc13d8603dd4631a6c43095a16186f2"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
@@ -73,28 +73,24 @@ You can also configure an automated system integration if you have a third party
 Follow the steps in the [AWS
 docs](https://docs.aws.amazon.com/sns/latest/dg/sns-http-https-endpoint-as-subscriber.html) on how to add an HTTPS endpoint as a subscriber to the alerts.
 
-## 6. Manually maintain buckets to analyze in the `buckets_to_analyze` variable
+## 6. Add existing buckets to a new Macie classification job.
 
 Macie is a new AWS service that uses machine learning (ML) and pattern matching to discover and help protect your sensitive
-data. To set up Macie to analyze the desired S3 buckets, you’ll need to create a **Macie classification job**. Typically,
-you’ll want it to analyze all the buckets in the region. However, the terraform AWS provider does not support specifying
-all the buckets in a region - it requires that an explicit list of buckets be provided. Therefore, you’ll
-need to maintain an explicit list of buckets per region, namely in the variable `buckets_to_analyze`. This list of buckets needs to be maintained in the future as new buckets are created in the account. Please read the
-[documentation](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/blob/master/modules/security/macie/variables.tf#L21-L30)
-for this variable in order to understand how to structure the list of buckets per region.
+data. The Landing Zone solution already configured Macie in all deployed accounts. The last step is to setup S3 buckets to be analyzed.
+To set up Macie to analyze the desired S3 buckets, you’ll need to create a **Macie classification job**. There is a bug
+in the [terraform-provider-aws](https://github.com/hashicorp/terraform-provider-aws/issues/20726), where the `aws_macie2_classification_job`
+can't be updated. Therefore, we ask you to manually create a new Classification Job and add all desired buckets.
 
-On each account, you can get a full list of existing S3 buckets using the AWS CLI:
+:::
 
-```
-aws s3 ls
-```
+If you are using Steampipe for checking your Compliance status, you should create the job by selecting a list of buckets,
+and **not** by bucket criterea. Steampipe fetchs the bucket list that's being analyzed by Macie, so if you specify critereas
+for the job, Steampipe will not match that the bucket is indeed being analyzed.
 
-For each bucket, the region can also be retrieved using the AWS CLI:
+:::
 
-
-```
-aws s3api get-bucket-location --bucket <BUCKET_NAME>
-```
+You can use either the [AWS Console](https://docs.aws.amazon.com/macie/latest/user/discovery-jobs-create.html), or the
+[AWS CLI](https://docs.aws.amazon.com/de_de/cli/latest/reference/macie2/create-classification-job.html#create-classification-job) to make the change.
 
 
 ## 7. Enable MFA Delete for all S3 buckets
@@ -141,6 +137,6 @@ Example:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "402d73f62a8fa3b89d18d1decb3ebeba"
+  "hash": "55c33e942915fa7a73d6a2c74329fa04"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
+++ b/docs/guides/build-it-yourself/achieve-compliance/deployment-walkthrough/manual-steps.md
@@ -73,7 +73,7 @@ You can also configure an automated system integration if you have a third party
 Follow the steps in the [AWS
 docs](https://docs.aws.amazon.com/sns/latest/dg/sns-http-https-endpoint-as-subscriber.html) on how to add an HTTPS endpoint as a subscriber to the alerts.
 
-## 6. Add existing buckets to a new Macie classification job.
+## 6. Add existing buckets to a new Macie classification job
 
 Macie is a new AWS service that uses machine learning (ML) and pattern matching to discover and help protect your sensitive
 data. The Landing Zone solution already configured Macie in all deployed accounts. The last step is to specify the S3 buckets to be analyzed.
@@ -138,6 +138,6 @@ Example:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "ce2b91bfd56b1180d1a9593d9d670721"
+  "hash": "2a04133c19a941e49653787d6877206c"
 }
 ##DOCS-SOURCER-END -->


### PR DESCRIPTION
Due to a bug in the AWS provider, the existing steps aren't working.

[Jira: PATCHER-70](https://gruntwork.atlassian.net/browse/PATCHER-70?atlOrigin=eyJpIjoiYmY5N2M5YWJiMTQzNDBiNGI2MzBjYjRlODM2MjkzMjUiLCJwIjoiaiJ9)
