### PR TITLE
[CORE-999] Correctly restore scroll ability when modal is dismissed

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -42,17 +42,20 @@ export const Modal: React.FC<ModalProps> = ({
     return false
   }
 
-  useEffect(() => {
-    if (showModal) {
-      document.body.style.overflow = "hidden"
-    }
-    const timer = setTimeout(() => {
-      if (!showModal) {
+  useEffect(
+    function preventScrollWhenDisplayingModal() {
+      document.body.style.overflow = showModal ? "hidden" : "unset"
+
+      // The statement above would ordinarily suffice except in instances where
+      // the component is unmounted from the DOM and therefore can not reset the
+      // overflow property. Hence, we have to use the useEffect cleanup function
+      // to ensure that the overflow property is reset to its default value.
+      return () => {
         document.body.style.overflow = "unset"
       }
-    }, 300)
-    return () => clearTimeout(timer)
-  }, [showModal])
+    },
+    [showModal]
+  )
 
   useEffect(() => {
     const listener = (e: any) => {


### PR DESCRIPTION
[CORE-999]

Fixes disabled-scroll after modal interaction.

#### Understanding the change

The bug was due to a sneaky setup of the react modal component:

- The component `Modal` previously changed the scroll value to "hidden" when `showModal` property is set to true. This was ok.
- It also had a cleanup function to reset the value when `showModal` is set as false. This was the problem given that the parent component `SubscriberOnlyModal` unmounted the `Modal` component once `showModal` was set as false so it never got a chance to do the cleanup. Now the cleanup will always happen regardless of the value of `showModal`

[CORE-999]: https://gruntwork.atlassian.net/browse/CORE-999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ