### PR TITLE
[CORE-926] Add related FAQ section to dev portal pages

### DIFF
--- a/_docs-sources/developer-portal/create-account.md
+++ b/_docs-sources/developer-portal/create-account.md
@@ -30,3 +30,9 @@ For security, sign in emails expire after 10 minutes. You can enter your email a
 ## 3. Provide account details
 
 If you are the admin for your organization, you'll be prompted to confirm details including your company address and phone number, as well as a billing email. Provide the required information and click **Continue** to finish signing in.
+
+## Related FAQs
+
+- [Invitation to the Developer Portal not received](https://github.com/orgs/gruntwork-io/discussions/716)
+- [Trouble logging into the Portal with email](https://github.com/orgs/gruntwork-io/discussions/395)
+- [How can the email associated with an account be changed?](https://github.com/orgs/gruntwork-io/discussions/714)

--- a/_docs-sources/developer-portal/invite-team.md
+++ b/_docs-sources/developer-portal/invite-team.md
@@ -39,3 +39,9 @@ This change will take effect immediately. Any team members who have accepted the
 ## Requesting additional licenses
 
 The number of licenses available depends on the level of your subscription. You can see the total number of licenses as well as the number remaining at the top of the [Team](https://app.gruntwork.io/team) page. If you need to invite more team members than your current license limit allows, you may request additional licenses, which are billed at a standard monthly rate. To do so, contact sales@gruntwork.io.
+
+## Related FAQs
+
+- [Invitation to the Developer Portal not received](https://github.com/orgs/gruntwork-io/discussions/716)
+- [Trouble logging into the Portal with email](https://github.com/orgs/gruntwork-io/discussions/395)
+- [How can the email associated with an account be changed?](https://github.com/orgs/gruntwork-io/discussions/714)

--- a/_docs-sources/developer-portal/link-github-id.md
+++ b/_docs-sources/developer-portal/link-github-id.md
@@ -13,3 +13,8 @@ Gruntwork provides all code included in your subscription through GitHub. You ne
 Once you’ve linked your account, the notice on the home page will disappear and you’ll find your GitHub ID recorded in your [Profile Settings](https://app.gruntwork.io/settings/profile). Going forward, you’ll have access to all private repositories included in your subscription. If you haven’t done so yet, we strongly recommend [adding an SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) to your GitHub account. An SSH key is required to access the Gruntwork IaC library without adding a password in your Terraform code.
 
 :::
+
+## Related FAQs
+
+- [I have linked my GitHub Account but do not have code access](https://github.com/orgs/gruntwork-io/discussions/715)
+- [How can I change my GitHub account(unlink/link)?](https://github.com/orgs/gruntwork-io/discussions/713)

--- a/docs/developer-portal/create-account.md
+++ b/docs/developer-portal/create-account.md
@@ -31,10 +31,16 @@ For security, sign in emails expire after 10 minutes. You can enter your email a
 
 If you are the admin for your organization, you'll be prompted to confirm details including your company address and phone number, as well as a billing email. Provide the required information and click **Continue** to finish signing in.
 
+## Related FAQs
+
+- [Invitation to the Developer Portal not received](https://github.com/orgs/gruntwork-io/discussions/716)
+- [Trouble logging into the Portal with email](https://github.com/orgs/gruntwork-io/discussions/395)
+- [How can the email associated with an account be changed?](https://github.com/orgs/gruntwork-io/discussions/714)
+
 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "01375ec9b14d989af4af205eba101d88"
+  "hash": "c6fa8fbd38119dc0f618c9be0b857f23"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/developer-portal/invite-team.md
+++ b/docs/developer-portal/invite-team.md
@@ -40,10 +40,16 @@ This change will take effect immediately. Any team members who have accepted the
 
 The number of licenses available depends on the level of your subscription. You can see the total number of licenses as well as the number remaining at the top of the [Team](https://app.gruntwork.io/team) page. If you need to invite more team members than your current license limit allows, you may request additional licenses, which are billed at a standard monthly rate. To do so, contact sales@gruntwork.io.
 
+## Related FAQs
+
+- [Invitation to the Developer Portal not received](https://github.com/orgs/gruntwork-io/discussions/716)
+- [Trouble logging into the Portal with email](https://github.com/orgs/gruntwork-io/discussions/395)
+- [How can the email associated with an account be changed?](https://github.com/orgs/gruntwork-io/discussions/714)
+
 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "702a33b934d092e229bc9c8d17e92387"
+  "hash": "bee09c3bb6a23fba09bc3061cd35ed0c"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/developer-portal/link-github-id.md
+++ b/docs/developer-portal/link-github-id.md
@@ -14,10 +14,15 @@ Once you’ve linked your account, the notice on the home page will disappear an
 
 :::
 
+## Related FAQs
+
+- [I have linked my GitHub Account but do not have code access](https://github.com/orgs/gruntwork-io/discussions/715)
+- [How can I change my GitHub account(unlink/link)?](https://github.com/orgs/gruntwork-io/discussions/713)
+
 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "bfc8321412501a574a26c60d30ee61ab"
+  "hash": "3508aa52df06adc08da5233176740dfd"
 }
 ##DOCS-SOURCER-END -->


### PR DESCRIPTION
[CORE-926]

Add related FAQ section to individual pages (Eben's feedback)

[CORE-926]: https://gruntwork.atlassian.net/browse/CORE-926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ