### PR TITLE
chore(CORE-521): Temporarily hide the cicd pipeline guide

### DIFF
--- a/_docs-sources/guides/build-it-yourself/pipelines/index.md
+++ b/_docs-sources/guides/build-it-yourself/pipelines/index.md
@@ -3,86 +3,12 @@ sidebar_label: What you’ll learn in this guide
 pagination_label: Set Up an Infrastructure CI/CD Pipeline
 ---
 
-import { CardList } from "/src/components/CardGroup"
-
 # Set Up an Infrastructure CI/CD Pipeline
 
 :::info
 
-This document is an excellent resource for understanding the problem space of CI/CD and the design choices that Gruntwork Pipelines makes.  
+We are in the process of updating this document. 
 
-If you are looking to get hands-on with Gruntwork Pipelines and deploy it yourself, see [the official examples in our service catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/master/examples/for-production/gruntwork-pipelines)
+In the meantime, if you are a Gruntwork customer looking to get hands-on with Gruntwork Pipelines, see [the official examples in our service catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/master/examples/for-production/gruntwork-pipelines)
 
 :::
-
-## Overview
-
-This is a comprehensive guide explaining the problem space of CI/CD, its threat vectors, and the design decisions that Gruntwork Pipelines 
-makes in order to keep your sensitive credentials secure. 
-
-## What this guide will not cover
-
-This guide is not hands-on! If you're looking to explore and play around with Gruntwork Pipelines, you should instead view and deploy [our official 
-examples in our service catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/master/examples/for-production/gruntwork-pipelines).
-
-CI/CD for infrastructure code is a large topic and a single guide cannot cover everything. There
-are several items that this guide will not cover, including:
-
-<div className="dlist">
-
-#### A pipeline for setting up new environments
-
-This guide will focus on a CI/CD workflow for making changes to infrastructure in an environment that is already set
-up. In other words, the design and implementation of the pipeline covered in this guide intentionally does not solve
-the use case of infrastructure code for setting up an environment from scratch. Setting up new environments typically
-require complex deployment orders and permissions modeling that complicate the task. This makes it hard to automate in
-a reasonable fashion that still respects the threat model we cover here.
-
-#### Automated testing and feature toggling strategies for infrastructure code
-
-An important factor of CI/CD pipelines is the existence of automated testing and feature toggles. Automated tests give
-you confidence in the code before it is deployed to production. Similarly, feature toggles allow you to partially
-integrate and deploy code for a feature without enabling it. By doing so, you are able to continuously integrate new
-developments over time. This guide will briefly introduce automated testing and feature toggles for infrastructure
-code, but will not do a deep dive on the subject. You can learn more about best practices for automated testing in our
-talk
-[Automated
-testing for Terraform, Docker, Packer, Kubernetes, and More](https://blog.gruntwork.io/new-talk-automated-testing-for-terraform-docker-packer-kubernetes-and-more-cba312171aa6) and blog post
-[Agility requires safety](https://www.ybrikman.com/writing/2016/02/14/agility-requires-safety/).
-
-</div>
-
-## Sections
-
-Feel free to read this guide from start to finish or skip around to whatever sections interest you.
-
-<CardList>
-  <Card
-    title="Core Concepts"
-    href="/guides/build-it-yourself/pipelines/core-concepts/why-is-it-important-to-have-ci-cd"
-  >
-    An overview of the core concepts you need to understand what a typical CI/CD pipeline entails for infrastructure code,
-    including a comparison with CI/CD for application code, a sample workflow, infrastructure to support CI/CD, and threat
-    models to consider to protect your infrastructure.
-  </Card>
-  <Card
-    title="Production-grade Design"
-    href="/guides/build-it-yourself/pipelines/production-grade-design/intro"
-  >
-    An overview of how to configure a secure, scalable, and robust CI/CD workflow that you can rely on for your
-    production application and infrastructure code.
-  </Card>
-  <Card
-    title="Deployment Walkthrough"
-    href="/guides/build-it-yourself/pipelines/deployment-walkthrough/pre-requisites"
-  >
-    A step-by-step guide to deploying a production-grade CI/CD pipeline in AWS using code from the Gruntwork
-    Infrastructure as Code Library.
-  </Card>
-  <Card
-    title="Next Steps"
-    href="/guides/build-it-yourself/pipelines/next-steps"
-  >
-    What to do once you’ve got your CI/CD pipeline set up.
-  </Card>
-</CardList>

--- a/docs/guides/build-it-yourself/pipelines/index.md
+++ b/docs/guides/build-it-yourself/pipelines/index.md
@@ -3,94 +3,20 @@ sidebar_label: What you’ll learn in this guide
 pagination_label: Set Up an Infrastructure CI/CD Pipeline
 ---
 
-import { CardList } from "/src/components/CardGroup"
-
 # Set Up an Infrastructure CI/CD Pipeline
 
 :::info
 
-This document is an excellent resource for understanding the problem space of CI/CD and the design choices that Gruntwork Pipelines makes.  
+We are in the process of updating this document. 
 
-If you are looking to get hands-on with Gruntwork Pipelines and deploy it yourself, see [the official examples in our service catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/master/examples/for-production/gruntwork-pipelines)
+In the meantime, if you are a Gruntwork customer looking to get hands-on with Gruntwork Pipelines, see [the official examples in our service catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/master/examples/for-production/gruntwork-pipelines)
 
 :::
-
-## Overview
-
-This is a comprehensive guide explaining the problem space of CI/CD, its threat vectors, and the design decisions that Gruntwork Pipelines 
-makes in order to keep your sensitive credentials secure. 
-
-## What this guide will not cover
-
-This guide is not hands-on! If you're looking to explore and play around with Gruntwork Pipelines, you should instead view and deploy [our official 
-examples in our service catalog](https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/master/examples/for-production/gruntwork-pipelines).
-
-CI/CD for infrastructure code is a large topic and a single guide cannot cover everything. There
-are several items that this guide will not cover, including:
-
-<div className="dlist">
-
-#### A pipeline for setting up new environments
-
-This guide will focus on a CI/CD workflow for making changes to infrastructure in an environment that is already set
-up. In other words, the design and implementation of the pipeline covered in this guide intentionally does not solve
-the use case of infrastructure code for setting up an environment from scratch. Setting up new environments typically
-require complex deployment orders and permissions modeling that complicate the task. This makes it hard to automate in
-a reasonable fashion that still respects the threat model we cover here.
-
-#### Automated testing and feature toggling strategies for infrastructure code
-
-An important factor of CI/CD pipelines is the existence of automated testing and feature toggles. Automated tests give
-you confidence in the code before it is deployed to production. Similarly, feature toggles allow you to partially
-integrate and deploy code for a feature without enabling it. By doing so, you are able to continuously integrate new
-developments over time. This guide will briefly introduce automated testing and feature toggles for infrastructure
-code, but will not do a deep dive on the subject. You can learn more about best practices for automated testing in our
-talk
-[Automated
-testing for Terraform, Docker, Packer, Kubernetes, and More](https://blog.gruntwork.io/new-talk-automated-testing-for-terraform-docker-packer-kubernetes-and-more-cba312171aa6) and blog post
-[Agility requires safety](https://www.ybrikman.com/writing/2016/02/14/agility-requires-safety/).
-
-</div>
-
-## Sections
-
-Feel free to read this guide from start to finish or skip around to whatever sections interest you.
-
-<CardList>
-  <Card
-    title="Core Concepts"
-    href="/guides/build-it-yourself/pipelines/core-concepts/why-is-it-important-to-have-ci-cd"
-  >
-    An overview of the core concepts you need to understand what a typical CI/CD pipeline entails for infrastructure code,
-    including a comparison with CI/CD for application code, a sample workflow, infrastructure to support CI/CD, and threat
-    models to consider to protect your infrastructure.
-  </Card>
-  <Card
-    title="Production-grade Design"
-    href="/guides/build-it-yourself/pipelines/production-grade-design/intro"
-  >
-    An overview of how to configure a secure, scalable, and robust CI/CD workflow that you can rely on for your
-    production application and infrastructure code.
-  </Card>
-  <Card
-    title="Deployment Walkthrough"
-    href="/guides/build-it-yourself/pipelines/deployment-walkthrough/pre-requisites"
-  >
-    A step-by-step guide to deploying a production-grade CI/CD pipeline in AWS using code from the Gruntwork
-    Infrastructure as Code Library.
-  </Card>
-  <Card
-    title="Next Steps"
-    href="/guides/build-it-yourself/pipelines/next-steps"
-  >
-    What to do once you’ve got your CI/CD pipeline set up.
-  </Card>
-</CardList>
 
 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "0d4a701ecaf6b15a54896e84ee9673cf"
+  "hash": "af79446fd34c141811965f2e708ba157"
 }
 ##DOCS-SOURCER-END -->

--- a/sidebars/pipelines-guide.js
+++ b/sidebars/pipelines-guide.js
@@ -12,44 +12,7 @@ const sidebar = [
       type: "doc",
       id: "guides/build-it-yourself/pipelines/index",
     },
-    items: [
-      {
-        "Core Concepts": [
-          "guides/build-it-yourself/pipelines/core-concepts/what-is-continuous-integration-and-continuous-delivery",
-          "guides/build-it-yourself/pipelines/core-concepts/why-is-it-important-to-have-ci-cd",
-          "guides/build-it-yourself/pipelines/core-concepts/trunk-based-development-model",
-          "guides/build-it-yourself/pipelines/core-concepts/types-of-infrastructure-code",
-          "guides/build-it-yourself/pipelines/core-concepts/ci-cd-workflows",
-          "guides/build-it-yourself/pipelines/core-concepts/threat-model-of-ci-cd",
-          "guides/build-it-yourself/pipelines/core-concepts/ci-cd-platforms",
-        ],
-      },
-      {
-        "Production Grade Design": [
-          "guides/build-it-yourself/pipelines/production-grade-design/intro",
-          "guides/build-it-yourself/pipelines/production-grade-design/use-generic-ci-cd-platforms-as-a-workflow-engine-but-run-infrastructure-deployments-from-within-your-account",
-          "guides/build-it-yourself/pipelines/production-grade-design/options-for-deploy-server",
-          "guides/build-it-yourself/pipelines/production-grade-design/limit-triggers-for-deploy-server",
-          "guides/build-it-yourself/pipelines/production-grade-design/use-a-vpc-to-lock-down-deploy-server",
-          "guides/build-it-yourself/pipelines/production-grade-design/use-minimal-iam-permissions-for-a-deployment",
-          "guides/build-it-yourself/pipelines/production-grade-design/use-approval-flows",
-          "guides/build-it-yourself/pipelines/production-grade-design/lock-down-vcs-systems",
-          "guides/build-it-yourself/pipelines/production-grade-design/summary-of-mitigations",
-          "guides/build-it-yourself/pipelines/production-grade-design/summary-of-deployment-sequence",
-        ],
-      },
-      {
-        "Deployment Walkthrough": [
-          "guides/build-it-yourself/pipelines/deployment-walkthrough/pre-requisites",
-          "guides/build-it-yourself/pipelines/deployment-walkthrough/deploy-a-vpc",
-          "guides/build-it-yourself/pipelines/deployment-walkthrough/deploy-the-ecs-deploy-runner",
-          "guides/build-it-yourself/pipelines/deployment-walkthrough/try-out-the-ecs-deploy-runner",
-          "guides/build-it-yourself/pipelines/deployment-walkthrough/define-pipeline-as-code",
-          "guides/build-it-yourself/pipelines/deployment-walkthrough/configure-ci-server",
-        ],
-      },
-      "guides/build-it-yourself/pipelines/next-steps",
-    ],
+    items: [],
   },
 ]
 


### PR DESCRIPTION
### What it is

Temporarily removes the existing DIY guide for GW pipelines by removing references to the content in the sidebar.

I recognize that the content will still be available, if you want to seek out the links, but this seemed like the lower risk approach while we work on re-writing this guide. It also allows us to re-use parts of it without needing to comb through git history.

Happy to remove it completely, if that's the consensus of the team.