### PR TITLE
Fixing sample usage module path for VPC deployment config

### DIFF
--- a/docs/reference/services/networking/virtual-private-cloud-vpc.md
+++ b/docs/reference/services/networking/virtual-private-cloud-vpc.md
@@ -105,7 +105,7 @@ If you want to deploy this repo in production, check out the following resources
 
 module "vpc" {
 
-  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/vpc?ref=v0.104.17"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/networking/vpc?ref=v0.104.17"
 
   # ----------------------------------------------------------------------------------------------------
   # REQUIRED VARIABLES
@@ -536,7 +536,7 @@ module "vpc" {
 # ------------------------------------------------------------------------------------------------------
 
 terraform {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/vpc?ref=v0.104.17"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/networking/vpc?ref=v0.104.17"
 }
 
 inputs = {


### PR DESCRIPTION
Sample Usage section of the docs has the incorrect path for the VPC module: https://docs.gruntwork.io/reference/services/networking/virtual-private-cloud-vpc/#sample-usage