### PR TITLE
Update the patcher releases data as of 31. May

### DIFF
--- a/static/patcher-changelogs/terraform-aws-ci/aws-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/aws-helpers.json
@@ -1,6 +1,9 @@
 {
   "module": "aws-helpers",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": false
+    },
     "v0.52.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/build-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/build-helpers.json
@@ -1,6 +1,9 @@
 {
   "module": "build-helpers",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": false
+    },
     "v0.52.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/check-url.json
+++ b/static/patcher-changelogs/terraform-aws-ci/check-url.json
@@ -1,6 +1,9 @@
 {
   "module": "check-url",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": false
+    },
     "v0.52.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/circleci-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/circleci-helpers.json
@@ -1,6 +1,9 @@
 {
   "module": "circleci-helpers",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": false
+    },
     "v0.52.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/ec2-backup.json
+++ b/static/patcher-changelogs/terraform-aws-ci/ec2-backup.json
@@ -1,6 +1,9 @@
 {
   "module": "ec2-backup",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": false
+    },
     "v0.52.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/ecs-deploy-runner-invoke-iam-policy.json
+++ b/static/patcher-changelogs/terraform-aws-ci/ecs-deploy-runner-invoke-iam-policy.json
@@ -1,6 +1,9 @@
 {
   "module": "ecs-deploy-runner-invoke-iam-policy",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": false
+    },
     "v0.52.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/ecs-deploy-runner-standard-configuration.json
+++ b/static/patcher-changelogs/terraform-aws-ci/ecs-deploy-runner-standard-configuration.json
@@ -1,6 +1,9 @@
 {
   "module": "ecs-deploy-runner-standard-configuration",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": false
+    },
     "v0.52.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/ecs-deploy-runner.json
+++ b/static/patcher-changelogs/terraform-aws-ci/ecs-deploy-runner.json
@@ -1,6 +1,9 @@
 {
   "module": "ecs-deploy-runner",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": true
+    },
     "v0.52.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-ci/git-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/git-helpers.json
@@ -1,6 +1,9 @@
 {
   "module": "git-helpers",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": false
+    },
     "v0.52.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/gruntwork-module-circleci-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/gruntwork-module-circleci-helpers.json
@@ -1,6 +1,9 @@
 {
   "module": "gruntwork-module-circleci-helpers",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": false
+    },
     "v0.52.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/iam-policies.json
+++ b/static/patcher-changelogs/terraform-aws-ci/iam-policies.json
@@ -1,6 +1,9 @@
 {
   "module": "iam-policies",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": false
+    },
     "v0.52.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/infrastructure-deploy-script.json
+++ b/static/patcher-changelogs/terraform-aws-ci/infrastructure-deploy-script.json
@@ -1,6 +1,9 @@
 {
   "module": "infrastructure-deploy-script",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": false
+    },
     "v0.52.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/infrastructure-deployer.json
+++ b/static/patcher-changelogs/terraform-aws-ci/infrastructure-deployer.json
@@ -1,6 +1,9 @@
 {
   "module": "infrastructure-deployer",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": false
+    },
     "v0.52.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/install-jenkins.json
+++ b/static/patcher-changelogs/terraform-aws-ci/install-jenkins.json
@@ -1,6 +1,9 @@
 {
   "module": "install-jenkins",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": false
+    },
     "v0.52.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/jenkins-server.json
+++ b/static/patcher-changelogs/terraform-aws-ci/jenkins-server.json
@@ -1,6 +1,9 @@
 {
   "module": "jenkins-server",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": false
+    },
     "v0.52.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/kubernetes-circleci-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/kubernetes-circleci-helpers.json
@@ -1,6 +1,9 @@
 {
   "module": "kubernetes-circleci-helpers",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": false
+    },
     "v0.52.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/monorepo-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/monorepo-helpers.json
@@ -1,6 +1,9 @@
 {
   "module": "monorepo-helpers",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": false
+    },
     "v0.52.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-ci/sign-binary-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/sign-binary-helpers.json
@@ -1,6 +1,9 @@
 {
   "module": "sign-binary-helpers",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": false
+    },
     "v0.52.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/terraform-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/terraform-helpers.json
@@ -1,6 +1,9 @@
 {
   "module": "terraform-helpers",
   "releases": {
+    "v0.52.1": {
+      "contains_changes": false
+    },
     "v0.52.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/auto-update.json
+++ b/static/patcher-changelogs/terraform-aws-security/auto-update.json
@@ -1,6 +1,9 @@
 {
   "module": "auto-update",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/aws-auth.json
+++ b/static/patcher-changelogs/terraform-aws-security/aws-auth.json
@@ -1,6 +1,9 @@
 {
   "module": "aws-auth",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/aws-config-bucket.json
+++ b/static/patcher-changelogs/terraform-aws-security/aws-config-bucket.json
@@ -1,6 +1,9 @@
 {
   "module": "aws-config-bucket",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/aws-config-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-security/aws-config-multi-region.json
@@ -1,6 +1,9 @@
 {
   "module": "aws-config-multi-region",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/aws-config-rules.json
+++ b/static/patcher-changelogs/terraform-aws-security/aws-config-rules.json
@@ -1,6 +1,9 @@
 {
   "module": "aws-config-rules",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/aws-config.json
+++ b/static/patcher-changelogs/terraform-aws-security/aws-config.json
@@ -1,6 +1,9 @@
 {
   "module": "aws-config",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/aws-organizations.json
+++ b/static/patcher-changelogs/terraform-aws-security/aws-organizations.json
@@ -1,6 +1,9 @@
 {
   "module": "aws-organizations",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/cloudtrail-bucket.json
+++ b/static/patcher-changelogs/terraform-aws-security/cloudtrail-bucket.json
@@ -1,6 +1,9 @@
 {
   "module": "cloudtrail-bucket",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/cloudtrail.json
+++ b/static/patcher-changelogs/terraform-aws-security/cloudtrail.json
@@ -1,6 +1,9 @@
 {
   "module": "cloudtrail",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/cross-account-iam-roles.json
+++ b/static/patcher-changelogs/terraform-aws-security/cross-account-iam-roles.json
@@ -1,6 +1,9 @@
 {
   "module": "cross-account-iam-roles",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/custom-iam-entity.json
+++ b/static/patcher-changelogs/terraform-aws-security/custom-iam-entity.json
@@ -1,6 +1,9 @@
 {
   "module": "custom-iam-entity",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ebs-encryption-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-security/ebs-encryption-multi-region.json
@@ -1,6 +1,9 @@
 {
   "module": "ebs-encryption-multi-region",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ebs-encryption.json
+++ b/static/patcher-changelogs/terraform-aws-security/ebs-encryption.json
@@ -1,6 +1,9 @@
 {
   "module": "ebs-encryption",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/fail2ban.json
+++ b/static/patcher-changelogs/terraform-aws-security/fail2ban.json
@@ -1,6 +1,9 @@
 {
   "module": "fail2ban",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/github-actions-iam-role.json
+++ b/static/patcher-changelogs/terraform-aws-security/github-actions-iam-role.json
@@ -1,6 +1,9 @@
 {
   "module": "github-actions-iam-role",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/guardduty-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-security/guardduty-multi-region.json
@@ -1,6 +1,9 @@
 {
   "module": "guardduty-multi-region",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/guardduty.json
+++ b/static/patcher-changelogs/terraform-aws-security/guardduty.json
@@ -1,6 +1,9 @@
 {
   "module": "guardduty",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": true
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/iam-access-analyzer-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-security/iam-access-analyzer-multi-region.json
@@ -1,6 +1,9 @@
 {
   "module": "iam-access-analyzer-multi-region",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/iam-groups.json
+++ b/static/patcher-changelogs/terraform-aws-security/iam-groups.json
@@ -1,6 +1,9 @@
 {
   "module": "iam-groups",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/iam-policies.json
+++ b/static/patcher-changelogs/terraform-aws-security/iam-policies.json
@@ -1,6 +1,9 @@
 {
   "module": "iam-policies",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/iam-user-password-policy.json
+++ b/static/patcher-changelogs/terraform-aws-security/iam-user-password-policy.json
@@ -1,6 +1,9 @@
 {
   "module": "iam-user-password-policy",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/iam-users.json
+++ b/static/patcher-changelogs/terraform-aws-security/iam-users.json
@@ -1,6 +1,9 @@
 {
   "module": "iam-users",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ip-lockdown.json
+++ b/static/patcher-changelogs/terraform-aws-security/ip-lockdown.json
@@ -1,6 +1,9 @@
 {
   "module": "ip-lockdown",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/kms-cmk-replica.json
+++ b/static/patcher-changelogs/terraform-aws-security/kms-cmk-replica.json
@@ -1,6 +1,9 @@
 {
   "module": "kms-cmk-replica",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/kms-grant-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-security/kms-grant-multi-region.json
@@ -1,6 +1,9 @@
 {
   "module": "kms-grant-multi-region",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/kms-master-key-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-security/kms-master-key-multi-region.json
@@ -1,6 +1,9 @@
 {
   "module": "kms-master-key-multi-region",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/kms-master-key.json
+++ b/static/patcher-changelogs/terraform-aws-security/kms-master-key.json
@@ -1,6 +1,9 @@
 {
   "module": "kms-master-key",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ntp.json
+++ b/static/patcher-changelogs/terraform-aws-security/ntp.json
@@ -1,6 +1,9 @@
 {
   "module": "ntp",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-security/os-hardening.json
+++ b/static/patcher-changelogs/terraform-aws-security/os-hardening.json
@@ -1,6 +1,9 @@
 {
   "module": "os-hardening",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/private-s3-bucket.json
+++ b/static/patcher-changelogs/terraform-aws-security/private-s3-bucket.json
@@ -1,6 +1,9 @@
 {
   "module": "private-s3-bucket",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/saml-iam-roles.json
+++ b/static/patcher-changelogs/terraform-aws-security/saml-iam-roles.json
@@ -1,6 +1,9 @@
 {
   "module": "saml-iam-roles",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/secrets-manager-resource-policies.json
+++ b/static/patcher-changelogs/terraform-aws-security/secrets-manager-resource-policies.json
@@ -1,6 +1,9 @@
 {
   "module": "secrets-manager-resource-policies",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ssh-grunt-selinux-policy.json
+++ b/static/patcher-changelogs/terraform-aws-security/ssh-grunt-selinux-policy.json
@@ -1,6 +1,9 @@
 {
   "module": "ssh-grunt-selinux-policy",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ssh-grunt.json
+++ b/static/patcher-changelogs/terraform-aws-security/ssh-grunt.json
@@ -1,6 +1,9 @@
 {
   "module": "ssh-grunt",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ssh-iam.json
+++ b/static/patcher-changelogs/terraform-aws-security/ssh-iam.json
@@ -1,6 +1,9 @@
 {
   "module": "ssh-iam",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ssm-healthchecks-iam-permissions.json
+++ b/static/patcher-changelogs/terraform-aws-security/ssm-healthchecks-iam-permissions.json
@@ -1,6 +1,9 @@
 {
   "module": "ssm-healthchecks-iam-permissions",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/tls-cert-private.json
+++ b/static/patcher-changelogs/terraform-aws-security/tls-cert-private.json
@@ -1,6 +1,9 @@
 {
   "module": "tls-cert-private",
   "releases": {
+    "v0.68.2": {
+      "contains_changes": false
+    },
     "v0.68.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/base/ec2-baseline.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/base/ec2-baseline.json
@@ -1,6 +1,9 @@
 {
   "module": "base/ec2-baseline",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/aurora.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/aurora.json
@@ -1,6 +1,9 @@
 {
   "module": "data-stores/aurora",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/ecr-repos.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/ecr-repos.json
@@ -1,6 +1,9 @@
 {
   "module": "data-stores/ecr-repos",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/elasticsearch.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/elasticsearch.json
@@ -1,6 +1,9 @@
 {
   "module": "data-stores/elasticsearch",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/memcached.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/memcached.json
@@ -1,6 +1,9 @@
 {
   "module": "data-stores/memcached",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/rds.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/rds.json
@@ -1,6 +1,9 @@
 {
   "module": "data-stores/rds",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/redis.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/redis.json
@@ -1,6 +1,9 @@
 {
   "module": "data-stores/redis",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/s3-bucket.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/s3-bucket.json
@@ -1,6 +1,9 @@
 {
   "module": "data-stores/s3-bucket",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-app.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-app.json
@@ -1,6 +1,9 @@
 {
   "module": "landingzone/account-baseline-app",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-root.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-root.json
@@ -1,6 +1,9 @@
 {
   "module": "landingzone/account-baseline-root",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-security.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-security.json
@@ -1,6 +1,9 @@
 {
   "module": "landingzone/account-baseline-security",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/gruntwork-access.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/gruntwork-access.json
@@ -1,6 +1,9 @@
 {
   "module": "landingzone/gruntwork-access",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/iam-users-and-groups.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/iam-users-and-groups.json
@@ -1,6 +1,9 @@
 {
   "module": "landingzone/iam-users-and-groups",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/bastion-host.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/bastion-host.json
@@ -1,6 +1,9 @@
 {
   "module": "mgmt/bastion-host",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/ecs-deploy-runner.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/ecs-deploy-runner.json
@@ -1,6 +1,9 @@
 {
   "module": "mgmt/ecs-deploy-runner",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/jenkins.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/jenkins.json
@@ -1,6 +1,9 @@
 {
   "module": "mgmt/jenkins",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/openvpn-server.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/openvpn-server.json
@@ -1,6 +1,9 @@
 {
   "module": "mgmt/openvpn-server",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/tailscale-subnet-router.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/tailscale-subnet-router.json
@@ -1,6 +1,9 @@
 {
   "module": "mgmt/tailscale-subnet-router",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/alb.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/alb.json
@@ -1,6 +1,9 @@
 {
   "module": "networking/alb",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/route53.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/route53.json
@@ -1,6 +1,9 @@
 {
   "module": "networking/route53",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/sns-topics.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/sns-topics.json
@@ -1,6 +1,9 @@
 {
   "module": "networking/sns-topics",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/vpc-mgmt.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/vpc-mgmt.json
@@ -1,6 +1,9 @@
 {
   "module": "networking/vpc-mgmt",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/vpc.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/vpc.json
@@ -1,6 +1,9 @@
 {
   "module": "networking/vpc",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/asg-service.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/asg-service.json
@@ -1,6 +1,9 @@
 {
   "module": "services/asg-service",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/ec2-instance.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/ec2-instance.json
@@ -1,6 +1,9 @@
 {
   "module": "services/ec2-instance",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": true
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-cluster.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-cluster.json
@@ -1,6 +1,9 @@
 {
   "module": "services/ecs-cluster",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-fargate-cluster.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-fargate-cluster.json
@@ -1,6 +1,9 @@
 {
   "module": "services/ecs-fargate-cluster",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-service.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-service.json
@@ -1,6 +1,9 @@
 {
   "module": "services/ecs-service",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-cluster.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-cluster.json
@@ -1,6 +1,9 @@
 {
   "module": "services/eks-cluster",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-core-services.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-core-services.json
@@ -1,6 +1,9 @@
 {
   "module": "services/eks-core-services",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-workers.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-workers.json
@@ -1,6 +1,9 @@
 {
   "module": "services/eks-workers",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/helm-service.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/helm-service.json
@@ -1,6 +1,9 @@
 {
   "module": "services/helm-service",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/k8s-namespace.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/k8s-namespace.json
@@ -1,6 +1,9 @@
 {
   "module": "services/k8s-namespace",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/k8s-service.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/k8s-service.json
@@ -1,6 +1,9 @@
 {
   "module": "services/k8s-service",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/lambda.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/lambda.json
@@ -1,6 +1,9 @@
 {
   "module": "services/lambda",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/public-static-website.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/public-static-website.json
@@ -1,6 +1,9 @@
 {
   "module": "services/public-static-website",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/Dockerfile.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/Dockerfile.json
@@ -1,6 +1,9 @@
 {
   "module": "tls-scripts/Dockerfile",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/core-concepts.md.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/core-concepts.md.json
@@ -1,6 +1,9 @@
 {
   "module": "tls-scripts/core-concepts.md",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/create-tls-cert.sh.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/create-tls-cert.sh.json
@@ -1,6 +1,9 @@
 {
   "module": "tls-scripts/create-tls-cert.sh",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/docker-compose.yml.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/docker-compose.yml.json
@@ -1,6 +1,9 @@
 {
   "module": "tls-scripts/docker-compose.yml",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/download-rds-ca-certs.sh.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/download-rds-ca-certs.sh.json
@@ -1,6 +1,9 @@
 {
   "module": "tls-scripts/download-rds-ca-certs.sh",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/generate-trust-stores.sh.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/generate-trust-stores.sh.json
@@ -1,6 +1,9 @@
 {
   "module": "tls-scripts/generate-trust-stores.sh",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/helpers.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/helpers.json
@@ -1,6 +1,9 @@
 {
   "module": "tls-scripts/helpers",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/install.sh.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/install.sh.json
@@ -1,6 +1,9 @@
 {
   "module": "tls-scripts/install.sh",
   "releases": {
+    "v0.104.7": {
+      "contains_changes": false
+    },
     "v0.104.6": {
       "contains_changes": false
     },


### PR DESCRIPTION
Data generated by running `DOCS_SITE_BASE_DIR="../docs/" yarn dev -p patcher-changelogs`.