### PR TITLE
Updated min. CIS repo version required for Patcher - PATCHER-116

### DIFF
--- a/_docs-sources/guides/stay-up-to-date/cis/cis-1.5.0/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/_docs-sources/guides/stay-up-to-date/cis/cis-1.5.0/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -130,7 +130,7 @@ versions of Gruntwork's CIS Reference Architecture (part of the Gruntwork librar
       <td>
         <p>
           <strong>
-            <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.40.0">
+            <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.40.1">
               v0.40.1
             </a>
           </strong>

--- a/_docs-sources/guides/stay-up-to-date/cis/cis-1.5.0/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/_docs-sources/guides/stay-up-to-date/cis/cis-1.5.0/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -131,7 +131,7 @@ versions of Gruntwork's CIS Reference Architecture (part of the Gruntwork librar
         <p>
           <strong>
             <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.40.0">
-              v0.40.0
+              v0.40.1
             </a>
           </strong>
         </p>
@@ -140,8 +140,7 @@ versions of Gruntwork's CIS Reference Architecture (part of the Gruntwork librar
   </tbody>
 </table>
 
-If you're a customer who signed up for the Gruntwork CIS RefArch from October 1, 2022 then you can use Patcher to
-safely apply the more than 200 version updates that are necessary to be compatible with CIS AWS v1.5.0.
+If you're a customer who signed up for the Gruntwork CIS RefArch from August 4, 2022 onwards then you can use Patcher to safely apply the more than 200 version updates that are necessary to be compatible with CIS AWS v1.5.0.
 
 Included in those more than 200 updates are 3 breaking changes that need to be applied to your
 infrastructure. These breaking changes include migrating to our new CIS RDS module. Patcher applies a series of patches

--- a/docs/guides/stay-up-to-date/cis/cis-1.5.0/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
+++ b/docs/guides/stay-up-to-date/cis/cis-1.5.0/deployment-walkthrough/step-2-update-references-to-the-gruntwork-infrastructure-as-code-library.md
@@ -130,8 +130,8 @@ versions of Gruntwork's CIS Reference Architecture (part of the Gruntwork librar
       <td>
         <p>
           <strong>
-            <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.40.0">
-              v0.40.0
+            <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.40.1">
+              v0.40.1
             </a>
           </strong>
         </p>
@@ -140,8 +140,7 @@ versions of Gruntwork's CIS Reference Architecture (part of the Gruntwork librar
   </tbody>
 </table>
 
-If you're a customer who signed up for the Gruntwork CIS RefArch from October 1, 2022 then you can use Patcher to
-safely apply the more than 200 version updates that are necessary to be compatible with CIS AWS v1.5.0.
+If you're a customer who signed up for the Gruntwork CIS RefArch from August 4, 2022 onwards then you can use Patcher to safely apply the more than 200 version updates that are necessary to be compatible with CIS AWS v1.5.0.
 
 Included in those more than 200 updates are 3 breaking changes that need to be applied to your
 infrastructure. These breaking changes include migrating to our new CIS RDS module. Patcher applies a series of patches
@@ -314,6 +313,6 @@ If you have successfully completed manually updating the modules to the minimum 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "46739fa913b27a01c8a920d59c43c5e3"
+  "hash": "94539032a21f6fb8b31ae6812144e0a6"
 }
 ##DOCS-SOURCER-END -->


### PR DESCRIPTION
Changed min version in step 2 from `v0.40.0` to `v0.40.1`. Patcher v0.1.1 requires the version to be `>= v0.40.1`.