### PR TITLE
Clean up Modules intro section

### DIFF
--- a/_docs-sources/reference/modules/intro.md
+++ b/_docs-sources/reference/modules/intro.md
@@ -3,8 +3,17 @@
 # Fortunately, this property only seems to affect # auto-generated sidebar items.
 # So we still _do_ display this page in the sidebar, but use a manual entry.
 sidebar_class_name: dont_show
+pagination_next: null
 ---
 
 # Gruntwork Module Catalog
 
 At Gruntwork, we've taken the thousands of hours we spent building infrastructure on AWS and condensed all that experience and code into pre-built packages or modules. Each module is a battle-tested, best-practices definition of a piece of infrastructure, such as a VPC, ECS cluster, or an Auto Scaling Group. Modules are versioned using Semantic Versioning to allow Gruntwork clients to keep up to date with the latest infrastructure best practices in a systematic way.
+
+## Why do we have Modules and Services
+
+The Gruntwork IaC Library is a collection of reusable code that enables you to deploy and manage infrastructure quickly and reliably. The library consists of two types of code: Modules and Services. Here's how they differ.
+
+**Modules:** Reusable code to deploy and manage one piece of infrastructure. Modules are fairly generic building blocks, so you don't typically deploy a single module directly, but rather, you write code that combines the modules you need for a specific use case. For example, one module might deploy the control plane for Kubernetes and a separate module could deploy worker nodes; you may need to combine both modules together to deploy a Kubernetes cluster. The Gruntwork Infrastructure as Code (IaC) Library contains hundreds of battle-tested, commercially supported and maintained modules that you can use and combine in many different ways.
+
+**Services:** Reusable code that combines multiple modules to configure a service for a specific use case. Services are designed for specific use cases and meant to be deployed directly. For example, the eks-cluster service combines all the modules you need to run an EKS (Kubernetes) cluster in a typical production environment, including modules for the control plane, worker nodes, secrets management, log aggregation, alerting, and so on. The Gruntwork Service Catalog is a collection of battle-tested, commercially supported and maintained services that you can use to deploy production-grade infrastructure in minutes.

--- a/docs/guides/build-it-yourself/pipelines/index.md
+++ b/docs/guides/build-it-yourself/pipelines/index.md
@@ -52,7 +52,6 @@ testing for Terraform, Docker, Packer, Kubernetes, and More](https://blog.gruntw
 
 </div>
 
-
 ## Sections
 
 Feel free to read this guide from start to finish or skip around to whatever sections interest you.
@@ -90,5 +89,8 @@ Feel free to read this guide from start to finish or skip around to whatever sec
 
 
 <!-- ##DOCS-SOURCER-START
-{"sourcePlugin":"local-copier","hash":"ce61548221a65c5a711904397d890781"}
+{
+  "sourcePlugin": "local-copier",
+  "hash": "0d4a701ecaf6b15a54896e84ee9673cf"
+}
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/intro.md
+++ b/docs/reference/modules/intro.md
@@ -3,16 +3,25 @@
 # Fortunately, this property only seems to affect # auto-generated sidebar items.
 # So we still _do_ display this page in the sidebar, but use a manual entry.
 sidebar_class_name: dont_show
+pagination_next: null
 ---
 
 # Gruntwork Module Catalog
 
 At Gruntwork, we've taken the thousands of hours we spent building infrastructure on AWS and condensed all that experience and code into pre-built packages or modules. Each module is a battle-tested, best-practices definition of a piece of infrastructure, such as a VPC, ECS cluster, or an Auto Scaling Group. Modules are versioned using Semantic Versioning to allow Gruntwork clients to keep up to date with the latest infrastructure best practices in a systematic way.
 
+## Why do we have Modules and Services
+
+The Gruntwork IaC Library is a collection of reusable code that enables you to deploy and manage infrastructure quickly and reliably. The library consists of two types of code: Modules and Services. Here's how they differ.
+
+**Modules:** Reusable code to deploy and manage one piece of infrastructure. Modules are fairly generic building blocks, so you don't typically deploy a single module directly, but rather, you write code that combines the modules you need for a specific use case. For example, one module might deploy the control plane for Kubernetes and a separate module could deploy worker nodes; you may need to combine both modules together to deploy a Kubernetes cluster. The Gruntwork Infrastructure as Code (IaC) Library contains hundreds of battle-tested, commercially supported and maintained modules that you can use and combine in many different ways.
+
+**Services:** Reusable code that combines multiple modules to configure a service for a specific use case. Services are designed for specific use cases and meant to be deployed directly. For example, the eks-cluster service combines all the modules you need to run an EKS (Kubernetes) cluster in a typical production environment, including modules for the control plane, worker nodes, secrets management, log aggregation, alerting, and so on. The Gruntwork Service Catalog is a collection of battle-tested, commercially supported and maintained services that you can use to deploy production-grade infrastructure in minutes.
+
 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "13f01310876b366407f2789801388af4"
+  "hash": "b920ff1271aa10ce2e3e0f15a543fb1c"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/intro/create-your-own-service-catalog.md
+++ b/docs/reference/services/intro/create-your-own-service-catalog.md
@@ -185,6 +185,7 @@ inputs = {
 }
 ```
 
+
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",


### PR DESCRIPTION
A few small fixes:
- Cleaned up the text that explains modules vs services
- Removed the "next" link that went no where.