### PR TITLE
 Update the patcher releases data as of 14. June

### DIFF
--- a/static/patcher-changelogs/terraform-aws-cache/elastic-cache.json
+++ b/static/patcher-changelogs/terraform-aws-cache/elastic-cache.json
@@ -1,6 +1,9 @@
 {
   "module": "elastic-cache",
   "releases": {
+    "v0.20.1": {
+      "contains_changes": false
+    },
     "v0.20.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cache/memcached.json
+++ b/static/patcher-changelogs/terraform-aws-cache/memcached.json
@@ -1,6 +1,9 @@
 {
   "module": "memcached",
   "releases": {
+    "v0.20.1": {
+      "contains_changes": false
+    },
     "v0.20.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cache/redis.json
+++ b/static/patcher-changelogs/terraform-aws-cache/redis.json
@@ -1,6 +1,9 @@
 {
   "module": "redis",
   "releases": {
+    "v0.20.1": {
+      "contains_changes": true
+    },
     "v0.20.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cache/redis_copy_snapshot.json
+++ b/static/patcher-changelogs/terraform-aws-cache/redis_copy_snapshot.json
@@ -1,6 +1,9 @@
 {
   "module": "redis_copy_snapshot",
   "releases": {
+    "v0.20.1": {
+      "contains_changes": false
+    },
     "v0.20.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/data-stores/efs.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/data-stores/efs.json
@@ -1,6 +1,9 @@
 {
   "module": "data-stores/efs",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/data-stores/rds.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/data-stores/rds.json
@@ -1,6 +1,9 @@
 {
   "module": "data-stores/rds",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": true
+    },
     "v0.47.1": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/landingzone/account-baseline-app.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/landingzone/account-baseline-app.json
@@ -1,6 +1,9 @@
 {
   "module": "landingzone/account-baseline-app",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/landingzone/account-baseline-root.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/landingzone/account-baseline-root.json
@@ -1,6 +1,9 @@
 {
   "module": "landingzone/account-baseline-root",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/landingzone/account-baseline-security.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/landingzone/account-baseline-security.json
@@ -1,6 +1,9 @@
 {
   "module": "landingzone/account-baseline-security",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc-app-network-acls.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc-app-network-acls.json
@@ -1,6 +1,9 @@
 {
   "module": "networking/vpc-app-network-acls",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc-mgmt-network-acls.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc-mgmt-network-acls.json
@@ -1,6 +1,9 @@
 {
   "module": "networking/vpc-mgmt-network-acls",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc-mgmt.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc-mgmt.json
@@ -1,6 +1,9 @@
 {
   "module": "networking/vpc-mgmt",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc.json
@@ -1,6 +1,9 @@
 {
   "module": "networking/vpc",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/observability/aws-config-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/observability/aws-config-multi-region.json
@@ -1,6 +1,9 @@
 {
   "module": "observability/aws-config-multi-region",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/observability/cloudtrail.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/observability/cloudtrail.json
@@ -1,6 +1,9 @@
 {
   "module": "observability/cloudtrail",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/observability/cloudwatch-logs-metric-filters.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/observability/cloudwatch-logs-metric-filters.json
@@ -1,6 +1,9 @@
 {
   "module": "observability/cloudwatch-logs-metric-filters",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/aws-securityhub.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/aws-securityhub.json
@@ -1,6 +1,9 @@
 {
   "module": "security/aws-securityhub",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/cleanup-expired-certs.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/cleanup-expired-certs.json
@@ -1,6 +1,9 @@
 {
   "module": "security/cleanup-expired-certs",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/cross-account-iam-roles.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/cross-account-iam-roles.json
@@ -1,6 +1,9 @@
 {
   "module": "security/cross-account-iam-roles",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/custom-iam-entity.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/custom-iam-entity.json
@@ -1,6 +1,9 @@
 {
   "module": "security/custom-iam-entity",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/iam-groups.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/iam-groups.json
@@ -1,6 +1,9 @@
 {
   "module": "security/iam-groups",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/iam-password-policy.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/iam-password-policy.json
@@ -1,6 +1,9 @@
 {
   "module": "security/iam-password-policy",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/macie.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/macie.json
@@ -1,6 +1,9 @@
 {
   "module": "security/macie",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/revoke-unused-iam-credentials.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/revoke-unused-iam-credentials.json
@@ -1,6 +1,9 @@
 {
   "module": "security/revoke-unused-iam-credentials",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/saml-iam-roles.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/saml-iam-roles.json
@@ -1,6 +1,9 @@
 {
   "module": "security/saml-iam-roles",
   "releases": {
+    "v0.47.2": {
+      "contains_changes": false
+    },
     "v0.47.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/base/ec2-baseline.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/base/ec2-baseline.json
@@ -1,6 +1,12 @@
 {
   "module": "base/ec2-baseline",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/aurora.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/aurora.json
@@ -1,6 +1,12 @@
 {
   "module": "data-stores/aurora",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/ecr-repos.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/ecr-repos.json
@@ -1,6 +1,12 @@
 {
   "module": "data-stores/ecr-repos",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/elasticsearch.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/elasticsearch.json
@@ -1,6 +1,12 @@
 {
   "module": "data-stores/elasticsearch",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/memcached.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/memcached.json
@@ -1,6 +1,12 @@
 {
   "module": "data-stores/memcached",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/rds.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/rds.json
@@ -1,6 +1,12 @@
 {
   "module": "data-stores/rds",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": true
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/redis.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/redis.json
@@ -1,6 +1,12 @@
 {
   "module": "data-stores/redis",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/s3-bucket.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/s3-bucket.json
@@ -1,6 +1,12 @@
 {
   "module": "data-stores/s3-bucket",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-app.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-app.json
@@ -1,6 +1,12 @@
 {
   "module": "landingzone/account-baseline-app",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-root.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-root.json
@@ -1,6 +1,12 @@
 {
   "module": "landingzone/account-baseline-root",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-security.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-security.json
@@ -1,6 +1,12 @@
 {
   "module": "landingzone/account-baseline-security",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/gruntwork-access.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/gruntwork-access.json
@@ -1,6 +1,12 @@
 {
   "module": "landingzone/gruntwork-access",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/iam-users-and-groups.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/iam-users-and-groups.json
@@ -1,6 +1,12 @@
 {
   "module": "landingzone/iam-users-and-groups",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/bastion-host.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/bastion-host.json
@@ -1,6 +1,12 @@
 {
   "module": "mgmt/bastion-host",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/ecs-deploy-runner.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/ecs-deploy-runner.json
@@ -1,6 +1,12 @@
 {
   "module": "mgmt/ecs-deploy-runner",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/jenkins.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/jenkins.json
@@ -1,6 +1,12 @@
 {
   "module": "mgmt/jenkins",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/openvpn-server.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/openvpn-server.json
@@ -1,6 +1,12 @@
 {
   "module": "mgmt/openvpn-server",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/alb.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/alb.json
@@ -1,6 +1,12 @@
 {
   "module": "networking/alb",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/route53.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/route53.json
@@ -1,6 +1,12 @@
 {
   "module": "networking/route53",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/sns-topics.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/sns-topics.json
@@ -1,6 +1,12 @@
 {
   "module": "networking/sns-topics",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/vpc-mgmt.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/vpc-mgmt.json
@@ -1,6 +1,12 @@
 {
   "module": "networking/vpc-mgmt",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/vpc.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/vpc.json
@@ -1,6 +1,12 @@
 {
   "module": "networking/vpc",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/asg-service.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/asg-service.json
@@ -1,6 +1,12 @@
 {
   "module": "services/asg-service",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/ec2-instance.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/ec2-instance.json
@@ -1,6 +1,12 @@
 {
   "module": "services/ec2-instance",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-cluster.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-cluster.json
@@ -1,6 +1,12 @@
 {
   "module": "services/ecs-cluster",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-fargate-cluster.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-fargate-cluster.json
@@ -1,6 +1,12 @@
 {
   "module": "services/ecs-fargate-cluster",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-service.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-service.json
@@ -1,6 +1,12 @@
 {
   "module": "services/ecs-service",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-cluster.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-cluster.json
@@ -1,6 +1,12 @@
 {
   "module": "services/eks-cluster",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-core-services.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-core-services.json
@@ -1,6 +1,12 @@
 {
   "module": "services/eks-core-services",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-karpenter.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-karpenter.json
@@ -1,11 +1,11 @@
 {
-  "module": "mgmt/tailscale-subnet-router",
+  "module": "services/eks-karpenter",
   "releases": {
     "v0.104.10": {
       "contains_changes": false
     },
     "v0.104.9": {
-      "contains_changes": true
+      "contains_changes": false
     },
     "v0.104.8": {
       "contains_changes": false
@@ -32,7 +32,7 @@
       "contains_changes": false
     },
     "v0.104.0": {
-      "contains_changes": true
+      "contains_changes": false
     },
     "v0.103.2": {
       "contains_changes": false
@@ -53,7 +53,7 @@
       "contains_changes": false
     },
     "v0.102.13": {
-      "contains_changes": true
+      "contains_changes": false
     },
     "v0.102.12": {
       "contains_changes": false
@@ -92,7 +92,7 @@
       "contains_changes": false
     },
     "v0.102.0": {
-      "contains_changes": true
+      "contains_changes": false
     },
     "v0.101.0": {
       "contains_changes": false
@@ -152,7 +152,7 @@
       "contains_changes": false
     },
     "v0.96.3": {
-      "contains_changes": true
+      "contains_changes": false
     },
     "v0.96.2": {
       "contains_changes": false
@@ -161,7 +161,7 @@
       "contains_changes": false
     },
     "v0.96.0": {
-      "contains_changes": true
+      "contains_changes": false
     },
     "v0.95.1": {
       "contains_changes": false
@@ -182,7 +182,7 @@
       "contains_changes": false
     },
     "v0.93.1": {
-      "contains_changes": true
+      "contains_changes": false
     },
     "v0.93.0": {
       "contains_changes": false
@@ -197,7 +197,7 @@
       "contains_changes": false
     },
     "v0.90.8": {
-      "contains_changes": true
+      "contains_changes": false
     },
     "v0.90.7": {
       "contains_changes": false
@@ -218,10 +218,10 @@
       "contains_changes": false
     },
     "v0.90.1": {
-      "contains_changes": true
+      "contains_changes": false
     },
     "v0.90.0": {
-      "contains_changes": true
+      "contains_changes": false
     },
     "v0.89.4": {
       "contains_changes": false
@@ -230,7 +230,7 @@
       "contains_changes": false
     },
     "v0.89.2": {
-      "contains_changes": true
+      "contains_changes": false
     },
     "v0.89.1": {
       "contains_changes": false
@@ -245,7 +245,7 @@
       "contains_changes": false
     },
     "v0.88.0": {
-      "contains_changes": true
+      "contains_changes": false
     },
     "v0.87.0": {
       "contains_changes": false
@@ -260,10 +260,10 @@
       "contains_changes": false
     },
     "v0.85.11": {
-      "contains_changes": true
+      "contains_changes": false
     },
     "v0.85.10": {
-      "contains_changes": true
+      "contains_changes": false
     },
     "v0.85.9": {
       "contains_changes": false
@@ -281,13 +281,13 @@
       "contains_changes": false
     },
     "v0.85.4": {
-      "contains_changes": true
+      "contains_changes": false
     },
     "v0.85.3": {
       "contains_changes": false
     },
     "v0.85.2": {
-      "contains_changes": true
+      "contains_changes": false
     },
     "v0.85.1": {
       "contains_changes": false

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-workers.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-workers.json
@@ -1,6 +1,12 @@
 {
   "module": "services/eks-workers",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/helm-service.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/helm-service.json
@@ -1,6 +1,12 @@
 {
   "module": "services/helm-service",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": false
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/k8s-namespace.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/k8s-namespace.json
@@ -1,6 +1,12 @@
 {
   "module": "services/k8s-namespace",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": false
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/k8s-service.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/k8s-service.json
@@ -1,6 +1,12 @@
 {
   "module": "services/k8s-service",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": false
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/lambda.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/lambda.json
@@ -1,6 +1,12 @@
 {
   "module": "services/lambda",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": false
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/public-static-website.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/public-static-website.json
@@ -1,6 +1,12 @@
 {
   "module": "services/public-static-website",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": true
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/Dockerfile.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/Dockerfile.json
@@ -1,6 +1,12 @@
 {
   "module": "tls-scripts/Dockerfile",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": false
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/core-concepts.md.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/core-concepts.md.json
@@ -1,6 +1,12 @@
 {
   "module": "tls-scripts/core-concepts.md",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": false
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/create-tls-cert.sh.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/create-tls-cert.sh.json
@@ -1,6 +1,12 @@
 {
   "module": "tls-scripts/create-tls-cert.sh",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": false
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/docker-compose.yml.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/docker-compose.yml.json
@@ -1,6 +1,12 @@
 {
   "module": "tls-scripts/docker-compose.yml",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": false
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/download-rds-ca-certs.sh.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/download-rds-ca-certs.sh.json
@@ -1,6 +1,12 @@
 {
   "module": "tls-scripts/download-rds-ca-certs.sh",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": false
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/generate-trust-stores.sh.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/generate-trust-stores.sh.json
@@ -1,6 +1,12 @@
 {
   "module": "tls-scripts/generate-trust-stores.sh",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": false
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/helpers.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/helpers.json
@@ -1,6 +1,12 @@
 {
   "module": "tls-scripts/helpers",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": false
+    },
     "v0.104.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/install.sh.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/install.sh.json
@@ -1,6 +1,12 @@
 {
   "module": "tls-scripts/install.sh",
   "releases": {
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": false
+    },
     "v0.104.8": {
       "contains_changes": false
     },


### PR DESCRIPTION
Data generated by running `DOCS_SITE_BASE_DIR="../docs/" yarn dev -p patcher-changelogs`.