### PR TITLE
Update patcher changelogs as of 4. August

### DIFF
--- a/static/patcher-changelogs/terraform-aws-eks/eks-alb-ingress-controller-iam-policy.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-alb-ingress-controller-iam-policy.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-alb-ingress-controller-iam-policy",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": false
+    },
     "v0.60.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-alb-ingress-controller.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-alb-ingress-controller.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-alb-ingress-controller",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": false
+    },
     "v0.60.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-aws-auth-merger.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-aws-auth-merger.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-aws-auth-merger",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": false
+    },
     "v0.60.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-cloudwatch-agent.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-cloudwatch-agent.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-cloudwatch-agent",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": false
+    },
     "v0.60.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-cluster-control-plane.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-cluster-control-plane.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-cluster-control-plane",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": true
+    },
     "v0.60.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-cluster-managed-workers.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-cluster-managed-workers.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-cluster-managed-workers",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": false
+    },
     "v0.60.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-cluster-workers-cross-access.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-cluster-workers-cross-access.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-cluster-workers-cross-access",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": false
+    },
     "v0.60.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-cluster-workers.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-cluster-workers.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-cluster-workers",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": false
+    },
     "v0.60.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-container-logs.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-container-logs.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-container-logs",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": true
+    },
     "v0.60.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-fargate-container-logs.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-fargate-container-logs.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-fargate-container-logs",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": false
+    },
     "v0.60.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-iam-role-assume-role-policy-for-service-account.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-iam-role-assume-role-policy-for-service-account.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-iam-role-assume-role-policy-for-service-account",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": false
+    },
     "v0.60.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-cluster-autoscaler-iam-policy.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-cluster-autoscaler-iam-policy.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-k8s-cluster-autoscaler-iam-policy",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": false
+    },
     "v0.60.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-cluster-autoscaler.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-cluster-autoscaler.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-k8s-cluster-autoscaler",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": false
+    },
     "v0.60.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-external-dns-iam-policy.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-external-dns-iam-policy.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-k8s-external-dns-iam-policy",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": false
+    },
     "v0.60.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-external-dns.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-external-dns.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-k8s-external-dns",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": false
+    },
     "v0.60.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-karpenter.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-karpenter.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-k8s-karpenter",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": false
+    },
     "v0.60.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-role-mapping.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-role-mapping.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-k8s-role-mapping",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": false
+    },
     "v0.60.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-scripts.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-scripts.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-scripts",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": false
+    },
     "v0.60.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-vpc-tags.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-vpc-tags.json
@@ -1,6 +1,9 @@
 {
   "module": "eks-vpc-tags",
   "releases": {
+    "v0.61.0": {
+      "contains_changes": false
+    },
     "v0.60.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-load-balancer/acm-tls-certificate.json
+++ b/static/patcher-changelogs/terraform-aws-load-balancer/acm-tls-certificate.json
@@ -1,6 +1,12 @@
 {
   "module": "acm-tls-certificate",
   "releases": {
+    "v0.29.10": {
+      "contains_changes": true
+    },
+    "v0.29.9": {
+      "contains_changes": true
+    },
     "v0.29.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-load-balancer/alb.json
+++ b/static/patcher-changelogs/terraform-aws-load-balancer/alb.json
@@ -1,6 +1,12 @@
 {
   "module": "alb",
   "releases": {
+    "v0.29.10": {
+      "contains_changes": false
+    },
+    "v0.29.9": {
+      "contains_changes": false
+    },
     "v0.29.8": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-load-balancer/lb-listener-rules.json
+++ b/static/patcher-changelogs/terraform-aws-load-balancer/lb-listener-rules.json
@@ -1,6 +1,12 @@
 {
   "module": "lb-listener-rules",
   "releases": {
+    "v0.29.10": {
+      "contains_changes": false
+    },
+    "v0.29.9": {
+      "contains_changes": false
+    },
     "v0.29.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-load-balancer/nlb.json
+++ b/static/patcher-changelogs/terraform-aws-load-balancer/nlb.json
@@ -1,6 +1,12 @@
 {
   "module": "nlb",
   "releases": {
+    "v0.29.10": {
+      "contains_changes": false
+    },
+    "v0.29.9": {
+      "contains_changes": false
+    },
     "v0.29.8": {
       "contains_changes": false
     },


### PR DESCRIPTION
Data generated by running `DOCS_SITE_BASE_DIR="../docs/" yarn dev -p patcher-changelogs`.