### PR TITLE
Updated docs to Patcher v0.4.2

### DIFF
--- a/_docs-sources/patcher/index.md
+++ b/_docs-sources/patcher/index.md
@@ -22,12 +22,16 @@ $ mv patcher /usr/local/bin
 
 ## Before Running Patcher
 
+### GitHub Personal Access Token
+
 To fetch information from GitHub, Patcher requires a [GitHub Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token), with the `repo` scope. Set the
 `GITHUB_OAUTH_TOKEN` environment variable to your GitHub Personal Access token:
 
 ```bash
 export GITHUB_OAUTH_TOKEN="<YOUR_GITHUB_PAT>"
 ```
+
+### Docker
 
 Starting in `0.4.1`, the Patcher update command applies patches using a Docker sandbox by default and will pull the latest version of the [`gruntwork/patcher_bash_env`](https://hub.docker.com/r/gruntwork/patcher_bash_env) image.
 

--- a/_docs-sources/patcher/index.md
+++ b/_docs-sources/patcher/index.md
@@ -29,10 +29,13 @@ To fetch information from GitHub, Patcher requires a [GitHub Personal Access Tok
 export GITHUB_OAUTH_TOKEN="<YOUR_GITHUB_PAT>"
 ```
 
+Starting in `0.4.1`, the Patcher update command applies patches using a Docker sandbox by default and will pull the latest version of the [`gruntwork/patcher_bash_env`](https://hub.docker.com/r/gruntwork/patcher_bash_env) image.
+
+To run the Patcher update command locally without Docker or in a CI pipeline you should add the `--skip-container-runtime` flag.
+
 ## Running Patcher
 
-Patcher should be run in a local Terraform or Terragrunt Git repo. It will analyze _all_ modules that belong to the current folder
-including its children. Patcher supports `source` values only from GitHub.
+Patcher should be run in a local Terraform or Terragrunt Git repo. It will analyze _all_ modules that belong to the current folder including its children. Patcher supports `source` values only from GitHub.
 
 If you purchased and deployed our [Reference Architecture](https://gruntwork.io/reference-architecture/) and have your deployment organized in an `infrastructure-live` repository, we recommend running Patcher inside each environment folder, e.g. `infrastructure-live/dev`.
 

--- a/_docs-sources/patcher/running-patcher/report.md
+++ b/_docs-sources/patcher/running-patcher/report.md
@@ -1,5 +1,17 @@
 # Patcher Report
 
+Starting in `0.4.2`, Patcher supports two modes: **interactive mode** and **non-interactive mode**.
+
+In interactive mode, the user can browse the discovered module dependencies.
+
+In non-interactive mode, Patcher outputs a list of module dependencies in JSON format.
+
+## Interactive Mode (Default)
+Example usage:
+```
+patcher report prod
+```
+
 The `patcher report` command is a read-only version of Patcher that shows the changelog per module and its usages.
 
 After scanning for dependencies, Patcher will show you the 'Modules View', similar to the screenshot below.
@@ -20,4 +32,24 @@ Some modules including third party modules may not have a CHANGELOGS.md file. In
 
 ![Patcher no changelogs screenshot](/img/guides/stay-up-to-date/patcher/patcher-report-no-changelog.png)
 
+## Non-Interactive Mode
+Example usage:
+```
+patcher report --non-interactive prod
+```
 
+The report command outpust a list of module dependencies in JSON format to `stdout`, for example:
+```json
+[
+   "gruntwork-io/terraform-aws-monitoring/logs/load-balancer-access-logs",
+   "gruntwork-io/terraform-aws-service-catalog/services/k8s-service",
+   "gruntwork-io/terraform-aws-messaging/sqs",
+   "gruntwork-io/terraform-aws-service-catalog/services/k8s-namespace",
+   "gruntwork-io/terraform-aws-cis-service-catalog/networking/vpc",
+   "gruntwork-io/terraform-aws-security/custom-iam-entity",
+   "gruntwork-io/terraform-aws-utilities/request-quota-increase",
+   "gruntwork-io/terraform-aws-service-catalog/networking/sns-topics",
+   "gruntwork-io/terraform-aws-cis-service-catalog/landingzone/account-baseline-app",
+   "gruntwork-io/terraform-aws-service-catalog/networking/route53"
+]
+```

--- a/_docs-sources/patcher/running-patcher/update.md
+++ b/_docs-sources/patcher/running-patcher/update.md
@@ -1,7 +1,5 @@
 # Patcher Update
 
-The Patcher update command allows you to update some or all of the module dependencies in the current folder and any child folders.
-
 :::info
 
 Starting in `0.4.1`, Patcher applies patches using a Docker sandbox by default and will pull the latest version of the [`gruntwork/patcher_bash_env`](https://hub.docker.com/r/gruntwork/patcher_bash_env) image.
@@ -9,6 +7,8 @@ Starting in `0.4.1`, Patcher applies patches using a Docker sandbox by default a
 To run Patcher locally without Docker or in a CI pipeline you should add the `--skip-container-runtime` flag.
 
 :::
+
+The Patcher update command allows you to update some or all of the module dependencies in the current folder and any child folders.
 
 Patcher supports two modes: **interactive mode** and **non-interactive mode**.
 
@@ -63,8 +63,6 @@ Some modules including third party modules may not have a CHANGELOGS.md file. In
 
 ## Non-Interactive Mode
 
-In non-interactive mode, Patcher updates all module dependencies in the current folder (and child folders) according to the specified update strategy.
-
 :::caution
 
 Starting in `0.4.1`, Patcher applies patches using a Docker sandbox by default.
@@ -72,6 +70,8 @@ Starting in `0.4.1`, Patcher applies patches using a Docker sandbox by default.
 To run Patcher in a CI pipeline you should add the `--skip-container-runtime` flag.
 
 :::
+
+In non-interactive mode, Patcher updates all module dependencies in the current folder (and child folders) according to the specified update strategy.
 
 Non-interactive mode supports both the `next-safe` and `next-breaking` update strategies.
 

--- a/_docs-sources/patcher/running-patcher/update.md
+++ b/_docs-sources/patcher/running-patcher/update.md
@@ -2,7 +2,15 @@
 
 The Patcher update command allows you to update some or all of the module dependencies in the current folder and any child folders.
 
-The update command supports two modes: **interactive mode** and **non-interactive mode**.
+:::info
+
+Starting in `0.4.1`, Patcher applies patches using a Docker sandbox by default and will pull the latest version of the [`gruntwork/patcher_bash_env`](https://hub.docker.com/r/gruntwork/patcher_bash_env) image.
+
+To run Patcher in a CI pipeline you should add the `--skip-container-runtime` flag.
+
+:::
+
+Patcher supports two modes: **interactive mode** and **non-interactive mode**.
 
 ## Interactive Mode
 
@@ -57,6 +65,12 @@ Some modules including third party modules may not have a CHANGELOGS.md file. In
 
 In non-interactive mode, Patcher updates all module dependencies in the current folder (and child folders) according to the specified update strategy.
 
+:::caution
+
+Starting in `0.4.1`, Patcher applies patches using a Docker sandbox by default. To run Patcher in a CI pipeline you should add the `--skip-container-runtime` flag.
+
+:::
+
 Non-interactive mode supports both the `next-safe` and `next-breaking` update strategies.
 
 ### Next Safe (Default)
@@ -65,11 +79,11 @@ Using the [next safe update strategy](/patcher/update-strategies#next-safe-updat
 
 Example usage:
 ```
-patcher update --non-interactive --update-strategy next-safe
+patcher update --non-interactive --skip-container-runtime --update-strategy next-safe prod
 ```
 Or just
 ```
-patcher update --non-interactive
+patcher update --non-interactive --skip-container-runtime prod
 ```
 
 ### Next Breaking
@@ -80,7 +94,7 @@ If Patcher updates a dependency to a breaking version, a `README-TO-COMPLETE-UPD
 
 Example usage:
 ```
-patcher update --non-interactive --update-strategy next-breaking
+patcher update --non-interactive --skip-container-runtime --update-strategy next-breaking prod
 ```
 
 ## Support for Third Party Modules

--- a/_docs-sources/patcher/running-patcher/update.md
+++ b/_docs-sources/patcher/running-patcher/update.md
@@ -6,7 +6,7 @@ The Patcher update command allows you to update some or all of the module depend
 
 Starting in `0.4.1`, Patcher applies patches using a Docker sandbox by default and will pull the latest version of the [`gruntwork/patcher_bash_env`](https://hub.docker.com/r/gruntwork/patcher_bash_env) image.
 
-To run Patcher in a CI pipeline you should add the `--skip-container-runtime` flag.
+To run Patcher locally without Docker or in a CI pipeline you should add the `--skip-container-runtime` flag.
 
 :::
 
@@ -67,7 +67,9 @@ In non-interactive mode, Patcher updates all module dependencies in the current 
 
 :::caution
 
-Starting in `0.4.1`, Patcher applies patches using a Docker sandbox by default. To run Patcher in a CI pipeline you should add the `--skip-container-runtime` flag.
+Starting in `0.4.1`, Patcher applies patches using a Docker sandbox by default.
+
+To run Patcher in a CI pipeline you should add the `--skip-container-runtime` flag.
 
 :::
 

--- a/docs/patcher/index.md
+++ b/docs/patcher/index.md
@@ -22,12 +22,16 @@ $ mv patcher /usr/local/bin
 
 ## Before Running Patcher
 
+### GitHub Personal Access Token
+
 To fetch information from GitHub, Patcher requires a [GitHub Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token), with the `repo` scope. Set the
 `GITHUB_OAUTH_TOKEN` environment variable to your GitHub Personal Access token:
 
 ```bash
 export GITHUB_OAUTH_TOKEN="<YOUR_GITHUB_PAT>"
 ```
+
+### Docker
 
 Starting in `0.4.1`, the Patcher update command applies patches using a Docker sandbox by default and will pull the latest version of the [`gruntwork/patcher_bash_env`](https://hub.docker.com/r/gruntwork/patcher_bash_env) image.
 
@@ -58,6 +62,6 @@ patcher report --loglevel debug
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "720a0f6cb36ef97478b172968877ff1d"
+  "hash": "7404617b36bd3d04bddebca633a30535"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/patcher/index.md
+++ b/docs/patcher/index.md
@@ -29,10 +29,13 @@ To fetch information from GitHub, Patcher requires a [GitHub Personal Access Tok
 export GITHUB_OAUTH_TOKEN="<YOUR_GITHUB_PAT>"
 ```
 
+Starting in `0.4.1`, the Patcher update command applies patches using a Docker sandbox by default and will pull the latest version of the [`gruntwork/patcher_bash_env`](https://hub.docker.com/r/gruntwork/patcher_bash_env) image.
+
+To run the Patcher update command locally without Docker or in a CI pipeline you should add the `--skip-container-runtime` flag.
+
 ## Running Patcher
 
-Patcher should be run in a local Terraform or Terragrunt Git repo. It will analyze _all_ modules that belong to the current folder
-including its children. Patcher supports `source` values only from GitHub.
+Patcher should be run in a local Terraform or Terragrunt Git repo. It will analyze _all_ modules that belong to the current folder including its children. Patcher supports `source` values only from GitHub.
 
 If you purchased and deployed our [Reference Architecture](https://gruntwork.io/reference-architecture/) and have your deployment organized in an `infrastructure-live` repository, we recommend running Patcher inside each environment folder, e.g. `infrastructure-live/dev`.
 
@@ -55,6 +58,6 @@ patcher report --loglevel debug
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "669a2a4da124e60e3f16e23b19c281f9"
+  "hash": "720a0f6cb36ef97478b172968877ff1d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/patcher/running-patcher/report.md
+++ b/docs/patcher/running-patcher/report.md
@@ -1,5 +1,17 @@
 # Patcher Report
 
+Starting in `0.4.2`, Patcher supports two modes: **interactive mode** and **non-interactive mode**.
+
+In interactive mode, the user can browse the discovered module dependencies.
+
+In non-interactive mode, Patcher outputs a list of module dependencies in JSON format.
+
+## Interactive Mode (Default)
+Example usage:
+```
+patcher report prod
+```
+
 The `patcher report` command is a read-only version of Patcher that shows the changelog per module and its usages.
 
 After scanning for dependencies, Patcher will show you the 'Modules View', similar to the screenshot below.
@@ -20,12 +32,32 @@ Some modules including third party modules may not have a CHANGELOGS.md file. In
 
 ![Patcher no changelogs screenshot](/img/guides/stay-up-to-date/patcher/patcher-report-no-changelog.png)
 
+## Non-Interactive Mode
+Example usage:
+```
+patcher report --non-interactive prod
+```
 
+The report command outpust a list of module dependencies in JSON format to `stdout`, for example:
+```json
+[
+   "gruntwork-io/terraform-aws-monitoring/logs/load-balancer-access-logs",
+   "gruntwork-io/terraform-aws-service-catalog/services/k8s-service",
+   "gruntwork-io/terraform-aws-messaging/sqs",
+   "gruntwork-io/terraform-aws-service-catalog/services/k8s-namespace",
+   "gruntwork-io/terraform-aws-cis-service-catalog/networking/vpc",
+   "gruntwork-io/terraform-aws-security/custom-iam-entity",
+   "gruntwork-io/terraform-aws-utilities/request-quota-increase",
+   "gruntwork-io/terraform-aws-service-catalog/networking/sns-topics",
+   "gruntwork-io/terraform-aws-cis-service-catalog/landingzone/account-baseline-app",
+   "gruntwork-io/terraform-aws-service-catalog/networking/route53"
+]
+```
 
 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "c1edfeb185cc8f36c8c8d7b28b410d2d"
+  "hash": "dfd6a16ded9deaced37f0acc5f66e0f3"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/patcher/running-patcher/update.md
+++ b/docs/patcher/running-patcher/update.md
@@ -2,7 +2,15 @@
 
 The Patcher update command allows you to update some or all of the module dependencies in the current folder and any child folders.
 
-The update command supports two modes: **interactive mode** and **non-interactive mode**.
+:::info
+
+Starting in `0.4.1`, Patcher applies patches using a Docker sandbox by default and will pull the latest version of the [`gruntwork/patcher_bash_env`](https://hub.docker.com/r/gruntwork/patcher_bash_env) image.
+
+To run Patcher in a CI pipeline you should add the `--skip-container-runtime` flag.
+
+:::
+
+Patcher supports two modes: **interactive mode** and **non-interactive mode**.
 
 ## Interactive Mode
 
@@ -57,6 +65,12 @@ Some modules including third party modules may not have a CHANGELOGS.md file. In
 
 In non-interactive mode, Patcher updates all module dependencies in the current folder (and child folders) according to the specified update strategy.
 
+:::caution
+
+Starting in `0.4.1`, Patcher applies patches using a Docker sandbox by default. To run Patcher in a CI pipeline you should add the `--skip-container-runtime` flag.
+
+:::
+
 Non-interactive mode supports both the `next-safe` and `next-breaking` update strategies.
 
 ### Next Safe (Default)
@@ -65,11 +79,11 @@ Using the [next safe update strategy](/patcher/update-strategies#next-safe-updat
 
 Example usage:
 ```
-patcher update --non-interactive --update-strategy next-safe
+patcher update --non-interactive --skip-container-runtime --update-strategy next-safe prod
 ```
 Or just
 ```
-patcher update --non-interactive
+patcher update --non-interactive --skip-container-runtime prod
 ```
 
 ### Next Breaking
@@ -80,7 +94,7 @@ If Patcher updates a dependency to a breaking version, a `README-TO-COMPLETE-UPD
 
 Example usage:
 ```
-patcher update --non-interactive --update-strategy next-breaking
+patcher update --non-interactive --skip-container-runtime --update-strategy next-breaking prod
 ```
 
 ## Support for Third Party Modules
@@ -106,6 +120,6 @@ Patcher cannot update from `4.0.x` to `5.0.0` and will instead show a `?` in the
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "a1a5840931017bfaf95f069bafd070de"
+  "hash": "0d8831edcd7b49e377d471e0cb4ee339"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/patcher/running-patcher/update.md
+++ b/docs/patcher/running-patcher/update.md
@@ -1,7 +1,5 @@
 # Patcher Update
 
-The Patcher update command allows you to update some or all of the module dependencies in the current folder and any child folders.
-
 :::info
 
 Starting in `0.4.1`, Patcher applies patches using a Docker sandbox by default and will pull the latest version of the [`gruntwork/patcher_bash_env`](https://hub.docker.com/r/gruntwork/patcher_bash_env) image.
@@ -9,6 +7,8 @@ Starting in `0.4.1`, Patcher applies patches using a Docker sandbox by default a
 To run Patcher locally without Docker or in a CI pipeline you should add the `--skip-container-runtime` flag.
 
 :::
+
+The Patcher update command allows you to update some or all of the module dependencies in the current folder and any child folders.
 
 Patcher supports two modes: **interactive mode** and **non-interactive mode**.
 
@@ -63,8 +63,6 @@ Some modules including third party modules may not have a CHANGELOGS.md file. In
 
 ## Non-Interactive Mode
 
-In non-interactive mode, Patcher updates all module dependencies in the current folder (and child folders) according to the specified update strategy.
-
 :::caution
 
 Starting in `0.4.1`, Patcher applies patches using a Docker sandbox by default.
@@ -72,6 +70,8 @@ Starting in `0.4.1`, Patcher applies patches using a Docker sandbox by default.
 To run Patcher in a CI pipeline you should add the `--skip-container-runtime` flag.
 
 :::
+
+In non-interactive mode, Patcher updates all module dependencies in the current folder (and child folders) according to the specified update strategy.
 
 Non-interactive mode supports both the `next-safe` and `next-breaking` update strategies.
 
@@ -122,6 +122,6 @@ Patcher cannot update from `4.0.x` to `5.0.0` and will instead show a `?` in the
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "01420cfd9fd4e0634ac193f5a32ed12b"
+  "hash": "bdb6c8796a65e330af0b443208ebb1de"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/patcher/running-patcher/update.md
+++ b/docs/patcher/running-patcher/update.md
@@ -6,7 +6,7 @@ The Patcher update command allows you to update some or all of the module depend
 
 Starting in `0.4.1`, Patcher applies patches using a Docker sandbox by default and will pull the latest version of the [`gruntwork/patcher_bash_env`](https://hub.docker.com/r/gruntwork/patcher_bash_env) image.
 
-To run Patcher in a CI pipeline you should add the `--skip-container-runtime` flag.
+To run Patcher locally without Docker or in a CI pipeline you should add the `--skip-container-runtime` flag.
 
 :::
 
@@ -67,7 +67,9 @@ In non-interactive mode, Patcher updates all module dependencies in the current 
 
 :::caution
 
-Starting in `0.4.1`, Patcher applies patches using a Docker sandbox by default. To run Patcher in a CI pipeline you should add the `--skip-container-runtime` flag.
+Starting in `0.4.1`, Patcher applies patches using a Docker sandbox by default.
+
+To run Patcher in a CI pipeline you should add the `--skip-container-runtime` flag.
 
 :::
 
@@ -120,6 +122,6 @@ Patcher cannot update from `4.0.x` to `5.0.0` and will instead show a `?` in the
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "0d8831edcd7b49e377d471e0cb4ee339"
+  "hash": "01420cfd9fd4e0634ac193f5a32ed12b"
 }
 ##DOCS-SOURCER-END -->


### PR DESCRIPTION
- Added a note that `patcher update` requires Docker by default.
- Updated the `patcher update --non-interactive` examples to include the `--skip-container-runtime` flag
- Updated the description of `patcher report` to include the non-interactive mode

This PR deliberately doesn't include information on how to use Patcher without Docker. This can't be documented until we've resolved how we are going to make terrapatch available.