### PR TITLE
Updated single-server documentation

### DIFF
--- a/docs/reference/modules/terraform-aws-server/single-server/single-server.md
+++ b/docs/reference/modules/terraform-aws-server/single-server/single-server.md
@@ -9,13 +9,13 @@ import VersionBadge from '../../../../../src/components/VersionBadge.tsx';
 import { HclListItem, HclListItemDescription, HclListItemTypeDetails, HclListItemDefaultValue, HclGeneralListItem } from '../../../../../src/components/HclListItem.tsx';
 import { ModuleUsage } from "../../../../../src/components/ModuleUsage";
 
-<VersionBadge repoTitle="Module Server" version="0.15.3" lastModifiedVersion="0.15.2"/>
+<VersionBadge repoTitle="Module Server" version="0.15.4" lastModifiedVersion="0.15.3"/>
 
 # Single Server Module
 
-<a href="https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/single-server" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.4/modules/single-server" className="link-button" title="View the source code for this module in GitHub.">View Source</a>
 
-<a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.15.2" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
+<a href="https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.15.3" className="link-button" title="Release notes for only versions which impacted this module.">Release Notes</a>
 
 This module makes it easy to deploy a single server--that is, a single EC2 instance (e.g. a bastion host, Jenkins
 server) rather than an Auto Scaling Group or ECS Cluster--along with the all the resources it typically needs:
@@ -101,7 +101,7 @@ resource "aws_iam_policy_attachment" "attachment" {
 
 module "single_server" {
 
-  source = "git::git@github.com:gruntwork-io/terraform-aws-server.git//modules/single-server?ref=v0.15.3"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-server.git//modules/single-server?ref=v0.15.4"
 
   # ----------------------------------------------------------------------------------------------------
   # REQUIRED VARIABLES
@@ -316,6 +316,24 @@ module "single_server" {
   # will trigger a destroy and recreate when set to true. Defaults to null.
   user_data_replace_on_change = null
 
+  # Whether the metadata service is available. Valid values include enabled or
+  # disabled. Defaults to enabled.
+  metadata_http_endpoint = "enabled"
+
+  # Desired HTTP PUT response hop limit for instance metadata requests. The larger
+  # the number, the further instance metadata requests can travel. Valid values are
+  # integer from 1 to 64. Defaults to 1.
+  metadata_http_put_response_hop_limit = 1
+
+  # Whether or not the metadata service requires session tokens, also referred to as
+  # Instance Metadata Service Version 2 (IMDSv2). Valid values include optional or
+  # required. Defaults to optional.
+  metadata_http_tokens = "optional"
+
+  # Enables or disables access to instance tags from the instance metadata service.
+  # Valid values include enabled or disabled. Defaults to disabled.
+  metadata_tags = "disabled"
+
 }
 
 
@@ -331,7 +349,7 @@ module "single_server" {
 # ------------------------------------------------------------------------------------------------------
 
 terraform {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-server.git//modules/single-server?ref=v0.15.3"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-server.git//modules/single-server?ref=v0.15.4"
 }
 
 inputs = {
@@ -548,6 +566,24 @@ inputs = {
   # When used in combination with user_data or user_data_base64, a user_data change
   # will trigger a destroy and recreate when set to true. Defaults to null.
   user_data_replace_on_change = null
+
+  # Whether the metadata service is available. Valid values include enabled or
+  # disabled. Defaults to enabled.
+  metadata_http_endpoint = "enabled"
+
+  # Desired HTTP PUT response hop limit for instance metadata requests. The larger
+  # the number, the further instance metadata requests can travel. Valid values are
+  # integer from 1 to 64. Defaults to 1.
+  metadata_http_put_response_hop_limit = 1
+
+  # Whether or not the metadata service requires session tokens, also referred to as
+  # Instance Metadata Service Version 2 (IMDSv2). Valid values include optional or
+  # required. Defaults to optional.
+  metadata_http_tokens = "optional"
+
+  # Enables or disables access to instance tags from the instance metadata service.
+  # Valid values include enabled or disabled. Defaults to disabled.
+  metadata_tags = "disabled"
 
 }
 
@@ -1005,6 +1041,46 @@ When used in combination with user_data or user_data_base64, a user_data change 
 <HclListItemDefaultValue defaultValue="null"/>
 </HclListItem>
 
+<HclListItem name="metadata_http_endpoint" requirement="optional" type="string">
+<HclListItemDescription>
+
+Whether the metadata service is available. Valid values include enabled or disabled. Defaults to enabled.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="enabled"/>
+</HclListItem>
+
+
+<HclListItem name="metadata_http_put_response_hop_limit" requirement="optional" type="number">
+<HclListItemDescription>
+
+Desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Valid values are integer from 1 to 64. Defaults to 1.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="1"/>
+</HclListItem>
+
+
+<HclListItem name="metadata_http_tokens" requirement="optional" type="string">
+<HclListItemDescription>
+
+Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Valid values include optional or required. Defaults to optional.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="optional"/>
+</HclListItem>
+
+
+<HclListItem name="metadata_tags" requirement="optional" type="string">
+<HclListItemDescription>
+
+Enables or disables access to instance tags from the instance metadata service. Valid values include enabled or disabled. Defaults to disabled.
+
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="disabled"/>
+</HclListItem>
+
+
 </TabItem>
 <TabItem value="outputs" label="Outputs">
 
@@ -1057,9 +1133,9 @@ When used in combination with user_data or user_data_base64, a user_data change 
 <!-- ##DOCS-SOURCER-START
 {
   "originalSources": [
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/single-server/readme.md",
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/single-server/variables.tf",
-    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.3/modules/single-server/outputs.tf"
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.4/modules/single-server/readme.md",
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.4/modules/single-server/variables.tf",
+    "https://github.com/gruntwork-io/terraform-aws-server/tree/v0.15.4/modules/single-server/outputs.tf"
   ],
   "sourcePlugin": "module-catalog-api",
   "hash": "4bcb3f99ecd27a2821f66d35c6274161"


### PR DESCRIPTION
Updating the single-server documentation with new module variables from the latest [v0.15.4 release.](https://github.com/gruntwork-io/terraform-aws-server/releases/tag/v0.15.4)