### PR TITLE
[CORE-578] Show sensitive variable advice in api usage docs

### DIFF
--- a/docs/reference/services/data-storage/amazon-aurora.md
+++ b/docs/reference/services/data-storage/amazon-aurora.md
@@ -93,6 +93,11 @@ If you want to deploy this repo in production, check out the following resources
 
 # ------------------------------------------------------------------------------------------------------
 # DEPLOY GRUNTWORK'S AURORA MODULE
+#
+# NOTE: This module uses some sensitive variables marked inline with "# SENSITIVE"
+# When using values other than defaults for these variables; set through environment variables or
+# another secure method.
+#
 # ------------------------------------------------------------------------------------------------------
 
 module "aurora" {
@@ -370,7 +375,7 @@ module "aurora" {
   # provided via AWS Secrets Manager. See the description of
   # db_config_secrets_manager_id. A value here overrides the value in
   # db_config_secrets_manager_id.
-  master_password = null
+  master_password = null # SENSITIVE
 
   # The value to use for the master username of the database. This can also be
   # provided via AWS Secrets Manager. See the description of
@@ -503,6 +508,11 @@ module "aurora" {
 
 # ------------------------------------------------------------------------------------------------------
 # DEPLOY GRUNTWORK'S AURORA MODULE
+#
+# NOTE: This module uses some sensitive variables marked inline with "# SENSITIVE"
+# When using values other than defaults for these variables; set through environment variables or
+# another secure method.
+#
 # ------------------------------------------------------------------------------------------------------
 
 terraform {
@@ -782,7 +792,7 @@ inputs = {
   # provided via AWS Secrets Manager. See the description of
   # db_config_secrets_manager_id. A value here overrides the value in
   # db_config_secrets_manager_id.
-  master_password = null
+  master_password = null # SENSITIVE
 
   # The value to use for the master username of the database. This can also be
   # provided via AWS Secrets Manager. See the description of
@@ -2230,6 +2240,6 @@ The ARN of the AWS Lambda Function used for sharing manual snapshots with second
     "https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.104.1/modules/data-stores/aurora/outputs.tf"
   ],
   "sourcePlugin": "service-catalog-api",
-  "hash": "6f7c4fdafc6ba7f616db101fce29aa29"
+  "hash": "514dc8e2d630bb7d994d6548e9442be5"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/data-storage/amazon-elasticsearch.md
+++ b/docs/reference/services/data-storage/amazon-elasticsearch.md
@@ -92,6 +92,11 @@ If you want to deploy this repo in production, check out the following resources
 
 # ------------------------------------------------------------------------------------------------------
 # DEPLOY GRUNTWORK'S ELASTICSEARCH MODULE
+#
+# NOTE: This module uses some sensitive variables marked inline with "# SENSITIVE"
+# When using values other than defaults for these variables; set through environment variables or
+# another secure method.
+#
 # ------------------------------------------------------------------------------------------------------
 
 module "elasticsearch" {
@@ -397,7 +402,7 @@ module "elasticsearch" {
   # Master account user password. Only used if advanced_security_options and
   # internal_user_database_enabled are set to true. WARNING: this password will be
   # stored in Terraform state.
-  master_user_password = null
+  master_user_password = null # SENSITIVE
 
   # Whether to monitor KMS key statistics
   monitor_kms_key = false
@@ -448,6 +453,11 @@ module "elasticsearch" {
 
 # ------------------------------------------------------------------------------------------------------
 # DEPLOY GRUNTWORK'S ELASTICSEARCH MODULE
+#
+# NOTE: This module uses some sensitive variables marked inline with "# SENSITIVE"
+# When using values other than defaults for these variables; set through environment variables or
+# another secure method.
+#
 # ------------------------------------------------------------------------------------------------------
 
 terraform {
@@ -755,7 +765,7 @@ inputs = {
   # Master account user password. Only used if advanced_security_options and
   # internal_user_database_enabled are set to true. WARNING: this password will be
   # stored in Terraform state.
-  master_user_password = null
+  master_user_password = null # SENSITIVE
 
   # Whether to monitor KMS key statistics
   monitor_kms_key = false
@@ -1528,6 +1538,6 @@ Domain-specific endpoint for Kibana without https scheme.
     "https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.104.1/modules/data-stores/elasticsearch/outputs.tf"
   ],
   "sourcePlugin": "service-catalog-api",
-  "hash": "43f94dc6f578caefd4ca55206b261cc7"
+  "hash": "ff93e25b3f16032c6eb115c9dbdf5efb"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/reference/services/data-storage/amazon-rds.md
+++ b/docs/reference/services/data-storage/amazon-rds.md
@@ -94,6 +94,11 @@ If you want to deploy this repo in production, check out the following resources
 
 # ------------------------------------------------------------------------------------------------------
 # DEPLOY GRUNTWORK'S RDS MODULE
+#
+# NOTE: This module uses some sensitive variables marked inline with "# SENSITIVE"
+# When using values other than defaults for these variables; set through environment variables or
+# another secure method.
+#
 # ------------------------------------------------------------------------------------------------------
 
 module "rds" {
@@ -399,7 +404,7 @@ module "rds" {
   # The value to use for the master password of the database. This can also be
   # provided via AWS Secrets Manager. See the description of
   # db_config_secrets_manager_id.
-  master_password = null
+  master_password = null # SENSITIVE
 
   # The value to use for the master username of the database. This can also be
   # provided via AWS Secrets Manager. See the description of
@@ -531,6 +536,11 @@ module "rds" {
 
 # ------------------------------------------------------------------------------------------------------
 # DEPLOY GRUNTWORK'S RDS MODULE
+#
+# NOTE: This module uses some sensitive variables marked inline with "# SENSITIVE"
+# When using values other than defaults for these variables; set through environment variables or
+# another secure method.
+#
 # ------------------------------------------------------------------------------------------------------
 
 terraform {
@@ -838,7 +848,7 @@ inputs = {
   # The value to use for the master password of the database. This can also be
   # provided via AWS Secrets Manager. See the description of
   # db_config_secrets_manager_id.
-  master_password = null
+  master_password = null # SENSITIVE
 
   # The value to use for the master username of the database. This can also be
   # provided via AWS Secrets Manager. See the description of
@@ -2302,6 +2312,6 @@ The ID of the Security Group that controls access to the RDS DB instance.
     "https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.104.1/modules/data-stores/rds/outputs.tf"
   ],
   "sourcePlugin": "service-catalog-api",
-  "hash": "bc957e8b04c01d26aae3385b16d158fd"
+  "hash": "fc9beb2ea71064cebf84ddabcb4ea290"
 }
 ##DOCS-SOURCER-END -->


### PR DESCRIPTION
[CORE-578]

Output from docs-sourcer run of the service-catalog-api and module-catalog-api plugins with changes in this PR: https://github.com/gruntwork-io/docs-sourcer/pull/122

[CORE-578]: https://gruntwork.atlassian.net/browse/CORE-578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ