### PR TITLE
[CORE-666] Source module and service catalog docs from latest releases by default

### DIFF
--- a/docs/reference/modules/terraform-aws-asg/asg-instance-refresh/asg-instance-refresh.md
+++ b/docs/reference/modules/terraform-aws-asg/asg-instance-refresh/asg-instance-refresh.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Auto Scaling Group Module with Instance Refresh
 
-<a href="https://github.com/gruntwork-io/terraform-aws-asg/tree/main/modules/asg-instance-refresh" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-asg/tree/v0.21.2/modules/asg-instance-refresh" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.21.1" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -648,11 +648,11 @@ A maximum duration that Terraform should wait for the EC2 Instances to be health
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-asg/tree/main/modules/asg-instance-refresh/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-asg/tree/main/modules/asg-instance-refresh/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-asg/tree/main/modules/asg-instance-refresh/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-asg/tree/v0.21.2/modules/asg-instance-refresh/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-asg/tree/v0.21.2/modules/asg-instance-refresh/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-asg/tree/v0.21.2/modules/asg-instance-refresh/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "3320f2e1e5b21b675b7fb93b1b23d089"
+  "hash": "50a0aeed6dc40a314f4952171ad60a39"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-asg/asg-rolling-deploy/asg-rolling-deploy.md
+++ b/docs/reference/modules/terraform-aws-asg/asg-rolling-deploy/asg-rolling-deploy.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Auto Scaling Group with Rolling Deployment Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-asg/tree/main/modules/asg-rolling-deploy" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-asg/tree/v0.21.2/modules/asg-rolling-deploy" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.21.2" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -56,7 +56,7 @@ update your launch templates (e.g. by specifying a new AMI to deploy), Terraform
 Note that if all we did was use `create_before_destroy`, on each redeploy, our ASG would reset to its hard-coded
 `desired_capacity`, losing the capacity changes from auto scaling policies. We solve this problem by using an
 [external data source](https://www.terraform.io/docs/providers/external/data_source.html) that runs the Python script
-[get-desired-capacity.py](https://github.com/gruntwork-io/terraform-aws-asg/tree/main/modules/asg-rolling-deploy/describe-autoscaling-group/get-desired-capacity.py) to fetch the latest value of the
+[get-desired-capacity.py](https://github.com/gruntwork-io/terraform-aws-asg/tree/v0.21.2/modules/asg-rolling-deploy/describe-autoscaling-group/get-desired-capacity.py) to fetch the latest value of the
 `desired_capacity` parameter:
 
 *   If the script finds a value from an already-existing ASG, we use it, to ensure that the changes form auto scaling
@@ -535,11 +535,11 @@ A maximum duration that Terraform should wait for the EC2 Instances to be health
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-asg/tree/main/modules/asg-rolling-deploy/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-asg/tree/main/modules/asg-rolling-deploy/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-asg/tree/main/modules/asg-rolling-deploy/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-asg/tree/v0.21.2/modules/asg-rolling-deploy/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-asg/tree/v0.21.2/modules/asg-rolling-deploy/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-asg/tree/v0.21.2/modules/asg-rolling-deploy/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "222ecc3c290bd86019249ebf367af02d"
+  "hash": "9771bbac245f268b3f0812114985ae15"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-asg/server-group/server-group.md
+++ b/docs/reference/modules/terraform-aws-asg/server-group/server-group.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Server Group Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-asg/tree/main/modules/server-group" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-asg/tree/v0.21.2/modules/server-group" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v0.21.2" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -37,7 +37,7 @@ Scaling Group (ASG).
 
 ## Quick start
 
-Check out the [server-group examples](https://github.com/gruntwork-io/terraform-aws-asg/tree/main/examples/server-group) for sample code that demonstrates how to use this module.
+Check out the [server-group examples](https://github.com/gruntwork-io/terraform-aws-asg/tree/v0.21.2/examples/server-group) for sample code that demonstrates how to use this module.
 
 ## Background
 
@@ -50,7 +50,7 @@ Check out the [server-group examples](https://github.com/gruntwork-io/terraform-
 The first question you may ask is, how is this different than an [Auto Scaling Group
 (ASG)](http://docs.aws.amazon.com/autoscaling/latest/userguide/AutoScalingGroup.html)? While an ASG does allow you to
 run a cluster of servers, automaticaly replace failed servers, and do zero-downtime deployment (see the
-[asg-rolling-deploy module](https://github.com/gruntwork-io/terraform-aws-asg/tree/main/modules/asg-rolling-deploy)), attaching ENIs and EBS Volumes to servers in an ASG is very
+[asg-rolling-deploy module](https://github.com/gruntwork-io/terraform-aws-asg/tree/v0.21.2/modules/asg-rolling-deploy)), attaching ENIs and EBS Volumes to servers in an ASG is very
 tricky:
 
 1.  Using ENIs and EBS Volumes with ASGs is not natively supported by Terraform. The
@@ -87,7 +87,7 @@ The solution used in this module is to:
 
 The server-group module will perform a zero-downtime, rolling deployment every time you make a change to the code and
 run `terraform apply`. This deployment process is implemented in a Python script called
-[rolling_deployment.py](https://github.com/gruntwork-io/terraform-aws-asg/tree/main/modules/server-group/rolling-deploy/rolling_deployment.py) which runs in a [local-exec
+[rolling_deployment.py](https://github.com/gruntwork-io/terraform-aws-asg/tree/v0.21.2/modules/server-group/rolling-deploy/rolling_deployment.py) which runs in a [local-exec
 provisioner](https://www.terraform.io/docs/provisioners/local-exec.html).
 
 Here is how it works:
@@ -1241,11 +1241,11 @@ Other modules can depend on this variable to ensure those modules only deploy af
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-asg/tree/main/modules/server-group/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-asg/tree/main/modules/server-group/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-asg/tree/main/modules/server-group/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-asg/tree/v0.21.2/modules/server-group/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-asg/tree/v0.21.2/modules/server-group/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-asg/tree/v0.21.2/modules/server-group/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "ada295e64913bbe7c77c31d5233ee0bb"
+  "hash": "fb183459031635c7930029d3ee2f7606"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-cache/elastic-cache/elastic-cache.md
+++ b/docs/reference/modules/terraform-aws-cache/elastic-cache/elastic-cache.md
@@ -9,13 +9,13 @@ import VersionBadge from '../../../../../src/components/VersionBadge.tsx';
 import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue, HclGeneralListItem } from '../../../../../src/components/HclListItem.tsx';
 import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
-<VersionBadge repoTitle="Cache Modules" version="0.19.2" />
+<VersionBadge repoTitle="Cache Modules" version="0.19.3" lastModifiedVersion="0.19.3"/>
 
 # ElasticCache Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-cache/tree/main/modules/elastic-cache" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-cache/tree/v0.19.3/modules/elastic-cache" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
-<a href="https://github.com/gruntwork-io/terraform-aws-cache/releases?q=elastic-cache" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.19.3" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This module creates an ElastiCache cluster, which manages either a Memcached cluster, a single-node Redis instance.
 
@@ -47,7 +47,7 @@ For more info, see [Scaling Memcached](http://docs.aws.amazon.com/AmazonElastiCa
 
 module "elastic_cache" {
 
-  source = "git::git@github.com:gruntwork-io/terraform-aws-cache.git//modules/elastic-cache?ref=v0.19.2"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-cache.git//modules/elastic-cache?ref=v0.19.3"
 
   # ----------------------------------------------------------------------------------------------------
   # REQUIRED VARIABLES
@@ -135,7 +135,7 @@ module "elastic_cache" {
 # ------------------------------------------------------------------------------------------------------
 
 terraform {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-cache.git//modules/elastic-cache?ref=v0.19.2"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-cache.git//modules/elastic-cache?ref=v0.19.3"
 }
 
 inputs = {
@@ -395,11 +395,11 @@ A set of tags to set for the ElastiCache Cluster.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-cache/tree/main/modules/elastic-cache/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-cache/tree/main/modules/elastic-cache/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-cache/tree/main/modules/elastic-cache/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-cache/tree/v0.19.3/modules/elastic-cache/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-cache/tree/v0.19.3/modules/elastic-cache/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-cache/tree/v0.19.3/modules/elastic-cache/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "c0409644a878023fcc814d1023d6a05f"
+  "hash": "115b2aa38223208adc1ef744c4043ada"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-cache/memcached/memcached.md
+++ b/docs/reference/modules/terraform-aws-cache/memcached/memcached.md
@@ -9,13 +9,13 @@ import VersionBadge from '../../../../../src/components/VersionBadge.tsx';
 import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue, HclGeneralListItem } from '../../../../../src/components/HclListItem.tsx';
 import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
-<VersionBadge repoTitle="Cache Modules" version="0.19.2" lastModifiedVersion="0.19.0"/>
+<VersionBadge repoTitle="Cache Modules" version="0.19.3" lastModifiedVersion="0.19.3"/>
 
 # Memcached Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-cache/tree/main/modules/memcached" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-cache/tree/v0.19.3/modules/memcached" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
-<a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.19.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.19.3" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This module creates an ElastiCache cluster that runs [Memcached](https://memcached.org/).
 
@@ -47,7 +47,7 @@ For more info, see [Scaling Memcached](http://docs.aws.amazon.com/AmazonElastiCa
 
 module "memcached" {
 
-  source = "git::git@github.com:gruntwork-io/terraform-aws-cache.git//modules/memcached?ref=v0.19.2"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-cache.git//modules/memcached?ref=v0.19.3"
 
   # ----------------------------------------------------------------------------------------------------
   # REQUIRED VARIABLES
@@ -131,7 +131,7 @@ module "memcached" {
 # ------------------------------------------------------------------------------------------------------
 
 terraform {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-cache.git//modules/memcached?ref=v0.19.2"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-cache.git//modules/memcached?ref=v0.19.3"
 }
 
 inputs = {
@@ -380,11 +380,11 @@ A set of tags to set for the ElastiCache Replication Group.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-cache/tree/main/modules/memcached/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-cache/tree/main/modules/memcached/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-cache/tree/main/modules/memcached/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-cache/tree/v0.19.3/modules/memcached/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-cache/tree/v0.19.3/modules/memcached/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-cache/tree/v0.19.3/modules/memcached/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "7d6324723f8d8b0d0545d1cc6b645f98"
+  "hash": "1b96245d9ec74b0b221ff7006c6a5472"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-cache/redis/redis.md
+++ b/docs/reference/modules/terraform-aws-cache/redis/redis.md
@@ -9,13 +9,13 @@ import VersionBadge from '../../../../../src/components/VersionBadge.tsx';
 import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue, HclGeneralListItem } from '../../../../../src/components/HclListItem.tsx';
 import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
-<VersionBadge repoTitle="Cache Modules" version="0.19.2" lastModifiedVersion="0.19.2"/>
+<VersionBadge repoTitle="Cache Modules" version="0.19.3" lastModifiedVersion="0.19.3"/>
 
 # Redis Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-cache/tree/main/modules/redis" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-cache/tree/v0.19.3/modules/redis" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
-<a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.19.2" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-cache/releases/tag/v0.19.3" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This module creates an ElastiCache cluster that runs [Redis](http://redis.io/).
 
@@ -101,7 +101,7 @@ For more info on scaling "cluster mode enabled" Redis clusters, see [Scaling Mul
 
 module "redis" {
 
-  source = "git::git@github.com:gruntwork-io/terraform-aws-cache.git//modules/redis?ref=v0.19.2"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-cache.git//modules/redis?ref=v0.19.3"
 
   # ----------------------------------------------------------------------------------------------------
   # REQUIRED VARIABLES
@@ -274,7 +274,7 @@ module "redis" {
 # ------------------------------------------------------------------------------------------------------
 
 terraform {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-cache.git//modules/redis?ref=v0.19.2"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-cache.git//modules/redis?ref=v0.19.3"
 }
 
 inputs = {
@@ -831,11 +831,11 @@ This is a list of user IDs  that should be added to the group defined in the 'us
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-cache/tree/main/modules/redis/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-cache/tree/main/modules/redis/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-cache/tree/main/modules/redis/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-cache/tree/v0.19.3/modules/redis/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-cache/tree/v0.19.3/modules/redis/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-cache/tree/v0.19.3/modules/redis/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "2f682d1858b08876c32ba90fa08845bc"
+  "hash": "fbd89a7c7987a86fbaca3e03876a9ffb"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/aws-helpers/aws-helpers.md
+++ b/docs/reference/modules/terraform-aws-ci/aws-helpers/aws-helpers.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # AWS Helpers
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/aws-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/aws-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.50.11" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -45,11 +45,11 @@ dependencies:
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/aws-helpers/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/aws-helpers/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/aws-helpers/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/aws-helpers/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/aws-helpers/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/aws-helpers/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "d3a667beb4f1c769d32958421e60cdbf"
+  "hash": "d1dc6cc1862d2fc43d260b51f240791c"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/build-helpers/build-helpers.md
+++ b/docs/reference/modules/terraform-aws-ci/build-helpers/build-helpers.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Build Helpers
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/build-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/build-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.50.11" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -72,7 +72,7 @@ job using the [Jenkins Parameterized Trigger
 Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Parameterized+Trigger+Plugin). The `deploy-app` CI job, in turn,
 would be a [parameterized build](https://wiki.jenkins-ci.org/display/JENKINS/Parameterized+Build) that takes as input
 a parameter called `ARTIFACT_ID` (the same parameter name that's in the `artifacts.properties` file) and use it, along
-with the scripts in the [terraform-helpers module](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/terraform-helpers) to automatically deploy the new AMI:
+with the scripts in the [terraform-helpers module](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/terraform-helpers) to automatically deploy the new AMI:
 
 ```bash
 cd templates
@@ -187,11 +187,11 @@ Note that the following conditions must be true in order to use this feature:
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/build-helpers/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/build-helpers/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/build-helpers/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/build-helpers/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/build-helpers/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/build-helpers/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "0a77e6b920cfe89519920b1dbb4c2855"
+  "hash": "ac7d42b419f514b4fabc5678f1efa256"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/check-url/check-url.md
+++ b/docs/reference/modules/terraform-aws-ci/check-url/check-url.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Check Url
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/check-url" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/check-url" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.50.11" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -81,11 +81,11 @@ Success! Got expected status code '200' and text '2.0.0' from URL http://www.my-
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/check-url/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/check-url/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/check-url/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/check-url/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/check-url/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/check-url/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "30fbc430fc852c62315ce7ef54bf878d"
+  "hash": "eab95f7dafdf65a0ee08664acc09f662"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/circleci-helpers/circleci-helpers.md
+++ b/docs/reference/modules/terraform-aws-ci/circleci-helpers/circleci-helpers.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # CircleCI Helpers
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/circleci-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/circleci-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.51.4" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -67,11 +67,11 @@ dependencies:
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/circleci-helpers/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/circleci-helpers/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/circleci-helpers/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/circleci-helpers/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/circleci-helpers/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/circleci-helpers/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "383615fb234d53ac3a2ba142ed260179"
+  "hash": "4b61bc7bd29a4af452aa88eeffdd71b3"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/ec2-backup/ec2-backup.md
+++ b/docs/reference/modules/terraform-aws-ci/ec2-backup/ec2-backup.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # EC2 Backup Lambda Function Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ec2-backup" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ec2-backup" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.51.1" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -51,8 +51,8 @@ DLM:
 
 ## Example code
 
-*   Check out the [jenkins example](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/examples/jenkins) for working sample code.
-*   See [vars.tf](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ec2-backup/vars.tf) for all parameters you can configure on this module.
+*   Check out the [jenkins example](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/examples/jenkins) for working sample code.
+*   See [vars.tf](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ec2-backup/vars.tf) for all parameters you can configure on this module.
 
 ## Specifying an instance
 
@@ -342,11 +342,11 @@ When true, all IAM policies will be managed as dedicated policies rather than in
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ec2-backup/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ec2-backup/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ec2-backup/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ec2-backup/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ec2-backup/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ec2-backup/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "86968ddce70c404b12b0cde78dde0969"
+  "hash": "1bacbaedd0956dd290057d0bf40f3bc7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/ecs-deploy-runner-invoke-iam-policy/ecs-deploy-runner-invoke-iam-policy.md
+++ b/docs/reference/modules/terraform-aws-ci/ecs-deploy-runner-invoke-iam-policy/ecs-deploy-runner-invoke-iam-policy.md
@@ -13,14 +13,14 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # ECS Deploy Runner Invoke IAM Policies module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner-invoke-iam-policy" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner-invoke-iam-policy" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.48.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This Terraform Module defines an [IAM
 policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html) that
 defines the minimal set of permissions necessary to trigger a deployment event for the deployment pipeline implemented
-in the [ecs-deploy-runner module](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner).
+in the [ecs-deploy-runner module](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner).
 
 ## Attaching IAM policy to IAM roles
 
@@ -209,11 +209,11 @@ The name of the IAM policy created with the permissions for invoking the ECS Dep
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner-invoke-iam-policy/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner-invoke-iam-policy/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner-invoke-iam-policy/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner-invoke-iam-policy/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner-invoke-iam-policy/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner-invoke-iam-policy/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "b2816eccb4fd98da667fdca2157dcb17"
+  "hash": "72f94c9c83702d8f2ca741502bb6fc5a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/ecs-deploy-runner-standard-configuration/ecs-deploy-runner-standard-configuration.md
+++ b/docs/reference/modules/terraform-aws-ci/ecs-deploy-runner-standard-configuration/ecs-deploy-runner-standard-configuration.md
@@ -13,12 +13,12 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # ECS Deploy Runner Standard Configuration module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner-standard-configuration" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner-standard-configuration" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.50.6" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This Terraform Module provides a streamlined interface to configure the [ecs-deploy-runner
-module](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner) for a standard infrastructure and applications pipeline. This includes:
+module](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner) for a standard infrastructure and applications pipeline. This includes:
 
 *   Base pipeline of build image, update variables, deploy infrastructure with Terraform/Terragrunt.
 *   Restricting git repos that can deploy infrastructure.
@@ -100,8 +100,8 @@ for more information).
 
 ## How do I invoke scripts in a given container?
 
-You can use the [infrastructure-deployer CLI](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deployer) to invoke a deployed ECS deploy runner. Refer
-to [How do I invoke the ECS deploy runner](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deployer/core-concepts.md#how-do-i-invoke-the-ecs-deploy-runner)
+You can use the [infrastructure-deployer CLI](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deployer) to invoke a deployed ECS deploy runner. Refer
+to [How do I invoke the ECS deploy runner](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deployer/core-concepts.md#how-do-i-invoke-the-ecs-deploy-runner)
 for more information.
 
 ## Sample Usage
@@ -822,11 +822,11 @@ Configuration map for the ecs-deploy-runner module that can be passed straight i
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner-standard-configuration/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner-standard-configuration/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner-standard-configuration/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner-standard-configuration/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner-standard-configuration/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner-standard-configuration/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "35521a665273e87d5ba80f525c333130"
+  "hash": "be566c1b15ebec7822ebda73a3c5a7cf"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/ecs-deploy-runner/ecs-deploy-runner.md
+++ b/docs/reference/modules/terraform-aws-ci/ecs-deploy-runner/ecs-deploy-runner.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Infrastructure Pipeline: ECS Deploy Runner
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.51.4" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -29,7 +29,7 @@ This module can be used to set up a secure CI/CD pipeline for your infrastructur
 
 These workflows can be implemented without directly running the steps from your CI servers. Instead, the CI server can coordinate the CI / CD flow, and for anything that requires sensitive / powerful IAM permissions, it can trigger pre-defined, locked-down jobs in an isolated ECS task, and stream the logs from that task as if it’s running locally.
 
-Refer to the [infrastructure-deployer CLI](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deployer) to integrate this with existing CI servers. You can also refer to the [infrastructure-deploy-script module](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deploy-script) for more information on the underlying deployment scripts.
+Refer to the [infrastructure-deployer CLI](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deployer) to integrate this with existing CI servers. You can also refer to the [infrastructure-deploy-script module](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deploy-script) for more information on the underlying deployment scripts.
 
 ![Terraform and Terragrunt CI/CD architecture](/img/reference/modules/terraform-aws-ci/ecs-deploy-runner/tftg-pipeline-architecture.png)
 
@@ -53,17 +53,17 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   [Overview](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner/core-concepts.md#overview): An overview of the architecture deployed by in this module, including how to implement a CI/CD pipeline for infrastructure code.
+*   [Overview](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner/core-concepts.md#overview): An overview of the architecture deployed by in this module, including how to implement a CI/CD pipeline for infrastructure code.
 
-*   [Threat model of the deploy runner](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner/core-concepts.md#threat-model-of-the-deploy-runner): An overview of the threat model used to design the security features of the solution, including a description of the potential attack vectors that are mitigated by the solution, and those attacks that require policy and behavioral changes to mitigate.
+*   [Threat model of the deploy runner](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner/core-concepts.md#threat-model-of-the-deploy-runner): An overview of the threat model used to design the security features of the solution, including a description of the potential attack vectors that are mitigated by the solution, and those attacks that require policy and behavioral changes to mitigate.
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/test): Automated tests for the modules and examples.
 
 ## Deploy
 
@@ -71,29 +71,29 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [examples folder](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [examples folder](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ## Manage
 
-*   [What configuration is recommended for container_images?](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner/core-concepts.md#what-configuration-is-recommended-for-container_images)
+*   [What configuration is recommended for container_images?](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner/core-concepts.md#what-configuration-is-recommended-for-container_images)
 
-*   [How do I restrict what args can be passed into the scripts?](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner/core-concepts.md#how-do-i-restrict-what-args-can-be-passed-into-the-scripts)
+*   [How do I restrict what args can be passed into the scripts?](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner/core-concepts.md#how-do-i-restrict-what-args-can-be-passed-into-the-scripts)
 
-*   [How do I trigger a deployment?](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner/core-concepts.md#how-do-i-trigger-a-deployment)
+*   [How do I trigger a deployment?](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner/core-concepts.md#how-do-i-trigger-a-deployment)
 
-*   [How do I trigger a deployment from CI?](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner/core-concepts.md#how-do-i-trigger-a-deployment-from-ci)
+*   [How do I trigger a deployment from CI?](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner/core-concepts.md#how-do-i-trigger-a-deployment-from-ci)
 
-*   [How do I customize the deployment task runtime environment?](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner/core-concepts.md#what-container-is-used-for-the-deploy-task)
+*   [How do I customize the deployment task runtime environment?](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner/core-concepts.md#what-container-is-used-for-the-deploy-task)
 
-*   [How do I use the deployment task container with a private VCS system such as GitHub Enterprise?](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner/core-concepts.md#how-do-i-use-the-ecs-deploy-runner-with-a-private-vcs-system-such-as-github-enterprise)
+*   [How do I use the deployment task container with a private VCS system such as GitHub Enterprise?](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner/core-concepts.md#how-do-i-use-the-ecs-deploy-runner-with-a-private-vcs-system-such-as-github-enterprise)
 
-*   [How do I stream logs from the deployment task?](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner/core-concepts.md#how-do-i-stream-logs-from-the-deployment-task)
+*   [How do I stream logs from the deployment task?](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner/core-concepts.md#how-do-i-stream-logs-from-the-deployment-task)
 
-*   [How do I access the stdout and stderr output from the underlying scripts?](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner/core-concepts.md#how-do-i-access-the-stdout-and-stderr-output-from-the-underlying-scripts)
+*   [How do I access the stdout and stderr output from the underlying scripts?](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner/core-concepts.md#how-do-i-access-the-stdout-and-stderr-output-from-the-underlying-scripts)
 
-*   [What are the IAM permissions necessary to trigger a deployment?](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner/core-concepts.md#what-are-the-iam-permissions-necessary-to-trigger-a-deployment)
+*   [What are the IAM permissions necessary to trigger a deployment?](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner/core-concepts.md#what-are-the-iam-permissions-necessary-to-trigger-a-deployment)
 
-*   [How do I see the list of supported containers?](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deployer/core-concepts.md#how-do-i-see-the-list-of-supported-containers)
+*   [How do I see the list of supported containers?](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deployer/core-concepts.md#how-do-i-see-the-list-of-supported-containers)
 
 ## Sample Usage
 
@@ -1233,11 +1233,11 @@ Security Group ID of the ECS task
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "815db459b96961214573cb5ba4a44cea"
+  "hash": "aec59afb3b0eb22755da3dccc9945c3f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/git-helpers/git-helpers.md
+++ b/docs/reference/modules/terraform-aws-ci/git-helpers/git-helpers.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Git Helpers
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/git-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/git-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.50.11" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -72,11 +72,11 @@ The main options to pass to `git-add-commit-push` are:
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/git-helpers/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/git-helpers/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/git-helpers/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/git-helpers/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/git-helpers/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/git-helpers/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "57cb34f70a1c58000f68736bfb8b58c5"
+  "hash": "bc2e2f3d5ae6c0f9b842fd23c7be50fe"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/gruntwork-module-circleci-helpers/gruntwork-module-circleci-helpers.md
+++ b/docs/reference/modules/terraform-aws-ci/gruntwork-module-circleci-helpers/gruntwork-module-circleci-helpers.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Gruntwork Module CircleCI Helpers
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/gruntwork-module-circleci-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/gruntwork-module-circleci-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.51.4" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -192,11 +192,11 @@ variables](https://circleci.com/docs/environment-variables/).
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/gruntwork-module-circleci-helpers/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/gruntwork-module-circleci-helpers/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/gruntwork-module-circleci-helpers/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/gruntwork-module-circleci-helpers/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/gruntwork-module-circleci-helpers/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/gruntwork-module-circleci-helpers/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "f997f7f687a267b0806b2a825f15c1f0"
+  "hash": "05093e46f2038cf76d6e838e132ff2a4"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/iam-policies/iam-policies.md
+++ b/docs/reference/modules/terraform-aws-ci/iam-policies/iam-policies.md
@@ -13,17 +13,17 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # IAM Policies
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/iam-policies" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/iam-policies" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.48.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This folder contains modules that create an IAM Policy with the minimum permissions needed to support specific CI use
 cases. It includes:
 
-*   [ecr-docker-push](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/iam-policies/ecr-docker-push): An IAM Policy that enables checking for an existing Docker image in Amazon ECR and pushing a new one.
-*   [ecs-service-deployment](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/iam-policies/ecs-service-deployment): An IAM Policy that enables deploying a new Docker image to the ECS Cluster.
-*   [terraform-remote-state-s3](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/iam-policies/terraform-remote-state-s3): An IAM Policy that enables using Terraform Remote State with S3.
-*   [terragrunt](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/iam-policies/terragrunt): An IAM Policy that enables using the locking and user-identity features of Terragrunt.
+*   [ecr-docker-push](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/iam-policies/ecr-docker-push): An IAM Policy that enables checking for an existing Docker image in Amazon ECR and pushing a new one.
+*   [ecs-service-deployment](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/iam-policies/ecs-service-deployment): An IAM Policy that enables deploying a new Docker image to the ECS Cluster.
+*   [terraform-remote-state-s3](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/iam-policies/terraform-remote-state-s3): An IAM Policy that enables using Terraform Remote State with S3.
+*   [terragrunt](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/iam-policies/terragrunt): An IAM Policy that enables using the locking and user-identity features of Terragrunt.
 
 ## Background
 
@@ -67,11 +67,11 @@ Some modules are configurable to support whatever level of
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/iam-policies/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/iam-policies/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/iam-policies/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/iam-policies/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/iam-policies/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/iam-policies/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "a4aeb7682dd54e923ebb86630b8084f9"
+  "hash": "dc078bb2e1236c268d482828fe919610"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/infrastructure-deploy-script/infrastructure-deploy-script.md
+++ b/docs/reference/modules/terraform-aws-ci/infrastructure-deploy-script/infrastructure-deploy-script.md
@@ -13,11 +13,11 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Infrastructure Pipeline: Infrastructure Deploy Scripts
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deploy-script" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deploy-script" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.51.5" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
-This module contains a script for deploying arbitrary infrastructure code stored in version control using [Terraform](https://www.terraform.io) and [Terragrunt](https://terragrunt.gruntwork.io). The deployment script can be used to set up secure CI/CD pipelines for infrastructure code. The deployment script can run in any environment (e.g directly in CI servers, ECS task, EKS pod) to remotely run infrastructure code based on version control events. Refer to the [ecs-deploy-runner module](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner) to run the deployment in an isolated ECS task, separate from the CI servers.
+This module contains a script for deploying arbitrary infrastructure code stored in version control using [Terraform](https://www.terraform.io) and [Terragrunt](https://terragrunt.gruntwork.io). The deployment script can be used to set up secure CI/CD pipelines for infrastructure code. The deployment script can run in any environment (e.g directly in CI servers, ECS task, EKS pod) to remotely run infrastructure code based on version control events. Refer to the [ecs-deploy-runner module](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner) to run the deployment in an isolated ECS task, separate from the CI servers.
 
 ## Features
 
@@ -33,15 +33,15 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   [Overview of scripts](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deploy-script/core-concepts.md#overview): An overview of the scripts included in this module, including how to deploy and use the scripts to implement a CI/CD pipeline for IaC code.
+*   [Overview of scripts](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deploy-script/core-concepts.md#overview): An overview of the scripts included in this module, including how to deploy and use the scripts to implement a CI/CD pipeline for IaC code.
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/test): Automated tests for the modules and examples.
 
 ## Deploy
 
@@ -49,23 +49,23 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [examples folder](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [examples folder](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ## Manage
 
-*   [Where do I run the deploy script?](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deploy-script/core-concepts.md#where-do-i-run-the-deploy-script)
+*   [Where do I run the deploy script?](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deploy-script/core-concepts.md#where-do-i-run-the-deploy-script)
 
-*   [What are the system requirements for the deploy script?](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deploy-script/core-concepts.md#system-requirements)
+*   [What are the system requirements for the deploy script?](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deploy-script/core-concepts.md#system-requirements)
 
 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deploy-script/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deploy-script/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deploy-script/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deploy-script/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deploy-script/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deploy-script/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "a87c2d85fcc5836ab89dbe1624a185fa"
+  "hash": "c37df2fde86bd416d7bc3045f3067fa2"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/infrastructure-deployer/infrastructure-deployer.md
+++ b/docs/reference/modules/terraform-aws-ci/infrastructure-deployer/infrastructure-deployer.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Infrastructure Pipeline: Infrastructure Deployer CLI
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deployer" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deployer" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.50.8" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -27,9 +27,9 @@ This module contains a CLI that can be used to set up a secure CI/CD pipeline fo
 
 *   Automatically update infrastructure configurations and deploying them
 
-These workflows can be invoked on an isolated ECS task setup by the [ecs-deploy-runner module](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner).
+These workflows can be invoked on an isolated ECS task setup by the [ecs-deploy-runner module](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner).
 
-Refer to the [ecs-deploy-runner module](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ecs-deploy-runner) for more information on the ECS task.
+Refer to the [ecs-deploy-runner module](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ecs-deploy-runner) for more information on the ECS task.
 
 ## Features
 
@@ -51,15 +51,15 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   [Overview](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deployer/core-concepts.md#overview): An overview of the CLI and how to use it within CI jobs to implement an automated workflow for infrastructure code.
+*   [Overview](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deployer/core-concepts.md#overview): An overview of the CLI and how to use it within CI jobs to implement an automated workflow for infrastructure code.
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/test): Automated tests for the modules and examples.
 
 ## Deploy
 
@@ -67,25 +67,25 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [examples folder](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [examples folder](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ## Manage
 
-*   [How do I install the infrastructure-deployer CLI?](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deployer/core-concepts.md#how-do-i-install-the-infrastructure-deployer-cli)
+*   [How do I install the infrastructure-deployer CLI?](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deployer/core-concepts.md#how-do-i-install-the-infrastructure-deployer-cli)
 
-*   [What are the IAM permissions](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deployer/core-concepts.md#what-are-the-iam-permissions-necessary-to-trigger-a-deployment)
+*   [What are the IAM permissions](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deployer/core-concepts.md#what-are-the-iam-permissions-necessary-to-trigger-a-deployment)
 
-*   [How do I invoke the ECS deploy runner?](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deployer/core-concepts.md#how-do-i-invoke-the-ecs-deploy-runner)
+*   [How do I invoke the ECS deploy runner?](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deployer/core-concepts.md#how-do-i-invoke-the-ecs-deploy-runner)
 
 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deployer/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deployer/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/infrastructure-deployer/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deployer/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deployer/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/infrastructure-deployer/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "e8c44ea30931623c50847a32501ec6d2"
+  "hash": "ef7c5b6386d2d6cbf9783ddc295d3a0c"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/install-jenkins/install-jenkins.md
+++ b/docs/reference/modules/terraform-aws-ci/install-jenkins/install-jenkins.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Install Jenkins Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/install-jenkins" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/install-jenkins" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.51.6" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -26,8 +26,8 @@ This module contains two scripts for working with [Jenkins CI server](https://je
 
 ## Example code
 
-*   Check out the [jenkins example](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/examples/jenkins) for working sample code.
-*   See [install.sh](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/install-jenkins/install.sh) and [run-jenkins.sh](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/install-jenkins/run-jenkins) for all options you can pass to these scripts.
+*   Check out the [jenkins example](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/examples/jenkins) for working sample code.
+*   See [install.sh](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/install-jenkins/install.sh) and [run-jenkins.sh](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/install-jenkins/run-jenkins) for all options you can pass to these scripts.
 
 ## Install Jenkins
 
@@ -45,13 +45,13 @@ gruntwork-install \
 
 The command above will copy `install.sh` to your server, run it, install Jenkins 2.164.3, and copy the `run-jenkins`
 script into `/usr/local/bin`. We recommend running this command in a [Packer template](https://www.packer.io/) so you
-can create an AMI with Jenkins installed. Check out the [jenkins example](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/examples/jenkins) for an example of such a
+can create an AMI with Jenkins installed. Check out the [jenkins example](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/examples/jenkins) for an example of such a
 Packer template.
 
 ## Run Jenkins
 
 Once you have an AMI with Jenkins installed, you need to deploy it on an EC2 Instance in AWS. The easiest way to do
-this is with the [jenkins-server module](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/jenkins-server). When the EC2 Instance is booting, you should
+this is with the [jenkins-server module](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/jenkins-server). When the EC2 Instance is booting, you should
 typically do two things in [User Data](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html):
 
 1.  Mount an EBS volume for the Jenkins home directory. You want to use an EBS volume so that your Jenkins data is
@@ -68,17 +68,17 @@ typically do two things in [User Data](https://docs.aws.amazon.com/AWSEC2/latest
       --jenkins-home "/jenkins"
     ```
 
-Check out the [jenkins example](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/examples/jenkins) for an example of such a User Data script.
+Check out the [jenkins example](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/examples/jenkins) for an example of such a User Data script.
 
 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/install-jenkins/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/install-jenkins/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/install-jenkins/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/install-jenkins/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/install-jenkins/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/install-jenkins/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "f15362fe839466e35d90dd355827b113"
+  "hash": "0ca69718b0260e4c89c3af38f1e6002e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/jenkins-server/jenkins-server.md
+++ b/docs/reference/modules/terraform-aws-ci/jenkins-server/jenkins-server.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Jenkins server
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/jenkins-server" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/jenkins-server" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.51.6" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -29,17 +29,17 @@ to run an ASG for Jenkins that can correctly reattach an EBS volume.
 
 ## Example code
 
-*   Check out the [jenkins example](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/examples/jenkins) for working sample code.
-*   See [vars.tf](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/jenkins-server/vars.tf) for all parameters you can configure on this module.
+*   Check out the [jenkins example](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/examples/jenkins) for working sample code.
+*   See [vars.tf](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/jenkins-server/vars.tf) for all parameters you can configure on this module.
 
 ## Jenkins AMI
 
-See the [install-jenkins module](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/install-jenkins) for a way to create an AMI with Jenkins installed and a
+See the [install-jenkins module](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/install-jenkins) for a way to create an AMI with Jenkins installed and a
 script you can run in User Data to start Jenkins while the server is booting.
 
 ## Backing up Jenkins
 
-See the [ec2-backup module](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/ec2-backup) for an automatic way to take scheduled backups of Jenkins and its EBS
+See the [ec2-backup module](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/ec2-backup) for an automatic way to take scheduled backups of Jenkins and its EBS
 volume.
 
 ## IAM permissions
@@ -1152,11 +1152,11 @@ A maximum duration to wait for each server to be healthy before timing out (e.g.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/jenkins-server/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/jenkins-server/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/jenkins-server/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/jenkins-server/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/jenkins-server/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/jenkins-server/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "1f523327bac0402a63f224f8aa14a432"
+  "hash": "810d4ffc447dc5cdcf4dd2d46c896ce6"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/kubernetes-circleci-helpers/kubernetes-circleci-helpers.md
+++ b/docs/reference/modules/terraform-aws-ci/kubernetes-circleci-helpers/kubernetes-circleci-helpers.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Kubernetes CircleCI Helpers
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/kubernetes-circleci-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/kubernetes-circleci-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.51.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -99,11 +99,11 @@ job:
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/kubernetes-circleci-helpers/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/kubernetes-circleci-helpers/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/kubernetes-circleci-helpers/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/kubernetes-circleci-helpers/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/kubernetes-circleci-helpers/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/kubernetes-circleci-helpers/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "48ef955a849cf20500c3525a4f556e42"
+  "hash": "a64fc30d991a1e7221280c29c6ee87f9"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/monorepo-helpers/monorepo-helpers.md
+++ b/docs/reference/modules/terraform-aws-ci/monorepo-helpers/monorepo-helpers.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Infrastructure Pipeline: Monorepo Helpers
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/monorepo-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/monorepo-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.50.8" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -41,15 +41,15 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   [Overview of scripts](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/monorepo-helpers/core-concepts.md#overview): An overview of the scripts included in this module, including how they work.
+*   [Overview of scripts](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/monorepo-helpers/core-concepts.md#overview): An overview of the scripts included in this module, including how they work.
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/test): Automated tests for the modules and examples.
 
 ## Deploy
 
@@ -57,7 +57,7 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this module out for experimenting and learning, check out the following resources:
 
-*   [CircleCI Quickstart](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/monorepo-helpers/core-concepts.md#circleci-quickstart): Quickstart guide for integrating the scripts into CircleCI to setup dynamic test selection.
+*   [CircleCI Quickstart](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/monorepo-helpers/core-concepts.md#circleci-quickstart): Quickstart guide for integrating the scripts into CircleCI to setup dynamic test selection.
 
 ### Production deployment
 
@@ -65,23 +65,23 @@ If you just want to try this module out for experimenting and learning, check ou
 
 ## Manage
 
-*   [How to configure direct test mappings](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/monorepo-helpers/core-concepts.md#how-to-configure-direct-test-mappings)
+*   [How to configure direct test mappings](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/monorepo-helpers/core-concepts.md#how-to-configure-direct-test-mappings)
 
-*   [How to override the files checked by validate-monorepo-test-mappings](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/monorepo-helpers/core-concepts.md#how-to-override-the-files-checked-by-validate-monorepo-test-mappings)
+*   [How to override the files checked by validate-monorepo-test-mappings](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/monorepo-helpers/core-concepts.md#how-to-override-the-files-checked-by-validate-monorepo-test-mappings)
 
-*   [Adding a new module to a repo with validate-monorepo-test-mappings](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/monorepo-helpers/core-concepts.md#adding-a-new-module-to-a-repo-with-validate-monorepo-test-mappings)
+*   [Adding a new module to a repo with validate-monorepo-test-mappings](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/monorepo-helpers/core-concepts.md#adding-a-new-module-to-a-repo-with-validate-monorepo-test-mappings)
 
-*   [Adding a new file that has no tests to a repo with validate-monorepo-test-mappings](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/monorepo-helpers/core-concepts.md#adding-a-new-file-that-has-no-tests-to-a-repo-with-validate-monorepo-test-mappings)
+*   [Adding a new file that has no tests to a repo with validate-monorepo-test-mappings](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/monorepo-helpers/core-concepts.md#adding-a-new-file-that-has-no-tests-to-a-repo-with-validate-monorepo-test-mappings)
 
 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/monorepo-helpers/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/monorepo-helpers/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/monorepo-helpers/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/monorepo-helpers/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/monorepo-helpers/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/monorepo-helpers/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "5f80088a6c31b9089d21b9de1a25e319"
+  "hash": "6f4b19f936857928f5a8c976887f3be1"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/sign-binary-helpers/sign-binary-helpers.md
+++ b/docs/reference/modules/terraform-aws-ci/sign-binary-helpers/sign-binary-helpers.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Binary signing Helpers
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/sign-binary-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/sign-binary-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.51.2" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -150,11 +150,11 @@ References:
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/sign-binary-helpers/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/sign-binary-helpers/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/sign-binary-helpers/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/sign-binary-helpers/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/sign-binary-helpers/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/sign-binary-helpers/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "4fc4cd8179dc4c7ef7f09f9c334b5743"
+  "hash": "8c5f92191e34128d8ae203ac48d3aac9"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ci/terraform-helpers/terraform-helpers.md
+++ b/docs/reference/modules/terraform-aws-ci/terraform-helpers/terraform-helpers.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Terraform Helpers
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/terraform-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/terraform-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ci/releases/tag/v0.50.8" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -38,7 +38,7 @@ You can install these scripts using the [Gruntwork Installer](https://github.com
 gruntwork-install --module-name "terraform-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "0.0.1"
 ```
 
-Note that `terraform-update-variable` depends on the [git-helpers module](https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/git-helpers) being installed!
+Note that `terraform-update-variable` depends on the [git-helpers module](https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/git-helpers) being installed!
 
 See the examples in the next section for how to use them.
 
@@ -341,11 +341,11 @@ and `apply` actions so that Terraform/Terragrunt can run. If you wish to impleme
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/terraform-helpers/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/terraform-helpers/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ci/tree/main/modules/terraform-helpers/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/terraform-helpers/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/terraform-helpers/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ci/tree/v0.51.6/modules/terraform-helpers/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "1bc28df88bb3a5a3b5f21c7250da37e4"
+  "hash": "510050e9528e38cd754ce2fb61552ffc"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-data-storage/aurora/aurora.md
+++ b/docs/reference/modules/terraform-aws-data-storage/aurora/aurora.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Aurora Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/aurora" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/aurora" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.26.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -43,9 +43,9 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   [What is Amazon RDS?](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/aurora/core-concepts.md#what-is-amazon-rds)
+*   [What is Amazon RDS?](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/aurora/core-concepts.md#what-is-amazon-rds)
 
-*   [Common gotchas with RDS](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/aurora/core-concepts.md#common-gotchas)
+*   [Common gotchas with RDS](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/aurora/core-concepts.md#common-gotchas)
 
 *   [RDS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Welcome.html): Amazon’s docs for RDS that cover core concepts such as the types of databases supported, security, backup & restore, and monitoring.
 
@@ -57,7 +57,7 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [examples folder](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [examples folder](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ### Production deployment
 
@@ -69,13 +69,13 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Day-to-day operations
 
-*   [How to connect to an Aurora instance](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/aurora/core-concepts.md#how-do-you-connect-to-the-database)
+*   [How to connect to an Aurora instance](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/aurora/core-concepts.md#how-do-you-connect-to-the-database)
 
 *   [How to authenticate to RDS with IAM](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAM.html)
 
-*   [How to scale Aurora](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/aurora/core-concepts.md#how-do-you-scale-this-database)
+*   [How to scale Aurora](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/aurora/core-concepts.md#how-do-you-scale-this-database)
 
-*   [How to backup Aurora snapshots to a separate AWS account](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-create-snapshot#how-do-you-backup-your-rds-snapshots-to-a-separate-aws-account)
+*   [How to backup Aurora snapshots to a separate AWS account](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-create-snapshot#how-do-you-backup-your-rds-snapshots-to-a-separate-aws-account)
 
 ### Major changes
 
@@ -1415,11 +1415,11 @@ Timeout for DB updating
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/aurora/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/aurora/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/aurora/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/aurora/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/aurora/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/aurora/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "ad4fc315c015153bafe3b93a8d3f1278"
+  "hash": "cc0d31177fd3fa2d09f17adb3a811dfa"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-data-storage/backup-plan/backup-plan.md
+++ b/docs/reference/modules/terraform-aws-data-storage/backup-plan/backup-plan.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Backup Plan Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/backup-plan" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/backup-plan" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.26.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -22,7 +22,7 @@ This Terraform Module creates the following AWS Backup resources:
 1.  Backup plans - specifying **how and when** to back things up
 2.  Resource selections - specifying **which resources** to back up
 
-You associate your plans with a [Backup vault](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/backup-vault).
+You associate your plans with a [Backup vault](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/backup-vault).
 
 ## What is a Backup Plan?
 
@@ -91,7 +91,7 @@ module "backup_plan" {
 
 ## How do you troubleshoot Backup jobs?
 
-See [Troubleshooting AWS Backup](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/core-concepts.md#troubleshooting-aws-backup) in the core-concepts guide.
+See [Troubleshooting AWS Backup](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/core-concepts.md#troubleshooting-aws-backup) in the core-concepts guide.
 
 ## Sample Usage
 
@@ -245,11 +245,11 @@ The ARN of the IAM service role used by Backup plans
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/backup-plan/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/backup-plan/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/backup-plan/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/backup-plan/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/backup-plan/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/backup-plan/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "da1342839b8ab55da7679cc0d34a0444"
+  "hash": "374f2e1bea1874757cf38c148105f64a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-data-storage/backup-vault/backup-vault.md
+++ b/docs/reference/modules/terraform-aws-data-storage/backup-vault/backup-vault.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Backup Vault Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/backup-vault" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/backup-vault" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.26.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -287,11 +287,11 @@ A map of tags assigned to the vault resources, including those inherited from th
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/backup-vault/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/backup-vault/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/backup-vault/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/backup-vault/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/backup-vault/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/backup-vault/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "21216abb0650e80bb7079a54ad94fe65"
+  "hash": "4c2b2894fada08a1a2b16abd06ac6d2f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-data-storage/efs/efs.md
+++ b/docs/reference/modules/terraform-aws-data-storage/efs/efs.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # EFS Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/efs" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/efs" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.25.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -45,13 +45,13 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [examples folder](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [examples folder](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ### Production deployment
 
 If you want to deploy this repo in production, check out the following resources:
 
-*   [efs module variables](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/efs/variables.tf): Configuration variables available for the EFS module. At minimum, you should configure the `allow_connections_from_cidr_blocks` and `allow_connections_from_security_groups` values to only allow access from your private VPC(s). You may also want to enable `storage_encrypted` to encrypt data at-rest.
+*   [efs module variables](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/efs/variables.tf): Configuration variables available for the EFS module. At minimum, you should configure the `allow_connections_from_cidr_blocks` and `allow_connections_from_security_groups` values to only allow access from your private VPC(s). You may also want to enable `storage_encrypted` to encrypt data at-rest.
 
 ## Manage
 
@@ -541,11 +541,11 @@ The IDs of the security groups created for the file system.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/efs/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/efs/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/efs/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/efs/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/efs/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/efs/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "7bd324a860d9476db334510f6b899561"
+  "hash": "6b254f2603092879b6f13eeffdfb9992"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-data-storage/lambda-cleanup-snapshots/lambda-cleanup-snapshots.md
+++ b/docs/reference/modules/terraform-aws-data-storage/lambda-cleanup-snapshots/lambda-cleanup-snapshots.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Delete Snapshots Lambda Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-cleanup-snapshots" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-cleanup-snapshots" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.26.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -29,7 +29,7 @@ Note that to use this module, you must have access to the Gruntwork [Continuous 
 
 This module allows you to configure a number of parameters, such as which database to backup, how often to run the
 backups, what account to share the backups with, and more. For a list of all available variables and their
-descriptions, see [variables.tf](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-cleanup-snapshots/variables.tf).
+descriptions, see [variables.tf](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-cleanup-snapshots/variables.tf).
 
 ## Sample Usage
 
@@ -291,11 +291,11 @@ Namespace of snapshots that will be cleaned up by this module. If specified then
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-cleanup-snapshots/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-cleanup-snapshots/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-cleanup-snapshots/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-cleanup-snapshots/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-cleanup-snapshots/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-cleanup-snapshots/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "0f7631d13b49e882347b094578286d6a"
+  "hash": "cf005dffb175675a5ba60305911f0786"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-data-storage/lambda-copy-shared-snapshot/lambda-copy-shared-snapshot.md
+++ b/docs/reference/modules/terraform-aws-data-storage/lambda-copy-shared-snapshot/lambda-copy-shared-snapshot.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Copy Snapshot Lambda Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-copy-shared-snapshot" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-copy-shared-snapshot" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.26.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -108,7 +108,7 @@ account 222222222222. To be able to make a copy of that snapshot in account 2222
 ## Background info
 
 For more info on how to backup RDS snapshots to a separate AWS account, check out the [lambda-create-snapshot module
-documentation](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-create-snapshot).
+documentation](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-create-snapshot).
 
 ## Sample Usage
 
@@ -390,11 +390,11 @@ Namespace all Lambda scheduling resources created by this module with this name.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-copy-shared-snapshot/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-copy-shared-snapshot/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-copy-shared-snapshot/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-copy-shared-snapshot/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-copy-shared-snapshot/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-copy-shared-snapshot/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "418789cfcbdd0545193388c8cd41092d"
+  "hash": "ddd53bcf61b79789d845cc04aca05447"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-data-storage/lambda-create-snapshot/lambda-create-snapshot.md
+++ b/docs/reference/modules/terraform-aws-data-storage/lambda-create-snapshot/lambda-create-snapshot.md
@@ -13,11 +13,11 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Database backup
 
-<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-create-snapshot" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-create-snapshot" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.26.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
-This module, along with the [lambda-share-snapshot](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-share-snapshot) and [lambda-copy-shared-snapshot](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-copy-shared-snapshot) modules, can be used to backup your RDS database to another AWS account (e.g., for disaster recovery) on a configurable schedule. Under the hood, each module runs a Lambda function that instructs your database to take a snapshot (this module), share the snapshot with another account (the `lambda-share-snapshot` module), and make a copy of the snapshot (`lambda-copy-shared-snapshot`).
+This module, along with the [lambda-share-snapshot](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-share-snapshot) and [lambda-copy-shared-snapshot](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-copy-shared-snapshot) modules, can be used to backup your RDS database to another AWS account (e.g., for disaster recovery) on a configurable schedule. Under the hood, each module runs a Lambda function that instructs your database to take a snapshot (this module), share the snapshot with another account (the `lambda-share-snapshot` module), and make a copy of the snapshot (`lambda-copy-shared-snapshot`).
 
 ![RDS architecture](/img/reference/modules/terraform-aws-data-storage/lambda-create-snapshot/data-backup-architecture.png)
 
@@ -29,7 +29,7 @@ This module, along with the [lambda-share-snapshot](https://github.com/gruntwork
 
 *   Configurable backup schedule (e.g., using cron expressions)
 
-*   Clean up old snapshots automatically using the [lambda-cleanup-snapshots](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-cleanup-snapshots) module.
+*   Clean up old snapshots automatically using the [lambda-cleanup-snapshots](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-cleanup-snapshots) module.
 
 ## Learn
 
@@ -39,9 +39,9 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   [What is Amazon RDS?](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/rds/core-concepts.md#what-is-amazon-rds)
+*   [What is Amazon RDS?](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/rds/core-concepts.md#what-is-amazon-rds)
 
-*   [How does this differ from RDS automatic snapshots?](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-create-snapshot/core-concepts.md#how-does-this-differ-from-rds-automatic-snapshots)
+*   [How does this differ from RDS automatic snapshots?](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-create-snapshot/core-concepts.md#how-does-this-differ-from-rds-automatic-snapshots)
 
 *   [RDS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Welcome.html): Amazon’s docs for RDS that cover core concepts such as the types of databases supported, security, backup & restore, and monitoring.
 
@@ -53,7 +53,7 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [examples folder](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [examples folder](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ### Production deployment
 
@@ -65,7 +65,7 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Day-to-day operations
 
-*   [How to backup RDS snapshots to a separate AWS account](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-create-snapshot/core-concepts.md#how-do-you-backup-your-rds-snapshots-to-a-separate-aws-account)
+*   [How to backup RDS snapshots to a separate AWS account](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-create-snapshot/core-concepts.md#how-do-you-backup-your-rds-snapshots-to-a-separate-aws-account)
 
 ### Major changes
 
@@ -436,11 +436,11 @@ Namespace all snapshots created by this module's jobs with this suffix. If not s
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-create-snapshot/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-create-snapshot/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-create-snapshot/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-create-snapshot/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-create-snapshot/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-create-snapshot/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "47a0a8a7a90da78b996879fd3706b169"
+  "hash": "b52da3fcdb142ac428f4fa07c8c836c0"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-data-storage/lambda-share-snapshot/lambda-share-snapshot.md
+++ b/docs/reference/modules/terraform-aws-data-storage/lambda-share-snapshot/lambda-share-snapshot.md
@@ -13,19 +13,19 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Share Snapshot Lambda Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-share-snapshot" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-share-snapshot" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.26.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This module creates an [AWS Lambda](https://aws.amazon.com/lambda/) function that can share snapshots of an [Amazon
 Relational Database (RDS)](https://aws.amazon.com/rds/) database with another AWS account. Typically, the snapshots
-are created by the [lambda-create-snapshot module](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-create-snapshot), which can be configured to
+are created by the [lambda-create-snapshot module](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-create-snapshot), which can be configured to
 automatically trigger this lambda function after each run.
 
 ## Background info
 
 For more info on how to backup RDS snapshots to a separate AWS account, check out the [lambda-create-snapshot module
-documentation](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-create-snapshot).
+documentation](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-create-snapshot).
 
 ## Sample Usage
 
@@ -198,11 +198,11 @@ The amount of time, in seconds, between retries.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-share-snapshot/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-share-snapshot/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-share-snapshot/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-share-snapshot/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-share-snapshot/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-share-snapshot/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "6ff21946a156cf9ae9352603f8f78bd7"
+  "hash": "4445f445ea3715d26d920139af22b405"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-data-storage/rds/rds.md
+++ b/docs/reference/modules/terraform-aws-data-storage/rds/rds.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # RDS Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/rds" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/rds" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.26.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -41,9 +41,9 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   [What is Amazon RDS?](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/rds/core-concepts.md#what-is-amazon-rds)
+*   [What is Amazon RDS?](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/rds/core-concepts.md#what-is-amazon-rds)
 
-*   [Common gotchas with RDS](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/rds/core-concepts.md#common-gotchas)
+*   [Common gotchas with RDS](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/rds/core-concepts.md#common-gotchas)
 
 *   [RDS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Welcome.html): Amazon’s docs for RDS that cover core concepts such as the types of databases supported, security, backup & restore, and monitoring.
 
@@ -55,7 +55,7 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [examples folder](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [examples folder](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ### Production deployment
 
@@ -67,13 +67,13 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Day-to-day operations
 
-*   [How to connect to an RDS instance](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/rds/core-concepts.md#how-do-you-connect-to-the-database)
+*   [How to connect to an RDS instance](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/rds/core-concepts.md#how-do-you-connect-to-the-database)
 
 *   [How to authenticate to RDS with IAM](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAM.html)
 
-*   [How to scale RDS](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/rds/core-concepts.md#how-do-you-scale-this-database)
+*   [How to scale RDS](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/rds/core-concepts.md#how-do-you-scale-this-database)
 
-*   [How to backup RDS snapshots to a separate AWS account](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/lambda-create-snapshot#how-do-you-backup-your-rds-snapshots-to-a-separate-aws-account)
+*   [How to backup RDS snapshots to a separate AWS account](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/lambda-create-snapshot#how-do-you-backup-your-rds-snapshots-to-a-separate-aws-account)
 
 ### Major changes
 
@@ -273,7 +273,7 @@ module "rds" {
   ignore_password_changes = false
 
   # The amount of provisioned IOPS for the primary instance. Setting this implies a
-  # storage_type of 'io1','io2, or 'gp3'. Set to 0 to disable.
+  # storage_type of 'io1' or 'io2'. Set to 0 to disable.
   iops = 0
 
   # The ARN of a KMS key that should be used to encrypt data on disk. Only used if
@@ -409,16 +409,9 @@ module "rds" {
   # Specifies whether the DB instance is encrypted.
   storage_encrypted = true
 
-  # The storage throughput value for the DB instance. Can only be set when
-  # var.storage_type is 'gp3'. Cannot be specified if the allocated_storage value is
-  # below a per-engine threshold. See the RDS User Guide:
-  # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#gp3-sto
-  # age
-  storage_throughput = null
-
   # The type of storage to use for the primary instance. Must be one of 'standard'
-  # (magnetic), 'gp2' (general purpose SSD), 'gp3' (general purpose SSD), io1'
-  # (provisioned IOPS SSD), or 'io2' (2nd gen provisioned IOPS SSD).
+  # (magnetic), 'gp2' (general purpose SSD), 'io1' (provisioned IOPS SSD), or 'io2'
+  # (2nd gen provisioned IOPS SSD).
   storage_type = "gp2"
 
   # Timeout for DB updating
@@ -621,7 +614,7 @@ inputs = {
   ignore_password_changes = false
 
   # The amount of provisioned IOPS for the primary instance. Setting this implies a
-  # storage_type of 'io1','io2, or 'gp3'. Set to 0 to disable.
+  # storage_type of 'io1' or 'io2'. Set to 0 to disable.
   iops = 0
 
   # The ARN of a KMS key that should be used to encrypt data on disk. Only used if
@@ -757,16 +750,9 @@ inputs = {
   # Specifies whether the DB instance is encrypted.
   storage_encrypted = true
 
-  # The storage throughput value for the DB instance. Can only be set when
-  # var.storage_type is 'gp3'. Cannot be specified if the allocated_storage value is
-  # below a per-engine threshold. See the RDS User Guide:
-  # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#gp3-sto
-  # age
-  storage_throughput = null
-
   # The type of storage to use for the primary instance. Must be one of 'standard'
-  # (magnetic), 'gp2' (general purpose SSD), 'gp3' (general purpose SSD), io1'
-  # (provisioned IOPS SSD), or 'io2' (2nd gen provisioned IOPS SSD).
+  # (magnetic), 'gp2' (general purpose SSD), 'io1' (provisioned IOPS SSD), or 'io2'
+  # (2nd gen provisioned IOPS SSD).
   storage_type = "gp2"
 
   # Timeout for DB updating
@@ -1157,7 +1143,7 @@ Creates an instance that disables terraform from updating the master_password.  
 <HclListItem name="iops" requirement="optional" type="number">
 <HclListItemDescription>
 
-The amount of provisioned IOPS for the primary instance. Setting this implies a storage_type of 'io1','io2, or 'gp3'. Set to 0 to disable.
+The amount of provisioned IOPS for the primary instance. Setting this implies a storage_type of 'io1' or 'io2'. Set to 0 to disable.
 
 </HclListItemDescription>
 <HclListItemDefaultValue defaultValue="0"/>
@@ -1415,19 +1401,10 @@ Specifies whether the DB instance is encrypted.
 <HclListItemDefaultValue defaultValue="true"/>
 </HclListItem>
 
-<HclListItem name="storage_throughput" requirement="optional" type="string">
-<HclListItemDescription>
-
-The storage throughput value for the DB instance. Can only be set when <a href="#storage_type"><code>storage_type</code></a> is 'gp3'. Cannot be specified if the allocated_storage value is below a per-engine threshold. See the RDS User Guide: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#gp3-storage
-
-</HclListItemDescription>
-<HclListItemDefaultValue defaultValue="null"/>
-</HclListItem>
-
 <HclListItem name="storage_type" requirement="optional" type="string">
 <HclListItemDescription>
 
-The type of storage to use for the primary instance. Must be one of 'standard' (magnetic), 'gp2' (general purpose SSD), 'gp3' (general purpose SSD), io1' (provisioned IOPS SSD), or 'io2' (2nd gen provisioned IOPS SSD).
+The type of storage to use for the primary instance. Must be one of 'standard' (magnetic), 'gp2' (general purpose SSD), 'io1' (provisioned IOPS SSD), or 'io2' (2nd gen provisioned IOPS SSD).
 
 </HclListItemDescription>
 <HclListItemDefaultValue defaultValue="&quot;gp2&quot;"/>
@@ -1491,11 +1468,11 @@ Timeout for DB updating
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/rds/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/rds/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/rds/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/rds/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/rds/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/rds/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "99adac3897461839f083dab2f3b58bdf"
+  "hash": "b97a766110b9b5d427600ac52e89c033"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-data-storage/redshift/redshift.md
+++ b/docs/reference/modules/terraform-aws-data-storage/redshift/redshift.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Redshift Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/redshift" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/redshift" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v0.26.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -47,7 +47,7 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [examples folder](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [examples folder](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ### Production deployment
 
@@ -125,10 +125,6 @@ module "redshift" {
   # never automatically applied.
   allow_major_version_upgrade = true
 
-  # A list of CIDR-formatted IP address ranges that this DB can connect. Use this if
-  # the database needs to connect to certain IP addresses for special operation
-  allow_outbound_connections_from_cidr_blocks = []
-
   # Indicates that minor engine upgrades will be applied automatically to the DB
   # instance during the maintenance window. If set to true, you should set
   # var.engine_version to MAJOR.MINOR and omit the .PATCH at the end (e.g., use 5.7
@@ -175,9 +171,6 @@ module "redshift" {
 
   # Timeout for DB deleting
   deleting_timeout = "40m"
-
-  # Elastic IP that will be associated with the cluster
-  elastic_ip = null
 
   # If true , enhanced VPC routing is enabled. Forces COPY and UNLOAD traffic
   # between the cluster and data repositories to go through your VPC.
@@ -307,10 +300,6 @@ inputs = {
   # never automatically applied.
   allow_major_version_upgrade = true
 
-  # A list of CIDR-formatted IP address ranges that this DB can connect. Use this if
-  # the database needs to connect to certain IP addresses for special operation
-  allow_outbound_connections_from_cidr_blocks = []
-
   # Indicates that minor engine upgrades will be applied automatically to the DB
   # instance during the maintenance window. If set to true, you should set
   # var.engine_version to MAJOR.MINOR and omit the .PATCH at the end (e.g., use 5.7
@@ -357,9 +346,6 @@ inputs = {
 
   # Timeout for DB deleting
   deleting_timeout = "40m"
-
-  # Elastic IP that will be associated with the cluster
-  elastic_ip = null
 
   # If true , enhanced VPC routing is enabled. Forces COPY and UNLOAD traffic
   # between the cluster and data repositories to go through your VPC.
@@ -517,15 +503,6 @@ Indicates whether major version upgrades (e.g. 9.4.x to 9.5.x) will ever be perm
 <HclListItemDefaultValue defaultValue="true"/>
 </HclListItem>
 
-<HclListItem name="allow_outbound_connections_from_cidr_blocks" requirement="optional" type="list(string)">
-<HclListItemDescription>
-
-A list of CIDR-formatted IP address ranges that this DB can connect. Use this if the database needs to connect to certain IP addresses for special operation
-
-</HclListItemDescription>
-<HclListItemDefaultValue defaultValue="[]"/>
-</HclListItem>
-
 <HclListItem name="auto_minor_version_upgrade" requirement="optional" type="bool">
 <HclListItemDescription>
 
@@ -623,15 +600,6 @@ Timeout for DB deleting
 
 </HclListItemDescription>
 <HclListItemDefaultValue defaultValue="&quot;40m&quot;"/>
-</HclListItem>
-
-<HclListItem name="elastic_ip" requirement="optional" type="string">
-<HclListItemDescription>
-
-Elastic IP that will be associated with the cluster
-
-</HclListItemDescription>
-<HclListItemDefaultValue defaultValue="null"/>
 </HclListItem>
 
 <HclListItem name="enhanced_vpc_routing" requirement="optional" type="bool">
@@ -890,11 +858,11 @@ The ID of the Security Group that controls access to the cluster
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/redshift/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/redshift/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/main/modules/redshift/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/redshift/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/redshift/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v0.26.0/modules/redshift/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "d2059774571319c68879af8788d36020"
+  "hash": "1c201b9e0861adcb3ec642ec681ad23b"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ecs/ecs-cluster/ecs-cluster.md
+++ b/docs/reference/modules/terraform-aws-ecs/ecs-cluster/ecs-cluster.md
@@ -13,13 +13,13 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # ECS Cluster Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-cluster" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-cluster" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.35.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This Terraform Module launches an [EC2 Container Service
 Cluster](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_clusters.html) that you can use to run
-Docker containers and services (see the [ecs-service module](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service/README.adoc)).
+Docker containers and services (see the [ecs-service module](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service/README.adoc)).
 
 **WARNING: Launch Configurations:** [Launch configurations](https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-configurations.html) are being phased out in favor of [Launch Templates](https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-templates.html). Before upgrading to the latest release please be sure to test and plan any changes to infrastructure that may be impacted. Launch templates are being introduced in [PR #371](https://github.com/gruntwork-io/terraform-aws-ecs/pull/371)
 
@@ -32,7 +32,7 @@ ECS and register itself as part of the right cluster.
 
 ## How do you run Docker containers on the cluster?
 
-See the [service module](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service/README.adoc).
+See the [service module](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service/README.adoc).
 
 ## How do you add additional security group rules?
 
@@ -97,7 +97,7 @@ currently no way in ECS to manage IAM policies on a per-Docker-container basis.
 
 ## How do you make changes to the EC2 Instances in the cluster?
 
-To deploy an update to an ECS Service, see the [ecs-service module](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service). To deploy an update to the
+To deploy an update to an ECS Service, see the [ecs-service module](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service). To deploy an update to the
 EC2 Instances in your ECS cluster, such as a new AMI, read on.
 
 Terraform and AWS do not provide a way to automatically roll out a change to the Instances in an ECS Cluster. Due to
@@ -122,8 +122,8 @@ To deploy a change such as rolling out a new AMI to all ECS Instances:
     python3 roll-out-ecs-cluster-update.py --asg-name ASG_NAME --cluster-name CLUSTER_NAME --aws-region AWS_REGION
     ```
 
-    If you have your output variables configured as shown in [outputs.tf](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/examples/docker-service-with-elb/outputs.tf)
-    of the [docker-service-with-elb example](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/examples/docker-service-with-elb), you can use the `terraform output`
+    If you have your output variables configured as shown in [outputs.tf](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/examples/docker-service-with-elb/outputs.tf)
+    of the [docker-service-with-elb example](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/examples/docker-service-with-elb), you can use the `terraform output`
     command to fill in most of the arguments automatically:
 
     ```
@@ -207,7 +207,7 @@ enable Capacity Providers on an existing ECS cluster that did not have Capacity 
 instances to ensure all the instances get associated with the new Capacity Provider.
 
 To rotate the instances, you can run the
-[roll-out-ecs-cluster-update.py](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-cluster/roll-out-ecs-cluster-update.py)
+[roll-out-ecs-cluster-update.py](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-cluster/roll-out-ecs-cluster-update.py)
 script in the `terraform-aws-ecs` module. Refer to the
 [documentation](#how-do-you-make-changes-to-the-ec2-instances-in-the-cluster)
 for more information on the script.
@@ -1297,11 +1297,11 @@ Set this variable to true to enable the use of Instance Metadata Service Version
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-cluster/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-cluster/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-cluster/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-cluster/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-cluster/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-cluster/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "443b2a8c989013cd93797735af1d69e7"
+  "hash": "cd99c3b61aa2e85f73d98ca7fdbd9b10"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ecs/ecs-daemon-service/ecs-daemon-service.md
+++ b/docs/reference/modules/terraform-aws-ecs/ecs-daemon-service/ecs-daemon-service.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # ECS Daemon Service Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-daemon-service" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-daemon-service" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.34.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -33,7 +33,7 @@ environment variables to set, and so on. To actually run an ECS Task, you define
 
 ## How do you create an ECS cluster?
 
-To use ECS, you first deploy one or more EC2 Instances into a "cluster". See the [ecs-cluster module](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-cluster)
+To use ECS, you first deploy one or more EC2 Instances into a "cluster". See the [ecs-cluster module](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-cluster)
 for how to create a cluster.
 
 ## How do you add additional IAM policies?
@@ -595,11 +595,11 @@ If true, Terraform will wait for the service to reach a steady state—as in, th
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-daemon-service/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-daemon-service/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-daemon-service/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-daemon-service/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-daemon-service/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-daemon-service/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "35bed95d6c3b803c9f726e1d1573faeb"
+  "hash": "b88760d95bf4431cc708ec35f2e4c3bb"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ecs/ecs-deploy-check-binaries/ecs-deploy-check-binaries.md
+++ b/docs/reference/modules/terraform-aws-ecs/ecs-deploy-check-binaries/ecs-deploy-check-binaries.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # ECS Deploy Check Scripts
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-deploy-check-binaries" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-deploy-check-binaries" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.35.1" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -108,11 +108,11 @@ pyenv shell 3.8.0 3.9.0 3.10.0 3.11.0
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-deploy-check-binaries/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-deploy-check-binaries/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-deploy-check-binaries/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-deploy-check-binaries/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-deploy-check-binaries/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-deploy-check-binaries/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "2e4d6a43977d3acc1b28e3ecf0d6852a"
+  "hash": "8db2df88f48536a2cf5abe6aaa5dda8b"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ecs/ecs-deploy/ecs-deploy.md
+++ b/docs/reference/modules/terraform-aws-ecs/ecs-deploy/ecs-deploy.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # ECS Deployment Scripts
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-deploy" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-deploy" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.35.1" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -48,7 +48,7 @@ The `run-ecs-task` script assumes you already have the following:
     resource](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html). You'll need to know the family
     name and revision of the ECS Task Definition you want to run.
 
-Check out the [deploy-ecs-task example](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/examples/deploy-ecs-task) for working sample code of both of the above.
+Check out the [deploy-ecs-task example](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/examples/deploy-ecs-task) for working sample code of both of the above.
 
 To run the ECS Task Definition `db-backup` at revision `3` in an ECS Cluster named `ecs-stage` in `us-west-2`, use the
 following command:
@@ -96,11 +96,11 @@ container instead of the command configured in the Task Definition.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-deploy/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-deploy/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-deploy/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-deploy/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-deploy/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-deploy/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "beb074c83415b14095641266a11da638"
+  "hash": "8d93dbca1e97c825fd74e7d1631c3289"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ecs/ecs-fargate/ecs-fargate.md
+++ b/docs/reference/modules/terraform-aws-ecs/ecs-fargate/ecs-fargate.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Fargate Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-fargate" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-fargate" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.24.1" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -24,11 +24,11 @@ guide in [the release notes](https://github.com/gruntwork-io/terraform-aws-ecs/r
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-fargate/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-fargate/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-fargate/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-fargate/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-fargate/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-fargate/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "98a4b38d5b6fabd3e802e79d155386ec"
+  "hash": "c0dee08c0120aed2d6c903ad0ab3ec1d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ecs/ecs-scripts/ecs-scripts.md
+++ b/docs/reference/modules/terraform-aws-ecs/ecs-scripts/ecs-scripts.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # ECS Scripts
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-scripts" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-scripts" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.32.1" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -31,7 +31,7 @@ You can install the helpers using the [Gruntwork Installer](https://github.com/g
 gruntwork-install --module-name "ecs-scripts" --repo "https://github.com/gruntwork-io/terraform-aws-ecs" --tag "0.0.1"
 ```
 
-For an example, see the [Packer](https://www.packer.io/) template under [/examples/example-ecs-instance-ami/build.json](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/examples/example-ecs-instance-ami/build.json).
+For an example, see the [Packer](https://www.packer.io/) template under [/examples/example-ecs-instance-ami/build.json](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/examples/example-ecs-instance-ami/build.json).
 
 ## Using the configure-ecs-instance helper
 
@@ -80,11 +80,11 @@ Run `configure-ecs-instance --help` to see all available options.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-scripts/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-scripts/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-scripts/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-scripts/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-scripts/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-scripts/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "9004d494ef6011b0f0c5b038d562f488"
+  "hash": "27a906f6e40430138611af9f0ddc75e9"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ecs/ecs-service-with-alb/ecs-service-with-alb.md
+++ b/docs/reference/modules/terraform-aws-ecs/ecs-service-with-alb/ecs-service-with-alb.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # ECS Service with ALB
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service-with-alb" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service-with-alb" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.24.1" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -24,11 +24,11 @@ guide in [the release notes](https://github.com/gruntwork-io/terraform-aws-ecs/r
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service-with-alb/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service-with-alb/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service-with-alb/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service-with-alb/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service-with-alb/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service-with-alb/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "32e7e2d053d2675ee2f770cf25e8d675"
+  "hash": "e3262dec92189d5597daa0b425a89047"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ecs/ecs-service-with-discovery/ecs-service-with-discovery.md
+++ b/docs/reference/modules/terraform-aws-ecs/ecs-service-with-discovery/ecs-service-with-discovery.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # ECS Service with Discovery
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service-with-discovery" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service-with-discovery" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.24.1" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -24,11 +24,11 @@ guide in [the release notes](https://github.com/gruntwork-io/terraform-aws-ecs/r
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service-with-discovery/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service-with-discovery/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service-with-discovery/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service-with-discovery/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service-with-discovery/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service-with-discovery/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "6e6cbf404c79fa0b97a51cf3dce3e6be"
+  "hash": "bc478070a3c9c206b1059398f6f802b2"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ecs/ecs-service/ecs-service.md
+++ b/docs/reference/modules/terraform-aws-ecs/ecs-service/ecs-service.md
@@ -13,11 +13,11 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # ECS Service
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.34.2" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
-This module creates an [Elastic Container Service (ECS) Service](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html) that you can use to run one or more related, long-running Docker containers, such as a web service. An ECS service can automatically deploy multiple instances of your Docker containers across an ECS cluster (see the [ecs-cluster module](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-cluster)), restart any failed Docker containers, route traffic across your containers using an optional Elastic Load Balancer (ELB), and optionally register the services to AWS Service Discovery Service.
+This module creates an [Elastic Container Service (ECS) Service](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html) that you can use to run one or more related, long-running Docker containers, such as a web service. An ECS service can automatically deploy multiple instances of your Docker containers across an ECS cluster (see the [ecs-cluster module](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-cluster)), restart any failed Docker containers, route traffic across your containers using an optional Elastic Load Balancer (ELB), and optionally register the services to AWS Service Discovery Service.
 
 ![ECS Service architecture](/img/reference/modules/terraform-aws-ecs/ecs-service/ecs-service-architecture.png)
 
@@ -37,7 +37,7 @@ This module creates an [Elastic Container Service (ECS) Service](http://docs.aws
 
 *   VPC support
 
-*   Verified deployments using the [ECS deployment checker binary](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-deploy-check-binaries)
+*   Verified deployments using the [ECS deployment checker binary](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-deploy-check-binaries)
 
 ## Learn
 
@@ -47,15 +47,15 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   [What is Amazon ECS?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/core-concepts.md#what-is-elastic-container-service)
+*   [What is Amazon ECS?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/core-concepts.md#what-is-elastic-container-service)
 
-*   [Helpful vocabulary for ECS](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/core-concepts.md#helpful-vocabulary)
+*   [Helpful vocabulary for ECS](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/core-concepts.md#helpful-vocabulary)
 
-*   [What is Fargate?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/core-concepts.md#what-is-fargate)
+*   [What is Fargate?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/core-concepts.md#what-is-fargate)
 
-*   [What is an ECS Service?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service/core-concepts.md#what-is-an-ecs-service)
+*   [What is an ECS Service?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service/core-concepts.md#what-is-an-ecs-service)
 
-*   [What is ECS Service Discovery?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service/core-concepts.md#what-is-ecs-service-discovery)
+*   [What is ECS Service Discovery?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service/core-concepts.md#what-is-ecs-service-discovery)
 
 *   [ECS Documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/Welcome.html): Amazon’s docs for ECS that cover core concepts such as the different cluster hosting options, scheduling properties, Docker, security, and monitoring.
 
@@ -63,27 +63,27 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-    *   [modules/ecs-cluster](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-cluster): use this module to provision an ECS cluster with ECS container instances.
+    *   [modules/ecs-cluster](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-cluster): use this module to provision an ECS cluster with ECS container instances.
 
-    *   [modules/ecs-scripts](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-scripts): use the scripts in this module to configure private docker registries and register ECS container instances to ECS clusters.
+    *   [modules/ecs-scripts](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-scripts): use the scripts in this module to configure private docker registries and register ECS container instances to ECS clusters.
 
-    *   [modules/ecs-service](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service): use this module to deploy one or more docker containers as a ECS service, with options to use ELBs (CLB, ALB, or NLB), Service Discovery, or Fargate.
+    *   [modules/ecs-service](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service): use this module to deploy one or more docker containers as a ECS service, with options to use ELBs (CLB, ALB, or NLB), Service Discovery, or Fargate.
 
-    *   [modules/ecs-daemon-service](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-daemon-service): use this module to deploy one or more docker containers that run on a regular schedule.
+    *   [modules/ecs-daemon-service](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-daemon-service): use this module to deploy one or more docker containers that run on a regular schedule.
 
-    *   [modules/ecs-deploy](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-deploy): use the scripts in this module to run one or more docker containers as a one time task on an ECS cluster.
+    *   [modules/ecs-deploy](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-deploy): use the scripts in this module to run one or more docker containers as a one time task on an ECS cluster.
 
-    *   [modules/ecs-deploy-check-binaries](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-deploy-check-binaries): use the python binary packages in this module to check ECS service deployments to ensure that they are active and healthy.
+    *   [modules/ecs-deploy-check-binaries](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-deploy-check-binaries): use the python binary packages in this module to check ECS service deployments to ensure that they are active and healthy.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/test): Automated tests for the modules and examples.
 
 ### Gruntwork analysis
 
-*   [EC2 vs Fargate launch types](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/core-concepts.md#ec2-vs-fargate-launch-types): A detailed comparison between the two available launch types for ECS, showing you the trade-offs between ECS container instances and Fargate.
+*   [EC2 vs Fargate launch types](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/core-concepts.md#ec2-vs-fargate-launch-types): A detailed comparison between the two available launch types for ECS, showing you the trade-offs between ECS container instances and Fargate.
 
 ## Deploy
 
@@ -91,7 +91,7 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [examples folder](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [examples folder](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ### Production deployment
 
@@ -115,23 +115,23 @@ Production-ready sample code from the Reference Architecture:
 
 ### Day-to-day operations
 
-*   [How do I use Fargate?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service/core-concepts.md#how-do-i-use-fargate)
+*   [How do I use Fargate?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service/core-concepts.md#how-do-i-use-fargate)
 
-*   [How do I associate the ECS Service with an ALB or NLB?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service/core-concepts.md#how-do-i-associate-the-ecs-service-with-an-alb-or-nlb)
+*   [How do I associate the ECS Service with an ALB or NLB?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service/core-concepts.md#how-do-i-associate-the-ecs-service-with-an-alb-or-nlb)
 
-*   [How do I setup Service Discovery?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service/core-concepts.md#how-do-i-setup-service-discovery)
+*   [How do I setup Service Discovery?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service/core-concepts.md#how-do-i-setup-service-discovery)
 
-*   [How do I add IAM policies to the ECS service?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service/core-concepts.md#how-do-you-add-additional-iam-policies-to-the-ecs-service)
+*   [How do I add IAM policies to the ECS service?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service/core-concepts.md#how-do-you-add-additional-iam-policies-to-the-ecs-service)
 
-*   [How do I scale an ECS service?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service/core-concepts.md#how-do-you-scale-an-ecs-service)
+*   [How do I scale an ECS service?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service/core-concepts.md#how-do-you-scale-an-ecs-service)
 
 ### Major changes
 
-*   [How do you make changes to the EC2 instances in the cluster?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/module/ecs-cluster/README.md#how-do-you-make-changes-to-the-ec-2-instances-in-the-cluster)
+*   [How do you make changes to the EC2 instances in the cluster?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/module/ecs-cluster/README.md#how-do-you-make-changes-to-the-ec-2-instances-in-the-cluster)
 
-*   [How do ECS Services deploy new versions of containers?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service/core-concepts.md#how-do-ecs-services-deploy-new-versions-of-containers)
+*   [How do ECS Services deploy new versions of containers?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service/core-concepts.md#how-do-ecs-services-deploy-new-versions-of-containers)
 
-*   [How do I do a canary deployment?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service/core-concepts.md#how-do-i-do-a-canary-deployment)
+*   [How do I do a canary deployment?](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service/core-concepts.md#how-do-i-do-a-canary-deployment)
 
 ## Sample Usage
 
@@ -1827,11 +1827,11 @@ If true, Terraform will wait for the service to reach a steady state—as in, th
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-service/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-service/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "8128f936b9cc7fc13f620eae3f9d589e"
+  "hash": "a117e6f9969127c3102d635b44a154aa"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-ecs/ecs-task-scheduler/ecs-task-scheduler.md
+++ b/docs/reference/modules/terraform-aws-ecs/ecs-task-scheduler/ecs-task-scheduler.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # ECS Task Scheduler Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-task-scheduler" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-task-scheduler" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-ecs/releases/tag/v0.34.2" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -26,7 +26,7 @@ This module provides two options for defining when ECS tasks will be run:
 *   [Event Patterns](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html)
 *   [Schedule Expressions](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html#eb-rate-expressions)
 
-In [variables.tf](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-task-scheduler/variables.tf) there are two variables (`task_event_pattern` and `task_schedule_expression`) that can be provided in the module definition. At least one, but not both of these fields, must be provided. This is what is passed to the EventBridge rule to determine when to invoke your ECS task.
+In [variables.tf](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-task-scheduler/variables.tf) there are two variables (`task_event_pattern` and `task_schedule_expression`) that can be provided in the module definition. At least one, but not both of these fields, must be provided. This is what is passed to the EventBridge rule to determine when to invoke your ECS task.
 
 Note that this approach has AWS limitations with monitoring the event trigger and ECS task. AWS EventBridge fires the event but does not monitor whether the task ran successfully so if there is a failure, EventBridge does not attempt any retries or report failures.
 
@@ -180,7 +180,7 @@ This module provides support for passing the following additional inputs and ove
     }
     ```
 
-See [variables.tf](https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-task-scheduler/variables.tf) for specific variable definitions.
+See [variables.tf](https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-task-scheduler/variables.tf) for specific variable definitions.
 
 ## Sample Usage
 
@@ -545,11 +545,11 @@ The scheduling expression to use (rate or cron - see README for usage examples).
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-task-scheduler/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-task-scheduler/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/main/modules/ecs-task-scheduler/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-task-scheduler/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-task-scheduler/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-ecs/tree/v0.35.1/modules/ecs-task-scheduler/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "be03fae73337bbb8c019a627280a9f44"
+  "hash": "047b8225e2226ff23e8cd7937ca53ca3"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-eks/eks-alb-ingress-controller-iam-policy/eks-alb-ingress-controller-iam-policy.md
+++ b/docs/reference/modules/terraform-aws-eks/eks-alb-ingress-controller-iam-policy/eks-alb-ingress-controller-iam-policy.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # ALB Ingress Controller IAM Policy Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-alb-ingress-controller-iam-policy" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-alb-ingress-controller-iam-policy" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.53.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -23,14 +23,14 @@ defines the minimal set of permissions necessary for the [AWS ALB Ingress
 Controller](https://github.com/kubernetes-sigs/aws-alb-ingress-controller). This policy can then be attached to EC2
 instances or IAM roles so that the controller deployed has enough permissions to manage an ALB.
 
-See [the eks-alb-ingress-controller module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-alb-ingress-controller) for a module that deploys the Ingress
+See [the eks-alb-ingress-controller module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-alb-ingress-controller) for a module that deploys the Ingress
 Controller on to your EKS cluster.
 
 ## Attaching IAM policy to workers
 
 To allow the ALB Ingress Controller to manage ALBs, it needs IAM permissions to use the AWS API to manage ALBs.
 Currently, the way to grant Pods IAM privileges is to use the worker IAM profiles provisioned by [the
-eks-cluster-workers module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-workers/README.md#how-do-you-add-additional-iam-policies).
+eks-cluster-workers module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-workers/README.md#how-do-you-add-additional-iam-policies).
 
 The Terraform templates in this module create an IAM policy that has the required permissions. You then need to use an
 [aws_iam_policy_attachment](https://www.terraform.io/docs/providers/aws/r/iam_policy_attachment.html) to attach that
@@ -195,11 +195,11 @@ The name of the IAM policy created with the permissions for the ALB ingress cont
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-alb-ingress-controller-iam-policy/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-alb-ingress-controller-iam-policy/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-alb-ingress-controller-iam-policy/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-alb-ingress-controller-iam-policy/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-alb-ingress-controller-iam-policy/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-alb-ingress-controller-iam-policy/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "5769cee951330f2e0ad6274832c97ba4"
+  "hash": "58678f5c9542e4a0b5de79861d16c702"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-eks/eks-alb-ingress-controller/eks-alb-ingress-controller.md
+++ b/docs/reference/modules/terraform-aws-eks/eks-alb-ingress-controller/eks-alb-ingress-controller.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # ALB Ingress Controller Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-alb-ingress-controller" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-alb-ingress-controller" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.56.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -110,7 +110,7 @@ correctly.
 
 You can use the `alb.ingress.kubernetes.io/subnets` annotation on `Ingress` resources to specify which subnets the controller should configure the ALB for.
 
-You can also omit the `alb.ingress.kubernetes.io/subnets` annotation, and the controller will [automatically discover subnets](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/controller/config/#subnet-auto-discovery) based on their tags. This method should work "out of the box", so long as you are using the [`eks-vpc-tags`](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-vpc-tags) module to tag your VPC subnets.
+You can also omit the `alb.ingress.kubernetes.io/subnets` annotation, and the controller will [automatically discover subnets](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/controller/config/#subnet-auto-discovery) based on their tags. This method should work "out of the box", so long as you are using the [`eks-vpc-tags`](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-vpc-tags) module to tag your VPC subnets.
 
 ### Security Groups
 
@@ -125,7 +125,7 @@ nodes.
 ### IAM permissions
 
 The container deployed in this module requires IAM permissions to manage ALB resources. See [the
-eks-alb-ingress-controller-iam-policy module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-alb-ingress-controller-iam-policy) for more information.
+eks-alb-ingress-controller-iam-policy module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-alb-ingress-controller-iam-policy) for more information.
 
 ## Using the Ingress Controller
 
@@ -200,7 +200,7 @@ nature of the controller in provisioning the ALBs.
 The AWS ALB Ingress Controller has first class support for
 [external-dns](https://github.com/kubernetes-incubator/external-dns), a third party tool that configures external DNS
 providers with domains to route to `Services` and `Ingresses` in Kubernetes. See our [eks-k8s-external-dns
-module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-external-dns) for more information on how to setup the tool.
+module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-external-dns) for more information on how to setup the tool.
 
 ## How do I deploy the Pods to Fargate?
 
@@ -478,11 +478,11 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-alb-ingress-controller/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-alb-ingress-controller/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-alb-ingress-controller/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-alb-ingress-controller/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-alb-ingress-controller/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-alb-ingress-controller/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "b29fe5f27fff6478533ae8ddde94ea34"
+  "hash": "4d0185aa48351556b25d64cbe4afbfe4"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-eks/eks-aws-auth-merger/eks-aws-auth-merger.md
+++ b/docs/reference/modules/terraform-aws-eks/eks-aws-auth-merger/eks-aws-auth-merger.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # EKS AWS Auth Merger
 
-<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-aws-auth-merger" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-aws-auth-merger" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.57.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -35,21 +35,21 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   *[What is Kubernetes RBAC?](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-role-mapping/README.md#what-is-kubernetes-role-based-access-control-rbac)*: overview of Kubernetes RBAC, the underlying system managing authentication and authorization in Kubernetes.
+*   *[What is Kubernetes RBAC?](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-role-mapping/README.md#what-is-kubernetes-role-based-access-control-rbac)*: overview of Kubernetes RBAC, the underlying system managing authentication and authorization in Kubernetes.
 
-*   *[What is AWS IAM role?](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-role-mapping/README.md#what-is-aws-iam-role)*: overview of AWS IAM Roles, the underlying system managing authentication and authorization in AWS.
+*   *[What is AWS IAM role?](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-role-mapping/README.md#what-is-aws-iam-role)*: overview of AWS IAM Roles, the underlying system managing authentication and authorization in AWS.
 
 *   *[Managing users or IAM roles for your cluster](https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html)*: The official AWS docs on how the `aws-auth` Kubernetes `ConfigMap` works.
 
-*   *[What is the aws-auth-merger?](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-aws-auth-merger/core-concepts.md#what-is-the-aws-auth-merger)*: overview of the `aws-auth-merger` and how it works to manage the `aws-auth` Kubernetes `ConfigMap`.
+*   *[What is the aws-auth-merger?](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-aws-auth-merger/core-concepts.md#what-is-the-aws-auth-merger)*: overview of the `aws-auth-merger` and how it works to manage the `aws-auth` Kubernetes `ConfigMap`.
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/test): Automated tests for the modules and examples.
 
 ## Deploy
 
@@ -57,7 +57,7 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [examples folder](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [examples folder](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ### Production deployment
 
@@ -69,15 +69,15 @@ If you want to deploy this repo in production, check out the following resources
 
 ## Manage
 
-*   [How to deploy and use the aws-auth-merger](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-aws-auth-merger/core-concepts.md#how-do-i-use-the-aws-auth-merger)
+*   [How to deploy and use the aws-auth-merger](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-aws-auth-merger/core-concepts.md#how-do-i-use-the-aws-auth-merger)
 
-*   [How to handle conflicts with automatic updates to the aws-auth ConfigMap by EKS](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-aws-auth-merger/core-concepts.md#how-do-i-handle-conflicts-with-automatic-updates-by-eks)
+*   [How to handle conflicts with automatic updates to the aws-auth ConfigMap by EKS](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-aws-auth-merger/core-concepts.md#how-do-i-handle-conflicts-with-automatic-updates-by-eks)
 
-*   [How to restrict users to specific actions on the EKS cluster](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-role-mapping/README.md#restricting-specific-actions)
+*   [How to restrict users to specific actions on the EKS cluster](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-role-mapping/README.md#restricting-specific-actions)
 
-*   [How to restrict users to specific namespaces on the EKS cluster](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-role-mapping/README.md#restricting-by-namespace)
+*   [How to restrict users to specific namespaces on the EKS cluster](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-role-mapping/README.md#restricting-by-namespace)
 
-*   [How to authenticate kubectl to EKS](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/core-concepts.md#how-to-authenticate-kubectl)
+*   [How to authenticate kubectl to EKS](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/core-concepts.md#how-to-authenticate-kubectl)
 
 ## Sample Usage
 
@@ -621,11 +621,11 @@ The name of the namespace that is used. If create_namespace is true, this output
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-aws-auth-merger/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-aws-auth-merger/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-aws-auth-merger/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-aws-auth-merger/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-aws-auth-merger/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-aws-auth-merger/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "b6eafe56a61adab0c6cb8af523b072f4"
+  "hash": "4aa450218577ea8c7c6e00ae6af12c72"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-eks/eks-cloudwatch-agent/eks-cloudwatch-agent.md
+++ b/docs/reference/modules/terraform-aws-eks/eks-cloudwatch-agent/eks-cloudwatch-agent.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # EKS CloudWatch Agent Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cloudwatch-agent" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cloudwatch-agent" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.53.1" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -225,11 +225,11 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cloudwatch-agent/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cloudwatch-agent/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cloudwatch-agent/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cloudwatch-agent/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cloudwatch-agent/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cloudwatch-agent/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "87f3adde3631f9034801c84a0235fb85"
+  "hash": "da47589a938d4303f963fd991cab93ec"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-eks/eks-cluster-control-plane/eks-cluster-control-plane.md
+++ b/docs/reference/modules/terraform-aws-eks/eks-cluster-control-plane/eks-cluster-control-plane.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # EKS Cluster Control Plane Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-control-plane" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-control-plane" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.57.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -22,7 +22,7 @@ Cluster](https://docs.aws.amazon.com/eks/latest/userguide/clusters.html).
 
 This module is responsible for the EKS Control Plane in [the EKS cluster topology](#what-is-an-eks-cluster). You must
 launch worker nodes in order to be able to schedule pods on your cluster. See the [eks-cluster-workers
-module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-workers) for managing EKS worker nodes.
+module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-workers) for managing EKS worker nodes.
 
 ## What is the EKS Control Plane?
 
@@ -46,7 +46,7 @@ Specifically, the control plane consists of:
     This includes resources like the
     [`LoadBalancers`](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/).
 
-You can read more about the different components of EKS in [the project README](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/core-concepts.md#what-is-an-eks-cluster).
+You can read more about the different components of EKS in [the project README](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/core-concepts.md#what-is-an-eks-cluster).
 
 ## What security group rules are created?
 
@@ -134,7 +134,7 @@ role that is being assumed. Specifically, you need to:
         that role).
 
 You can use the
-[eks-iam-role-assume-role-policy-for-service-account module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-iam-role-assume-role-policy-for-service-account) to
+[eks-iam-role-assume-role-policy-for-service-account module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-iam-role-assume-role-policy-for-service-account) to
 construct the policy using a more convenient interface. Refer to the module documentation for more info.
 
 Once you have an IAM Role that can be assumed by the Kubernetes Service Account, you can configure your Pods to exchange
@@ -242,7 +242,7 @@ Some additional notes on using Fargate:
     [the `aws_eks_fargate_profile` resource](https://www.terraform.io/docs/providers/aws/r/eks_fargate_profile.html) to
     provision Fargate Profiles with Terraform). The Pod Execution Role created by the module may be reused for other
     Fargate Profiles.
-*   Fargate does not support DaemonSets. This means that you can't rely on the [eks-container-logs](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-container-logs)
+*   Fargate does not support DaemonSets. This means that you can't rely on the [eks-container-logs](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-container-logs)
     module to forward logs to CloudWatch. Instead, you need to manually configure a sidecar `fluentd` container that
     forwards the log entries to CloudWatch Logs. Refer to [this AWS blog
     post](https://aws.amazon.com/blogs/containers/how-to-capture-application-logs-when-using-amazon-eks-on-aws-fargate/)
@@ -284,7 +284,7 @@ If you omit the `addon_version`, correct versions are automatically applied.
 Note that you must update the nodes to use the corresponding `kubelet` version as well. This means that when you update
 minor versions, you will also need to update the AMIs used by the worker nodes to match the version and rotate the
 workers. For more information on rotating worker nodes, refer to [How do I roll out an update to the
-instances?](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-workers/README.md#how-do-i-roll-out-an-update-to-the-instances) in the `eks-cluster-workers`
+instances?](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-workers/README.md#how-do-i-roll-out-an-update-to-the-instances) in the `eks-cluster-workers`
 module README.
 
 ### Detailed upgrade steps
@@ -1559,11 +1559,11 @@ The path to the kubergrunt binary, if in use.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-control-plane/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-control-plane/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-control-plane/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-control-plane/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-control-plane/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-control-plane/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "4e418d06777796cdd3302110e8670abf"
+  "hash": "33a7473642506e489d9930eca6cae718"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-eks/eks-cluster-managed-workers/eks-cluster-managed-workers.md
+++ b/docs/reference/modules/terraform-aws-eks/eks-cluster-managed-workers/eks-cluster-managed-workers.md
@@ -13,19 +13,19 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # EKS Cluster Managed Workers Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-managed-workers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-managed-workers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.57.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
-**This module provisions [EKS Managed Node Groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html), as opposed to self managed ASGs. See the [eks-cluster-workers](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-workers) module for a module to provision self managed worker groups.**
+**This module provisions [EKS Managed Node Groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html), as opposed to self managed ASGs. See the [eks-cluster-workers](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-workers) module for a module to provision self managed worker groups.**
 
 This Terraform module launches worker nodes using [EKS Managed Node
 Groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html) that you can use to run Kubernetes
 Pods and Deployments.
 
 This module is responsible for the EKS Worker Nodes in [the EKS cluster
-topology](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-control-plane/README.md#what-is-an-eks-cluster). You must launch a control plane in order
-for the worker nodes to function. See the [eks-cluster-control-plane module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-control-plane) for
+topology](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-control-plane/README.md#what-is-an-eks-cluster). You must launch a control plane in order
+for the worker nodes to function. See the [eks-cluster-control-plane module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-control-plane) for
 managing an EKS control plane.
 
 ## Differences with self managed workers
@@ -67,7 +67,7 @@ Here is a list of additional tradeoffs to consider between the two flavors:
 
 This module will not automatically scale in response to resource usage by default, the
 `autoscaling_group_configurations.*.max_size` option is only used to give room for new instances during rolling updates.
-To enable auto-scaling in response to resource utilization, deploy the [Kubernetes Cluster Autoscaler module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-cluster-autoscaler).
+To enable auto-scaling in response to resource utilization, deploy the [Kubernetes Cluster Autoscaler module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-cluster-autoscaler).
 
 Note that the cluster autoscaler supports ASGs that manage nodes in a single availability zone or ASGs that manage nodes in multiple availability zones. However, there is a caveat:
 
@@ -938,11 +938,11 @@ Map of Node Group names to ARNs of the created EKS Node Groups
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-managed-workers/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-managed-workers/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-managed-workers/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-managed-workers/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-managed-workers/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-managed-workers/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "5b0997495d263fef2629abc7961c10b6"
+  "hash": "b8388371ec2599c606086603e42ffade"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-eks/eks-cluster-workers-cross-access/eks-cluster-workers-cross-access.md
+++ b/docs/reference/modules/terraform-aws-eks/eks-cluster-workers-cross-access/eks-cluster-workers-cross-access.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # EKS Cluster Workers Cross Access Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-workers-cross-access" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-workers-cross-access" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.53.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -139,11 +139,11 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-workers-cross-access/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-workers-cross-access/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-workers-cross-access/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-workers-cross-access/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-workers-cross-access/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-workers-cross-access/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "ed114c3e58de9194168b692ad85dc7cc"
+  "hash": "733d16f65c3ee3a62c4ee854df6fdc38"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-eks/eks-cluster-workers/eks-cluster-workers.md
+++ b/docs/reference/modules/terraform-aws-eks/eks-cluster-workers/eks-cluster-workers.md
@@ -13,35 +13,35 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # EKS Cluster Workers Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-workers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-workers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.57.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
-**This module provisions self managed ASGs, in contrast to [EKS Managed Node Groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html). See the [eks-cluster-managed-workers](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-managed-workers) module for a module to deploy Managed Node Groups.**
+**This module provisions self managed ASGs, in contrast to [EKS Managed Node Groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html). See the [eks-cluster-managed-workers](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-managed-workers) module for a module to deploy Managed Node Groups.**
 
 This Terraform Module launches worker nodes for an [Elastic Container Service for Kubernetes
 Cluster](https://docs.aws.amazon.com/eks/latest/userguide/clusters.html) that you can use to run Kubernetes Pods and
 Deployments.
 
 This module is responsible for the EKS Worker Nodes in [the EKS cluster
-topology](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-control-plane/README.md#what-is-an-eks-cluster). You must launch a control plane in order
-for the worker nodes to function. See the [eks-cluster-control-plane module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-control-plane) for
+topology](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-control-plane/README.md#what-is-an-eks-cluster). You must launch a control plane in order
+for the worker nodes to function. See the [eks-cluster-control-plane module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-control-plane) for
 managing an EKS control plane.
 
 ## Differences with managed node groups
 
 See the \[Differences with self managed workers] section in the documentation for [eks-cluster-managed-workers
-module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-managed-workers) for a detailed overview of differences with EKS Managed Node Groups.
+module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-managed-workers) for a detailed overview of differences with EKS Managed Node Groups.
 
 ## What should be included in the user-data script?
 
 In order for the EKS worker nodes to function, it must register itself to the Kubernetes API run by the EKS control
 plane. This is handled by the bootstrap script provided in the EKS optimized AMI. The user-data script should call the
 bootstrap script at some point during its execution. You can get this information from the [eks-cluster-control-plane
-module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-control-plane).
+module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-control-plane).
 
 For an example of a user data script, see the [eks-cluster example's user-data.sh
-script](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/examples/eks-cluster-with-iam-role-mappings/user-data/user-data.sh).
+script](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/examples/eks-cluster-with-iam-role-mappings/user-data/user-data.sh).
 
 You can read more about the bootstrap script in [the official documentation for EKS](https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html).
 
@@ -144,7 +144,7 @@ EOF
 ```
 
 **Note**: The IAM policies you add will apply to ALL Pods running on these EC2 Instances. See the [How do I associate
-IAM roles to the Pods?](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-control-plane/README.md#how-do-i-associate-iam-roles-to-the-pods) section of the
+IAM roles to the Pods?](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-control-plane/README.md#how-do-i-associate-iam-roles-to-the-pods) section of the
 `eks-cluster-control-plane` module README for more fine-grained allocation of IAM credentials to Pods.
 
 ## How do I SSH into the nodes?
@@ -228,7 +228,7 @@ The following are the steps you can take to perform a blue-green release for thi
 This module will not automatically scale in response to resource usage by default, the
 `autoscaling_group_configurations.*.max_size` option is only used to give room for new instances during rolling updates.
 To enable auto-scaling in response to resource utilization, you must set the `include_autoscaler_discovery_tags` input
-variable to `true` and also deploy the [Kubernetes Cluster Autoscaler module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-cluster-autoscaler).
+variable to `true` and also deploy the [Kubernetes Cluster Autoscaler module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-cluster-autoscaler).
 
 Note that the cluster autoscaler supports ASGs that manage nodes in a single availability zone or ASGs that manage nodes in multiple availability zones. However, there is a caveat:
 
@@ -1472,11 +1472,11 @@ AWS ID of the security group created for the EKS worker nodes.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-workers/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-workers/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-workers/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-workers/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-workers/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-workers/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "244afe91521cd46166d37050eeb0e41f"
+  "hash": "ebf7a96dc63b63578fc8f2be9351a64e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-eks/eks-container-logs/eks-container-logs.md
+++ b/docs/reference/modules/terraform-aws-eks/eks-container-logs/eks-container-logs.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # EKS Container Logs Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-container-logs" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-container-logs" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.56.4" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -25,7 +25,7 @@ Kinesis Firehose.
 This module uses the community helm chart, with a set of best practices inputs.
 
 **This module is for setting up log aggregation for EKS Pods on EC2 workers (self-managed or managed node groups). For
-Fargate pods, take a look at the [eks-fargate-container-logs](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-fargate-container-logs) module.**
+Fargate pods, take a look at the [eks-fargate-container-logs](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-fargate-container-logs) module.**
 
 ## How does this work?
 
@@ -349,11 +349,11 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-container-logs/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-container-logs/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-container-logs/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-container-logs/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-container-logs/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-container-logs/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "6a7439116fcbbd5e9caac442b2680f9a"
+  "hash": "b3ff21976864e06a6d26906ce7c5f6fd"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-eks/eks-fargate-container-logs/eks-fargate-container-logs.md
+++ b/docs/reference/modules/terraform-aws-eks/eks-fargate-container-logs/eks-fargate-container-logs.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # EKS Fargate Container Logs Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-fargate-container-logs" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-fargate-container-logs" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.56.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -25,7 +25,7 @@ Bit](https://fluentbit.io/) instance that runs on Fargate worker nodes. This all
 aggregation on Fargate Pods in EKS without setting up a side car container.
 
 **This module is for setting up log aggregation for EKS Fargate Pods. For other pods, take a look at the
-[eks-container-logs](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-container-logs) module.**
+[eks-container-logs](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-container-logs) module.**
 
 ## How does this work?
 
@@ -633,11 +633,11 @@ The ID of the Kubernetes ConfigMap containing the logging configuration. This ca
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-fargate-container-logs/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-fargate-container-logs/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-fargate-container-logs/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-fargate-container-logs/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-fargate-container-logs/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-fargate-container-logs/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "feefbbb2bf41e89503120d762c3cc064"
+  "hash": "4367ff8f46e2b1eba3afffa16a4625df"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-eks/eks-iam-role-assume-role-policy-for-service-account/eks-iam-role-assume-role-policy-for-service-account.md
+++ b/docs/reference/modules/terraform-aws-eks/eks-iam-role-assume-role-policy-for-service-account/eks-iam-role-assume-role-policy-for-service-account.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # EKS IAM Role Assume Role Policy for Kubernetes Service Accounts
 
-<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-iam-role-assume-role-policy-for-service-account" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-iam-role-assume-role-policy-for-service-account" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.53.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -22,7 +22,7 @@ Kubernetes Service Accounts. This requires a compatible EKS cluster that support
 Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) feature.
 
 See the [corresponding section of the eks-cluster-control-plane module
-README](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-control-plane/README.md#how-do-i-associate-iam-roles-to-the-pods) for information on how to set
+README](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-control-plane/README.md#how-do-i-associate-iam-roles-to-the-pods) for information on how to set
 up IRSA and how it works.
 
 ## Sample Usage
@@ -211,11 +211,11 @@ JSON value for IAM Role Assume Role Policy that allows Kubernetes Service Accoun
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-iam-role-assume-role-policy-for-service-account/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-iam-role-assume-role-policy-for-service-account/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-iam-role-assume-role-policy-for-service-account/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-iam-role-assume-role-policy-for-service-account/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-iam-role-assume-role-policy-for-service-account/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-iam-role-assume-role-policy-for-service-account/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "066d0e90a41abba8fa88d1515fcc40fa"
+  "hash": "328865b552be74386e6bce1f0558ed5b"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-eks/eks-k8s-cluster-autoscaler-iam-policy/eks-k8s-cluster-autoscaler-iam-policy.md
+++ b/docs/reference/modules/terraform-aws-eks/eks-k8s-cluster-autoscaler-iam-policy/eks-k8s-cluster-autoscaler-iam-policy.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # K8S Cluster Autoscaler IAM Policy Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-cluster-autoscaler-iam-policy" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-cluster-autoscaler-iam-policy" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.54.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -24,14 +24,14 @@ Autoscaler](https://github.com/kubernetes/autoscaler/blob/b6d53e8/cluster-autosc
 attached to the EC2 instance profile of the worker nodes in a Kubernetes cluster which will allow the autoscaler to
 manage scaling up and down EC2 instances in targeted Auto Scaling Groups in response to resource utilization.
 
-See [the eks-k8s-cluster-autoscaler module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-cluster-autoscaler) for a module that deploys the Cluster
+See [the eks-k8s-cluster-autoscaler module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-cluster-autoscaler) for a module that deploys the Cluster
 Autoscaler to your EKS cluster.
 
 ## Attaching IAM policy to workers
 
 To allow the Cluster Autoscaler to manage Auto Scaling Groups, it needs IAM permissions to monitor and adjust them.
 Currently, the way to grant Pods IAM privileges is to use the worker IAM profiles provisioned by [the
-eks-cluster-workers module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-workers/README.md#how-do-you-add-additional-iam-policies).
+eks-cluster-workers module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-workers/README.md#how-do-you-add-additional-iam-policies).
 
 The Terraform templates in this module create an IAM policy that has the required permissions. You then need to use an
 [aws_iam_policy_attachment](https://www.terraform.io/docs/providers/aws/r/iam_policy_attachment.html) to attach that
@@ -216,11 +216,11 @@ The name of the IAM policy created with the permissions for the Kubernetes clust
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-cluster-autoscaler-iam-policy/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-cluster-autoscaler-iam-policy/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-cluster-autoscaler-iam-policy/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-cluster-autoscaler-iam-policy/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-cluster-autoscaler-iam-policy/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-cluster-autoscaler-iam-policy/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "136216f0be87ce58801444a3dd5ec69c"
+  "hash": "b1eb9fe9a012a059e852b588e7b4fc05"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-eks/eks-k8s-cluster-autoscaler/eks-k8s-cluster-autoscaler.md
+++ b/docs/reference/modules/terraform-aws-eks/eks-k8s-cluster-autoscaler/eks-k8s-cluster-autoscaler.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # K8S Cluster Autoscaler Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-cluster-autoscaler" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-cluster-autoscaler" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.57.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -21,9 +21,9 @@ This Terraform Module installs a [Cluster Autoscaler](https://github.com/kuberne
 to automatically scale up and down the nodes in a cluster in response to resource utilization.
 
 This module is responsible for manipulating each Auto Scaling Group (ASG) that was created by the [EKS cluster
-workers](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-workers) module. By default, the ASG is configured to allow zero-downtime
+workers](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-workers) module. By default, the ASG is configured to allow zero-downtime
 deployments but is not configured to scale automatically. You must launch an [EKS control
-plane](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-control-plane) with worker nodes for this module to function.
+plane](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-control-plane) with worker nodes for this module to function.
 
 ## Important Considerations
 
@@ -351,11 +351,11 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-cluster-autoscaler/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-cluster-autoscaler/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-cluster-autoscaler/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-cluster-autoscaler/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-cluster-autoscaler/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-cluster-autoscaler/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "f66393c2e5601073ba0d698eabacadcc"
+  "hash": "b0f3f9801d8a993eec80634eb8873cb0"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-eks/eks-k8s-external-dns-iam-policy/eks-k8s-external-dns-iam-policy.md
+++ b/docs/reference/modules/terraform-aws-eks/eks-k8s-external-dns-iam-policy/eks-k8s-external-dns-iam-policy.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # K8S External DNS IAM Policy Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-external-dns-iam-policy" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-external-dns-iam-policy" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.53.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -23,14 +23,14 @@ defines the minimal set of permissions necessary for the [external-dns
 application](https://github.com/kubernetes-incubator/external-dns). This policy can then be attached to EC2
 instances or IAM roles so that the app deployed has enough permissions to manage Route 53 Hosted Zones.
 
-See [the eks-k8s-external-dns module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-external-dns) for a module that deploys the external-dns
+See [the eks-k8s-external-dns module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-external-dns) for a module that deploys the external-dns
 application on to your EKS cluster.
 
 ## Attaching IAM policy to workers
 
 To allow the external-dns app to manage Route 53 Hosted Zones, it needs IAM permissions to use the AWS API to manage the
 zones. Currently, the way to grant Pods IAM privileges is to use the worker IAM profiles provisioned by [the
-eks-cluster-workers module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-workers/README.md#how-do-you-add-additional-iam-policies).
+eks-cluster-workers module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-workers/README.md#how-do-you-add-additional-iam-policies).
 
 The Terraform templates in this module create an IAM policy that has the required permissions. You then need to use an
 [aws_iam_policy_attachment](https://www.terraform.io/docs/providers/aws/r/iam_policy_attachment.html) to attach that
@@ -210,11 +210,11 @@ The name of the IAM policy created with the permissions for the external-dns Kub
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-external-dns-iam-policy/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-external-dns-iam-policy/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-external-dns-iam-policy/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-external-dns-iam-policy/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-external-dns-iam-policy/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-external-dns-iam-policy/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "7ef40f412d6eadc1300bff43d27734a0"
+  "hash": "e8051c5423ca309ee192846ba7dd66fe"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-eks/eks-k8s-external-dns/eks-k8s-external-dns.md
+++ b/docs/reference/modules/terraform-aws-eks/eks-k8s-external-dns/eks-k8s-external-dns.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # K8S External DNS Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-external-dns" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-external-dns" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.56.1" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -35,7 +35,7 @@ work, you need to map the domain name to the `Ingress` endpoint, so that request
 been created and provisioned. However, this can be cumbersome due to the asynchronous nature of Kubernetes operations.
 
 For example, if you are using an `Ingress` controller that maps to actual physical loadbalancers in the cloud (e.g the
-[ALB Ingress Controller deployed using the eks-alb-ingress-controller module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-alb-ingress-controller)), the
+[ALB Ingress Controller deployed using the eks-alb-ingress-controller module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-alb-ingress-controller)), the
 endpoint may take several minutes before it is available. You will have to wait for that time, continuously polling the
 `Ingress` resource until the underlying resource is provisioned and the endpoint is available before you can configure the
 DNS setting.
@@ -61,7 +61,7 @@ This module uses [`helm` v3](https://helm.sh/docs/) to deploy the controller to 
 ### IAM permissions
 
 The container deployed in this module requires IAM permissions to manage Route 53 Hosted Zones. See [the
-eks-k8s-external-dns-iam-policy module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-external-dns-iam-policy) for more information.
+eks-k8s-external-dns-iam-policy module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-external-dns-iam-policy) for more information.
 
 ## How do I restrict which Hosted Zones the app should manage?
 
@@ -450,11 +450,11 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-external-dns/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-external-dns/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-external-dns/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-external-dns/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-external-dns/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-external-dns/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "782a1aed9480930dce2d67caf1aac695"
+  "hash": "de282dcacb95befec0d5231437c54828"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-eks/eks-k8s-role-mapping/eks-k8s-role-mapping.md
+++ b/docs/reference/modules/terraform-aws-eks/eks-k8s-role-mapping/eks-k8s-role-mapping.md
@@ -13,13 +13,13 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # EKS K8S Role Mapping Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-role-mapping" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-role-mapping" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.56.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 **NOTE: This module manages a single ConfigMap to use with Kubernetes AWS IAM authentication. If you wish to break up
 the ConfigMap across multiple smaller ConfigMaps to manage entries in isolated modules (e.g., when you add a new IAM
-role in a separate module from the EKS cluster), refer to the [eks-aws-auth-merger](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-aws-auth-merger).**
+role in a separate module from the EKS cluster), refer to the [eks-aws-auth-merger](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-aws-auth-merger).**
 
 This Module can be used to manage the mapping of AWS IAM roles and users to Kubernetes RBAC groups for finer grained
 access control of your EKS Cluster.
@@ -59,7 +59,7 @@ as much or as little permissions as necessary when accessing resources in the AW
 
 This Module provides code for you to manage the mapping between AWS IAM roles and Kubernetes RBAC roles so that you can
 maintain a consistent set of mappings between the two systems. This works hand in hand with the [EKS authentication
-system](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/core-concepts.md#how-do-i-authenticate-kubectl-to-the-eks-cluster), providing the information to Kubernetes to resolve the user to the right RBAC group based on the provided IAM role credentials.
+system](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/core-concepts.md#how-do-i-authenticate-kubectl-to-the-eks-cluster), providing the information to Kubernetes to resolve the user to the right RBAC group based on the provided IAM role credentials.
 
 ## Examples
 
@@ -543,11 +543,11 @@ The name of the ConfigMap created to store the mapping. This exists so that down
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-role-mapping/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-role-mapping/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-k8s-role-mapping/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-role-mapping/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-role-mapping/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-k8s-role-mapping/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "7f107a02439d9777b65e9d529783345d"
+  "hash": "e1d35659f1884117179fa38bce2d0c94"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-eks/eks-scripts/eks-scripts.md
+++ b/docs/reference/modules/terraform-aws-eks/eks-scripts/eks-scripts.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # EKS Scripts Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-scripts" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-scripts" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.55.2" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -31,7 +31,7 @@ gruntwork-install --module-name "eks-scripts" --repo "https://github.com/gruntwo
 ```
 
 For an example, see the [Packer](https://www.packer.io/) template under
-[examples/eks-cluster-with-supporting-services/packer/build.json](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/examples/eks-cluster-with-supporting-services/packer/build.json).
+[examples/eks-cluster-with-supporting-services/packer/build.json](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/examples/eks-cluster-with-supporting-services/packer/build.json).
 
 ## Using the map-ec2-tags-to-node-labels helper
 
@@ -96,7 +96,7 @@ and you specified `ec2.gruntwork.io/` as your tag prefix (`map-ec2-tags-to-node-
 
 In order for the script to be able to successfully retrieve the tags for EC2 instance, the instances need to be
 associated with an IAM profile that grants it access to retrieve the EC2 tags on the instance. If you launch the workers
-using the [eks-cluster-workers module](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-workers), this is automatically attached to the worker IAM role.
+using the [eks-cluster-workers module](https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-cluster-workers), this is automatically attached to the worker IAM role.
 
 ### map_ec2\_tags_to_node_labels.py symlink
 
@@ -108,11 +108,11 @@ tests.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-scripts/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-scripts/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-scripts/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-scripts/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-scripts/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-scripts/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "c348486fc7470963ec30f91dc7bb9f3e"
+  "hash": "59a26cd107790576b3bed05d05bae0c4"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-eks/eks-vpc-tags/eks-vpc-tags.md
+++ b/docs/reference/modules/terraform-aws-eks/eks-vpc-tags/eks-vpc-tags.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # EKS VPC Tags Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-vpc-tags" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-vpc-tags" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.53.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -143,11 +143,11 @@ Tags for public subnets in the VPC to use for integration with EKS.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-vpc-tags/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-vpc-tags/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-vpc-tags/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-vpc-tags/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-vpc-tags/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-eks/tree/v0.57.0/modules/eks-vpc-tags/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "4117780a3869ce0386deb39c122a25b5"
+  "hash": "dd91553325814193e18cb4d5b907aed9"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-lambda/api-gateway-account-settings/api-gateway-account-settings.md
+++ b/docs/reference/modules/terraform-aws-lambda/api-gateway-account-settings/api-gateway-account-settings.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # API Gateway Account Settings Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-account-settings" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-account-settings" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.21.6" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -34,7 +34,7 @@ The corresponding screen from the AWS Console is shown below:
 
 ## Quick start
 
-Check out the [examples](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/examples) for sample code that demonstrates how to use this module.
+Check out the [examples](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/examples) for sample code that demonstrates how to use this module.
 
 ## Sample Usage
 
@@ -191,11 +191,11 @@ When true, all IAM policies will be managed as dedicated policies rather than in
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-account-settings/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-account-settings/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-account-settings/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-account-settings/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-account-settings/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-account-settings/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "0e1909080df124ee1d551ce24f578783"
+  "hash": "2b99e08d9fe5a26b6b91ab9a0a2a17fd"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-lambda/api-gateway-proxy-methods/api-gateway-proxy-methods.md
+++ b/docs/reference/modules/terraform-aws-lambda/api-gateway-proxy-methods/api-gateway-proxy-methods.md
@@ -13,16 +13,16 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # API Gateway Lambda Function Proxy Methods Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-proxy-methods" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-proxy-methods" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.20.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
-This module must be used in conjunction with [the api-gateway-proxy module](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-proxy) to configure an API
+This module must be used in conjunction with [the api-gateway-proxy module](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-proxy) to configure an API
 Gateway REST API to route all requests from a root path to a lambda function.
 
-Refer to [the module docs](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-proxy/README.md) for the `api-gateway-proxy` module for more details on how to
+Refer to [the module docs](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-proxy/README.md) for the `api-gateway-proxy` module for more details on how to
 use this module. Specifically, see the section [Can I expose additional lambda functions in a decentralized
-manner?](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-proxy/core-concepts.md#can-i-expose-additional-lambda-functions-in-a-decentralized-manner)
+manner?](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-proxy/core-concepts.md#can-i-expose-additional-lambda-functions-in-a-decentralized-manner)
 
 ## Sample Usage
 
@@ -291,11 +291,11 @@ ID of the API Gateway method for the root proxy (only created if path_prefix is 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-proxy-methods/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-proxy-methods/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-proxy-methods/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-proxy-methods/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-proxy-methods/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-proxy-methods/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "a377a2e677519508ce6081a5e3165a1b"
+  "hash": "8474569d1237894635475d082a8bb437"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-lambda/api-gateway-proxy/api-gateway-proxy.md
+++ b/docs/reference/modules/terraform-aws-lambda/api-gateway-proxy/api-gateway-proxy.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # API Gateway Proxy Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-proxy" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-proxy" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.20.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -34,7 +34,7 @@ recommend using a framework like Serverless to avoid the verbose configuration o
 :::note
 
 If you are looking for a module to route different requests and methods to different Lambda functions, refer to the
-[lambda-http-api-gateway](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-http-api-gateway) module.
+[lambda-http-api-gateway](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-http-api-gateway) module.
 
 :::
 
@@ -58,33 +58,33 @@ before, make sure to read [How to use the Gruntwork Infrastructure as Code Libra
 
 ### Core concepts
 
-*   [What is API Gateway?](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-proxy/core-concepts.md#what-is-api-gateway)
+*   [What is API Gateway?](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-proxy/core-concepts.md#what-is-api-gateway)
 *   [What is the difference between the different endpoint
-    types?](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-proxy/core-concepts.md#what-is-the-difference-between-the-different-endpoint-types)
+    types?](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-proxy/core-concepts.md#what-is-the-difference-between-the-different-endpoint-types)
 *   [API Gateway Documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/welcome.html): Amazon's docs
     on API Gateway covering core concepts such as security, monitoring, and invoking APIs.
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
-*   [examples](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/examples): This folder contains working examples of how to use the submodules.
-*   [test](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/test): Automated tests for the modules and examples.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/examples): This folder contains working examples of how to use the submodules.
+*   [test](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/test): Automated tests for the modules and examples.
 
 ## Deploy
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [examples folder](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [examples folder](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ## Manage
 
 ### Day-to-day operations
 
 *   [How do I expose AWS Lambda functions using API
-    Gateway?](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-proxy/core-concepts.md#how-do-i-expose-aws-lambda-functions-using-api-gateway)
+    Gateway?](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-proxy/core-concepts.md#how-do-i-expose-aws-lambda-functions-using-api-gateway)
 *   [Can I expose additional lambda functions in a decentralized
-    manner?](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-proxy/core-concepts.md#can-i-expose-additional-lambda-functions-in-a-decentralized-manner)
-*   [How do I pass in the us_east\_1 aws provider?](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-proxy/core-concepts.md#how-do-i-pass-in-the-us_east\_1-aws-provider)
+    manner?](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-proxy/core-concepts.md#can-i-expose-additional-lambda-functions-in-a-decentralized-manner)
+*   [How do I pass in the us_east\_1 aws provider?](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-proxy/core-concepts.md#how-do-i-pass-in-the-us_east\_1-aws-provider)
 
 ## Sample Usage
 
@@ -695,11 +695,11 @@ The URL of the API Gateway that you can use to invoke it.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-proxy/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-proxy/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-proxy/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-proxy/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-proxy/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-proxy/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "ac728d22d123c909e31e437f8a087cb4"
+  "hash": "6f406fdfae8f83bfa9f2afcfb69d1a62"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-lambda/keep-warm/keep-warm.md
+++ b/docs/reference/modules/terraform-aws-lambda/keep-warm/keep-warm.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Keep Warm Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/keep-warm" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/keep-warm" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.20.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -338,11 +338,11 @@ When true, all IAM policies will be managed as dedicated policies rather than in
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/keep-warm/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/keep-warm/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/keep-warm/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/keep-warm/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/keep-warm/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/keep-warm/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "23d61108052080a450509ff71dc5934f"
+  "hash": "7a73070fb1a4d2488bf800361300148f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-lambda/lambda-edge-log-group/lambda-edge-log-group.md
+++ b/docs/reference/modules/terraform-aws-lambda/lambda-edge-log-group/lambda-edge-log-group.md
@@ -13,11 +13,11 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Log group for Lambda Edge
 
-<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-edge-log-group" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-edge-log-group" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.21.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
-This module creates a Cloudwatch log group to receive Lambda Edge function logs in one single AWS Region. This module is meant to be used as a building block for the [`lambda-edge-multi-region-log-groups` module](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-edge-multi-region-log-groups).
+This module creates a Cloudwatch log group to receive Lambda Edge function logs in one single AWS Region. This module is meant to be used as a building block for the [`lambda-edge-multi-region-log-groups` module](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-edge-multi-region-log-groups).
 
 ## Why are the resources in this module not created within the Lambda Edge Module?
 
@@ -28,7 +28,7 @@ region that have [Regional Edge Caches](https://aws.amazon.com/blogs/networking-
 Unfortunately, it is not possible to use a `for_each` on provider blocks and there are multiple issues related to
 using nested providers. That means that, currently, the only way to create multi-regional modules is by code generating each
 block and passing down the providers. A full example of creating the providers and using this module can be found at the
-[lambda-edge example](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/examples/lambda-edge).
+[lambda-edge example](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/examples/lambda-edge).
 
 ## Which regions have regional edge caches?
 
@@ -318,11 +318,11 @@ When true, precreate the CloudWatch Log Group to use for log aggregation from th
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-edge-log-group/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-edge-log-group/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-edge-log-group/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-edge-log-group/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-edge-log-group/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-edge-log-group/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "7451c1eabe3f3ed0955af5a963ee53f7"
+  "hash": "e9eb0749db7ef5368ff48df4a004771b"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-lambda/lambda-edge-multi-region-log-groups/lambda-edge-multi-region-log-groups.md
+++ b/docs/reference/modules/terraform-aws-lambda/lambda-edge-multi-region-log-groups/lambda-edge-multi-region-log-groups.md
@@ -13,11 +13,11 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Multiregional Log groups for Lambda Edge
 
-<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-edge-multi-region-log-groups" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-edge-multi-region-log-groups" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.21.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
-This module uses the [`lambda-edge-log-group` module](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-edge-log-group) to create a Cloudwatch log group to receive Lambda Edge function logs in multiple AWS Regions.
+This module uses the [`lambda-edge-log-group` module](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-edge-log-group) to create a Cloudwatch log group to receive Lambda Edge function logs in multiple AWS Regions.
 
 ## Why are the resources in this module not created within the Lambda Edge Module?
 
@@ -27,8 +27,8 @@ region that have [Regional Edge Caches](https://aws.amazon.com/blogs/networking-
 
 Unfortunately, it is not possible to use a `for_each` on provider blocks and there are multiple issues related to
 using nested providers. That means that, currently, the only way to create multi-regional modules is by code generating each
-block and passing down the providers using the [`codegen`](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/codegen/) module. A full example of creating the providers and using
-this module can be found at the [lambda-edge example](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/examples/lambda-edge).
+block and passing down the providers using the [`codegen`](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/codegen/) module. A full example of creating the providers and using
+this module can be found at the [lambda-edge example](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/examples/lambda-edge).
 
 ## Which regions have regional edge caches?
 
@@ -300,11 +300,11 @@ Map of log group names per region
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-edge-multi-region-log-groups/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-edge-multi-region-log-groups/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-edge-multi-region-log-groups/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-edge-multi-region-log-groups/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-edge-multi-region-log-groups/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-edge-multi-region-log-groups/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "605207ced75f6dc05f080d399ea662c6"
+  "hash": "e7b1977f29f42716b9298f8e95ddfcdc"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-lambda/lambda-edge/lambda-edge.md
+++ b/docs/reference/modules/terraform-aws-lambda/lambda-edge/lambda-edge.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Lambda@Edge Function Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-edge" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-edge" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.21.8" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -65,7 +65,7 @@ resource "aws_lambda_permission" "with_sns" {
 
 Lambda@Edge stores CloudWatch Logs in the AWS Regions closest to the location where the function receives traffic and is
 executed. That means a log group must be created in every region that have [Regional Edge Caches](https://aws.amazon.com/blogs/networking-and-content-delivery/aggregating-lambdaedge-logs/).
-Instructions on how to do this can be found at the   [`lambda-edge-multi-region-log-groups` module](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-edge-multi-region-log-groups). To see which regions are receiving traffic, you can find graphs of metrics for the
+Instructions on how to do this can be found at the   [`lambda-edge-multi-region-log-groups` module](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-edge-multi-region-log-groups). To see which regions are receiving traffic, you can find graphs of metrics for the
 function on the CloudFront console and choose your region there.
 
 ## How to trigger this Lambda function from Cloudfront
@@ -814,11 +814,11 @@ Name of the (optionally) created CloudWatch log groups for the lambda function.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-edge/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-edge/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-edge/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-edge/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-edge/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-edge/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "3001aa275fbb3bffe37a81156c9748bd"
+  "hash": "4eb202e1bdb835083afd792e273f3ef5"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-lambda/lambda-http-api-gateway/lambda-http-api-gateway.md
+++ b/docs/reference/modules/terraform-aws-lambda/lambda-http-api-gateway/lambda-http-api-gateway.md
@@ -22,7 +22,7 @@ license: gruntwork
 built-with: terraform
 -->
 
-<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-http-api-gateway" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-http-api-gateway" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.21.7" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -39,7 +39,7 @@ they can be invoked on HTTP calls.
 :::note
 
 If you are looking for a simple proxy to route all requests to a Lambda function, refer to the
-[api-gateway-proxy](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/api-gateway-proxy) module.
+[api-gateway-proxy](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/api-gateway-proxy) module.
 
 :::
 
@@ -70,7 +70,7 @@ If you’ve never used the Gruntwork Modules before, make sure to read
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [examples/lambda-http-api-gateway](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/examples/lambda-http-api-gateway): This example contains sample code that uses
+*   [examples/lambda-http-api-gateway](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/examples/lambda-http-api-gateway): This example contains sample code that uses
     this module to route two different requests to two different Lambda functions.
 
 ## Manage
@@ -729,11 +729,11 @@ A map from the route keys to the IDs of the corresponding API Gateway V2 Route r
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-http-api-gateway/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-http-api-gateway/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda-http-api-gateway/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-http-api-gateway/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-http-api-gateway/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda-http-api-gateway/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "dea49c7034b9972a7d79cf266d62b52c"
+  "hash": "5cd64d763c873a04ab7f6a68b5bc6eff"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-lambda/lambda/lambda.md
+++ b/docs/reference/modules/terraform-aws-lambda/lambda/lambda.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Lambda Function Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.21.8" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -105,7 +105,7 @@ Lambda function are still in use. If necessary, the variable `enable_eni_cleanup
 of the function from the VPC during `terraform destroy` and unblock the Security Group for destruction. Note: this
 requires the [`aws` cli tool](https://aws.amazon.com/cli/) to be installed.
 
-Check out the [lambda-vpc example](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/examples/lambda-vpc) for working sample code. Make sure to note the Known Issues
+Check out the [lambda-vpc example](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/examples/lambda-vpc) for working sample code. Make sure to note the Known Issues
 section in that example's README.
 
 ## How do you share Lambda functions across multiple AWS accounts?
@@ -1296,11 +1296,11 @@ Name of the (optionally) created CloudWatch log group for the lambda function.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "25ef2f22c5a47b6d2b90fefefdd71d5e"
+  "hash": "b838d0a7ea33fc27de2bfdaa1514c2ea"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-lambda/run-lambda-entrypoint/run-lambda-entrypoint.md
+++ b/docs/reference/modules/terraform-aws-lambda/run-lambda-entrypoint/run-lambda-entrypoint.md
@@ -22,7 +22,7 @@ license: gruntwork
 built-with: go
 -->
 
-<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/run-lambda-entrypoint" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/run-lambda-entrypoint" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.20.3" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -34,7 +34,7 @@ to the lambda runtime. This entrypoint will pull the provided secrets manager en
 secrets manager entry to environment variables that are injected into the lambda runtime.
 
 This module only includes an entrypoint CLI. If you are looking for a module to deploy container based Lambda functions,
-refer to the [lambda](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda) module.
+refer to the [lambda](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda) module.
 
 ## Motivation
 
@@ -78,7 +78,7 @@ If you’ve never used the Gruntwork Modules before, make sure to read
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [examples/lambda-docker](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/examples/lambda-docker): This example contains a sample `Dockerfile` that uses this
+*   [examples/lambda-docker](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/examples/lambda-docker): This example contains a sample `Dockerfile` that uses this
     entrypoint to expose secrets to a python based Lambda function.
 
 ## Manage
@@ -133,7 +133,7 @@ To support this use case, the `run-lambda-entrypoint` CLI includes the ability t
 is not running in a Lambda environment. When `run-lambda-entrypoint` is invoked with the arg `--rie-path`, it will wrap
 the provided entrypoint script with the RIE when running in local mode.
 
-Refer to the [secret-reflector-go](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/examples/lambda-docker/secret-reflector-go) example for an example of how to set
+Refer to the [secret-reflector-go](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/examples/lambda-docker/secret-reflector-go) example for an example of how to set
 this up with a Go based Lambda function.
 
 ### How do I pass in Secrets Manager ARNs for environment variable lookup?
@@ -184,11 +184,11 @@ will assume it is the name of a Secrets Manager entry in the same region as the 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/run-lambda-entrypoint/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/run-lambda-entrypoint/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/run-lambda-entrypoint/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/run-lambda-entrypoint/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/run-lambda-entrypoint/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/run-lambda-entrypoint/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "b7da49dc817d84b84c1037fba2488e1f"
+  "hash": "dba52158b8e957979d50d4e8c1382506"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-lambda/scheduled-lambda-job/scheduled-lambda-job.md
+++ b/docs/reference/modules/terraform-aws-lambda/scheduled-lambda-job/scheduled-lambda-job.md
@@ -13,18 +13,18 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Scheduled Lambda Job Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/scheduled-lambda-job" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/scheduled-lambda-job" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v0.20.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This module makes it easy to run an [AWS Lambda](https://aws.amazon.com/lambda/) function (such as one created with the
-[lambda module](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda)) on a scheduled basis. This is useful for periodic background jobs, such as taking a
+[lambda module](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda)) on a scheduled basis. This is useful for periodic background jobs, such as taking a
 daily snapshot of your servers.
 
 ## Background info
 
 For more information on AWS Lambda, how it works, and how to configure your functions, check out the [lambda module
-documentation](https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/lambda).
+documentation](https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/lambda).
 
 ## Sample Usage
 
@@ -235,11 +235,11 @@ Cloudwatch Event Rule schedule expression
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/scheduled-lambda-job/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/scheduled-lambda-job/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/main/modules/scheduled-lambda-job/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/scheduled-lambda-job/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/scheduled-lambda-job/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.8/modules/scheduled-lambda-job/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "c13f9c64211d355634fca7288a0df226"
+  "hash": "7bd4fe29fdbdb5a51fee07ed717340d7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-load-balancer/acm-tls-certificate/acm-tls-certificate.md
+++ b/docs/reference/modules/terraform-aws-load-balancer/acm-tls-certificate/acm-tls-certificate.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # ACM TLS Certificate
 
-<a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/main/modules/acm-tls-certificate" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/v0.29.4/modules/acm-tls-certificate" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.29.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -483,11 +483,11 @@ Global tags to apply to all ACM certificates issued via this module. These globa
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/main/modules/acm-tls-certificate/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/main/modules/acm-tls-certificate/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/main/modules/acm-tls-certificate/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/v0.29.4/modules/acm-tls-certificate/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/v0.29.4/modules/acm-tls-certificate/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/v0.29.4/modules/acm-tls-certificate/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "99dec7e2898e3a9cbdd299d4f260b855"
+  "hash": "fe5cef609dd9b94feddd4600e593e3c6"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-load-balancer/alb/alb.md
+++ b/docs/reference/modules/terraform-aws-load-balancer/alb/alb.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Application Load Balancer (ALB) Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/main/modules/alb" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/v0.29.4/modules/alb" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.29.4" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -1080,11 +1080,11 @@ A map from port to the AWS ARNs of the listeners for the ALB that has been deplo
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/main/modules/alb/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/main/modules/alb/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/main/modules/alb/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/v0.29.4/modules/alb/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/v0.29.4/modules/alb/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/v0.29.4/modules/alb/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "f8b7b3f426a432f184e0efc6bc55952b"
+  "hash": "659ab9a71f9978d67c0b929c9c2744b9"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-load-balancer/lb-listener-rules/lb-listener-rules.md
+++ b/docs/reference/modules/terraform-aws-load-balancer/lb-listener-rules/lb-listener-rules.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Load Balancer Listener Rules
 
-<a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/main/modules/lb-listener-rules" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/v0.29.4/modules/lb-listener-rules" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.29.4" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -725,11 +725,11 @@ The ARNs of the rules of type redirect. The key is the same key of the rule from
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/main/modules/lb-listener-rules/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/main/modules/lb-listener-rules/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/main/modules/lb-listener-rules/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/v0.29.4/modules/lb-listener-rules/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/v0.29.4/modules/lb-listener-rules/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/v0.29.4/modules/lb-listener-rules/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "70b1035e58931a57256a5cf5c6570b3d"
+  "hash": "7aa889e7c041621f87dc878499520402"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-load-balancer/nlb/nlb.md
+++ b/docs/reference/modules/terraform-aws-load-balancer/nlb/nlb.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Network Load Balancer (NLB) Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/main/modules/nlb" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/v0.29.4/modules/nlb" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v0.23.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -29,11 +29,11 @@ For information on why the module was removed, refer to the discussion in [PR
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/main/modules/nlb/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/main/modules/nlb/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/main/modules/nlb/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/v0.29.4/modules/nlb/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/v0.29.4/modules/nlb/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-load-balancer/tree/v0.29.4/modules/nlb/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "1a490fb90e4a5a8f3e4cabd17f001c8f"
+  "hash": "a1752d636aa1b4e264fd20b90eae3f69"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-messaging/kinesis/kinesis.md
+++ b/docs/reference/modules/terraform-aws-messaging/kinesis/kinesis.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Kinesis Stream Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/kinesis" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/kinesis" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-messaging/releases/tag/v0.10.2" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -413,11 +413,11 @@ A map of key value pairs to apply as tags to the Kinesis stream.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/kinesis/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/kinesis/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/kinesis/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/kinesis/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/kinesis/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/kinesis/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "644a7df3de0613d76306c7d56cedae72"
+  "hash": "361fc53067fba1a3276c7851193c4182"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-messaging/msk/msk.md
+++ b/docs/reference/modules/terraform-aws-messaging/msk/msk.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Amazon Managed Streaming for Apache Kafka (Amazon MSK) Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/msk" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/msk" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-messaging/releases/tag/v0.10.1" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -986,11 +986,11 @@ A comma separated list of one or more hostname:port pairs to use to connect to t
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/msk/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/msk/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/msk/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/msk/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/msk/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/msk/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "d65f46f2c3017fc58e8b04f86f8ec4eb"
+  "hash": "9db118fba98f7042b86d318c4be29920"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-messaging/sns-sqs-connection/sns-sqs-connection.md
+++ b/docs/reference/modules/terraform-aws-messaging/sns-sqs-connection/sns-sqs-connection.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Simple Notification Service (SNS) Topic to Simple Queuing Service (SQS) Connection Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/sns-sqs-connection" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/sns-sqs-connection" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-messaging/releases/tag/v0.10.2" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -166,11 +166,11 @@ The queue URL for the Simple Queue Service (SQS).
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/sns-sqs-connection/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/sns-sqs-connection/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/sns-sqs-connection/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/sns-sqs-connection/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/sns-sqs-connection/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/sns-sqs-connection/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "efecc1ecbc3f3549af362b3c0f76267f"
+  "hash": "ee70a69373aed6abb655ac181c68149f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-messaging/sns/sns.md
+++ b/docs/reference/modules/terraform-aws-messaging/sns/sns.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Simple Notification Service (SNS) Topic Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/sns" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/sns" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-messaging/releases/tag/v0.10.2" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -331,11 +331,11 @@ A map of key value pairs to apply as tags to the SNS topic.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/sns/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/sns/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/sns/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/sns/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/sns/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/sns/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "923c18888080a83c09b99b1683b88f12"
+  "hash": "4013bd888b9aa6b755e604e881d80905"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-messaging/sqs-lambda-connection/sqs-lambda-connection.md
+++ b/docs/reference/modules/terraform-aws-messaging/sqs-lambda-connection/sqs-lambda-connection.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Simple Queuing Service (SQS) To Lambda Connection Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/sqs-lambda-connection" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/sqs-lambda-connection" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-messaging/releases/tag/v0.9.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -148,11 +148,11 @@ The largest number of records that Lambda will retrieve from your event source a
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/sqs-lambda-connection/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/sqs-lambda-connection/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/sqs-lambda-connection/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/sqs-lambda-connection/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/sqs-lambda-connection/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/sqs-lambda-connection/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "a964108418e4a845751c52a8a39e523f"
+  "hash": "8c5d20f1941fd4d2b31bf8ca3684d9e7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-messaging/sqs/sqs.md
+++ b/docs/reference/modules/terraform-aws-messaging/sqs/sqs.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Simple Queuing Service (SQS) Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/sqs" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/sqs" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-messaging/releases/tag/v0.10.2" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -636,11 +636,11 @@ The visibility timeout for the queue. An integer from 0 to 43200 (12 hours).
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/sqs/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/sqs/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/main/modules/sqs/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/sqs/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/sqs/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-messaging/tree/v0.10.2/modules/sqs/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "3cafd6dd08d4b9078d247d709eb8943b"
+  "hash": "d9c00fc5d4d6ab65f0cdd2a46566772f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-monitoring/alarms/alarms.md
+++ b/docs/reference/modules/terraform-aws-monitoring/alarms/alarms.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Alarm modules
 
-<a href="https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/alarms" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.35.8" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -21,29 +21,29 @@ This folder contains modules that configure [CloudWatch
 Alarms](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/AlarmThatSendsEmail.html) to go off and
 email or SMS you when something is going wrong. The modules are:
 
-*   [asg-cpu-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms/asg-cpu-alarms): An alarm that goes off if CPU usage in an Auto Scaling Group (ASG) is too high.
-*   [asg-disk-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms/asg-disk-alarms): An alarm that goes off if disk usage in an Auto Scaling Group (ASG) is too high.
-*   [asg-memory-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms/asg-memory-alarms): An alarm that goes off if memory usage in an Auto Scaling Group (ASG) is
+*   [asg-cpu-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/alarms/asg-cpu-alarms): An alarm that goes off if CPU usage in an Auto Scaling Group (ASG) is too high.
+*   [asg-disk-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/alarms/asg-disk-alarms): An alarm that goes off if disk usage in an Auto Scaling Group (ASG) is too high.
+*   [asg-memory-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/alarms/asg-memory-alarms): An alarm that goes off if memory usage in an Auto Scaling Group (ASG) is
     too high.
-*   [ec2-cpu-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms/ec2-cpu-alarms): An alarm that goes off if CPU usage for an EC2 Instance is too high.
-*   [ec2-disk-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms/ec2-disk-alarms): An alarm that goes off if disk usage for an EC2 Instance is too high.
-*   [ec2-memory-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms/ec2-memory-alarms): An alarm that goes off if memory usage for an EC2 Instance is too high.
-*   [ecs-cluster-alamrs](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms/ecs-cluster-alarms): Alarms for an ECS cluster that go off if CPU or memory usage is too high
+*   [ec2-cpu-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/alarms/ec2-cpu-alarms): An alarm that goes off if CPU usage for an EC2 Instance is too high.
+*   [ec2-disk-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/alarms/ec2-disk-alarms): An alarm that goes off if disk usage for an EC2 Instance is too high.
+*   [ec2-memory-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/alarms/ec2-memory-alarms): An alarm that goes off if memory usage for an EC2 Instance is too high.
+*   [ecs-cluster-alamrs](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/alarms/ecs-cluster-alarms): Alarms for an ECS cluster that go off if CPU or memory usage is too high
     across the cluster.
-*   [ecs-service-alamrs](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms/ecs-cluster-alarms): Alarms for an ECS service that go off if CPU or memory usage is too high
+*   [ecs-service-alamrs](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/alarms/ecs-cluster-alarms): Alarms for an ECS service that go off if CPU or memory usage is too high
     for this service.
-*   [elb-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms/elb-alarms): A set of ELB alarms that go off if the latency gets too high, or there are
+*   [elb-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/alarms/elb-alarms): A set of ELB alarms that go off if the latency gets too high, or there are
     too many 5xx errors, or too few requests are coming in.
-*   [lambda-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms/lambda-alarms): An alarm that goes off when a lambda function breaches an associated metric.
-*   [rds-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms/rds-alarms): A set of RDS alarms that go off if the CPU usage, number of connections, or latency gets
+*   [lambda-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/alarms/lambda-alarms): An alarm that goes off when a lambda function breaches an associated metric.
+*   [rds-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/alarms/rds-alarms): A set of RDS alarms that go off if the CPU usage, number of connections, or latency gets
     too high or if the available memory or disk space gets too low.
-*   [route53-health-check-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms/route53-health-check-alarms): Monitor a given domain (e.g. example.com) using Route
+*   [route53-health-check-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/alarms/route53-health-check-alarms): Monitor a given domain (e.g. example.com) using Route
     53 and trigger an alarm if that domain is down or unresponsive.
-*   [scheduled-job-alarm](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms/scheduled-job-alarm): An alarm that goes off if a scheduled job (e.g. a cron job) fails to
+*   [scheduled-job-alarm](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/alarms/scheduled-job-alarm): An alarm that goes off if a scheduled job (e.g. a cron job) fails to
     run.
-*   [sqs-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms/sqs-alarms): Alarms that go off if the number of visible messages is too high or age of oldest message surpasses the threshold.
+*   [sqs-alarms](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/alarms/sqs-alarms): Alarms that go off if the number of visible messages is too high or age of oldest message surpasses the threshold.
 
-Click on each module above to see its documentation. Head over to the [examples folder](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/examples) for examples.
+Click on each module above to see its documentation. Head over to the [examples folder](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/examples) for examples.
 
 ## Information regarding tags for metric alarms
 
@@ -59,11 +59,11 @@ Tags associated with a metric alarm are not propagated with the alarm payload wh
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/alarms/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/alarms/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/alarms/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/alarms/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "f4ea378dc178607a67bafc0d3a56d3dc"
+  "hash": "f44eeadde1e0ff55b45050ac05adad40"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-monitoring/metrics/metrics.md
+++ b/docs/reference/modules/terraform-aws-monitoring/metrics/metrics.md
@@ -13,29 +13,29 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Metrics modules
 
-<a href="https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/metrics" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/metrics" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-monitoring/releases/tag/v0.34.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This folder contains modules for working with CloudWatch metrics:
 
-*   [cloudwatch-custom-metrics-iam-policy](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/metrics/cloudwatch-custom-metrics-iam-policy): A module that defines
+*   [cloudwatch-custom-metrics-iam-policy](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/metrics/cloudwatch-custom-metrics-iam-policy): A module that defines
     an IAM policy that allows reading/writing CloudWatch metrics.
-*   [cloudwatch-dashboard-metric-widget](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/metrics/cloudwatch-dashboard-metric-widget): Configures a CloudWatch Dashboard metric widget.
-*   [cloudwatch-dashboard-text-widget](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/metrics/cloudwatch-dashboard-text-widget): Configures a CloudWatch Dashboard text widget.
-*   [cloudwatch-dashboard](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/metrics/cloudwatch-dashboard): Configures and deploys a CloudWatch Dashboard.
+*   [cloudwatch-dashboard-metric-widget](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/metrics/cloudwatch-dashboard-metric-widget): Configures a CloudWatch Dashboard metric widget.
+*   [cloudwatch-dashboard-text-widget](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/metrics/cloudwatch-dashboard-text-widget): Configures a CloudWatch Dashboard text widget.
+*   [cloudwatch-dashboard](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/metrics/cloudwatch-dashboard): Configures and deploys a CloudWatch Dashboard.
 
-Click on each module above to see its documentation. Head over to the [examples folder](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/examples) for examples.
+Click on each module above to see its documentation. Head over to the [examples folder](https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/examples) for examples.
 
 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/metrics/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/metrics/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-monitoring/tree/main/modules/metrics/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/metrics/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/metrics/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-monitoring/tree/v0.35.9/modules/metrics/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "347501b012628642c9eb5b5d6527fc45"
+  "hash": "d184122b4c597164baddfd10c8978da3"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-openvpn/backup-openvpn-pki/backup-openvpn-pki.md
+++ b/docs/reference/modules/terraform-aws-openvpn/backup-openvpn-pki/backup-openvpn-pki.md
@@ -13,12 +13,12 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Backup PKI Assets Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/backup-openvpn-pki" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/backup-openvpn-pki" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.19.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This module is used to backup the OpenVPN Public Key Infrastructure (PKI) to S3 on a server that has been installed using
-the [install-openvpn](https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/install-openvpn) module.
+the [install-openvpn](https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/install-openvpn) module.
 
 The PKI is the set of certificates used to verify the server and users' identities for VPN authentication purposes. This
 normally lives on the OpenVPN server in the `/etc/openvpn-ca` and `/etc/openvpn` directories. If we didn't back these files
@@ -28,11 +28,11 @@ up, we would have to reissue client certificates if the OpenVPN server ever need
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/backup-openvpn-pki/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/backup-openvpn-pki/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/backup-openvpn-pki/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/backup-openvpn-pki/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/backup-openvpn-pki/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/backup-openvpn-pki/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "738ffd61f5cb5a77023c0e5950b8ad3b"
+  "hash": "d75c505937c2efc8de67a71016b2ed40"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-openvpn/init-openvpn/init-openvpn.md
+++ b/docs/reference/modules/terraform-aws-openvpn/init-openvpn/init-openvpn.md
@@ -13,22 +13,22 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Init OpenVPN Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/init-openvpn" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/init-openvpn" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.18.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This module is used to initialize the OpenVPN server, its Public Key Infrastructure (PKI), Certificate Authority
-(CA) and configuration on a server that has been installed using the [install-openvpn](https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/install-openvpn) module.
+(CA) and configuration on a server that has been installed using the [install-openvpn](https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/install-openvpn) module.
 
 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/init-openvpn/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/init-openvpn/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/init-openvpn/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/init-openvpn/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/init-openvpn/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/init-openvpn/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "23949bd714b0eb8ed5cdd60eb1a4d871"
+  "hash": "073339d80de6c2653a5b39bc08c9d923"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-openvpn/install-openvpn/install-openvpn.md
+++ b/docs/reference/modules/terraform-aws-openvpn/install-openvpn/install-openvpn.md
@@ -13,23 +13,23 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Install OpenVPN Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/install-openvpn" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/install-openvpn" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.19.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This module is used to install the OpenVPN package and related template files onto a server. It is expected that
-the [init-openvpn](https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/init-openvpn) module will be run on the server during boot to configure the OpenVPN server installed by this
+the [init-openvpn](https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/init-openvpn) module will be run on the server during boot to configure the OpenVPN server installed by this
 package.
 
 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/install-openvpn/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/install-openvpn/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/install-openvpn/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/install-openvpn/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/install-openvpn/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/install-openvpn/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "dd7c3317bec85d5b0f2b0eeb94921b9f"
+  "hash": "f617eb26cbb701babedb408ca9d55658"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-openvpn/openvpn-admin/openvpn-admin.md
+++ b/docs/reference/modules/terraform-aws-openvpn/openvpn-admin/openvpn-admin.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # openvpn-admin
 
-<a href="https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/openvpn-admin" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/openvpn-admin" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.24.4" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -32,11 +32,11 @@ certificates and the OpenVPN server to process those requests.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/openvpn-admin/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/openvpn-admin/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/openvpn-admin/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/openvpn-admin/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/openvpn-admin/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/openvpn-admin/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "7504335bd0e795931cdd4a4775de5d8d"
+  "hash": "f5a55ee142c5061a7640c79560fb061c"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-openvpn/openvpn-server/openvpn-server.md
+++ b/docs/reference/modules/terraform-aws-openvpn/openvpn-server/openvpn-server.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # OpenVPN Server Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/openvpn-server" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/openvpn-server" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.25.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -83,7 +83,7 @@ resource "aws_iam_policy_attachment" "attachment" {
 
 ## What if I want to enable MFA?
 
-The scripts [init-openvpn](https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/init-openvpn) and [install-openvpn](https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/install-openvpn) support setting up the
+The scripts [init-openvpn](https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/init-openvpn) and [install-openvpn](https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/install-openvpn) support setting up the
 [duo_openvpn](https://github.com/duosecurity/duo_openvpn) plugin for 2FA authentication. To enable the duo plugin, you
 need to:
 
@@ -96,7 +96,7 @@ need to:
     `--duo-skey`, and `--duo-host` to configure the integration key, secret key, and API hostname respectively. You can
     obtain these by following [the Duo setup instructions for OpenVPN](https://duo.com/docs/openvpn).
 
-See the [packer-duo](https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/examples/packer-duo) and [openvpn-host-duo](https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/examples/openvpn-host-duo) examples for an
+See the [packer-duo](https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/examples/packer-duo) and [openvpn-host-duo](https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/examples/openvpn-host-duo) examples for an
 example configuration to deploy the OpenVPN server with Duo enabled.
 
 Once the plugin is setup, all authentication for the client will result in a password prompt. To authenticate, you pass
@@ -1043,11 +1043,11 @@ The base64-encoded User Data script to run on the server when it is booting. Thi
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/openvpn-server/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/openvpn-server/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/openvpn-server/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/openvpn-server/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/openvpn-server/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/openvpn-server/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "9e9ee41f382310f5bb35ee0a597d892b"
+  "hash": "cb4aa88ce86aff14e948d0ca2c7ec1ba"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-openvpn/start-openvpn-admin/start-openvpn-admin.md
+++ b/docs/reference/modules/terraform-aws-openvpn/start-openvpn-admin/start-openvpn-admin.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Start OpenVPN Admin
 
-<a href="https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/start-openvpn-admin" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/start-openvpn-admin" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v0.19.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -24,11 +24,11 @@ certificate revocation requests on the OpenVPN server
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/start-openvpn-admin/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/start-openvpn-admin/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/main/modules/start-openvpn-admin/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/start-openvpn-admin/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/start-openvpn-admin/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-openvpn/tree/v0.25.0/modules/start-openvpn-admin/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "d564e5e36ed1a91d7bda4be453dc885f"
+  "hash": "2ca3e13c98d458503e118d175e3c4614"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/auto-update/auto-update.md
+++ b/docs/reference/modules/terraform-aws-security/auto-update/auto-update.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Security Modules
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/auto-update" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/auto-update" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.65.9" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -37,23 +37,23 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   [How to install Auto Update](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/auto-update/core-concepts.md#installation)
+*   [How to install Auto Update](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/auto-update/core-concepts.md#installation)
 
-*   [How Auto Update works on Ubuntu](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/auto-update/core-concepts.md#ubuntu-support)
+*   [How Auto Update works on Ubuntu](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/auto-update/core-concepts.md#ubuntu-support)
 
-*   [How Auto Update works on Amazon Linux and CentOS](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/auto-update/core-concepts.md#amazon-linux-and-centos-support)
+*   [How Auto Update works on Amazon Linux and CentOS](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/auto-update/core-concepts.md#amazon-linux-and-centos-support)
 
-*   [Auto Update Limitations](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/auto-update/core-concepts.md#limitations)
+*   [Auto Update Limitations](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/auto-update/core-concepts.md#limitations)
 
-*   [Core Security Concepts](https://github.com/gruntwork-io/terraform-aws-security/tree/main/README.adoc#core-concepts)
+*   [Core Security Concepts](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/README.adoc#core-concepts)
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/test): Automated tests for the modules and examples.
 
 ## Deploy
 
@@ -61,7 +61,7 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [auto-update example](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples/auto-update): The `examples/auto-update` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [auto-update example](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples/auto-update): The `examples/auto-update` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ### Production deployment
 
@@ -73,11 +73,11 @@ If you want to deploy this repo in production, check out the following resources
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/auto-update/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/auto-update/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/auto-update/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/auto-update/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/auto-update/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/auto-update/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "d345452b41c21acac9a37331d05c4e63"
+  "hash": "3e07024fb5b82c7f04764f6890000bdb"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/aws-auth/aws-auth.md
+++ b/docs/reference/modules/terraform-aws-security/aws-auth/aws-auth.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # AWS Auth Helper
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-auth" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-auth" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.65.9" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -175,7 +175,7 @@ eval $(aws-auth --serial-number arn:aws:iam::123456789011:mfa/jondoe --token-cod
 
 If you store your secrets in a CLI-friendly password manager, such as [pass](https://www.passwordstore.org/),
 [lpass](https://github.com/lastpass/lastpass-cli) or
-[1Password CLI](https://support.1password.com/command-line-getting-started/), then you can reduce this even further! Instructions on how to set this up for Lastpass / `lpass` can be found [here](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-auth/AWS-AUTH-LASTPASS.md) and 1Password / `op` [here](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-auth/AWS-AUTH-1PASSWORD.md).
+[1Password CLI](https://support.1password.com/command-line-getting-started/), then you can reduce this even further! Instructions on how to set this up for Lastpass / `lpass` can be found [here](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-auth/AWS-AUTH-LASTPASS.md) and 1Password / `op` [here](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-auth/AWS-AUTH-1PASSWORD.md).
 
 First, store your permanent AWS credentials in `pass`:
 
@@ -250,11 +250,11 @@ If you you need to run `aws-auth` with a cronjob, you may want to set the `$USER
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-auth/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-auth/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-auth/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-auth/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-auth/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-auth/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "98e4866ad06ae2aa97c29db833df894d"
+  "hash": "33dfa594e2d6a9d15a42d12d5447fd96"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/aws-config-bucket/aws-config-bucket.md
+++ b/docs/reference/modules/terraform-aws-security/aws-config-bucket/aws-config-bucket.md
@@ -13,15 +13,15 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # AWS Config Bucket
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-bucket" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-bucket" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.65.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This module creates an S3 bucket for storing AWS Config data, including all the appropriate lifecycle, encryption, and
 permission settings for AWS Config.
 
-This module is not meant to be used directly. Instead, it's used under the hood in the [aws-config](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config)
-and [account-baseline-root](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/account-baseline-root) modules. Please see those modules for more information.
+This module is not meant to be used directly. Instead, it's used under the hood in the [aws-config](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config)
+and [account-baseline-root](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/account-baseline-root) modules. Please see those modules for more information.
 
 ## Sample Usage
 
@@ -493,11 +493,11 @@ The name of the S3 bucket used by AWS Config to store configuration items.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-bucket/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-bucket/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-bucket/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-bucket/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-bucket/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-bucket/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "fe13fb03955d240c1a5675d8516cc878"
+  "hash": "8cce2bdb67a453e6da025d1f80a5f5a5"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/aws-config-multi-region/aws-config-multi-region.md
+++ b/docs/reference/modules/terraform-aws-security/aws-config-multi-region/aws-config-multi-region.md
@@ -13,11 +13,11 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # AWS Config Multi Region Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-multi-region" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-multi-region" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.66.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
-This module wraps the [aws-config core module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config/README.md) to configure [AWS Config](https://aws.amazon.com/config/) in all enabled regions for the AWS Account, and optionally can aggregate AWS Config across multiple accounts.
+This module wraps the [aws-config core module](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config/README.md) to configure [AWS Config](https://aws.amazon.com/config/) in all enabled regions for the AWS Account, and optionally can aggregate AWS Config across multiple accounts.
 
 ![multi account multi region aws config](/img/reference/modules/terraform-aws-security/aws-config-multi-region/multi-account-multi-region-aws-config.png)
 
@@ -45,25 +45,25 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   Learn more about AWS Config in the [aws-config core module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config/README.adoc).
+*   Learn more about AWS Config in the [aws-config core module](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config/README.adoc).
 
-*   [How to use a multi-region module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/codegen/core-concepts.md#how-to-use-a-multi-region-module)
+*   [How to use a multi-region module](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/codegen/core-concepts.md#how-to-use-a-multi-region-module)
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [codegen](https://github.com/gruntwork-io/terraform-aws-security/tree/main/codegen): Code generation utilities that help generate modules in this repo.
+*   [codegen](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/codegen): Code generation utilities that help generate modules in this repo.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/test): Automated tests for the modules and examples.
 
 ## Deploy
 
 *   [How to configure a production-grade AWS account structure](https://gruntwork.io/guides/foundations/how-to-configure-production-grade-aws-account-structure/)
 
-*   [How does Config work with multiple AWS accounts and multiple regions?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-multi-region/core-concepts.md#how-does-config-work-with-multiple-aws-accounts-and-multiple-regions)
+*   [How does Config work with multiple AWS accounts and multiple regions?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-multi-region/core-concepts.md#how-does-config-work-with-multiple-aws-accounts-and-multiple-regions)
 
 ## Sample Usage
 
@@ -1303,11 +1303,11 @@ The ARNs of the SNS Topic used by the config notifications.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-multi-region/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-multi-region/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-multi-region/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-multi-region/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-multi-region/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-multi-region/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "47a13bf1ece9d20e257582c0f8df8fd6"
+  "hash": "a9b21717d3d0ddfdabc33d451e659df9"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/aws-config-rules/aws-config-rules.md
+++ b/docs/reference/modules/terraform-aws-security/aws-config-rules/aws-config-rules.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # AWS Organizations Config Rules
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-rules" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-rules" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.65.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -41,27 +41,27 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   [What is AWS Organizations?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-organizations/core-concepts.md#what-is-aws-organizations)
+*   [What is AWS Organizations?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-organizations/core-concepts.md#what-is-aws-organizations)
 
-*   [What is AWS Config?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config/core-concepts.md#what-is-aws-config)
+*   [What is AWS Config?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config/core-concepts.md#what-is-aws-config)
 
-*   [What are Config Rules?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config/core-concepts.md#what-are-config-rules)
+*   [What are Config Rules?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config/core-concepts.md#what-are-config-rules)
 
-*   [What are Managed Config Rules?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-rules/core-concepts.md#what-are-managed-config-rules)
+*   [What are Managed Config Rules?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-rules/core-concepts.md#what-are-managed-config-rules)
 
-*   [How do Organization-Level Config Rules Compare to Account-Level Config Rules?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-rules/core-concepts.md#how-do-organization-level-config-rules-compare-to-account-level-config-rules)
+*   [How do Organization-Level Config Rules Compare to Account-Level Config Rules?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-rules/core-concepts.md#how-do-organization-level-config-rules-compare-to-account-level-config-rules)
 
-*   [What resources does this module create?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-rules/core-concepts.md#what-resources-does-this-module-create)
+*   [What resources does this module create?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-rules/core-concepts.md#what-resources-does-this-module-create)
 
 *   [How to configure a production-grade AWS account structure](https://gruntwork.io/guides/foundations/how-to-configure-production-grade-aws-account-structure/)
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/test): Automated tests for the modules and examples.
 
 ## Deploy
 
@@ -69,7 +69,7 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [examples/aws-config-rules](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples/aws-config-rules): The `examples/aws-organizations-config-rules` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [examples/aws-config-rules](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples/aws-config-rules): The `examples/aws-organizations-config-rules` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ### Production deployment
 
@@ -83,11 +83,11 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Day-to-day operations
 
-*   [How do I configure the rules?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-rules/core-concepts.md#how-do-i-configure-the-rules)
+*   [How do I configure the rules?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-rules/core-concepts.md#how-do-i-configure-the-rules)
 
-*   [How do I add additional rules?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-rules/core-concepts.md#how-do-i-add-additional-rules)
+*   [How do I add additional rules?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-rules/core-concepts.md#how-do-i-add-additional-rules)
 
-*   [How do I exclude specific accounts?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-rules/core-concepts.md#how-do-i-exclude-specific-accounts)
+*   [How do I exclude specific accounts?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-rules/core-concepts.md#how-do-i-exclude-specific-accounts)
 
 ## Sample Usage
 
@@ -678,11 +678,11 @@ Map of config rule ARNs. Key is rule ID, value is rule ARN
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-rules/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-rules/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-rules/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-rules/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-rules/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-rules/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "b63930fbcaf38698cd5dce22850cc48c"
+  "hash": "94405a599c5689304b4bd10bdf98542e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/aws-config/aws-config.md
+++ b/docs/reference/modules/terraform-aws-security/aws-config/aws-config.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # AWS Config
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.67.6" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -39,19 +39,19 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   [What is AWS Config?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config/core-concepts.md#what-is-aws-config)
+*   [What is AWS Config?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config/core-concepts.md#what-is-aws-config)
 
-*   [What are Config Rules?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config/core-concepts.md#what-are-config-rules)
+*   [What are Config Rules?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config/core-concepts.md#what-are-config-rules)
 
-*   [What resources does this module create?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config/core-concepts.md#what-resources-does-this-module-create)
+*   [What resources does this module create?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config/core-concepts.md#what-resources-does-this-module-create)
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/test): Automated tests for the modules and examples.
 
 ## Deploy
 
@@ -59,7 +59,7 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [examples/aws-config](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples/aws-config): The `examples/aws-config` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [examples/aws-config](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples/aws-config): The `examples/aws-config` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ### Production deployment
 
@@ -71,9 +71,9 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Day-to-day operations
 
-*   [What does a configuration item look like, and how do I view it?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config/core-concepts.md#what-does-a-configuration-item-look-like-and-how-do-i-view-it)
+*   [What does a configuration item look like, and how do I view it?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config/core-concepts.md#what-does-a-configuration-item-look-like-and-how-do-i-view-it)
 
-*   [How does Config work with multiple AWS accounts and multiple regions?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config-multi-region/core-concepts.md#how-does-config-work-with-multiple-aws-accounts-and-multiple-regions)
+*   [How does Config work with multiple AWS accounts and multiple regions?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config-multi-region/core-concepts.md#how-does-config-work-with-multiple-aws-accounts-and-multiple-regions)
 
 ## Sample Usage
 
@@ -958,11 +958,11 @@ The ARN of the SNS topic to which Config delivers notifications.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-config/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-config/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "a504ab14bd3e8b94681c5145dcbcb8e5"
+  "hash": "05fc38245a98f073303291325bf835eb"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/aws-organizations/aws-organizations.md
+++ b/docs/reference/modules/terraform-aws-security/aws-organizations/aws-organizations.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # AWS Organizations
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-organizations" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-organizations" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.65.9" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -39,23 +39,23 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   [What is AWS Organizations?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-organizations/core-concepts.md#what-is-aws-organizations)
+*   [What is AWS Organizations?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-organizations/core-concepts.md#what-is-aws-organizations)
 
-*   [What is a Root account?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-organizations/core-concepts.md#what-is-a-root-account)
+*   [What is a Root account?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-organizations/core-concepts.md#what-is-a-root-account)
 
-*   [What are Organization Accounts?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-organizations/core-concepts.md#what-are-organization-accounts)
+*   [What are Organization Accounts?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-organizations/core-concepts.md#what-are-organization-accounts)
 
-*   [What resources does this module create?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-organizations/core-concepts.md#what-resources-does-this-module-create)
+*   [What resources does this module create?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-organizations/core-concepts.md#what-resources-does-this-module-create)
 
 *   [How to configure a production-grade AWS account structure](https://gruntwork.io/guides/foundations/how-to-configure-production-grade-aws-account-structure/)
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/test): Automated tests for the modules and examples.
 
 ## Deploy
 
@@ -63,7 +63,7 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [examples/aws-organizations](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples/aws-organizations): The `examples/aws-organizations` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [examples/aws-organizations](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples/aws-organizations): The `examples/aws-organizations` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ### Production deployment
 
@@ -77,9 +77,9 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Day-to-day operations
 
-*   [How do I provision new accounts?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-organizations/core-concepts.md#how-do-i-provision-new-accounts)
+*   [How do I provision new accounts?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-organizations/core-concepts.md#how-do-i-provision-new-accounts)
 
-*   [How do I remove accounts?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-organizations/core-concepts.md#how-do-i-remove-accounts)
+*   [How do I remove accounts?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-organizations/core-concepts.md#how-do-i-remove-accounts)
 
 ## Sample Usage
 
@@ -424,11 +424,11 @@ Identifier of the root of this organization.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-organizations/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-organizations/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-organizations/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-organizations/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-organizations/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-organizations/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "3b6aab9e57c69220fa7a206ed07c8d1a"
+  "hash": "867813cc4e3671b281d6e12888ec7b6a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/cloudtrail-bucket/cloudtrail-bucket.md
+++ b/docs/reference/modules/terraform-aws-security/cloudtrail-bucket/cloudtrail-bucket.md
@@ -13,17 +13,17 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # CloudTrail Bucket
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail-bucket" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail-bucket" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.67.5" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This module creates an S3 bucket for storing CloudTrail data and a KMS Customer Master Key (CMK) for encrypting that
 data, including all the appropriate lifecycle, encryption, and permission settings for CloudTrail.
 
-This module is used under the hood in the [cloudtrail](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail)
-and [account-baseline-root](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/account-baseline-root) modules.
+This module is used under the hood in the [cloudtrail](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail)
+and [account-baseline-root](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/account-baseline-root) modules.
 
-It can also be used directly when configuring cross account access, for example when it is desirable to [have the central Cloudtrail S3 bucket exist outside of the management account.](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail/core-concepts.md#multi-account-cloudtrail-setup-storing-the-cloudtrail-bucket-in-an-account-other-than-the-management-account)
+It can also be used directly when configuring cross account access, for example when it is desirable to [have the central Cloudtrail S3 bucket exist outside of the management account.](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail/core-concepts.md#multi-account-cloudtrail-setup-storing-the-cloudtrail-bucket-in-an-account-other-than-the-management-account)
 
 ## Sample Usage
 
@@ -903,11 +903,11 @@ The name of the S3 bucket where cloudtrail logs are delivered.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail-bucket/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail-bucket/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail-bucket/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail-bucket/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail-bucket/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail-bucket/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "5728d9a8a578489efb073ad716395e0c"
+  "hash": "9d3b9dd7e8b872ae19cac0b59392d4d1"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/cloudtrail/cloudtrail.md
+++ b/docs/reference/modules/terraform-aws-security/cloudtrail/cloudtrail.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # AWS CloudTrail
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.67.6" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -39,25 +39,25 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   [What is CloudTrail?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail/core-concepts.md#what-is-cloudtrail)
+*   [What is CloudTrail?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail/core-concepts.md#what-is-cloudtrail)
 
-*   [Why use CloudTrail?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail/core-concepts.md#why-use-cloudtrail)
+*   [Why use CloudTrail?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail/core-concepts.md#why-use-cloudtrail)
 
-*   [What is a CloudTrail Trail?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail/core-concepts.md#what-is-a-cloudtrail-trail)
+*   [What is a CloudTrail Trail?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail/core-concepts.md#what-is-a-cloudtrail-trail)
 
-*   [What’s the difference between CloudTrail and AWS Config?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail/core-concepts.md#whats-the-difference-between-cloudtrail-and-aws-config)
+*   [What’s the difference between CloudTrail and AWS Config?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail/core-concepts.md#whats-the-difference-between-cloudtrail-and-aws-config)
 
-*   [CloudTrail Threat Model](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail/core-concepts.md#cloudtrail-threat-model)
+*   [CloudTrail Threat Model](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail/core-concepts.md#cloudtrail-threat-model)
 
-*   [What resources does this module create?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail/core-concepts.md#resources-created)
+*   [What resources does this module create?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail/core-concepts.md#resources-created)
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/test): Automated tests for the modules and examples.
 
 ## Deploy
 
@@ -65,7 +65,7 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [examples/cloudtrail](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples/cloudtrail): The `examples/cloudtrail` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [examples/cloudtrail](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples/cloudtrail): The `examples/cloudtrail` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ### Production deployment
 
@@ -81,15 +81,15 @@ If you want to deploy this repo in production, check out the following resources
 
 ### Day-to-day operations
 
-*   [Where are CloudTrail logs stored?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail/core-concepts.md#where-are-cloudtrail-logs-stored)
+*   [Where are CloudTrail logs stored?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail/core-concepts.md#where-are-cloudtrail-logs-stored)
 
-*   [What kind of data do CloudTrail log entries contain?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail/core-concepts.md#what-kind-of-data-do-cloudtrail-log-entries-contain)
+*   [What kind of data do CloudTrail log entries contain?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail/core-concepts.md#what-kind-of-data-do-cloudtrail-log-entries-contain)
 
-*   [What’s the best way to view CloudTrail Log Data?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail/core-concepts.md#whats-the-best-way-to-view-cloudtrail-log-data)
+*   [What’s the best way to view CloudTrail Log Data?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail/core-concepts.md#whats-the-best-way-to-view-cloudtrail-log-data)
 
 ### Major changes
 
-*   [Can you get alerted when certain API events occur?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail/core-concepts.md#can-you-get-alerted-when-certain-api-events-occur)
+*   [Can you get alerted when certain API events occur?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail/core-concepts.md#can-you-get-alerted-when-certain-api-events-occur)
 
 ## Sample Usage
 
@@ -1399,11 +1399,11 @@ The name of the cloudtrail trail.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cloudtrail/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cloudtrail/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "194fc71454a6384abe3b2cbe69c22be1"
+  "hash": "39a10e5925567817d00533ad494ca702"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/cross-account-iam-roles/cross-account-iam-roles.md
+++ b/docs/reference/modules/terraform-aws-security/cross-account-iam-roles/cross-account-iam-roles.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # A best-practices set of IAM roles for cross-account access
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cross-account-iam-roles" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cross-account-iam-roles" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.65.9" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -34,7 +34,7 @@ This module creates the following IAM roles (all optional):
 These IAM Roles are intended to be assumed by human users (i.e., IAM Users in another AWS account). The default
 maximum session expiration for these roles is 12 hours (configurable via the `var.max_session_duration_human_users`).
 Note that these are the *maximum* session expirations; the actual value for session expiration is specified when
-making API calls to assume the IAM role (see [aws-auth](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-auth)).
+making API calls to assume the IAM role (see [aws-auth](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-auth)).
 
 *   **allow-read-only-access-from-other-accounts**: Users from the accounts in
     `var.allow_read_only_access_from_other_account_arns` will get read-only access to all services in this account.
@@ -65,16 +65,16 @@ making API calls to assume the IAM role (see [aws-auth](https://github.com/grunt
 These IAM Roles are intended to be assumed by machine users (i.e., an EC2 Instance in another AWS account). The default
 maximum session expiration for these roles is 1 hour (configurable via the `var.max_session_duration_machine_users`).
 Note that these are the *maximum* session expirations; the actual value for session expiration is specified when
-making API calls to assume the IAM role (see [aws-auth](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/aws-auth)).
+making API calls to assume the IAM role (see [aws-auth](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/aws-auth)).
 
 *   **allow-ssh-grunt-access-from-other-accounts**: Users (or more likely, EC2 Instances) from the accounts in
     `var.allow_ssh_grunt_access_from_other_account_arns` will get read access to IAM Groups and public SSH keys. This is
-    useful to allow [ssh-grunt](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt) running on EC2 Instances in other AWS accounts to validate SSH
+    useful to allow [ssh-grunt](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt) running on EC2 Instances in other AWS accounts to validate SSH
     connections against IAM users defined in this AWS account.
 
 *   **allow-ssh-grunt-houston-access-from-other-accounts**: Users (or more likely, EC2 Instances) from the accounts in
     `var.allow_ssh_grunt_houston_access_from_other_account_arns` will get read access to Gruntwork Houston. This is
-    useful to allow [ssh-grunt](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt) running on EC2 Instances in other AWS accounts to validate SSH
+    useful to allow [ssh-grunt](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt) running on EC2 Instances in other AWS accounts to validate SSH
     connections against Gruntwork Houston running in this AWS account.
 
 *   **allow-auto-deploy-access-from-other-accounts**: Users from the accounts in `var.allow_auto_deploy_from_other_account_arns`
@@ -101,7 +101,7 @@ roles with the AWS CLI takes quite a few steps, so use the [aws-auth script](htt
 ## Background Information
 
 For background information on IAM, IAM users, IAM policies, and more, check out the [background information docs in
-the iam-policies module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-policies#background-information).
+the iam-policies module](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-policies#background-information).
 
 ## Sample Usage
 
@@ -1253,11 +1253,11 @@ When true, all IAM policies will be managed as dedicated policies rather than in
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cross-account-iam-roles/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cross-account-iam-roles/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cross-account-iam-roles/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cross-account-iam-roles/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cross-account-iam-roles/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cross-account-iam-roles/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "46fcc156caf5d28f992d94c8108a1556"
+  "hash": "ae88a77572864e906ae9ba65c5cc7f32"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/custom-iam-entity/custom-iam-entity.md
+++ b/docs/reference/modules/terraform-aws-security/custom-iam-entity/custom-iam-entity.md
@@ -13,11 +13,11 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Custom IAM Entity
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/custom-iam-entity" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/custom-iam-entity" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.67.3" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
-This Gruntwork Terraform Module creates an IAM group and/or role and attaches a provided set of IAM managed policies to the group. This can be used in conjunction with the [iam-groups](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-groups), [cross-account-iam-roles](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cross-account-iam-roles), and [saml-iam-roles](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/saml-iam-roles) modules which create a set of groups and roles with smart defaults. Use this module to easily create IAM groups and roles with a defined set of permissions.
+This Gruntwork Terraform Module creates an IAM group and/or role and attaches a provided set of IAM managed policies to the group. This can be used in conjunction with the [iam-groups](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-groups), [cross-account-iam-roles](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cross-account-iam-roles), and [saml-iam-roles](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/saml-iam-roles) modules which create a set of groups and roles with smart defaults. Use this module to easily create IAM groups and roles with a defined set of permissions.
 
 ### Requirements
 
@@ -25,7 +25,7 @@ This Gruntwork Terraform Module creates an IAM group and/or role and attaches a 
 
 ### Instructions
 
-Check out the [custom-iam-entity example](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples/custom-iam-entity) for a working example.
+Check out the [custom-iam-entity example](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples/custom-iam-entity) for a working example.
 
 #### Resources Created
 
@@ -36,7 +36,7 @@ If neither role nor group are provided, this module does nothing.
 
 #### Resources NOT Created
 
-*   **IAM users** - This module does not create any IAM Users, nor assign any existing IAM Users to IAM Groups. You can use the [iam-users module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-users) to create users.
+*   **IAM users** - This module does not create any IAM Users, nor assign any existing IAM Users to IAM Groups. You can use the [iam-users module](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-users) to create users.
 *   **IAM policies** - This module only attaches policies by ARN or by name. It does not create any new policies.
 
 #### MFA support
@@ -51,7 +51,7 @@ The reason for this difference is difficult to explain, but boils down to limita
 ## Background Information
 
 For background information on IAM, IAM users, IAM policies, and more, check out the [background information docs in
-the iam-policies module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-policies#background-information).
+the iam-policies module](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-policies#background-information).
 
 ## Sample Usage
 
@@ -486,11 +486,11 @@ The name of the IAM role.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/custom-iam-entity/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/custom-iam-entity/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/custom-iam-entity/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/custom-iam-entity/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/custom-iam-entity/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/custom-iam-entity/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "58ca69bbd19d2f9f92c5764a4bcca8af"
+  "hash": "a15a9e2272683524a581f7ae388ab566"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/ebs-encryption-multi-region/ebs-encryption-multi-region.md
+++ b/docs/reference/modules/terraform-aws-security/ebs-encryption-multi-region/ebs-encryption-multi-region.md
@@ -13,11 +13,11 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # EBS Encryption Multi Region Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ebs-encryption-multi-region" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ebs-encryption-multi-region" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.66.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
-This module wraps the [ebs-encryption core module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ebs-encryption/README.md) to configure [AWS EBS encryption](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html) in all enabled regions for the AWS Account.
+This module wraps the [ebs-encryption core module](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ebs-encryption/README.md) to configure [AWS EBS encryption](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html) in all enabled regions for the AWS Account.
 
 ## Features
 
@@ -37,17 +37,17 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 *   [AWS blog: Opt-in to Default Encryption for New EBS Volumes](https://aws.amazon.com/blogs/aws/new-opt-in-to-default-encryption-for-new-ebs-volumes/)
 
-*   [How to use a multi-region module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/codegen/core-concepts.md#how-to-use-a-multi-region-module)
+*   [How to use a multi-region module](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/codegen/core-concepts.md#how-to-use-a-multi-region-module)
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [codegen](https://github.com/gruntwork-io/terraform-aws-security/tree/main/codegen): Code generation utilities that help generate modules in this repo.
+*   [codegen](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/codegen): Code generation utilities that help generate modules in this repo.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/test): Automated tests for the modules and examples.
 
 ## Deploy
 
@@ -219,11 +219,11 @@ A map from region to the ARN of the KMS key used for default EBS encryption for 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ebs-encryption-multi-region/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ebs-encryption-multi-region/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ebs-encryption-multi-region/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ebs-encryption-multi-region/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ebs-encryption-multi-region/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ebs-encryption-multi-region/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "45baa8f7b9253eadc5c00a1b6ec962af"
+  "hash": "2be26a9fd62c18cfc6d95c0e32bfad36"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/ebs-encryption/ebs-encryption.md
+++ b/docs/reference/modules/terraform-aws-security/ebs-encryption/ebs-encryption.md
@@ -13,14 +13,14 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Elastic Block Storage Encryption
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ebs-encryption" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ebs-encryption" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.66.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This module configures EC2 Elastic Block Storage encryption defaults, allowing encryption to be enabled for all new EBS
 volumes and selection of a KMS Customer Managed Key to use by default.
 
-This module is not meant to be used directly. Instead, it's used under the hood in the [account-baseline-\*](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules)
+This module is not meant to be used directly. Instead, it's used under the hood in the [account-baseline-\*](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules)
 modules. Please see those modules for more information.
 
 ## Background Information
@@ -188,11 +188,11 @@ The default KMS key used for EBS encryption.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ebs-encryption/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ebs-encryption/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ebs-encryption/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ebs-encryption/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ebs-encryption/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ebs-encryption/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "73b69a96c77cbcd82f23ea689b2d9ab9"
+  "hash": "398c956e1ad7d4bd3958c7fdf17913bc"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/fail2ban/fail2ban.md
+++ b/docs/reference/modules/terraform-aws-security/fail2ban/fail2ban.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Fail2Ban Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/fail2ban" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/fail2ban" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.65.9" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -28,11 +28,11 @@ Instance.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/fail2ban/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/fail2ban/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/fail2ban/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/fail2ban/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/fail2ban/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/fail2ban/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "7ee43d8fda38003b146a18f5e5f3b63c"
+  "hash": "5ee123f1ea49e6dff2c268ced5d603be"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/github-actions-iam-role/github-actions-iam-role.md
+++ b/docs/reference/modules/terraform-aws-security/github-actions-iam-role/github-actions-iam-role.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # IAM Role for GitHub Actions
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/github-actions-iam-role" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/github-actions-iam-role" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.67.3" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -535,11 +535,11 @@ The name of the IAM role.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/github-actions-iam-role/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/github-actions-iam-role/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/github-actions-iam-role/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/github-actions-iam-role/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/github-actions-iam-role/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/github-actions-iam-role/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "32284f283bdb97288054ef019a3dfb5a"
+  "hash": "6033bef24977ab7119eab75f102e80ca"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/guardduty-multi-region/guardduty-multi-region.md
+++ b/docs/reference/modules/terraform-aws-security/guardduty-multi-region/guardduty-multi-region.md
@@ -13,15 +13,15 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # AWS GuardDuty Multi Region Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty-multi-region" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty-multi-region" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.66.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
-This module wraps the [guardduty core module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty/README.adoc) to configure [AWS GuardDuty](https://aws.amazon.com/guardduty/) in all enabled regions for the AWS Account.
+This module wraps the [guardduty core module](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty/README.adoc) to configure [AWS GuardDuty](https://aws.amazon.com/guardduty/) in all enabled regions for the AWS Account.
 
 ## Features
 
-*   Uses the [guardduty module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty) to enable AWS GuardDuty across all regions (recommended best practice) on your AWS account
+*   Uses the [guardduty module](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty) to enable AWS GuardDuty across all regions (recommended best practice) on your AWS account
 
 *   Continuously monitor your AWS account for malicious activity and unauthorized behavior
 
@@ -37,19 +37,19 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   Learn more about GuardDuty in the [guardduty core module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty/README.adoc).
+*   Learn more about GuardDuty in the [guardduty core module](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty/README.adoc).
 
-*   [How to use a multi-region module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/codegen/core-concepts.md#how-to-use-a-multi-region-module)
+*   [How to use a multi-region module](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/codegen/core-concepts.md#how-to-use-a-multi-region-module)
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [codegen](https://github.com/gruntwork-io/terraform-aws-security/tree/main/codegen): Code generation utilities that help generate modules in this repo.
+*   [codegen](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/codegen): Code generation utilities that help generate modules in this repo.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/test): Automated tests for the modules and examples.
 
 ## Deploy
 
@@ -354,11 +354,11 @@ The IDs of the GuardDuty detectors.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty-multi-region/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty-multi-region/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty-multi-region/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty-multi-region/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty-multi-region/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty-multi-region/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "1140ac70d0e341e6fc1193b3d6e068f5"
+  "hash": "b7e7177606ca3c088f183b3326df2809"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/guardduty/guardduty.md
+++ b/docs/reference/modules/terraform-aws-security/guardduty/guardduty.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # AWS GuardDuty
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.66.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -37,29 +37,29 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   [What Is GuardDuty?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty/core-concepts.md#what-is-guardduty)
+*   [What Is GuardDuty?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty/core-concepts.md#what-is-guardduty)
 
-*   [Why Use GuardDuty?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty/core-concepts.md#why-use-guardduty)
+*   [Why Use GuardDuty?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty/core-concepts.md#why-use-guardduty)
 
-*   [What Is A Finding?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty/core-concepts.md#what-is-a-finding)
+*   [What Is A Finding?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty/core-concepts.md#what-is-a-finding)
 
-*   [Where Should I Enable GuardDuty?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty/core-concepts.md#where-should-i-enable-guardduty)
+*   [Where Should I Enable GuardDuty?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty/core-concepts.md#where-should-i-enable-guardduty)
 
-*   [Resources Created](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty/core-concepts.md#resources-created)
+*   [Resources Created](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty/core-concepts.md#resources-created)
 
-*   [Gotchas](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty/core-concepts.md#gotchas)
+*   [Gotchas](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty/core-concepts.md#gotchas)
 
-*   [Known Issues](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty/core-concepts.md#known-issues)
+*   [Known Issues](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty/core-concepts.md#known-issues)
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [codegen](https://github.com/gruntwork-io/terraform-aws-security/tree/main/codegen): Code generation utilities that help generate modules in this repo.
+*   [codegen](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/codegen): Code generation utilities that help generate modules in this repo.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/test): Automated tests for the modules and examples.
 
 ## Deploy
 
@@ -67,7 +67,7 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this module out, check out the following resources:
 
-*   [guardduty example](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples/guardduty).
+*   [guardduty example](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples/guardduty).
 
 ### Production deployment
 
@@ -75,7 +75,7 @@ If you want to deploy this module in production, check out the following resourc
 
 *   ***Coming soon***. We have not yet added this module to the [Acme example Reference Architecture](https://github.com/gruntwork-io/infrastructure-modules-multi-account-acme).
 
-*   [Terraform Module to enable GuardDuty in all enabled regions of an AWS Account](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty-multi-region).
+*   [Terraform Module to enable GuardDuty in all enabled regions of an AWS Account](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty-multi-region).
 
 *   [How to configure a production-grade AWS account structure](https://gruntwork.io/guides/foundations/how-to-configure-production-grade-aws-account-structure/)
 
@@ -354,11 +354,11 @@ The ID of the GuardDuty detector.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/guardduty/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/guardduty/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "a9995a43f71b736720ad243209b54220"
+  "hash": "fc1e5036079a946b5206044de16bab85"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/iam-access-analyzer-multi-region/iam-access-analyzer-multi-region.md
+++ b/docs/reference/modules/terraform-aws-security/iam-access-analyzer-multi-region/iam-access-analyzer-multi-region.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # AWS IAM Access Analyzer
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-access-analyzer-multi-region" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-access-analyzer-multi-region" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.66.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -35,21 +35,21 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   [What is the AWS IAM Access Analyzer?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-access-analyzer-multi-region/core-concepts.md#what-is-the-aws-iam-access-analyzer?)
+*   [What is the AWS IAM Access Analyzer?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-access-analyzer-multi-region/core-concepts.md#what-is-the-aws-iam-access-analyzer?)
 
-*   [What resources does IAM Access Analyzer analyze?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-access-analyzer-multi-region/core-concepts.md#what-resources-does-iam-access-analyzer-analyze?)
+*   [What resources does IAM Access Analyzer analyze?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-access-analyzer-multi-region/core-concepts.md#what-resources-does-iam-access-analyzer-analyze?)
 
 *   [IAM Access Analyzer documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/what-is-access-analyzer.html)
 
-*   [How to use a multi-region module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/codegen/core-concepts.md#how-to-use-a-multi-region-module)
+*   [How to use a multi-region module](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/codegen/core-concepts.md#how-to-use-a-multi-region-module)
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/test): Automated tests for the modules and examples.
 
 ## Deploy
 
@@ -57,13 +57,13 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this out for experimenting and learning, check out the following resources:
 
-*   [examples folder](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [examples folder](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ## Manage
 
-*   [Who can manage the analyzer?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-access-analyzer-multi-region/core-concepts.md#who-can-manage-the-analyzer?)
+*   [Who can manage the analyzer?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-access-analyzer-multi-region/core-concepts.md#who-can-manage-the-analyzer?)
 
-*   [What to do with the access analyzer findings?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-access-analyzer-multi-region/core-concepts.md#what-to-do-with-the-access-analyzer-findings?)
+*   [What to do with the access analyzer findings?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-access-analyzer-multi-region/core-concepts.md#what-to-do-with-the-access-analyzer-findings?)
 
 ## Sample Usage
 
@@ -158,11 +158,11 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-access-analyzer-multi-region/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-access-analyzer-multi-region/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-access-analyzer-multi-region/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-access-analyzer-multi-region/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-access-analyzer-multi-region/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-access-analyzer-multi-region/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "2281e4882a0b09dacac86ccfd4604d51"
+  "hash": "59d141a45ebc3e59f8c2b286d346d3a3"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/iam-groups/iam-groups.md
+++ b/docs/reference/modules/terraform-aws-security/iam-groups/iam-groups.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # A Best-Practices Set of IAM Groups
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-groups" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-groups" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.65.9" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -52,7 +52,7 @@ This module optionally creates the following IAM Groups:
     since users can grant arbitrary permissions!
 *   **use-existing-iam-roles:** IAM Users in this group can pass *existing* IAM Roles to AWS resources to which they have
     been granted access. These IAM Users cannot create *new* IAM Roles, only use existing ones. See
-    [the three levels of IAM permissions](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-policies#the-three-levels-of-iam-permissions) for more information.
+    [the three levels of IAM permissions](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-policies#the-three-levels-of-iam-permissions) for more information.
 *   **ssh-grunt-sudo-users:** IAM Users in this group have SSH access with `sudo` privileges to any EC2 Instance configured
     to use this group to manage SSH logins.
 *   **ssh-grunt-users:** IAM Users in this group have SSH access without `sudo` privileges to any EC2 Instance configured
@@ -83,7 +83,7 @@ own account unless this IAM Policy is attached to his account.
 
 ### IAM Users
 
-This module does not create any IAM Users, nor assign any existing IAM Users to IAM Groups. You can use the [iam-users module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-users) to create users.
+This module does not create any IAM Users, nor assign any existing IAM Users to IAM Groups. You can use the [iam-users module](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-users) to create users.
 
 ### IAM Roles
 
@@ -108,7 +108,7 @@ otherwise enable IAM Users to access the billing console:
 ## Background Information
 
 For background information on IAM, IAM users, IAM policies, and more, check out the [background information docs in
-the iam-policies module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-policies#background-information).
+the iam-policies module](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-policies#background-information).
 
 ## Sample Usage
 
@@ -1046,11 +1046,11 @@ Should we create the IAM Group for user self-management? Allows users to manage 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-groups/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-groups/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-groups/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-groups/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-groups/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-groups/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "ba91d38f48082b0956599afe4ddd8e93"
+  "hash": "c663a5c082eccaaa6d3e66bf2840726a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/iam-policies/iam-policies.md
+++ b/docs/reference/modules/terraform-aws-security/iam-policies/iam-policies.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # A Best-Practices Set of IAM Policy Documents
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-policies" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-policies" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.67.3" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -25,7 +25,7 @@ Note that these documents are Terraform [data sources](https://www.terraform.io/
 so they don't create anything themselves and are not intended to be used on their own. The way to use them is to take
 the outputs from this module (which are all JSON IAM documents) and plug them into other Terraform resources, such
 as `aws_iam_policy`, `aws_iam_user_policy`, `aws_iam_group_policy`, and `aws_iam_role_policy`. See the
-[iam-groups](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-groups) and [cross-account-iam-roles](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/cross-account-iam-roles) modules for examples.
+[iam-groups](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-groups) and [cross-account-iam-roles](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/cross-account-iam-roles) modules for examples.
 
 If you're not familiar with IAM concepts, start with the [Background Information](#background-information) section as a
 way to familiarize yourself with the terminology.
@@ -82,10 +82,10 @@ This module creates the following IAM Policy documents:
     certain IAM roles in other AWS accounts (e.g. stage, prod). The documents that are created and which IAM roles they
     have access to is controlled by the variable `var.allow_access_from_other_account_arns`.
 
-*   **ssh_grunt_permissions**: provides the permissions [ssh-grunt](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt) needs to validate SSH keys with
+*   **ssh_grunt_permissions**: provides the permissions [ssh-grunt](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt) needs to validate SSH keys with
     IAM.
 
-*   **ssh_grunt_houston_permissions**: provides the permissions [ssh-grunt](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt) needs to validate SSH
+*   **ssh_grunt_houston_permissions**: provides the permissions [ssh-grunt](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt) needs to validate SSH
     keys with Houston.
 
 *   **auto_deploy_permissions**: provides the permissions in `var.auto_deploy_permissions` to do automated deployment.
@@ -742,11 +742,11 @@ If set to true, all the Policies created by this module that are used as Trust P
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-policies/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-policies/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-policies/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-policies/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-policies/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-policies/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "dab3c85180ebccd92ecaeef8c496908a"
+  "hash": "49fd1fbb99a00876b181a2f924ca0086"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/iam-user-password-policy/iam-user-password-policy.md
+++ b/docs/reference/modules/terraform-aws-security/iam-user-password-policy/iam-user-password-policy.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Set a Password Policy for IAM Users
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-user-password-policy" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-user-password-policy" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.65.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -334,11 +334,11 @@ Whether to require uppercase characters for user passwords.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-user-password-policy/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-user-password-policy/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-user-password-policy/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-user-password-policy/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-user-password-policy/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-user-password-policy/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "ede0117c097112a3b1870e62e6d8b158"
+  "hash": "ce01c51977dc2ff4d76311e7a8ef760f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/iam-users/iam-users.md
+++ b/docs/reference/modules/terraform-aws-security/iam-users/iam-users.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # IAM Users
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-users" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-users" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.65.10" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -504,11 +504,11 @@ A map of usernames to that user's AWS SSH Security Credential ID
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-users/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-users/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/iam-users/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-users/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-users/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/iam-users/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "d36433f177e315b1875d24b403ab038b"
+  "hash": "d17e80672a8a32d1dcdc5741562f826b"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/ip-lockdown/ip-lockdown.md
+++ b/docs/reference/modules/terraform-aws-security/ip-lockdown/ip-lockdown.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # ip-lockdown Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ip-lockdown" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ip-lockdown" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.44.10" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -33,7 +33,7 @@ In the example below we restrict access to [ec2-instance-metadata endpoint](http
 
 Normally users make a `curl` call to get metadata like the AWS region or credentials associated with this EC2 Instance's IAM Role. Following the invocation of ip-lockdown, only users foo, bar, and root can query that data.
 
-The complete example of using terraform to deploy a generated AMI into your AWS account and automatically invoke `ip-lockdown` from the `User Data` is also available in the [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples/ip-lockdown/aws-example) folder.
+The complete example of using terraform to deploy a generated AMI into your AWS account and automatically invoke `ip-lockdown` from the `User Data` is also available in the [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples/ip-lockdown/aws-example) folder.
 
 #### Installation
 
@@ -62,11 +62,11 @@ gruntwork-install --module-name ip-lockdown --tag <MODULE_SECURITY_VERSION> --re
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ip-lockdown/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ip-lockdown/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ip-lockdown/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ip-lockdown/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ip-lockdown/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ip-lockdown/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "047a631d8bd5d3fe4f1ce518238d2733"
+  "hash": "4054825fe8fb674c893bd4fb8196d428"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/kms-cmk-replica/kms-cmk-replica.md
+++ b/docs/reference/modules/terraform-aws-security/kms-cmk-replica/kms-cmk-replica.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # KMS Customer Managed Key Multi-Region Replication module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-cmk-replica" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-cmk-replica" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.67.3" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -22,7 +22,7 @@ Key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#custome
 [the multi-region replication feature of
 KMS](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html).
 
-This module is intended to be used in conjunction with the [kms-master-key module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-master-key) to replicate a KMS
+This module is intended to be used in conjunction with the [kms-master-key module](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-master-key) to replicate a KMS
 key managed with that module to other regions. Note that the KMS key must be marked as multi-region in order to support
 multi-region replication.
 
@@ -371,11 +371,11 @@ A map of CMK name to CMK ID.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-cmk-replica/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-cmk-replica/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-cmk-replica/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-cmk-replica/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-cmk-replica/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-cmk-replica/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "6131a01ac69ce6e8261265d206a25b5d"
+  "hash": "1c92d325d1a20091d951c29404e70ea5"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/kms-grant-multi-region/kms-grant-multi-region.md
+++ b/docs/reference/modules/terraform-aws-security/kms-grant-multi-region/kms-grant-multi-region.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # AWS KMS Grants
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-grant-multi-region" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-grant-multi-region" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.66.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -31,21 +31,21 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   [What is KMS?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-master-key/README.md#what-is-kms)
+*   [What is KMS?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-master-key/README.md#what-is-kms)
 
-*   [What is a Customer Master Key?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-master-key/README.md#what-is-a-customer-master-key)
+*   [What is a Customer Master Key?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-master-key/README.md#what-is-a-customer-master-key)
 
 *   [KMS documentation](https://docs.aws.amazon.com/kms/latest/developerguide/overview.html): Amazon’s docs for KMS that cover core concepts such as various key types, how to encrypt and decrypt, deletion of keys, and automatic key rotation.
 
-*   [How to use a multi-region module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/codegen/core-concepts.md#how-to-use-a-multi-region-module)
+*   [How to use a multi-region module](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/codegen/core-concepts.md#how-to-use-a-multi-region-module)
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/test): Automated tests for the modules and examples.
 
 ## Deploy
 
@@ -53,13 +53,13 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this out for experimenting and learning, check out the following resources:
 
-*   [examples folder](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [examples folder](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ## Manage
 
-*   [What is the difference between KMS Grants and Key Policies?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-grant-multi-region/core-concepts.md#what-is-the-difference-between-kms-grants-and-key-policies)
+*   [What is the difference between KMS Grants and Key Policies?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-grant-multi-region/core-concepts.md#what-is-the-difference-between-kms-grants-and-key-policies)
 
-*   [How do I use KMS Grants to share encrypted AMIs across accounts?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-grant-multi-region/core-concepts.md#how-do-i-use-kms-grants-to-share-encrypted-amis-across-accounts)
+*   [How do I use KMS Grants to share encrypted AMIs across accounts?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-grant-multi-region/core-concepts.md#how-do-i-use-kms-grants-to-share-encrypted-amis-across-accounts)
 
 ## Sample Usage
 
@@ -172,11 +172,11 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-grant-multi-region/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-grant-multi-region/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-grant-multi-region/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-grant-multi-region/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-grant-multi-region/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-grant-multi-region/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "ce6a4fcd67c0448e0cf627a7baa1f83b"
+  "hash": "7814ec79f7c440f4d553f3f39b7f40ef"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/kms-master-key-multi-region/kms-master-key-multi-region.md
+++ b/docs/reference/modules/terraform-aws-security/kms-master-key-multi-region/kms-master-key-multi-region.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # AWS KMS Customer Master Keys (CMK)
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-master-key-multi-region" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-master-key-multi-region" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.66.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -37,23 +37,23 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   [What is KMS?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-master-key/README.md#what-is-kms)
+*   [What is KMS?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-master-key/README.md#what-is-kms)
 
-*   [What is the difference between creating one key in all regions and creating a single all-region key?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-master-key-multi-region/core-concepts.md#what-is-the-difference-between-creating-one-key-in-all-regions-and-creating-a-single-all-region-key)
+*   [What is the difference between creating one key in all regions and creating a single all-region key?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-master-key-multi-region/core-concepts.md#what-is-the-difference-between-creating-one-key-in-all-regions-and-creating-a-single-all-region-key)
 
-*   [What is a Customer Master Key?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-master-key/README.md#what-is-a-customer-master-key)
+*   [What is a Customer Master Key?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-master-key/README.md#what-is-a-customer-master-key)
 
 *   [KMS documentation](https://docs.aws.amazon.com/kms/latest/developerguide/overview.html): Amazon’s docs for KMS that cover core concepts such as various key types, how to encrypt and decrypt, deletion of keys, and automatic key rotation.
 
-*   [How to use a multi-region module](https://github.com/gruntwork-io/terraform-aws-security/tree/main/codegen/core-concepts.md#how-to-use-a-multi-region-module)
+*   [How to use a multi-region module](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/codegen/core-concepts.md#how-to-use-a-multi-region-module)
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/test): Automated tests for the modules and examples.
 
 ## Deploy
 
@@ -61,17 +61,17 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this out for experimenting and learning, check out the following resources:
 
-*   [examples folder](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [examples folder](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ## Manage
 
-*   [Differences between CMK Administrators vs. CMK Users](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-master-key/README.md#cmk-administrators-vs-cmk-users)
+*   [Differences between CMK Administrators vs. CMK Users](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-master-key/README.md#cmk-administrators-vs-cmk-users)
 
-*   [Differences between managing access control with KMS key policies vs. IAM policies](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-master-key/README.md#managing-a-keys-permissions-with-the-key-policy-vs-iam-policies)
+*   [Differences between managing access control with KMS key policies vs. IAM policies](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-master-key/README.md#managing-a-keys-permissions-with-the-key-policy-vs-iam-policies)
 
-*   [What is the difference between KMS Grants and Key Policies?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-grant-multi-region/core-concepts.md#what-is-the-difference-between-kms-grants-and-key-policies)
+*   [What is the difference between KMS Grants and Key Policies?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-grant-multi-region/core-concepts.md#what-is-the-difference-between-kms-grants-and-key-policies)
 
-*   [How do I use KMS Grants to share encrypted AMIs across accounts?](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-grant-multi-region/core-concepts.md#how-do-i-use-kms-grants-to-share-encrypted-amis-across-accounts)
+*   [How do I use KMS Grants to share encrypted AMIs across accounts?](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-grant-multi-region/core-concepts.md#how-do-i-use-kms-grants-to-share-encrypted-amis-across-accounts)
 
 ## Sample Usage
 
@@ -518,11 +518,11 @@ A map from region to IDs of the replica KMS CMKs that were created. The value wi
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-master-key-multi-region/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-master-key-multi-region/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-master-key-multi-region/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-master-key-multi-region/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-master-key-multi-region/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-master-key-multi-region/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "2df8fae928e766b1ab923bce09e50054"
+  "hash": "2ba0f7e30401b7da2fb573bae9a9b23e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/kms-master-key/kms-master-key.md
+++ b/docs/reference/modules/terraform-aws-security/kms-master-key/kms-master-key.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # KMS Master Key Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-master-key" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-master-key" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.67.2" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -446,11 +446,11 @@ A map of CMK name to CMK ID.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-master-key/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-master-key/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/kms-master-key/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-master-key/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-master-key/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/kms-master-key/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "d1abc308fbebe624d122b15876ee3d16"
+  "hash": "48702a483180e1862183c54e86c71563"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/ntp/ntp.md
+++ b/docs/reference/modules/terraform-aws-security/ntp/ntp.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # NTP Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ntp" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ntp" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.67.1" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -35,11 +35,11 @@ Originally, Amazon recommended installing `ntpd` to prevent clock drift. Today, 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ntp/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ntp/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ntp/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ntp/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ntp/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ntp/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "6233b8579215a151ad4ca8afb9b7fba9"
+  "hash": "36487fe00aced078be2f094ba1418f4d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/os-hardening/os-hardening.md
+++ b/docs/reference/modules/terraform-aws-security/os-hardening/os-hardening.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # OS Hardening
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/os-hardening" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/os-hardening" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.67.7" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -31,8 +31,8 @@ is mounting multiple partitions. We hope to implement more CIS recommendations o
 
 There are two major components to this module:
 
-*   [ami-builder](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/os-hardening/ami-builder): This is a Terraform template that launches an EC2 Instance with Packer pre-installed.
-*   [partition-scripts](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/os-hardening/partition-scripts): This is a set of bash scripts that create multiple disk partitions, format them
+*   [ami-builder](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/os-hardening/ami-builder): This is a Terraform template that launches an EC2 Instance with Packer pre-installed.
+*   [partition-scripts](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/os-hardening/partition-scripts): This is a set of bash scripts that create multiple disk partitions, format them
     as ext4, and mount them to various paths with various mount options such as `noexec` or `nosuid`. These scripts are
     meant to be run in a Packer template that uses the Packer [amazon-chroot](https://www.packer.io/docs/builders/amazon-chroot.html)
     builder.
@@ -45,7 +45,7 @@ Fundamentally, to generate an AMI you must:
 4.  SSH into the ami-builder EC2 Instance and run `packer build amazon-linux.json` to build the AMI.
 5.  Terminate the ami-builder EC2 Instance.
 
-We recognize that is a lot of manual steps to build a single AMI, so check out the [os-hardening example](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples/os-hardening)
+We recognize that is a lot of manual steps to build a single AMI, so check out the [os-hardening example](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples/os-hardening)
 for a pre-built Packer template plus a script (`packer-build.sh`) that will automate all the above steps.
 
 ### Why do I need to launch a separate EC2 Instance to run Packer?
@@ -55,7 +55,7 @@ See below for additional details on what this is and how to use it.
 
 ## How to Use this Module
 
-**The best way to use this module is to substantially copy the [os-hardening example code](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples/os-hardening).
+**The best way to use this module is to substantially copy the [os-hardening example code](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples/os-hardening).
 Unlike most Gruntwork examples, the example for this module contains a full Packer build file plus a wrapper script to
 create the AMI with a single command and may be viewed as a "canonical" way to instantiate the os-hardening modules.**
 
@@ -71,11 +71,11 @@ hardened OS will use. Follow these steps:
     and sizes:
 
     *   `partition-volume`: For each desired partition, add an argument like `--partition '/home:4G'`. For additional
-        details see [partition-volume](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/os-hardening/partition-scripts/bin/partition-volume). Note that for the last `--partition` entry only,
+        details see [partition-volume](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/os-hardening/partition-scripts/bin/partition-volume). Note that for the last `--partition` entry only,
         you may specify `*` for the size to tell the script to create the largest possible partition based on remaining
         disk space. Also, make sure your partition sizes don't exceed the space available on your EBS Volume!
     *   `cleanup-volume`: For each desired partition, add an argument like `--mount-point '/home'`. For additional details see
-        [cleanup-volume](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/os-hardening/partition-scripts/bin/cleanup-volume)
+        [cleanup-volume](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/os-hardening/partition-scripts/bin/cleanup-volume)
 
     Note that you will redundantly pass the same list of partition paths to each of the above scripts, but only
     `partition-volume` needs both the mount point *and* the desired partition size.
@@ -86,10 +86,10 @@ That's it! The Packer template will take care of the rest.
 
 ### How to Build the AMI with Packer
 
-Now we're ready to build the actual AMI. Note: The [os-hardening example](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples/os-hardening) contains a script
+Now we're ready to build the actual AMI. Note: The [os-hardening example](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples/os-hardening) contains a script
 that automates all these steps, but, for the sake of understanding, we'll describe them individually below:
 
-1.  Launch the [ami-builder](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/os-hardening/ami-builder) EC2 Instance. We will execute Packer from this EC2 Instance.
+1.  Launch the [ami-builder](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/os-hardening/ami-builder) EC2 Instance. We will execute Packer from this EC2 Instance.
 
 2.  On your local machine run `rsync` so that your local directory is continually synced to the ami-builder:
 
@@ -127,7 +127,7 @@ additional volumes mounted as encrypted volumes.
 
 ### Using Your Hardened OS as a "Base AMI"
 
-A best practice we encourage is to first build your hardened OS Image using these modules and the [os-hardening example](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples/os-hardening).
+A best practice we encourage is to first build your hardened OS Image using these modules and the [os-hardening example](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples/os-hardening).
 You can now view this AMI as your "base AMI", and all other Packer builds can be built on top of this AMI. For example,
 you might have:
 
@@ -270,11 +270,11 @@ needed additional space to build a new AMI was not unreasonable.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/os-hardening/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/os-hardening/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/os-hardening/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/os-hardening/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/os-hardening/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/os-hardening/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "c642a080ba30f9ead819c7c714846bf5"
+  "hash": "f6e0184ca0788e2b6a8709b0bf400fb4"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/private-s3-bucket/private-s3-bucket.md
+++ b/docs/reference/modules/terraform-aws-security/private-s3-bucket/private-s3-bucket.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Private S3 Bucket
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/private-s3-bucket" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/private-s3-bucket" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.67.4" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -1013,11 +1013,11 @@ The name of an IAM role that can be used to configure replication from various s
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/private-s3-bucket/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/private-s3-bucket/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/private-s3-bucket/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/private-s3-bucket/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/private-s3-bucket/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/private-s3-bucket/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "3d34c54e6abe1ef11c613063d6c1c46c"
+  "hash": "11c8810827142ed2aa915bb867eb654b"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/saml-iam-roles/saml-iam-roles.md
+++ b/docs/reference/modules/terraform-aws-security/saml-iam-roles/saml-iam-roles.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # A best-practices set of IAM roles for SAML access
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/saml-iam-roles" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/saml-iam-roles" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.65.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -47,7 +47,7 @@ This module creates the following IAM roles (all optional):
 
 *   **allow-ssh-grunt-access-from-saml**: Users authenticated by the SAML providers in
     `var.allow_ssh_grunt_access_from_saml_provider_arns` will get read access to IAM Groups and public SSH keys. This is
-    useful to allow [ssh-grunt](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt) running on EC2 Instances in other AWS accounts to validate SSH
+    useful to allow [ssh-grunt](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt) running on EC2 Instances in other AWS accounts to validate SSH
     connections against IAM users defined in this AWS account.
 
 *   **allow-dev-access-from-saml**:Users authenticated by the SAML providers in
@@ -890,11 +890,11 @@ A map of tags to apply to the IAM roles.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/saml-iam-roles/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/saml-iam-roles/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/saml-iam-roles/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/saml-iam-roles/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/saml-iam-roles/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/saml-iam-roles/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "31d42d0380ffe1f7b2da6d59c5aaa80d"
+  "hash": "b18beaa8c380fb4a5bd3612a34739cd6"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/secrets-manager-resource-policies/secrets-manager-resource-policies.md
+++ b/docs/reference/modules/terraform-aws-security/secrets-manager-resource-policies/secrets-manager-resource-policies.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Resource-based policies for Secrets Manager secrets
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/secrets-manager-resource-policies" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/secrets-manager-resource-policies" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.67.3" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -88,11 +88,11 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/secrets-manager-resource-policies/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/secrets-manager-resource-policies/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/secrets-manager-resource-policies/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/secrets-manager-resource-policies/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/secrets-manager-resource-policies/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/secrets-manager-resource-policies/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "714a8e70c635c326d232c9dd83a21ee3"
+  "hash": "df84eeb5b19e8743101dfdc372122443"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/ssh-grunt-selinux-policy/ssh-grunt-selinux-policy.md
+++ b/docs/reference/modules/terraform-aws-security/ssh-grunt-selinux-policy/ssh-grunt-selinux-policy.md
@@ -13,11 +13,11 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # SSH Grunt SELinux Policy
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt-selinux-policy" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt-selinux-policy" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.44.10" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
-This module installs a SELinux Local Policy Module that is necessary to make [ssh-grunt](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt) work on
+This module installs a SELinux Local Policy Module that is necessary to make [ssh-grunt](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt) work on
 systems with SELinux, such as CentOS.
 
 The reason we need a policy is that `ssh-grunt` uses is executed on each attempted SSH login by the
@@ -84,11 +84,11 @@ $ sudo semodule -i ssh-grunt.pp
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt-selinux-policy/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt-selinux-policy/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt-selinux-policy/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt-selinux-policy/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt-selinux-policy/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt-selinux-policy/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "55b81bbe0db19a9d0e3251c73c4f64a3"
+  "hash": "07ce8c4c416e1def3d5f34cfa6fc9329"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/ssh-grunt/ssh-grunt.md
+++ b/docs/reference/modules/terraform-aws-security/ssh-grunt/ssh-grunt.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # SSH Grunt
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.67.8" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -47,19 +47,19 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 ### Core concepts
 
-*   [How to install ssh-grunt on your servers](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt/core-concepts.md#install-ssh-grunt-on-your-servers)
+*   [How to install ssh-grunt on your servers](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt/core-concepts.md#install-ssh-grunt-on-your-servers)
 
-*   [How SSH Grunt works](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt/core-concepts.md#how-it-works)
+*   [How SSH Grunt works](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt/core-concepts.md#how-it-works)
 
-*   [Core Security Concepts](https://github.com/gruntwork-io/terraform-aws-security/tree/main/README.adoc#core-concepts)
+*   [Core Security Concepts](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/README.adoc#core-concepts)
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules): the main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/test): Automated tests for the modules and examples.
 
 ## Deploy
 
@@ -67,9 +67,9 @@ This repo is a part of [the Gruntwork Infrastructure as Code Library](https://gr
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [ssh-grunt examples](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples/ssh-grunt): The `examples/ssh-grunt` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [ssh-grunt examples](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples/ssh-grunt): The `examples/ssh-grunt` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
-*   [Packer template](https://github.com/gruntwork-io/terraform-aws-security/tree/main/examples/ssh-grunt/packer/ssh-grunt-iam.json)
+*   [Packer template](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/examples/ssh-grunt/packer/ssh-grunt-iam.json)
 
 ### Production deployment
 
@@ -85,19 +85,19 @@ If you want to deploy this module in production, check out the following resourc
 
 ### Day-to-day operations
 
-*   [How to manage SSH keys](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt/core-concepts.md#upload-public-ssh-keys)
+*   [How to manage SSH keys](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt/core-concepts.md#upload-public-ssh-keys)
 
-*   [IAM permissions required for ssh-grunt to work](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt/core-concepts.md#set-up-iam-permissions)
+*   [IAM permissions required for ssh-grunt to work](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt/core-concepts.md#set-up-iam-permissions)
 
 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "4126c60564c0388950bece507596fa94"
+  "hash": "c2944792bb17afe247f3094a2fafc5cc"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/ssh-iam/ssh-iam.md
+++ b/docs/reference/modules/terraform-aws-security/ssh-iam/ssh-iam.md
@@ -13,22 +13,22 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # ssh-iam has been renamed!
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-iam" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-iam" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.13.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
-`ssh-iam` has been renamed to [ssh-grunt](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt). Please update all links to point to
-[ssh-grunt](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-grunt)!
+`ssh-iam` has been renamed to [ssh-grunt](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt). Please update all links to point to
+[ssh-grunt](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-grunt)!
 
 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-iam/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-iam/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssh-iam/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-iam/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-iam/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssh-iam/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "e6568c0ca6ed462c77f533c9e8023277"
+  "hash": "14bea5849505e3ff268318539448dc7a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/ssm-healthchecks-iam-permissions/ssm-healthchecks-iam-permissions.md
+++ b/docs/reference/modules/terraform-aws-security/ssm-healthchecks-iam-permissions/ssm-healthchecks-iam-permissions.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # SSM Healthchecks IAM Permissions
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssm-healthchecks-iam-permissions" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssm-healthchecks-iam-permissions" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.65.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -94,11 +94,11 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssm-healthchecks-iam-permissions/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssm-healthchecks-iam-permissions/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/ssm-healthchecks-iam-permissions/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssm-healthchecks-iam-permissions/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssm-healthchecks-iam-permissions/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/ssm-healthchecks-iam-permissions/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "b42f3e39af37258a5291220cd1e85c87"
+  "hash": "6d32f6138fadd3c1541cf053172d21c6"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-security/tls-cert-private/tls-cert-private.md
+++ b/docs/reference/modules/terraform-aws-security/tls-cert-private/tls-cert-private.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Generate a TLS/SSL Certificate for a Private Service
 
-<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/tls-cert-private" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/tls-cert-private" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.47.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -35,7 +35,7 @@ using a commercial CA or public, free CA like [Let's Encrypt](https://letsencryp
 1.  Edit the `docker-compose.yml` file and fill in your desired argument values.
 2.  Now run `docker-compose up` and your TLS certs will output to a local `output` directory!
 
-To see documentation on the arguments in `docker-compose.yml`, see the [main.sh](https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/tls-cert-private/scripts/main.sh) file.
+To see documentation on the arguments in `docker-compose.yml`, see the [main.sh](https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/tls-cert-private/scripts/main.sh) file.
 
 Note that the Docker Compose file mounts the local machine folder `./output` in the Docker container. Mac and Windows
 users sohuld take note that, in some cases, volume mounting may be extremely slow, or even one-way-only if you use an
@@ -177,11 +177,11 @@ TLS certificates for any public services.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/tls-cert-private/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/tls-cert-private/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-security/tree/main/modules/tls-cert-private/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/tls-cert-private/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/tls-cert-private/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-security/tree/v0.67.8/modules/tls-cert-private/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "28fd9799cc31e3e0918918640cfae3db"
+  "hash": "e682ec874015dae1807ade0a27b15ae0"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-server/attach-eni/attach-eni.md
+++ b/docs/reference/modules/terraform-aws-server/attach-eni/attach-eni.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Attach ENI Scripts
 
-<a href="https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/attach-eni" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/attach-eni" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.15.3" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -30,7 +30,7 @@ This folder contains scripts you can use to attach [Elastic Network Interfaces
 
 An ENI allows you to have IP addresses that remain static, even if the underlying EC2 Instances are changing.
 
-Check out the [attach-eni example](https://github.com/gruntwork-io/terraform-aws-server/tree/main/examples/attach-eni) for how to use these scripts with Terraform.
+Check out the [attach-eni example](https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/examples/attach-eni) for how to use these scripts with Terraform.
 
 ## Installing the attach-eni script
 
@@ -47,7 +47,7 @@ The `attach-eni` script has the following prerequisites:
 1.  It must be run as root
 2.  It must be run on an EC2 instance
 3.  The EC2 instance must have an IAM role with permissions to search ENIs and EC2 tags, as well as attach ENIs (see the
-    [attach-eni example](https://github.com/gruntwork-io/terraform-aws-server/tree/main/examples/attach-eni))
+    [attach-eni example](https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/examples/attach-eni))
 4.  The EC2 instance must have the AWS CLI and jq installed
 
 Typically, you'll want to run the `attach-eni` script in the User Data of your EC2 instances so it attaches the ENI at
@@ -71,11 +71,11 @@ This tells the script to try find and attach an ENI with the same `Name` tag as 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/attach-eni/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/attach-eni/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/attach-eni/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/attach-eni/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/attach-eni/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/attach-eni/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "36a67dd78150ac1ba86c0828df183a9d"
+  "hash": "165b89b6fff232c97a17031745253efb"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-server/disable-instance-metadata/disable-instance-metadata.md
+++ b/docs/reference/modules/terraform-aws-server/disable-instance-metadata/disable-instance-metadata.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Disable Instance Metadata Access script
 
-<a href="https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/disable-instance-metadata" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/disable-instance-metadata" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.13.4" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -26,7 +26,7 @@ Once that is done, you can call this script to further secure your instance by d
 `disable-instance-metadata`: This script can be run on an EC2 instance to disable further access to the Instance Metadata service from that instance. It uses
 the AWS API to disable access to the endpoint.
 
-Check out the [route53-helpers example](https://github.com/gruntwork-io/terraform-aws-server/tree/main/examples/route53-helpers) for how to use these scripts with Packer and Terraform.
+Check out the [route53-helpers example](https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/examples/route53-helpers) for how to use these scripts with Packer and Terraform.
 
 ## Installing the scripts
 
@@ -42,7 +42,7 @@ The `disable-instance-metadata` script has the following prerequisites:
 
 1.  It must be run on an EC2 instance
 2.  The EC2 instance must have an IAM role with permissions to modify the Instance Metadata service's options. See the
-    [route53-helpers example](https://github.com/gruntwork-io/terraform-aws-server/tree/main/examples/route53-helpers)) for a reference implementation.
+    [route53-helpers example](https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/examples/route53-helpers)) for a reference implementation.
 3.  The EC2 instance must have the AWS CLI (version 2.2.37 or higher), unzip and jq installed.
 
 Run the `disable-instance-metadata` script in the User Data of your EC2 instances, after any required calls to the Instance Metadata service have been made. This way, your instances will still be able to access the Instance Metadata service when needed, but will also disable further access to the service upon boot.
@@ -75,11 +75,11 @@ This will result in subsequent calls to the Instance Metadata service to fail.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/disable-instance-metadata/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/disable-instance-metadata/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/disable-instance-metadata/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/disable-instance-metadata/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/disable-instance-metadata/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/disable-instance-metadata/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "13cbd95402ae9b58d5747b3f082a9bba"
+  "hash": "1a8e0ef93729dfb5218a0eb14ec6033b"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-server/ec2-backup/ec2-backup.md
+++ b/docs/reference/modules/terraform-aws-server/ec2-backup/ec2-backup.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # EC2 Backup Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/ec2-backup" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/ec2-backup" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.15.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -303,11 +303,11 @@ The name of the IAM role associated with the data lifecycle manager
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/ec2-backup/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/ec2-backup/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/ec2-backup/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/ec2-backup/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/ec2-backup/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/ec2-backup/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "f81d2a164916254f14d0568f0f2caf63"
+  "hash": "498b2df48f48977f67c1c19a6168888a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-server/persistent-ebs-volume/persistent-ebs-volume.md
+++ b/docs/reference/modules/terraform-aws-server/persistent-ebs-volume/persistent-ebs-volume.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Persistent EBS Volume Scripts
 
-<a href="https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/persistent-ebs-volume" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/persistent-ebs-volume" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.15.3" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -40,7 +40,7 @@ volume can only be associated with a single EC2 Instance, so if you need the dat
 multiple servers, check out the [Amazon Elastic File System](https://aws.amazon.com/efs/), which provides a service
 built on top of NFS.
 
-Check out the [persistent-ebs-volume example](https://github.com/gruntwork-io/terraform-aws-server/tree/main/examples/persistent-ebs-volume) for how to use these scripts with
+Check out the [persistent-ebs-volume example](https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/examples/persistent-ebs-volume) for how to use these scripts with
 Terraform.
 
 ## Installing the scripts
@@ -58,7 +58,7 @@ The scripts have the following prerequisites:
 1.  They must be run as root
 2.  They must be run on an EC2 instance
 3.  The EC2 instance must have an IAM role with permissions to list, attach, and detach volumes (see the
-    [persistent-ebs-volume example](https://github.com/gruntwork-io/terraform-aws-server/tree/main/examples/persistent-ebs-volume))
+    [persistent-ebs-volume example](https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/examples/persistent-ebs-volume))
 4.  The EC2 instance must have the AWS CLI and jq installed
 
 Run the `mount-ebs-volume` script in the User Data of your EC2 instances so it mounts the volume at boot. Run the
@@ -220,11 +220,11 @@ detaching the device.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/persistent-ebs-volume/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/persistent-ebs-volume/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/persistent-ebs-volume/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/persistent-ebs-volume/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/persistent-ebs-volume/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/persistent-ebs-volume/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "38c905c8a8a63b82db1bb604a556d764"
+  "hash": "6238b5122e1db759879219266ae308ad"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-server/require-instance-metadata-service-version/require-instance-metadata-service-version.md
+++ b/docs/reference/modules/terraform-aws-server/require-instance-metadata-service-version/require-instance-metadata-service-version.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Require Instance Metadata Service version script
 
-<a href="https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/require-instance-metadata-service-version" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/require-instance-metadata-service-version" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.13.6" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -24,7 +24,7 @@ This folder contains a script (`require-instance-metadata-service-version`) you 
 
 Learn more at [the official AWS EC2 Instance Metadata Service documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).
 
-Check out the [route53-helpers example](https://github.com/gruntwork-io/terraform-aws-server/tree/main/examples/route53-helpers) for how to use these scripts with Packer and Terraform.
+Check out the [route53-helpers example](https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/examples/route53-helpers) for how to use these scripts with Packer and Terraform.
 
 ## Installing bash-commons
 
@@ -49,7 +49,7 @@ The `require-instance-metadata-service-version` script has the following prerequ
 1.  It must be run on an EC2 instance
 2.  It requires that `bash-commons` version `v0.1.8` or newer is installed on the EC2 Instance. See instructions above.
 3.  The EC2 instance must have an IAM role with permissions to modify the Instance Metadata service's options. See the
-    [route53-helpers example](https://github.com/gruntwork-io/terraform-aws-server/tree/main/examples/route53-helpers)) for a reference implementation.
+    [route53-helpers example](https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/examples/route53-helpers)) for a reference implementation.
 4.  The EC2 instance must have the AWS CLI (version 2.2.37 or higher), unzip and jq installed.
 
 Run the `require-instance-metadata-service-version` script in the User Data of your EC2 instances, prior to any calls to the Instance Metadata Service to configure if you want `2.0` credentials to be `required` or `optional`.
@@ -98,11 +98,11 @@ Setting Instance Metadata Service version 2 state to optional
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/require-instance-metadata-service-version/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/require-instance-metadata-service-version/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/require-instance-metadata-service-version/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/require-instance-metadata-service-version/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/require-instance-metadata-service-version/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/require-instance-metadata-service-version/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "0cce4c1e8966bdd1d826cd88b33fd57a"
+  "hash": "f77b307a545bf15976c6a6672d704237"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-server/route53-helpers/route53-helpers.md
+++ b/docs/reference/modules/terraform-aws-server/route53-helpers/route53-helpers.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Route 53 Helpers
 
-<a href="https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/route53-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/route53-helpers" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.13.4" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -23,7 +23,7 @@ The helpers are:
 *   `add-dns-a-record`: A script that can be run on an EC2 instance to add a DNS A record pointing to the instance's IP
     address.
 
-Check out the [route53-helpers example](https://github.com/gruntwork-io/terraform-aws-server/tree/main/examples/route53-helpers) for how to use these scripts with Terraform.
+Check out the [route53-helpers example](https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/examples/route53-helpers) for how to use these scripts with Terraform.
 
 ## Installing the helpers
 
@@ -69,17 +69,17 @@ Here is an example of an IAM policy your EC2 instance needs attached to its IAM 
 }
 ```
 
-Check out the [route53-helpers example](https://github.com/gruntwork-io/terraform-aws-server/tree/main/examples/route53-helpers) to see what this looks like in action.
+Check out the [route53-helpers example](https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/examples/route53-helpers) to see what this looks like in action.
 
 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/route53-helpers/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/route53-helpers/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/route53-helpers/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/route53-helpers/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/route53-helpers/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/route53-helpers/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "f4b5dd0ab1b374309052d0bf13dbf5cf"
+  "hash": "7b07e2be98f93ea44c65110230a8b92d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-server/single-server/single-server.md
+++ b/docs/reference/modules/terraform-aws-server/single-server/single-server.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Single Server Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/single-server" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/single-server" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.15.2" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -1057,11 +1057,11 @@ When used in combination with user_data or user_data_base64, a user_data change 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/single-server/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/single-server/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/main/modules/single-server/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/single-server/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/single-server/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/single-server/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "465b3b2ea058d63a66c91ca2d2491e43"
+  "hash": "5ff22bf619b701d0e484a27e4c604353"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-static-assets/s3-cloudfront/s3-cloudfront.md
+++ b/docs/reference/modules/terraform-aws-static-assets/s3-cloudfront/s3-cloudfront.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # S3 CloudFront Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/modules/s3-cloudfront" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/modules/s3-cloudfront" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.15.9" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -21,13 +21,13 @@ This module deploys a [CloudFront](https://aws.amazon.com/cloudfront/) distribut
 (CDN) in front of an [S3 bucket](https://aws.amazon.com/s3/). This reduces latency for your users, by caching your
 static content in servers around the world. It also allows you to use SSL with the static content in an S3 bucket.
 
-See the [s3-static-website module](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/modules/s3-static-website) for how to deploy static content in an S3 bucket.
+See the [s3-static-website module](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/modules/s3-static-website) for how to deploy static content in an S3 bucket.
 
 ## Quick Start
 
-*   See the [cloudfront-s3-public](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/examples/cloudfront-s3-public) and
-    [cloudfront-s3-private](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/examples/cloudfront-s3-private) examples for working sample code.
-*   Check out [vars.tf](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/modules/s3-cloudfront/vars.tf) for all parameters you can set for this module.
+*   See the [cloudfront-s3-public](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/examples/cloudfront-s3-public) and
+    [cloudfront-s3-private](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/examples/cloudfront-s3-private) examples for working sample code.
+*   Check out [vars.tf](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/modules/s3-cloudfront/vars.tf) for all parameters you can set for this module.
 
 ## Public vs private S3 buckets
 
@@ -130,7 +130,7 @@ most use cases, but is not particularly flexible. In particular, the limitations
 *   Only one default cache behavior is supported
     ([cache behaviors](https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#cache-behavior-arguments)
     is an inline block). You can control the default cache settings using a number of parameters, including
-    `cached_methods`, `default_ttl`, `min_ttl`, `max_ttl`, and many others (see [vars.tf](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/modules/s3-cloudfront/vars.tf) for the full list).
+    `cached_methods`, `default_ttl`, `min_ttl`, `max_ttl`, and many others (see [vars.tf](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/modules/s3-cloudfront/vars.tf) for the full list).
 
 *   Only two error responses are supported
     ([error responses](https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#custom-error-response-arguments)
@@ -1405,11 +1405,11 @@ If you have specified whitelist in <a href="#forward_cookies"><code>forward_cook
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/modules/s3-cloudfront/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/modules/s3-cloudfront/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/modules/s3-cloudfront/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/modules/s3-cloudfront/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/modules/s3-cloudfront/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/modules/s3-cloudfront/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "ee2d070128a69ee11cb1d5fe7724de9b"
+  "hash": "2e85d483328f13ec064d85e1818ab0dc"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-static-assets/s3-static-website/s3-static-website.md
+++ b/docs/reference/modules/terraform-aws-static-assets/s3-static-website/s3-static-website.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # S3 Static Website
 
-<a href="https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/modules/s3-static-website" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/modules/s3-static-website" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.16.1" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -29,7 +29,7 @@ This module creates an AWS S3 bucket that can be used to host a static website. 
 
 *   Optionally configure a custom domain name for the website.
 
-*   Optionally deploy a CDN in front of S3 using the [s3-cloudfront module](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/modules/s3-cloudfront).
+*   Optionally deploy a CDN in front of S3 using the [s3-cloudfront module](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/modules/s3-cloudfront).
 
 ## Learn
 
@@ -37,23 +37,23 @@ The reason to serve static content from S3 rather than from your own app server 
 
 ### Core concepts
 
-*   [Quick Start](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/modules/s3-static-website/core-concepts.md#quick-start)
+*   [Quick Start](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/modules/s3-static-website/core-concepts.md#quick-start)
 
-*   [How to test the website](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/modules/s3-static-website/core-concepts.md#how-to-test-the-website)
+*   [How to test the website](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/modules/s3-static-website/core-concepts.md#how-to-test-the-website)
 
-*   [How to configure HTTPS (SSL) or a CDN?](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/modules/s3-static-website/core-concepts.md#how-to-configure-http)
+*   [How to configure HTTPS (SSL) or a CDN?](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/modules/s3-static-website/core-concepts.md#how-to-configure-http)
 
-*   [How to handle www + root domains](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/modules/s3-static-website/core-concepts.md#how-to-handle)
+*   [How to handle www + root domains](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/modules/s3-static-website/core-concepts.md#how-to-handle)
 
-*   [How do I configure Cross Origin Resource Sharing (CORS)?](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/modules/s3-static-website/core-concepts.md#how-do-i-configure-cross-origin-resource-sharing-cors)
+*   [How do I configure Cross Origin Resource Sharing (CORS)?](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/modules/s3-static-website/core-concepts.md#how-do-i-configure-cross-origin-resource-sharing-cors)
 
 ### Repo organization
 
-*   [modules](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/modules): The main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
+*   [modules](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/modules): The main implementation code for this repo, broken down into multiple standalone, orthogonal submodules.
 
-*   [examples](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/examples): This folder contains working examples of how to use the submodules.
+*   [examples](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/examples): This folder contains working examples of how to use the submodules.
 
-*   [test](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/test): Automated tests for the modules and examples.
+*   [test](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/test): Automated tests for the modules and examples.
 
 ## Deploy
 
@@ -61,7 +61,7 @@ The reason to serve static content from S3 rather than from your own app server 
 
 If you just want to try this repo out for experimenting and learning, check out the following resources:
 
-*   [Examples folder](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
+*   [Examples folder](https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/examples): The `examples` folder contains sample code optimized for learning, experimenting, and testing (but not production usage).
 
 ### Production deployment
 
@@ -854,11 +854,11 @@ A value that can be used to chain resources to depend on the website bucket bein
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/modules/s3-static-website/readme.adoc",
-    "https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/modules/s3-static-website/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-static-assets/tree/main/modules/s3-static-website/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/modules/s3-static-website/readme.adoc",
+    "https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/modules/s3-static-website/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-static-assets/tree/v0.16.1/modules/s3-static-website/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "51d3b5567fc2e2dd327f30966c0a1313"
+  "hash": "e36d5369d7b72937fd195ec0ddb329ed"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-utilities/executable-dependency/executable-dependency.md
+++ b/docs/reference/modules/terraform-aws-utilities/executable-dependency/executable-dependency.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Executable Dependency
 
-<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/executable-dependency" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/executable-dependency" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.8.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -27,7 +27,7 @@ if it's not installed already: e.g., [terraform-aws-eks](https://github.com/grun
 
 ## Example code
 
-See the [executable-dependency example](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/examples/executable-dependency) for working sample code.
+See the [executable-dependency example](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/examples/executable-dependency) for working sample code.
 
 ## Usage
 
@@ -245,11 +245,11 @@ The path to use to run the executable. Will either be the path of the executable
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/executable-dependency/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/executable-dependency/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/executable-dependency/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/executable-dependency/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/executable-dependency/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/executable-dependency/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "0dfe956315e9e6f4287d5b64e0f340d7"
+  "hash": "465718a033e6b271a232cb32f2009126"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-utilities/instance-type/instance-type.md
+++ b/docs/reference/modules/terraform-aws-utilities/instance-type/instance-type.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Instance Type
 
-<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/instance-type" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/instance-type" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.9.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -25,7 +25,7 @@ module to automatically figure out which instance type you should use.
 
 ## Example code
 
-See the [instance-type example](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/examples/instance-type) for working sample code.
+See the [instance-type example](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/examples/instance-type) for working sample code.
 
 ## Usage
 
@@ -161,11 +161,11 @@ The recommended instance type to use in this AWS region. This will be the first 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/instance-type/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/instance-type/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/instance-type/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/instance-type/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/instance-type/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/instance-type/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "3eebf57769c098f3c87a10970ea93c4b"
+  "hash": "1161978b4fd3c89a22868fef40cfc816"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-utilities/join-path/join-path.md
+++ b/docs/reference/modules/terraform-aws-utilities/join-path/join-path.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Join Path Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/join-path" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/join-path" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.7.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -25,7 +25,7 @@ This module uses Python under the hood so, the Python must be installed on the O
 
 ## Example code
 
-See the [join-path example](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/examples/join-path) for working sample code.
+See the [join-path example](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/examples/join-path) for working sample code.
 
 ## Usage
 
@@ -150,11 +150,11 @@ A list of folder and file names to combine into a path, using the proper path se
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/join-path/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/join-path/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/join-path/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/join-path/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/join-path/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/join-path/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "e0b4d1fd8b14830ce4927dec5de87afe"
+  "hash": "8204a67a8f5e1434230e0e5532e6c406"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-utilities/list-remove/list-remove.md
+++ b/docs/reference/modules/terraform-aws-utilities/list-remove/list-remove.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # List Remove Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/list-remove" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/list-remove" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.7.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -43,7 +43,7 @@ The output `new_list` should be the list `["us-east-1a", "us-east-1d", "us-east-
 
 ## Example code
 
-See the [list-remove example](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/examples/list-remove) for working sample code.
+See the [list-remove example](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/examples/list-remove) for working sample code.
 
 ## Sample Usage
 
@@ -161,11 +161,11 @@ Any types represent complex values of variable type. For details, please consult
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/list-remove/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/list-remove/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/list-remove/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/list-remove/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/list-remove/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/list-remove/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "e7255c95f1dad29cd9c6f21c0a9effd1"
+  "hash": "81693e272fa1cfc8a02fdead6ae80377"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-utilities/operating-system/operating-system.md
+++ b/docs/reference/modules/terraform-aws-utilities/operating-system/operating-system.md
@@ -13,19 +13,19 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Operating System Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/operating-system" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/operating-system" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.8.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This is a module that can be used to figure out what operating system is being used to run Terraform. This may be used
 to modify Terraform's behavior depending on the OS, such as modifying the way you format file paths on Linux vs
-Windows (see also the [join-path module](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/join-path)).
+Windows (see also the [join-path module](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/join-path)).
 
 This module uses Python under the hood so, the Python must be installed on the OS.
 
 ## Example code
 
-See the [operating-system example](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/examples/operating-system) for working sample code.
+See the [operating-system example](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/examples/operating-system) for working sample code.
 
 ## Usage
 
@@ -53,11 +53,11 @@ path_separator        = "${module.os.path_separator}"
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/operating-system/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/operating-system/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/operating-system/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/operating-system/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/operating-system/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/operating-system/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "106c79db1428867e215870407b798983"
+  "hash": "20974b3df2df0de3966b9f2272bb7064"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-utilities/prepare-pex-environment/prepare-pex-environment.md
+++ b/docs/reference/modules/terraform-aws-utilities/prepare-pex-environment/prepare-pex-environment.md
@@ -13,12 +13,12 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Prepare PEX Environment Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/prepare-pex-environment" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/prepare-pex-environment" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.8.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
-**NOTE**: This module should not be used directly. Use [run-pex-as-data-source](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/run-pex-as-data-source) or
-[run-pex-as-resource](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/run-pex-as-resource) instead.
+**NOTE**: This module should not be used directly. Use [run-pex-as-data-source](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/run-pex-as-data-source) or
+[run-pex-as-resource](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/run-pex-as-resource) instead.
 
 This module can be used to prepare an runtime environment that can call out to a PEX binary. Specifically, this module:
 
@@ -30,7 +30,7 @@ This module uses Python under the hood so, the Python must be installed on the O
 
 ## What is PEX?
 
-PEX (or Python EXecutable) is an executable python environment in the spirit of [virtualenvs](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/prepare-pex-environment/virtualenv.org). It is
+PEX (or Python EXecutable) is an executable python environment in the spirit of [virtualenvs](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/prepare-pex-environment/virtualenv.org). It is
 generated using the [pex](https://github.com/pantsbuild/pex) library, and is an executable zip file containing:
 
 *   An bootstrap script in python that unpacks the requirements and includes them in the `PYTHONPATH` (`sys.path`).
@@ -71,7 +71,7 @@ This will search [`pypi`](https://pypi.org/) for the python packages defined in 
 specified platform and python versions, download the wheel/package, inject the bootstrap script and produce an
 executable zip file.
 
-See the [`pex/sample-python-script` example](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/examples/pex/sample-python-script) for an example implementation that you
+See the [`pex/sample-python-script` example](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/examples/pex/sample-python-script) for an example implementation that you
 can use as a template.
 
 ### Known limitations of PEX
@@ -226,11 +226,11 @@ The python path that should be used for running PEX file. This should be set as 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/prepare-pex-environment/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/prepare-pex-environment/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/prepare-pex-environment/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/prepare-pex-environment/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/prepare-pex-environment/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/prepare-pex-environment/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "e585c56f7084a4edaaefef510348bde1"
+  "hash": "95f431b24d9f66130352233e2b56237f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-utilities/request-quota-increase/request-quota-increase.md
+++ b/docs/reference/modules/terraform-aws-utilities/request-quota-increase/request-quota-increase.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Request AWS Quota Increase
 
-<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/request-quota-increase" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/request-quota-increase" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.9.1" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -31,7 +31,7 @@ This module can be used to request a quota increase for an AWS Resource.
 
 ### Example code
 
-See the [request-quota-increase example](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/examples/request-quota-increase) for working sample code.
+See the [request-quota-increase example](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/examples/request-quota-increase) for working sample code.
 
 ## Usage
 
@@ -51,7 +51,7 @@ module "path" {
 
 The argument to pass is:
 
-*   `request_quota_increase`: A map with the desired resource and the new quota. The current supported resources are `nat_gateway` and `nacl_rules`. Feel free to contribute to this module to add support for more `quota_code` and `service_code` options in [main.tf](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/request-quota-increase/main.tf)!
+*   `request_quota_increase`: A map with the desired resource and the new quota. The current supported resources are `nat_gateway` and `nacl_rules`. Feel free to contribute to this module to add support for more `quota_code` and `service_code` options in [main.tf](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/request-quota-increase/main.tf)!
 
 When you run `apply`, the `new_quotas` output variable will confirm to you that a quota request has been made!
 
@@ -233,11 +233,11 @@ A map where the key is the resource and the value is the desired quota. The only
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/request-quota-increase/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/request-quota-increase/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/request-quota-increase/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/request-quota-increase/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/request-quota-increase/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/request-quota-increase/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "1e98eec77fd8fd8548379690d3929736"
+  "hash": "83d4cad63cf946d695d294646f3edac9"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-utilities/require-executable/require-executable.md
+++ b/docs/reference/modules/terraform-aws-utilities/require-executable/require-executable.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Require Executable Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/require-executable" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/require-executable" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.9.1" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -28,7 +28,7 @@ This module uses Python under the hood, so Python must be installed and availabl
 
 ## Example code
 
-See the [require-executable example](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/examples/require-executable) for working sample code.
+See the [require-executable example](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/examples/require-executable) for working sample code.
 
 ## Conditional check
 
@@ -170,11 +170,11 @@ A map of the executables to the resolved path where they reside.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/require-executable/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/require-executable/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/require-executable/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/require-executable/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/require-executable/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/require-executable/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "d4f0751994f18a37d2d0f8a130fb5c28"
+  "hash": "509eabced1c12afaaa4e585689d20794"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-utilities/run-pex-as-data-source/run-pex-as-data-source.md
+++ b/docs/reference/modules/terraform-aws-utilities/run-pex-as-data-source/run-pex-as-data-source.md
@@ -13,15 +13,15 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Run PEX as Data Source
 
-<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/run-pex-as-data-source" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/run-pex-as-data-source" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.8.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This module runs the provided PEX binary in a portable manner that works with multiple platforms and python versions, to
 be used as an [external data source](https://www.terraform.io/docs/providers/external/data_source.html) in Terraform.
 
-This module uses [`prepare-pex-environment`](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/prepare-pex-environment) under the hood. See [What is
-PEX?](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/prepare-pex-environment/README.md#what-is-pex) for more details on what is a PEX file and how to construct one
+This module uses [`prepare-pex-environment`](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/prepare-pex-environment) under the hood. See [What is
+PEX?](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/prepare-pex-environment/README.md#what-is-pex) for more details on what is a PEX file and how to construct one
 for use with this module.
 
 ## Data Source vs Resource
@@ -34,7 +34,7 @@ allow you to call out to arbitrary binaries available on the operator machine. T
 *   [local-exec Provisioners](https://www.terraform.io/docs/provisioners/local-exec.html), where you can run the binary to
     provision a resource.
 
-This module uses the data source approach (you can see the [run-pex-as-resource module](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/run-pex-as-resource) for
+This module uses the data source approach (you can see the [run-pex-as-resource module](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/run-pex-as-resource) for
 running it as a data source). Which approach to use depends on your needs:
 
 *   Data sources are calculated every time a terraform state needs to be refreshed. This includes all `plan` and `apply`
@@ -251,11 +251,11 @@ Data source result of executing the PEX binary.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/run-pex-as-data-source/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/run-pex-as-data-source/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/run-pex-as-data-source/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/run-pex-as-data-source/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/run-pex-as-data-source/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/run-pex-as-data-source/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "e298e464722855c3b9045b60411cfc9b"
+  "hash": "cb9ed0af8dc98c2a6c20b8ef39df6a37"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-utilities/run-pex-as-resource/run-pex-as-resource.md
+++ b/docs/reference/modules/terraform-aws-utilities/run-pex-as-resource/run-pex-as-resource.md
@@ -13,15 +13,15 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Run PEX as Resource
 
-<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/run-pex-as-resource" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/run-pex-as-resource" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-utilities/releases/tag/v0.8.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This module runs the provided PEX binary in a portable manner that works with multiple platforms and python versions, in
 the context of a [local-exec provisioner](https://www.terraform.io/docs/provisioners/local-exec.html) in Terraform.
 
-This module uses [`prepare-pex-environment`](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/prepare-pex-environment) under the hood. See [What is
-PEX?](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/prepare-pex-environment/README.md#what-is-pex) for more details on what is a PEX file and how to construct one
+This module uses [`prepare-pex-environment`](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/prepare-pex-environment) under the hood. See [What is
+PEX?](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/prepare-pex-environment/README.md#what-is-pex) for more details on what is a PEX file and how to construct one
 for use with this module.
 
 ## Data Source vs Resource
@@ -34,7 +34,7 @@ allow you to call out to arbitrary binaries available on the operator machine. T
 *   [local-exec Provisioners](https://www.terraform.io/docs/provisioners/local-exec.html), where you can run the binary to
     provision a resource.
 
-This module uses the Provisioner approach (you can see the [run-pex-as-data-source module](https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/run-pex-as-data-source)
+This module uses the Provisioner approach (you can see the [run-pex-as-data-source module](https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/run-pex-as-data-source)
 for running it as a data source). Which approach to use depends on your needs:
 
 *   Data sources are calculated every time a terraform state needs to be refreshed. This includes all `plan` and `apply`
@@ -306,11 +306,11 @@ This output is populated when the pex script successfully runs to completion. As
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/run-pex-as-resource/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/run-pex-as-resource/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/main/modules/run-pex-as-resource/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/run-pex-as-resource/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/run-pex-as-resource/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-utilities/tree/v0.9.1/modules/run-pex-as-resource/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "6ed6198e6e54528be9e822f90ee0276a"
+  "hash": "135f6e8171cfd0f34e7181dfcceed310"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-vpc/network-acl-inbound/network-acl-inbound.md
+++ b/docs/reference/modules/terraform-aws-vpc/network-acl-inbound/network-acl-inbound.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Network ACL Inbound Terraform Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/network-acl-inbound" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/network-acl-inbound" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.22.3" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -24,7 +24,7 @@ with because they are stateless, which means that opening an inbound port is oft
 which your services use to respond. This can be very easy to forget, so this module adds not only the inbound ports to
 an ACL, but also the ephemeral outbound ports for return traffic.
 
-See the [network-acl-outbound](https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/network-acl-outbound) module for the analogous version of this module, but for opening
+See the [network-acl-outbound](https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/network-acl-outbound) module for the analogous version of this module, but for opening
 outbound ports.
 
 ## What's a Network ACL?
@@ -215,11 +215,11 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/network-acl-inbound/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/network-acl-inbound/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/network-acl-inbound/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/network-acl-inbound/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/network-acl-inbound/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/network-acl-inbound/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "2ce3375225e2e341f3604b748ca55652"
+  "hash": "d4cd3fa5f111e155bc906c6daecba567"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-vpc/network-acl-outbound/network-acl-outbound.md
+++ b/docs/reference/modules/terraform-aws-vpc/network-acl-outbound/network-acl-outbound.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Network ACL Outbound Terraform Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/network-acl-outbound" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/network-acl-outbound" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.22.3" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -24,7 +24,7 @@ because they are stateless, which means that opening an outbound port is often n
 which the remote services can use to respond. This can be very easy to forget, so this module adds not only the
 outbound to an ACL, but also the ephemeral inbound ports for return traffic.
 
-See the [network-acl-inbound](https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/network-acl-inbound) module for the analogous version of this module, but for opening
+See the [network-acl-inbound](https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/network-acl-inbound) module for the analogous version of this module, but for opening
 inbound ports.
 
 ## What's a Network ACL?
@@ -217,11 +217,11 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/network-acl-outbound/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/network-acl-outbound/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/network-acl-outbound/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/network-acl-outbound/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/network-acl-outbound/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/network-acl-outbound/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "3ddf9b6f343a2e9d686b8d355dce8a0d"
+  "hash": "fa7104c473d952584857caeef32972e4"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-vpc/port-range-calculator/port-range-calculator.md
+++ b/docs/reference/modules/terraform-aws-vpc/port-range-calculator/port-range-calculator.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Port Calculator Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/port-range-calculator" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/port-range-calculator" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.22.3" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -178,11 +178,11 @@ Map of port ranges to the ranges to allow. This is provided as a convenience out
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/port-range-calculator/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/port-range-calculator/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/port-range-calculator/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/port-range-calculator/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/port-range-calculator/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/port-range-calculator/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "752c01f9f7ba38f747e8e4fcd00d494f"
+  "hash": "6b8118e482b267cedc8cdf80b28c3995"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-vpc/vpc-app-network-acls/vpc-app-network-acls.md
+++ b/docs/reference/modules/terraform-aws-vpc/vpc-app-network-acls/vpc-app-network-acls.md
@@ -13,13 +13,13 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # VPC-App Network ACLs Terraform Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-app-network-acls" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-app-network-acls" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.22.5" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This Terraform Module adds a default set of [Network
 ACLs](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_ACLs.html) to a VPC created using the
-[vpc-app](https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-app) module. The ACLs enforce the following security settings (based on [A Reference VPC
+[vpc-app](https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-app) module. The ACLs enforce the following security settings (based on [A Reference VPC
 Architecture](https://www.whaletech.co/2014/10/02/reference-vpc-architecture.html)):
 
 *   **Public subnet**: Allow all requests.
@@ -619,11 +619,11 @@ Use this variable to ensure the Network ACL does not get created until the VPC i
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-app-network-acls/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-app-network-acls/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-app-network-acls/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-app-network-acls/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-app-network-acls/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-app-network-acls/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "89fd562be20f04b3c58d9c5891589107"
+  "hash": "eb1b7a64d0718e440f1221fa1d60012f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-vpc/vpc-app/vpc-app.md
+++ b/docs/reference/modules/terraform-aws-vpc/vpc-app/vpc-app.md
@@ -13,12 +13,12 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # VPC-App Terraform Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-app" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-app" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.22.7" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This Terraform Module launches a single VPC meant to house applications. By contrast, DevOps-related services such as
-Jenkins or InfluxDB should be in a "mgmt" VPC. (See the [vpc-mgmt](https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-mgmt) module.)
+Jenkins or InfluxDB should be in a "mgmt" VPC. (See the [vpc-mgmt](https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-mgmt) module.)
 
 ## What's a VPC?
 
@@ -58,8 +58,8 @@ To summarize:
 *   In a given subnet tier, there are usually three or four actual subnets, one for each Availability Zone.
 *   Therefore, if we created a single VPC in the `us-west-2` region, which has Availability Zones `us-west-2a`,`us-west-2b`,
     and `us-west-2c`, each subnet tier would have three subnets (one per Availability Zone) for a total of 9 subnets in all.
-*   The only way to reach this VPC is from the public Internet via a publicly exposed sevice, or via the [mgmt VPC](https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-mgmt),
-    which uses [VPC Peering](https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-peering) to make this VPC accessible from the mgmt VPC.
+*   The only way to reach this VPC is from the public Internet via a publicly exposed sevice, or via the [mgmt VPC](https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-mgmt),
+    which uses [VPC Peering](https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-peering) to make this VPC accessible from the mgmt VPC.
 *   Philosophically, everything in a VPC should be isolated from all resources in any other VPC. In particular, we want
     to ensure that our stage environment is completely independent from prod. This architecture helps to reinforce that.
 
@@ -74,7 +74,7 @@ nearly all use-cases, and is consistent with many examples and existing document
 
 ## Other VPC Core Concepts
 
-Learn about [Other VPC Core Concepts](https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules//_docs/vpc-core-concepts.md) like subnets, NAT Gateways, and VPC Endpoints.
+Learn about [Other VPC Core Concepts](https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules//_docs/vpc-core-concepts.md) like subnets, NAT Gateways, and VPC Endpoints.
 
 ## Sample Usage
 
@@ -1439,11 +1439,11 @@ A map of all public subnets, with the subnet name as the key, and all `aws-subne
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-app/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-app/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-app/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-app/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-app/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-app/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "9c77867db30709e7e6978d264c9054fe"
+  "hash": "2e62686b1d824cc26e4475f41bcc610d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-vpc/vpc-dns-forwarder-rules/vpc-dns-forwarder-rules.md
+++ b/docs/reference/modules/terraform-aws-vpc/vpc-dns-forwarder-rules/vpc-dns-forwarder-rules.md
@@ -13,19 +13,19 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # VPC DNS Forwarder Rules Terraform Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-dns-forwarder-rules" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-dns-forwarder-rules" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.22.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This Terraform Module creates [Route 53 Resolver Forwarding
 Rules](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-rules-managing.html) for a VPC that will
-utilize Route 53 Resolver Endpoints created with the [vpc-dns-forwarder module](https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-dns-forwarder). These forwarding
+utilize Route 53 Resolver Endpoints created with the [vpc-dns-forwarder module](https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-dns-forwarder). These forwarding
 rules, combined with Route 53 Resolvers, allow DNS queries for specific domains to be resolved by peered VPCs.
 
 ## How do you specify the hostnames that use the forwarder?
 
 By default, no DNS query will be routed through the Route 53 Resolvers created by the [vpc-dns-forwarder
-module](https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-dns-forwarder). You need to create forwarding rules that specify which specific domains should be
+module](https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-dns-forwarder). You need to create forwarding rules that specify which specific domains should be
 resolved through the Route 53 Resolvers so that they are resolved over the peering connection. You can use this module
 to construct the forwarding rules.
 
@@ -180,11 +180,11 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-dns-forwarder-rules/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-dns-forwarder-rules/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-dns-forwarder-rules/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-dns-forwarder-rules/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-dns-forwarder-rules/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-dns-forwarder-rules/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "81b8f80c48f465573c37efe312ee9a83"
+  "hash": "567a0205ce5aa9b76a679c7a60db1724"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-vpc/vpc-dns-forwarder/vpc-dns-forwarder.md
+++ b/docs/reference/modules/terraform-aws-vpc/vpc-dns-forwarder/vpc-dns-forwarder.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # VPC DNS Forwarder Terraform Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-dns-forwarder" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-dns-forwarder" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.22.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -47,7 +47,7 @@ private endpoints internal to the target VPC.
 
 By default, no DNS query will be routed through the Route 53 Resolvers created by this module. You need to create
 forwarding rules that specify which specific domains should be resolved through the Route 53 Resolvers created by this
-module. You can use the [vpc-dns-forwarder-rules module](https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-dns-forwarder-rules) to construct the forwarding rules.
+module. You can use the [vpc-dns-forwarder-rules module](https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-dns-forwarder-rules) to construct the forwarding rules.
 
 ## Sample Usage
 
@@ -380,11 +380,11 @@ The secondary IP address of the DNS resolver in the origin VPC. This is the IP t
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-dns-forwarder/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-dns-forwarder/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-dns-forwarder/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-dns-forwarder/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-dns-forwarder/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-dns-forwarder/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "125e45f6562c16ce7cad386ac44c3804"
+  "hash": "fe6536c892280364d3473045a849f193"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-vpc/vpc-flow-logs/vpc-flow-logs.md
+++ b/docs/reference/modules/terraform-aws-vpc/vpc-flow-logs/vpc-flow-logs.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # VPC Flow Logs Terraform Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-flow-logs" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-flow-logs" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.22.4" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -687,11 +687,11 @@ The name of the S3 bucket where flow logs are published.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-flow-logs/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-flow-logs/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-flow-logs/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-flow-logs/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-flow-logs/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-flow-logs/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "d999134d00eeb088d714628dd0f37123"
+  "hash": "cb81eb772506d682397fcea1ed19e03d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-vpc/vpc-interface-endpoint/vpc-interface-endpoint.md
+++ b/docs/reference/modules/terraform-aws-vpc/vpc-interface-endpoint/vpc-interface-endpoint.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # Interface VPC Endpoint
 
-<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-interface-endpoint" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-interface-endpoint" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.22.6" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -193,7 +193,7 @@ Not specifying a rule allows all traffic.
 
 ## Other VPC Core Concepts
 
-Learn about [Other VPC Core Concepts](https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules//_docs/vpc-core-concepts.md) like subnets and NAT Gateways.
+Learn about [Other VPC Core Concepts](https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules//_docs/vpc-core-concepts.md) like subnets and NAT Gateways.
 
 ## Sample Usage
 
@@ -8273,11 +8273,11 @@ If you have private dns enabled, then your streaming calls would automatically g
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-interface-endpoint/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-interface-endpoint/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-interface-endpoint/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-interface-endpoint/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-interface-endpoint/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-interface-endpoint/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "d6ec5194c523ff047d521c3aaac19ba2"
+  "hash": "3a7ea60eb19d7220010741b187163b5b"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-vpc/vpc-mgmt-network-acls/vpc-mgmt-network-acls.md
+++ b/docs/reference/modules/terraform-aws-vpc/vpc-mgmt-network-acls/vpc-mgmt-network-acls.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # \[DEPRECATED] VPC-Mgmt Network ACLs Terraform Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-mgmt-network-acls" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-mgmt-network-acls" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.22.3" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -28,7 +28,7 @@ aware that, in a future release, once we feel the new functionality in `vpc-app`
 
 This Terraform Module adds a default set of [Network
 ACLs](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_ACLs.html) to a VPC created using the
-[vpc-mgmt](https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-mgmt) module. The ACLs enforce the following security settings  (based on [A Reference VPC
+[vpc-mgmt](https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-mgmt) module. The ACLs enforce the following security settings  (based on [A Reference VPC
 Architecture](https://www.whaletech.co/2014/10/02/reference-vpc-architecture.html)):
 
 *   **Public subnet**: Allow all requests.
@@ -343,11 +343,11 @@ The number to use for the first rule that is created by this module. All rules i
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-mgmt-network-acls/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-mgmt-network-acls/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-mgmt-network-acls/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-mgmt-network-acls/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-mgmt-network-acls/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-mgmt-network-acls/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "94052430ceda92a71a6203bd32258b69"
+  "hash": "0c3791badc9049f6188388d535d44503"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-vpc/vpc-mgmt/vpc-mgmt.md
+++ b/docs/reference/modules/terraform-aws-vpc/vpc-mgmt/vpc-mgmt.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # \[DEPRECATED] VPC-Mgmt Terraform Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-mgmt" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-mgmt" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.22.5" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -27,7 +27,7 @@ aware that, in a future release, once we feel the new functionality in `vpc-app`
 `vpc-mgmt` entirely.
 
 This Terraform Module launches a single VPC meant to house DevOps and other management services. By contrast, the apps
-that power your business should run in an "app" VPC. (See the [vpc-app](https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-app) module.)
+that power your business should run in an "app" VPC. (See the [vpc-app](https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-app) module.)
 
 ## What's a VPC?
 
@@ -65,7 +65,7 @@ To summarize:
 
 ## VPC Peering
 
-Learn more about VPC Peering in the [vpc-peering](https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-peering) module.
+Learn more about VPC Peering in the [vpc-peering](https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-peering) module.
 
 ## SSH Access via the Bastion Host
 
@@ -79,7 +79,7 @@ examples](https://github.com/gruntwork-io/terraform-aws-server/tree/main/example
 
 ## Other VPC Core Concepts
 
-Learn about [Other VPC Core Concepts](https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules//_docs/vpc-core-concepts.md) like subnets, NAT Gateways, and VPC Endpoints.
+Learn about [Other VPC Core Concepts](https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules//_docs/vpc-core-concepts.md) like subnets, NAT Gateways, and VPC Endpoints.
 
 ## Sample Usage
 
@@ -1007,11 +1007,11 @@ A null_resource that indicates that the VPC is ready, including all of its resou
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-mgmt/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-mgmt/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-mgmt/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-mgmt/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-mgmt/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-mgmt/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "c269650d2ce8eeecb12fdfc2bc158ae8"
+  "hash": "42c5fee35e2c2515f284a3ba7153b32c"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-vpc/vpc-peering-cross-accounts-accepter/vpc-peering-cross-accounts-accepter.md
+++ b/docs/reference/modules/terraform-aws-vpc/vpc-peering-cross-accounts-accepter/vpc-peering-cross-accounts-accepter.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # vpc-peering-cross-accounts-accepter
 
-<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-peering-cross-accounts-accepter" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-peering-cross-accounts-accepter" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.20.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -327,11 +327,11 @@ Peering connection ID.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-peering-cross-accounts-accepter/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-peering-cross-accounts-accepter/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-peering-cross-accounts-accepter/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-peering-cross-accounts-accepter/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-peering-cross-accounts-accepter/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-peering-cross-accounts-accepter/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "1de60565a0cfe571cc8d17e85f457d31"
+  "hash": "648b6bc251263258456220053b77edf3"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-vpc/vpc-peering-cross-accounts-requester/vpc-peering-cross-accounts-requester.md
+++ b/docs/reference/modules/terraform-aws-vpc/vpc-peering-cross-accounts-requester/vpc-peering-cross-accounts-requester.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # vpc-peering-cross-accounts-requester
 
-<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-peering-cross-accounts-requester" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-peering-cross-accounts-requester" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.20.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -299,11 +299,11 @@ Peering connection ID.
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-peering-cross-accounts-requester/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-peering-cross-accounts-requester/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-peering-cross-accounts-requester/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-peering-cross-accounts-requester/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-peering-cross-accounts-requester/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-peering-cross-accounts-requester/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "69c42a06a9e8f45841e800f00d322868"
+  "hash": "af0cb93322a40dfecabad63a3f6303e7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-vpc/vpc-peering-external/vpc-peering-external.md
+++ b/docs/reference/modules/terraform-aws-vpc/vpc-peering-external/vpc-peering-external.md
@@ -13,7 +13,7 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # VPC Peering For External VPCs Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-peering-external" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-peering-external" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.22.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
@@ -309,11 +309,11 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-peering-external/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-peering-external/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-peering-external/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-peering-external/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-peering-external/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-peering-external/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "5d08500c5c98394619ba728d9dcc5773"
+  "hash": "cbb5e41f2cd3a44ff59aaa7e37e54cd2"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/modules/terraform-aws-vpc/vpc-peering/vpc-peering.md
+++ b/docs/reference/modules/terraform-aws-vpc/vpc-peering/vpc-peering.md
@@ -13,15 +13,15 @@ import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
 # VPC-Peering Terraform Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-peering" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-peering" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
 <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.22.0" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This Terraform Module creates [VPC Peering
 Connections](http://docs.aws.amazon.com/AmazonVPC/latest/PeeringGuide/Welcome.html) between VPCs. Normally, VPCs are
 completely isolated from each other, but sometimes, you want to allow traffic to flow between them, such as allowing
-DevOps tools running in a Mgmt VPC (see [vpc-mgmt](https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-mgmt)) to talk to apps running in a Stage or Prod VPC (see
-[vpc-app](https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-app)). This module can create peering connections and route table entries that make this sort of
+DevOps tools running in a Mgmt VPC (see [vpc-mgmt](https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-mgmt)) to talk to apps running in a Stage or Prod VPC (see
+[vpc-app](https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-app)). This module can create peering connections and route table entries that make this sort of
 cross-VPC communication possible.
 
 ## What's a VPC?
@@ -237,11 +237,11 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-peering/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-peering/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/main/modules/vpc-peering/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-peering/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-peering/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-vpc/tree/v0.22.7/modules/vpc-peering/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
-  "hash": "98007582d1790e43a235b62ff6262f36"
+  "hash": "823a3b5f1073539b1421b399dbaf09f1"
 }
 ##DOCS-SOURCER-END -->


### PR DESCRIPTION
[CORE-666]

Docs generated by running the module and service-catalog plugins in the `docs-sourcer` with a latest release directive(now default)

**Changes based on https://github.com/gruntwork-io/docs-sourcer/pull/119**

[CORE-666]: https://gruntwork.atlassian.net/browse/CORE-666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ