### PR TITLE
Revert inadvertent changes to stay-up-to-date guide's index page

### DIFF
--- a/_docs-sources/guides/stay-up-to-date/index.md
+++ b/_docs-sources/guides/stay-up-to-date/index.md
@@ -16,22 +16,7 @@ import CardGroup from "/src/components/CardGroup"
 
 <CardGroup cols={1} gap="1rem" stacked equalHeightRows={false} commonCardProps={{padding: "1.25rem"}}>
 
-<Card title="Update to 2023-02" href="/guides/stay-up-to-date/releases/2023-02" />
-<Card title="Update to 2023-01" href="/guides/stay-up-to-date/releases/2023-01" />
-<Card title="Update to 2022-12" href="/guides/stay-up-to-date/releases/2022-12" />
-<Card title="Update to 2022-11" href="/guides/stay-up-to-date/releases/2022-11" />
-<Card title="Update to 2022-10" href="/guides/stay-up-to-date/releases/2022-10" />
-<Card title="Update to 2022-09" href="/guides/stay-up-to-date/releases/2022-09" />
-<Card title="Update to 2022-08" href="/guides/stay-up-to-date/releases/2022-08" />
-<Card title="Update to 2022-07" href="/guides/stay-up-to-date/releases/2022-07" />
-<Card title="Update to 2022-06" href="/guides/stay-up-to-date/releases/2022-06" />
-<Card title="Update to 2022-05" href="/guides/stay-up-to-date/releases/2022-05" />
-<Card title="Update to 2022-04" href="/guides/stay-up-to-date/releases/2022-04" />
-<Card title="Update to 2022-03" href="/guides/stay-up-to-date/releases/2022-03" />
-<Card title="Update to 2022-02" href="/guides/stay-up-to-date/releases/2022-02" />
-<Card title="Update to 2022-01" href="/guides/stay-up-to-date/releases/2022-01" />
-<Card title="Update to 2021-12" href="/guides/stay-up-to-date/releases/2021-12" />
-<Card title="See older releases" href="/guides/stay-up-to-date/releases" />
+<!-- replaced-by-docs-sourcer-automatically-do-not-edit -->
 
 </CardGroup>
 

--- a/_docs-sources/guides/stay-up-to-date/index.md
+++ b/_docs-sources/guides/stay-up-to-date/index.md
@@ -16,7 +16,22 @@ import CardGroup from "/src/components/CardGroup"
 
 <CardGroup cols={1} gap="1rem" stacked equalHeightRows={false} commonCardProps={{padding: "1.25rem"}}>
 
-<!-- replaced-by-docs-sourcer-automatically-do-not-edit -->
+<Card title="Update to 2023-02" href="/guides/stay-up-to-date/releases/2023-02" />
+<Card title="Update to 2023-01" href="/guides/stay-up-to-date/releases/2023-01" />
+<Card title="Update to 2022-12" href="/guides/stay-up-to-date/releases/2022-12" />
+<Card title="Update to 2022-11" href="/guides/stay-up-to-date/releases/2022-11" />
+<Card title="Update to 2022-10" href="/guides/stay-up-to-date/releases/2022-10" />
+<Card title="Update to 2022-09" href="/guides/stay-up-to-date/releases/2022-09" />
+<Card title="Update to 2022-08" href="/guides/stay-up-to-date/releases/2022-08" />
+<Card title="Update to 2022-07" href="/guides/stay-up-to-date/releases/2022-07" />
+<Card title="Update to 2022-06" href="/guides/stay-up-to-date/releases/2022-06" />
+<Card title="Update to 2022-05" href="/guides/stay-up-to-date/releases/2022-05" />
+<Card title="Update to 2022-04" href="/guides/stay-up-to-date/releases/2022-04" />
+<Card title="Update to 2022-03" href="/guides/stay-up-to-date/releases/2022-03" />
+<Card title="Update to 2022-02" href="/guides/stay-up-to-date/releases/2022-02" />
+<Card title="Update to 2022-01" href="/guides/stay-up-to-date/releases/2022-01" />
+<Card title="Update to 2021-12" href="/guides/stay-up-to-date/releases/2021-12" />
+<Card title="See older releases" href="/guides/stay-up-to-date/releases" />
 
 </CardGroup>
 

--- a/docs/guides/stay-up-to-date/index.md
+++ b/docs/guides/stay-up-to-date/index.md
@@ -114,6 +114,6 @@ href="/guides/stay-up-to-date/cis/cis-1.5.0"
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "83b5997fd4c9852bc578ed27cb2e494e"
+  "hash": "62b70a3abb786b70597a9ce74277234a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/index.md
+++ b/docs/guides/stay-up-to-date/index.md
@@ -113,7 +113,7 @@ href="/guides/stay-up-to-date/cis/cis-1.5.0"
 
 <!-- ##DOCS-SOURCER-START
 {
-  "sourcePlugin": "local-copier",
+  "sourcePlugin": "releases",
   "hash": "62b70a3abb786b70597a9ce74277234a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/index.md
+++ b/docs/guides/stay-up-to-date/index.md
@@ -16,7 +16,22 @@ import CardGroup from "/src/components/CardGroup"
 
 <CardGroup cols={1} gap="1rem" stacked equalHeightRows={false} commonCardProps={{padding: "1.25rem"}}>
 
-<!-- replaced-by-docs-sourcer-automatically-do-not-edit -->
+<Card title="Update to 2023-02" href="/guides/stay-up-to-date/releases/2023-02" />
+<Card title="Update to 2023-01" href="/guides/stay-up-to-date/releases/2023-01" />
+<Card title="Update to 2022-12" href="/guides/stay-up-to-date/releases/2022-12" />
+<Card title="Update to 2022-11" href="/guides/stay-up-to-date/releases/2022-11" />
+<Card title="Update to 2022-10" href="/guides/stay-up-to-date/releases/2022-10" />
+<Card title="Update to 2022-09" href="/guides/stay-up-to-date/releases/2022-09" />
+<Card title="Update to 2022-08" href="/guides/stay-up-to-date/releases/2022-08" />
+<Card title="Update to 2022-07" href="/guides/stay-up-to-date/releases/2022-07" />
+<Card title="Update to 2022-06" href="/guides/stay-up-to-date/releases/2022-06" />
+<Card title="Update to 2022-05" href="/guides/stay-up-to-date/releases/2022-05" />
+<Card title="Update to 2022-04" href="/guides/stay-up-to-date/releases/2022-04" />
+<Card title="Update to 2022-03" href="/guides/stay-up-to-date/releases/2022-03" />
+<Card title="Update to 2022-02" href="/guides/stay-up-to-date/releases/2022-02" />
+<Card title="Update to 2022-01" href="/guides/stay-up-to-date/releases/2022-01" />
+<Card title="Update to 2021-12" href="/guides/stay-up-to-date/releases/2021-12" />
+<Card title="See older releases" href="/guides/stay-up-to-date/releases" />
 
 </CardGroup>
 

--- a/tests/guides/stay-up-to-date/index.md.spec.ts
+++ b/tests/guides/stay-up-to-date/index.md.spec.ts
@@ -1,0 +1,19 @@
+const fs = require("fs")
+
+const stayUpToDateIndexFile = fs.readFileSync(
+  "docs/guides/stay-up-to-date/index.md",
+  "utf8"
+)
+
+const releasesPlaceholder =
+  "<!-- replaced-by-docs-sourcer-automatically-do-not-edit -->"
+
+describe("Guides: stay-up-to-date index file", () => {
+  it("should not contain releases placeholder", () => {
+    // This a temporary workaround to prevent the index.page from being overwritten
+    // with the releases placeholder & committed to the main branch. The local plugin
+    // of the docs-sourcer package automatically copies `_docs_sources_/` into `docs`
+    // When this test fails, revert the change made to `docs/guides/stay-up-to-date/index.md`
+    expect(stayUpToDateIndexFile).not.toContain(releasesPlaceholder)
+  })
+})

--- a/tests/guides/stay-up-to-date/index.md.spec.ts
+++ b/tests/guides/stay-up-to-date/index.md.spec.ts
@@ -6,7 +6,7 @@ const stayUpToDateIndexFile = fs.readFileSync(
 )
 
 const stayUpToDateIndexFileInDocsSources = fs.readFileSync(
-  "docs_sources/guides/stay-up-to-date/index.md",
+  "_docs-sources/guides/stay-up-to-date/index.md",
   "utf8"
 )
 
@@ -14,13 +14,14 @@ const releasesPlaceholder =
   "<!-- replaced-by-docs-sourcer-automatically-do-not-edit -->"
 
 describe("Guides: stay-up-to-date index file", () => {
-  it("should have releases placeholder in only docs_sources", () => {
+  // This a temporary workaround to prevent the inadvertent changes to the
+  // placeholder or the index page in docs from being overwritten with the
+  // releases placeholder & committed to the main branch. The local plugin
+  // of the docs-sourcer package automatically copies `_docs-sources/` into `docs`
+  // When this test fails, revert the change made to `docs/guides/stay-up-to-date/index.md`
+  // or `_docs-sources/guides/stay-up-to-date/index.md`
+  it("should have releases placeholder in only _docs-sources", () => {
     expect(stayUpToDateIndexFileInDocsSources).toContain(releasesPlaceholder)
-
-    // This a temporary workaround to prevent the index.page from being overwritten
-    // with the releases placeholder & committed to the main branch. The local plugin
-    // of the docs-sourcer package automatically copies `_docs_sources_/` into `docs`
-    // When this test fails, revert the change made to `docs/guides/stay-up-to-date/index.md`
     expect(stayUpToDateIndexFile).not.toContain(releasesPlaceholder)
   })
 })

--- a/tests/guides/stay-up-to-date/index.md.spec.ts
+++ b/tests/guides/stay-up-to-date/index.md.spec.ts
@@ -5,11 +5,18 @@ const stayUpToDateIndexFile = fs.readFileSync(
   "utf8"
 )
 
+const stayUpToDateIndexFileInDocsSources = fs.readFileSync(
+  "docs_sources/guides/stay-up-to-date/index.md",
+  "utf8"
+)
+
 const releasesPlaceholder =
   "<!-- replaced-by-docs-sourcer-automatically-do-not-edit -->"
 
 describe("Guides: stay-up-to-date index file", () => {
-  it("should not contain releases placeholder", () => {
+  it("should have releases placeholder in only docs_sources", () => {
+    expect(stayUpToDateIndexFileInDocsSources).toContain(releasesPlaceholder)
+
     // This a temporary workaround to prevent the index.page from being overwritten
     // with the releases placeholder & committed to the main branch. The local plugin
     // of the docs-sourcer package automatically copies `_docs_sources_/` into `docs`


### PR DESCRIPTION
#### What does this do?
- Reverts last change that removed the list of releases
- Add a test that prevents this from being committed to the main branch 