### PR TITLE
Adding envcommon docs

### DIFF
--- a/_docs-sources/learning-center/envcommon/defining.md
+++ b/_docs-sources/learning-center/envcommon/defining.md
@@ -44,9 +44,8 @@ inputs = {
     num_nat_gateways                          = 1
 }
 ```
+Our example is relatively straight forward, our module only has three required variables, but there are actually 79 more optional variables. As you expand your usage to supply values to more optional values, the amount of code you don't have to write would increase significantly.
 
 ## Wrapping up
-
-Our example is relatively straight forward, our module only has three required variables, but there are actually 79 more optional variables. As you expand your usage to supply values to more optional values, the amount of code you don't have to write would increase significantly.
 
 Now that you know how to develop an envcommon module, let's dive in to how you can use one to deploy resources to a specific environment.

--- a/_docs-sources/learning-center/envcommon/defining.md
+++ b/_docs-sources/learning-center/envcommon/defining.md
@@ -44,7 +44,7 @@ inputs = {
     num_nat_gateways                          = 1
 }
 ```
-Our example is relatively straight forward — our module only has three required variables, but there are actually 79 more optional variables. As you expand your usage to supply values to more optional values, the amount of code you don't have to write would increase significantly.
+Our example is relatively straight forward — our module only has three required variables, but there are actually 79 more optional variables. As you expand your usage to supply values to more optional values, the amount of code you don't have to write increases significantly.
 
 ## Wrapping up
 

--- a/_docs-sources/learning-center/envcommon/defining.md
+++ b/_docs-sources/learning-center/envcommon/defining.md
@@ -1,0 +1,2 @@
+# Defining an envcommon module
+

--- a/_docs-sources/learning-center/envcommon/defining.md
+++ b/_docs-sources/learning-center/envcommon/defining.md
@@ -1,7 +1,39 @@
 # Defining an envcommon module
 
+Now that you have an understanding of [what envcommon is](index.md), you can develop your own envcommon module.
+
+By default, all envcommon modules should be placed in a directory named `_envcommon`. Beyond that, it is up to you as a developer to determine how to structure the code. Gruntwork recommends structuring your envcommon directory by creating directories for each resource category (e.g., storage, networking) then using a name for the Terragrunt file that represents the resource(s) it will create.
+
+For example, if you are defining an envcommon module for a AWS VPC in which you will deploy applications, you might put it in a directory named `networking` and a file named `vpc-app.hcl`, resulting in `_envcommon/networking/vpc-app.hcl`.
+
+Next, we'll fine the envcommon module. It's important to remember that a Terragrunt module is structured the same as an Terragrunt file. The only difference is that this module defines default variable values and locals that can be used in any environment.
+
 ## The Terraform block
+
+```hcl title=_envcommon/networking/vpc-app.hcl
+terraform {
+  source = "${local.source_base_url}?ref=v0.47.1"
+}
+```
 
 ## Locals
 
+```hcl title=_envcommon/networking/vpc-app.hcl
+locals {
+    source_base_url = "git::ssh://git@github.com/gruntwork-io/terraform-aws-service-catalog.git//modules/networking/vpc"
+
+    account_name = local.account_vars.locals.account_name
+    region = "us-east-1"
+}
+```
+
 ## Specifying variable values
+
+```hcl title=_envcommon/networking/vpc-app.hcl
+inputs = {
+    // cidr_block is a required input but note we are excluding it!
+    vpc_name                                  = local.account_name
+    aws_region                                = local.region
+    num_nat_gateways                          = 1
+}
+```

--- a/_docs-sources/learning-center/envcommon/defining.md
+++ b/_docs-sources/learning-center/envcommon/defining.md
@@ -1,2 +1,7 @@
 # Defining an envcommon module
 
+## The Terraform block
+
+## Locals
+
+## Specifying variable values

--- a/_docs-sources/learning-center/envcommon/defining.md
+++ b/_docs-sources/learning-center/envcommon/defining.md
@@ -10,30 +10,43 @@ Next, we'll fine the envcommon module. It's important to remember that a Terragr
 
 ## The Terraform block
 
+First, define a `terraform` block. This allows you to specify the source URL for the terraform module you are using. Gruntwork recommends using a `local` block to define the source url. This allows you to define the source url for the module once, in envcommon, then expose that variable up to any module that leverages this envcommon module. After the source url, we specify a version of the module.
+
 ```hcl title=_envcommon/networking/vpc-app.hcl
 terraform {
-  source = "${local.source_base_url}?ref=v0.47.1"
+  source = "${local.source_base_url}?ref=v0.104.19"
 }
 ```
 
 ## Locals
 
+As with all Terragrunt modules, you can specify a `locals` block in an envcommon module. Locals allows you to assign an expression to a value, such as setting a common region name or dynamically reading values from configuration files. In the example below, we show how you can read account specific information from another terragrunt file, then use that information as a local.
+
 ```hcl title=_envcommon/networking/vpc-app.hcl
 locals {
     source_base_url = "git::ssh://git@github.com/gruntwork-io/terraform-aws-service-catalog.git//modules/networking/vpc"
 
+    account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
     account_name = local.account_vars.locals.account_name
-    region = "us-east-1"
 }
 ```
 
 ## Specifying variable values
 
+Finally, you can define inputs. This is where the envcommon pattern really starts to demonstrate value by keeping your code DRY.
+
+In the example block below, we've set default values for the `vpc_name` and `num_nat_gateways` variables. A quick inspection of the [`vpc-app`](../../reference/modules/terraform-aws-vpc/vpc-app/) module shows us that we're only missing one additional required variable — `cidr_block`. This means that consumers of our envcommon module only need to specify a value for one input variable, a 66% reduction! You could even expand this example to always use the same CIDR block, allowing the users to override it should they require a different block.
+
 ```hcl title=_envcommon/networking/vpc-app.hcl
 inputs = {
     // cidr_block is a required input but note we are excluding it!
     vpc_name                                  = local.account_name
-    aws_region                                = local.region
     num_nat_gateways                          = 1
 }
 ```
+
+## Wrapping up
+
+Our example is relatively straight forward, our module only has three required variables, but there are actually 79 more optional variables. As you expand your usage to supply values to more optional values, the amount of code you don't have to write would increase significantly.
+
+Now that you know how to develop an envcommon module, let's dive in to how you can use one to deploy resources to a specific environment.

--- a/_docs-sources/learning-center/envcommon/defining.md
+++ b/_docs-sources/learning-center/envcommon/defining.md
@@ -44,7 +44,7 @@ inputs = {
     num_nat_gateways                          = 1
 }
 ```
-Our example is relatively straight forward, our module only has three required variables, but there are actually 79 more optional variables. As you expand your usage to supply values to more optional values, the amount of code you don't have to write would increase significantly.
+Our example is relatively straight forward — our module only has three required variables, but there are actually 79 more optional variables. As you expand your usage to supply values to more optional values, the amount of code you don't have to write would increase significantly.
 
 ## Wrapping up
 

--- a/_docs-sources/learning-center/envcommon/index.md
+++ b/_docs-sources/learning-center/envcommon/index.md
@@ -1,2 +1,11 @@
 # What is envcommon?
 
+envcommon is a pattern that allows infrastructure as code developers to reference a terraform module, set locals, and set default (but mutable) default variable values. This pattern helps keep your Terragrunt architecture DRY, reducing the likelihood of errors when making changes across environments.
+
+This patterns has benefits for module developers and consumers — Engineers developing modules can centrally define defaults that can be applied to all usage while engineers consuming modules don't have to repeat as much code when leveraging the module.
+
+One analogy is to think about envcommon in the same way you might think about purchasing a new car. The manufacturer offers a "base model" with several configurable options, such as interior upgrades, but at the end of the purchase you will have a car. As the purchaser, you might just need the base model without any upgrades, or you may upgrade the stereo to a premium option.
+
+Similarly, with envcommon you may define a "base" resource, such as an AWS RDS for PostgreSQL instance. By default, all consumers of the module might get a `db.t3.medium` instance with a `50gb`  general purpose SSD. While this might work in the majority of your environments, for a production deployment you might need an instance with more memory, CPU, and storage space. With envcommon, you would simplify override the variable names for the instance size/type and the amount of desired storage. Everything else remains the same.
+
+Now that we've established what the envcommon pattern is and how it can help simplify your infrastructure as code, let's dive into how you can define an envcommon module.

--- a/_docs-sources/learning-center/envcommon/index.md
+++ b/_docs-sources/learning-center/envcommon/index.md
@@ -1,0 +1,2 @@
+# What is envcommon?
+

--- a/_docs-sources/learning-center/envcommon/usage.md
+++ b/_docs-sources/learning-center/envcommon/usage.md
@@ -32,7 +32,7 @@ include "envcommon" {
 }
 ```
 
-Note that we're using the [`find_in_parent_folders()`](https://terragrunt.gruntwork.io/docs/reference/built-in-functions/#find_in_parent_folders) terragrunt built-in function to find the root directory of the repository, then specifying the path to the envcommon module from there.
+Note that we're using the built-in terragrunt function [`find_in_parent_folders()`](https://terragrunt.gruntwork.io/docs/reference/built-in-functions/#find_in_parent_folders) to find the root directory of the repository, then specifying the path to the envcommon module from there.
 
 ## Specifying Dependencies
 

--- a/_docs-sources/learning-center/envcommon/usage.md
+++ b/_docs-sources/learning-center/envcommon/usage.md
@@ -1,6 +1,3 @@
-# Using envcommon
-
-
 # Using envcommon in an infrastructure-unit
 
 ### infrastructure-unit
@@ -9,7 +6,7 @@ An infrastructure unit is the Gruntwork term for the deployment of an infrastruc
 
 In this section, we'll walk through the approach we employ at Gruntwork for leveraging modules in envcommon as infrastructure-units. When you purchase a DevOps Foundation, the generated repository containing your infrastructure-as-code is automatically laid out to use this approach.
 
-### Terraform block
+### The Terraform block
 
 Gruntwork recommends that infrastructure-unit definitions contain a `terraform` block, in addition the the `terraform` block in the underlying envcommon module. This allows users to change module versions granularly across environments, rather than changing a global value and updating all of your environments at once.
 
@@ -21,7 +18,7 @@ terraform {
 }
 ```
 
-### Include the envcommon module
+### Including the envcommon module
 
 Including an envcommon module requires using an [`include`](https://terragrunt.gruntwork.io/docs/features/keep-your-terragrunt-architecture-dry/#using-exposed-includes-to-override-common-configurations) block. This allows you to use or override any default values and reference locals in the envcommon module.
 
@@ -35,7 +32,7 @@ include "envcommon" {
 }
 ```
 
-### Dependencies
+### Specifying Dependencies
 
 [Dependencies](https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#dependency) are a Terragrunt concept that allow you to specify that certain infrastructure-units must be applied before this infrastructure-unit. Dependencies can leveraged regardless of the source of the underlying module. This means that an infrastructure-unit that uses an envcommon module can reference dependencies the same way as an infrastructure-unit that does not use an envcommon module.
 
@@ -47,7 +44,7 @@ dependency "kms" {
 }
 ```
 
-### Locals
+### Using Locals
 
 Like Dependencies, [Locals](https://terragrunt.gruntwork.io/docs/features/locals/) are a Terragrunt concept that allow you to bind a name to an expression. Locals are a useful tool when leveraging the envcommon pattern to set environment specific values, like CIDR blocks, resource name prefixes, and more. An infrastructure-unit that uses an envcommon module can reference dependencies the same way as an infrastructure-unit that does not use an envcommon module.
 
@@ -59,7 +56,7 @@ locals {
 }
 ```
 
-### Inputs
+### Overriding Inputs
 
 Inputs allow you to pass in values to the underlying module specified in the `include` block. This is where the envcommon pattern shows it convenience and helps to keep your code clean and DRY.
 

--- a/_docs-sources/learning-center/envcommon/usage.md
+++ b/_docs-sources/learning-center/envcommon/usage.md
@@ -1,12 +1,12 @@
 # Using envcommon in an infrastructure-unit
 
-### infrastructure-unit
+## infrastructure-unit
 
 An infrastructure unit is the Gruntwork term for the deployment of an infrastructure as code module in a single environment. For example, deploying the [`vpc-app`](../../reference/modules/terraform-aws-vpc/vpc-app/) module in your development AWS account is a single infrastructure-unit.
 
-In this section, we'll walk through the approach we employ at Gruntwork for leveraging modules in envcommon as infrastructure-units. When you purchase a DevOps Foundation, the generated repository containing your infrastructure-as-code is automatically laid out to use this approach.
+In this section, we'll walk through the approach we employ at Gruntwork for leveraging modules in envcommon as infrastructure-units. When you purchase a DevOps Foundation, the generated repository containing your infrastructure as code is automatically laid out to use this approach.
 
-### The Terraform block
+## The Terraform block
 
 Gruntwork recommends that infrastructure-unit definitions contain a `terraform` block, in addition the the `terraform` block in the underlying envcommon module. This allows users to change module versions granularly across environments, rather than changing a global value and updating all of your environments at once.
 
@@ -18,7 +18,7 @@ terraform {
 }
 ```
 
-### Including the envcommon module
+## Including the envcommon module
 
 Including an envcommon module requires using an [`include`](https://terragrunt.gruntwork.io/docs/features/keep-your-terragrunt-architecture-dry/#using-exposed-includes-to-override-common-configurations) block. This allows you to use or override any default values and reference locals in the envcommon module.
 
@@ -32,7 +32,7 @@ include "envcommon" {
 }
 ```
 
-### Specifying Dependencies
+## Specifying Dependencies
 
 [Dependencies](https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#dependency) are a Terragrunt concept that allow you to specify that certain infrastructure-units must be applied before this infrastructure-unit. Dependencies can leveraged regardless of the source of the underlying module. This means that an infrastructure-unit that uses an envcommon module can reference dependencies the same way as an infrastructure-unit that does not use an envcommon module.
 
@@ -44,7 +44,7 @@ dependency "kms" {
 }
 ```
 
-### Using Locals
+## Using Locals
 
 Like Dependencies, [Locals](https://terragrunt.gruntwork.io/docs/features/locals/) are a Terragrunt concept that allow you to bind a name to an expression. Locals are a useful tool when leveraging the envcommon pattern to set environment specific values, like CIDR blocks, resource name prefixes, and more. An infrastructure-unit that uses an envcommon module can reference dependencies the same way as an infrastructure-unit that does not use an envcommon module.
 
@@ -56,7 +56,7 @@ locals {
 }
 ```
 
-### Overriding Inputs
+## Overriding Inputs
 
 Inputs allow you to pass in values to the underlying module specified in the `include` block. This is where the envcommon pattern shows it convenience and helps to keep your code clean and DRY.
 

--- a/_docs-sources/learning-center/envcommon/usage.md
+++ b/_docs-sources/learning-center/envcommon/usage.md
@@ -14,7 +14,7 @@ To ensure that we're using the same module as the envcommon module, we can refer
 
 ```hcl title=/dev/us-east-1/dev/networking/vpc/terragrunt.hcl
 terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.47.1"
+  source = "${include.envcommon.locals.source_base_url}?ref=v0.104.19"
 }
 ```
 
@@ -31,6 +31,8 @@ include "envcommon" {
   expose = true
 }
 ```
+
+Note that we're using the [`find_in_parent_folders()`](https://terragrunt.gruntwork.io/docs/reference/built-in-functions/#find_in_parent_folders) terragrunt built-in function to find the root directory of the repository, then specifying the path to the envcommon module from there.
 
 ## Specifying Dependencies
 

--- a/_docs-sources/learning-center/envcommon/usage.md
+++ b/_docs-sources/learning-center/envcommon/usage.md
@@ -12,9 +12,9 @@ Gruntwork recommends that infrastructure-unit definitions contain a `terraform` 
 
 To ensure that we're using the same module as the envcommon module, we can reference the `source_base_url` value from the envcommon `include` block (which we'll learn more about in the next section), then specify the release version after `ref`. In the example below, we reference the `base_source_url` from our envcommon module, then override the version to `v0.47.0`.
 
-```hcl
+```hcl title=/dev/us-east-1/dev/networking/vpc/terragrunt.hcl
 terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.47.0"
+  source = "${include.envcommon.locals.source_base_url}?ref=v0.47.1"
 }
 ```
 

--- a/_docs-sources/learning-center/envcommon/usage.md
+++ b/_docs-sources/learning-center/envcommon/usage.md
@@ -1,0 +1,80 @@
+# Using envcommon
+
+
+# Using envcommon in an infrastructure-unit
+
+### infrastructure-unit
+
+An infrastructure unit is the Gruntwork term for the deployment of an infrastructure as code module in a single environment. For example, deploying the [`vpc-app`](../../reference/modules/terraform-aws-vpc/vpc-app/) module in your development AWS account is a single infrastructure-unit.
+
+In this section, we'll walk through the approach we employ at Gruntwork for leveraging modules in envcommon as infrastructure-units. When you purchase a DevOps Foundation, the generated repository containing your infrastructure-as-code is automatically laid out to use this approach.
+
+### Terraform block
+
+Gruntwork recommends that infrastructure-unit definitions contain a `terraform` block, in addition the the `terraform` block in the underlying envcommon module. This allows users to change module versions granularly across environments, rather than changing a global value and updating all of your environments at once.
+
+To ensure that we're using the same module as the envcommon module, we can reference the `source_base_url` value from the envcommon `include` block (which we'll learn more about in the next section), then specify the release version after `ref`. In the example below, we reference the `base_source_url` from our envcommon module, then override the version to `v0.47.0`.
+
+```hcl
+terraform {
+  source = "${include.envcommon.locals.source_base_url}?ref=v0.47.0"
+}
+```
+
+### Include the envcommon module
+
+Including an envcommon module requires using an [`include`](https://terragrunt.gruntwork.io/docs/features/keep-your-terragrunt-architecture-dry/#using-exposed-includes-to-override-common-configurations) block. This allows you to use or override any default values and reference locals in the envcommon module.
+
+For example, this `include` block references an envcommon module in `_envcommon/networking/vpc-app.hcl`. We need to set `expose = true` in the block to allow referencing the `locals` block in the envcommon module.
+
+```hcl title=/dev/us-east-1/dev/networking/vpc/terragrunt.hcl
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/networking/vpc-app.hcl"
+  # We want to reference the variables from the included config in this configuration, so we expose it.
+  expose = true
+}
+```
+
+### Dependencies
+
+[Dependencies](https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#dependency) are a Terragrunt concept that allow you to specify that certain infrastructure-units must be applied before this infrastructure-unit. Dependencies can leveraged regardless of the source of the underlying module. This means that an infrastructure-unit that uses an envcommon module can reference dependencies the same way as an infrastructure-unit that does not use an envcommon module.
+
+For example, say you needed to add a dependency block that specified a KMS key that is defined in the parent directory of the vpc, must exist before we can apply our example infrastructure-unit.
+
+```hcl title=/dev/us-east-1/dev/networking/kms/terragrunt.hcl
+dependency "kms" {
+    config_path = "../kms"
+}
+```
+
+### Locals
+
+Like Dependencies, [Locals](https://terragrunt.gruntwork.io/docs/features/locals/) are a Terragrunt concept that allow you to bind a name to an expression. Locals are a useful tool when leveraging the envcommon pattern to set environment specific values, like CIDR blocks, resource name prefixes, and more. An infrastructure-unit that uses an envcommon module can reference dependencies the same way as an infrastructure-unit that does not use an envcommon module.
+
+Continuing our vpc-app example, we could specify the CIDR block in a local.
+
+```hcl title=/dev/us-east-1/dev/networking/vpc/terragrunt.hcl
+locals {
+  cidr_block = "10.0.0.0/16"
+}
+```
+
+### Inputs
+
+Inputs allow you to pass in values to the underlying module specified in the `include` block. This is where the envcommon pattern shows it convenience and helps to keep your code clean and DRY.
+
+Inputs specified in an input block are passed into the `include` block and override default values set in the underlying module. This allows you, a module consumer, to reduce the amount of code you need to use to leverage a module.
+
+Continuing our VPC app module example, say there were 20 required input variables to the Terraform module, but across all of your environments, there were only two input variables that needed to be set.
+
+Without envcommon, each time a consumer wanted to leverage your module, they'd need to specify all 20 input variables, increasing the likelihood of getting a value wrong.
+
+With envcommon, you can specify reasonable defaults for all values, then module consumers can override the two environment specific input variables. Not only does this reduce the amount of code consumers have to enter, it encourages code re-use, and reduces the likelihood of a user inputting the incorrect value for an input variable. For example, you may have an organization wide standard that a VPC always have at least three private and public subnets. With the envcommon you can specify the three private and public subnets in envcommon, then allow the user to override the CIDR block input variable per environment.
+
+Finishing out the vpc-app example, we override the CIDR block for an environment specific VPC by specifying the `cidr_block` input variable in the `inputs` block and provide the value we specified in the `locals` block.
+
+```hcl title=/dev/us-east-1/dev/networking/vpc/terragrunt.hcl
+inputs = {
+  cidr_block = local.cidr_block
+}
+```

--- a/_docs-sources/learning-center/index.md
+++ b/_docs-sources/learning-center/index.md
@@ -1,0 +1,3 @@
+# Learning Center
+
+Welcome to the Gruntwork Learning Center! In this category of documentation, you'll find information specific to patterns and practices Gruntwork use to simplify developing infrastructure as code. These patterns are leveraged in Gruntwork [products](../products.md), but we keep them documented separately because they can be applied generically outside of using Gruntwork products.

--- a/docs/learning-center/envcommon/defining.md
+++ b/docs/learning-center/envcommon/defining.md
@@ -44,7 +44,7 @@ inputs = {
     num_nat_gateways                          = 1
 }
 ```
-Our example is relatively straight forward, our module only has three required variables, but there are actually 79 more optional variables. As you expand your usage to supply values to more optional values, the amount of code you don't have to write would increase significantly.
+Our example is relatively straight forward — our module only has three required variables, but there are actually 79 more optional variables. As you expand your usage to supply values to more optional values, the amount of code you don't have to write would increase significantly.
 
 ## Wrapping up
 
@@ -54,6 +54,6 @@ Now that you know how to develop an envcommon module, let's dive in to how you c
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "b54247d219c0255c217d4cc2df08e054"
+  "hash": "f1ffdf5d9d0f5fe1b49c531f2ddc8392"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/learning-center/envcommon/defining.md
+++ b/docs/learning-center/envcommon/defining.md
@@ -1,15 +1,47 @@
 # Defining an envcommon module
 
+Now that you have an understanding of [what envcommon is](index.md), you can develop your own envcommon module.
+
+By default, all envcommon modules should be placed in a directory named `_envcommon`. Beyond that, it is up to you as a developer to determine how to structure the code. Gruntwork recommends structuring your envcommon directory by creating directories for each resource category (e.g., storage, networking) then using a name for the Terragrunt file that represents the resource(s) it will create.
+
+For example, if you are defining an envcommon module for a AWS VPC in which you will deploy applications, you might put it in a directory named `networking` and a file named `vpc-app.hcl`, resulting in `_envcommon/networking/vpc-app.hcl`.
+
+Next, we'll fine the envcommon module. It's important to remember that a Terragrunt module is structured the same as an Terragrunt file. The only difference is that this module defines default variable values and locals that can be used in any environment.
+
 ## The Terraform block
+
+```hcl title=_envcommon/networking/vpc-app.hcl
+terraform {
+  source = "${local.source_base_url}?ref=v0.47.1"
+}
+```
 
 ## Locals
 
+```hcl title=_envcommon/networking/vpc-app.hcl
+locals {
+    source_base_url = "git::ssh://git@github.com/gruntwork-io/terraform-aws-service-catalog.git//modules/networking/vpc"
+
+    account_name = local.account_vars.locals.account_name
+    region = "us-east-1"
+}
+```
+
 ## Specifying variable values
+
+```hcl title=_envcommon/networking/vpc-app.hcl
+inputs = {
+    // cidr_block is a required input but note we are excluding it!
+    vpc_name                                  = local.account_name
+    aws_region                                = local.region
+    num_nat_gateways                          = 1
+}
+```
 
 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "10217b8caecdc7401b3ffca16bd40f0e"
+  "hash": "2150117d7e02f5dedda1b4975c623349"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/learning-center/envcommon/defining.md
+++ b/docs/learning-center/envcommon/defining.md
@@ -1,0 +1,10 @@
+# Defining an envcommon module
+
+
+
+<!-- ##DOCS-SOURCER-START
+{
+  "sourcePlugin": "local-copier",
+  "hash": "06286343f52596b9cb76d43be1e51544"
+}
+##DOCS-SOURCER-END -->

--- a/docs/learning-center/envcommon/defining.md
+++ b/docs/learning-center/envcommon/defining.md
@@ -44,10 +44,9 @@ inputs = {
     num_nat_gateways                          = 1
 }
 ```
+Our example is relatively straight forward, our module only has three required variables, but there are actually 79 more optional variables. As you expand your usage to supply values to more optional values, the amount of code you don't have to write would increase significantly.
 
 ## Wrapping up
-
-Our example is relatively straight forward, our module only has three required variables, but there are actually 79 more optional variables. As you expand your usage to supply values to more optional values, the amount of code you don't have to write would increase significantly.
 
 Now that you know how to develop an envcommon module, let's dive in to how you can use one to deploy resources to a specific environment.
 
@@ -55,6 +54,6 @@ Now that you know how to develop an envcommon module, let's dive in to how you c
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "eebf1dff8f69e4186d9333f00183685e"
+  "hash": "b54247d219c0255c217d4cc2df08e054"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/learning-center/envcommon/defining.md
+++ b/docs/learning-center/envcommon/defining.md
@@ -1,10 +1,15 @@
 # Defining an envcommon module
 
+## The Terraform block
+
+## Locals
+
+## Specifying variable values
 
 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "06286343f52596b9cb76d43be1e51544"
+  "hash": "10217b8caecdc7401b3ffca16bd40f0e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/learning-center/envcommon/defining.md
+++ b/docs/learning-center/envcommon/defining.md
@@ -10,38 +10,51 @@ Next, we'll fine the envcommon module. It's important to remember that a Terragr
 
 ## The Terraform block
 
+First, define a `terraform` block. This allows you to specify the source URL for the terraform module you are using. Gruntwork recommends using a `local` block to define the source url. This allows you to define the source url for the module once, in envcommon, then expose that variable up to any module that leverages this envcommon module. After the source url, we specify a version of the module.
+
 ```hcl title=_envcommon/networking/vpc-app.hcl
 terraform {
-  source = "${local.source_base_url}?ref=v0.47.1"
+  source = "${local.source_base_url}?ref=v0.104.19"
 }
 ```
 
 ## Locals
 
+As with all Terragrunt modules, you can specify a `locals` block in an envcommon module. Locals allows you to assign an expression to a value, such as setting a common region name or dynamically reading values from configuration files. In the example below, we show how you can read account specific information from another terragrunt file, then use that information as a local.
+
 ```hcl title=_envcommon/networking/vpc-app.hcl
 locals {
     source_base_url = "git::ssh://git@github.com/gruntwork-io/terraform-aws-service-catalog.git//modules/networking/vpc"
 
+    account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
     account_name = local.account_vars.locals.account_name
-    region = "us-east-1"
 }
 ```
 
 ## Specifying variable values
 
+Finally, you can define inputs. This is where the envcommon pattern really starts to demonstrate value by keeping your code DRY.
+
+In the example block below, we've set default values for the `vpc_name` and `num_nat_gateways` variables. A quick inspection of the [`vpc-app`](../../reference/modules/terraform-aws-vpc/vpc-app/) module shows us that we're only missing one additional required variable — `cidr_block`. This means that consumers of our envcommon module only need to specify a value for one input variable, a 66% reduction! You could even expand this example to always use the same CIDR block, allowing the users to override it should they require a different block.
+
 ```hcl title=_envcommon/networking/vpc-app.hcl
 inputs = {
     // cidr_block is a required input but note we are excluding it!
     vpc_name                                  = local.account_name
-    aws_region                                = local.region
     num_nat_gateways                          = 1
 }
 ```
+
+## Wrapping up
+
+Our example is relatively straight forward, our module only has three required variables, but there are actually 79 more optional variables. As you expand your usage to supply values to more optional values, the amount of code you don't have to write would increase significantly.
+
+Now that you know how to develop an envcommon module, let's dive in to how you can use one to deploy resources to a specific environment.
 
 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "2150117d7e02f5dedda1b4975c623349"
+  "hash": "eebf1dff8f69e4186d9333f00183685e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/learning-center/envcommon/defining.md
+++ b/docs/learning-center/envcommon/defining.md
@@ -44,7 +44,7 @@ inputs = {
     num_nat_gateways                          = 1
 }
 ```
-Our example is relatively straight forward — our module only has three required variables, but there are actually 79 more optional variables. As you expand your usage to supply values to more optional values, the amount of code you don't have to write would increase significantly.
+Our example is relatively straight forward — our module only has three required variables, but there are actually 79 more optional variables. As you expand your usage to supply values to more optional values, the amount of code you don't have to write increases significantly.
 
 ## Wrapping up
 
@@ -54,6 +54,6 @@ Now that you know how to develop an envcommon module, let's dive in to how you c
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "f1ffdf5d9d0f5fe1b49c531f2ddc8392"
+  "hash": "d73b94deab84738d02add83743130546"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/learning-center/envcommon/index.md
+++ b/docs/learning-center/envcommon/index.md
@@ -1,10 +1,19 @@
 # What is envcommon?
 
+envcommon is a pattern that allows infrastructure as code developers to reference a terraform module, set locals, and set default (but mutable) default variable values. This pattern helps keep your Terragrunt architecture DRY, reducing the likelihood of errors when making changes across environments.
+
+This patterns has benefits for module developers and consumers — Engineers developing modules can centrally define defaults that can be applied to all usage while engineers consuming modules don't have to repeat as much code when leveraging the module.
+
+One analogy is to think about envcommon in the same way you might think about purchasing a new car. The manufacturer offers a "base model" with several configurable options, such as interior upgrades, but at the end of the purchase you will have a car. As the purchaser, you might just need the base model without any upgrades, or you may upgrade the stereo to a premium option.
+
+Similarly, with envcommon you may define a "base" resource, such as an AWS RDS for PostgreSQL instance. By default, all consumers of the module might get a `db.t3.medium` instance with a `50gb`  general purpose SSD. While this might work in the majority of your environments, for a production deployment you might need an instance with more memory, CPU, and storage space. With envcommon, you would simplify override the variable names for the instance size/type and the amount of desired storage. Everything else remains the same.
+
+Now that we've established what the envcommon pattern is and how it can help simplify your infrastructure as code, let's dive into how you can define an envcommon module.
 
 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "d33603cb6aaa908a220901e06b739317"
+  "hash": "2530a9bb75d68866d5907c1e5907f5a7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/learning-center/envcommon/index.md
+++ b/docs/learning-center/envcommon/index.md
@@ -1,0 +1,10 @@
+# What is envcommon?
+
+
+
+<!-- ##DOCS-SOURCER-START
+{
+  "sourcePlugin": "local-copier",
+  "hash": "d33603cb6aaa908a220901e06b739317"
+}
+##DOCS-SOURCER-END -->

--- a/docs/learning-center/envcommon/usage.md
+++ b/docs/learning-center/envcommon/usage.md
@@ -14,7 +14,7 @@ To ensure that we're using the same module as the envcommon module, we can refer
 
 ```hcl title=/dev/us-east-1/dev/networking/vpc/terragrunt.hcl
 terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.47.1"
+  source = "${include.envcommon.locals.source_base_url}?ref=v0.104.19"
 }
 ```
 
@@ -31,6 +31,8 @@ include "envcommon" {
   expose = true
 }
 ```
+
+Note that we're using the [`find_in_parent_folders()`](https://terragrunt.gruntwork.io/docs/reference/built-in-functions/#find_in_parent_folders) terragrunt built-in function to find the root directory of the repository, then specifying the path to the envcommon module from there.
 
 ## Specifying Dependencies
 
@@ -80,6 +82,6 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "203f127a8672ff91d13aefb8facf396e"
+  "hash": "d4770f947f5c1f8906026ce89ddd1050"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/learning-center/envcommon/usage.md
+++ b/docs/learning-center/envcommon/usage.md
@@ -32,7 +32,7 @@ include "envcommon" {
 }
 ```
 
-Note that we're using the [`find_in_parent_folders()`](https://terragrunt.gruntwork.io/docs/reference/built-in-functions/#find_in_parent_folders) terragrunt built-in function to find the root directory of the repository, then specifying the path to the envcommon module from there.
+Note that we're using the built-in terragrunt function [`find_in_parent_folders()`](https://terragrunt.gruntwork.io/docs/reference/built-in-functions/#find_in_parent_folders) to find the root directory of the repository, then specifying the path to the envcommon module from there.
 
 ## Specifying Dependencies
 
@@ -82,6 +82,6 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "d4770f947f5c1f8906026ce89ddd1050"
+  "hash": "9855461a1d9c2c8ab87983e539cd6af3"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/learning-center/envcommon/usage.md
+++ b/docs/learning-center/envcommon/usage.md
@@ -12,9 +12,9 @@ Gruntwork recommends that infrastructure-unit definitions contain a `terraform` 
 
 To ensure that we're using the same module as the envcommon module, we can reference the `source_base_url` value from the envcommon `include` block (which we'll learn more about in the next section), then specify the release version after `ref`. In the example below, we reference the `base_source_url` from our envcommon module, then override the version to `v0.47.0`.
 
-```hcl
+```hcl title=/dev/us-east-1/dev/networking/vpc/terragrunt.hcl
 terraform {
-  source = "${include.envcommon.locals.source_base_url}?ref=v0.47.0"
+  source = "${include.envcommon.locals.source_base_url}?ref=v0.47.1"
 }
 ```
 
@@ -80,6 +80,6 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "3d45bf88381893e476e03de0aede3c95"
+  "hash": "203f127a8672ff91d13aefb8facf396e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/learning-center/envcommon/usage.md
+++ b/docs/learning-center/envcommon/usage.md
@@ -1,6 +1,3 @@
-# Using envcommon
-
-
 # Using envcommon in an infrastructure-unit
 
 ### infrastructure-unit
@@ -9,7 +6,7 @@ An infrastructure unit is the Gruntwork term for the deployment of an infrastruc
 
 In this section, we'll walk through the approach we employ at Gruntwork for leveraging modules in envcommon as infrastructure-units. When you purchase a DevOps Foundation, the generated repository containing your infrastructure-as-code is automatically laid out to use this approach.
 
-### Terraform block
+### The Terraform block
 
 Gruntwork recommends that infrastructure-unit definitions contain a `terraform` block, in addition the the `terraform` block in the underlying envcommon module. This allows users to change module versions granularly across environments, rather than changing a global value and updating all of your environments at once.
 
@@ -21,7 +18,7 @@ terraform {
 }
 ```
 
-### Include the envcommon module
+### Including the envcommon module
 
 Including an envcommon module requires using an [`include`](https://terragrunt.gruntwork.io/docs/features/keep-your-terragrunt-architecture-dry/#using-exposed-includes-to-override-common-configurations) block. This allows you to use or override any default values and reference locals in the envcommon module.
 
@@ -35,7 +32,7 @@ include "envcommon" {
 }
 ```
 
-### Dependencies
+### Specifying Dependencies
 
 [Dependencies](https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#dependency) are a Terragrunt concept that allow you to specify that certain infrastructure-units must be applied before this infrastructure-unit. Dependencies can leveraged regardless of the source of the underlying module. This means that an infrastructure-unit that uses an envcommon module can reference dependencies the same way as an infrastructure-unit that does not use an envcommon module.
 
@@ -47,7 +44,7 @@ dependency "kms" {
 }
 ```
 
-### Locals
+### Using Locals
 
 Like Dependencies, [Locals](https://terragrunt.gruntwork.io/docs/features/locals/) are a Terragrunt concept that allow you to bind a name to an expression. Locals are a useful tool when leveraging the envcommon pattern to set environment specific values, like CIDR blocks, resource name prefixes, and more. An infrastructure-unit that uses an envcommon module can reference dependencies the same way as an infrastructure-unit that does not use an envcommon module.
 
@@ -59,7 +56,7 @@ locals {
 }
 ```
 
-### Inputs
+### Overriding Inputs
 
 Inputs allow you to pass in values to the underlying module specified in the `include` block. This is where the envcommon pattern shows it convenience and helps to keep your code clean and DRY.
 
@@ -83,6 +80,6 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "e6a4dd5069f040f90a80492122cd988a"
+  "hash": "8476d824a6c4382b0f5dcecb7fd65b91"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/learning-center/envcommon/usage.md
+++ b/docs/learning-center/envcommon/usage.md
@@ -1,12 +1,12 @@
 # Using envcommon in an infrastructure-unit
 
-### infrastructure-unit
+## infrastructure-unit
 
 An infrastructure unit is the Gruntwork term for the deployment of an infrastructure as code module in a single environment. For example, deploying the [`vpc-app`](../../reference/modules/terraform-aws-vpc/vpc-app/) module in your development AWS account is a single infrastructure-unit.
 
-In this section, we'll walk through the approach we employ at Gruntwork for leveraging modules in envcommon as infrastructure-units. When you purchase a DevOps Foundation, the generated repository containing your infrastructure-as-code is automatically laid out to use this approach.
+In this section, we'll walk through the approach we employ at Gruntwork for leveraging modules in envcommon as infrastructure-units. When you purchase a DevOps Foundation, the generated repository containing your infrastructure as code is automatically laid out to use this approach.
 
-### The Terraform block
+## The Terraform block
 
 Gruntwork recommends that infrastructure-unit definitions contain a `terraform` block, in addition the the `terraform` block in the underlying envcommon module. This allows users to change module versions granularly across environments, rather than changing a global value and updating all of your environments at once.
 
@@ -18,7 +18,7 @@ terraform {
 }
 ```
 
-### Including the envcommon module
+## Including the envcommon module
 
 Including an envcommon module requires using an [`include`](https://terragrunt.gruntwork.io/docs/features/keep-your-terragrunt-architecture-dry/#using-exposed-includes-to-override-common-configurations) block. This allows you to use or override any default values and reference locals in the envcommon module.
 
@@ -32,7 +32,7 @@ include "envcommon" {
 }
 ```
 
-### Specifying Dependencies
+## Specifying Dependencies
 
 [Dependencies](https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#dependency) are a Terragrunt concept that allow you to specify that certain infrastructure-units must be applied before this infrastructure-unit. Dependencies can leveraged regardless of the source of the underlying module. This means that an infrastructure-unit that uses an envcommon module can reference dependencies the same way as an infrastructure-unit that does not use an envcommon module.
 
@@ -44,7 +44,7 @@ dependency "kms" {
 }
 ```
 
-### Using Locals
+## Using Locals
 
 Like Dependencies, [Locals](https://terragrunt.gruntwork.io/docs/features/locals/) are a Terragrunt concept that allow you to bind a name to an expression. Locals are a useful tool when leveraging the envcommon pattern to set environment specific values, like CIDR blocks, resource name prefixes, and more. An infrastructure-unit that uses an envcommon module can reference dependencies the same way as an infrastructure-unit that does not use an envcommon module.
 
@@ -56,7 +56,7 @@ locals {
 }
 ```
 
-### Overriding Inputs
+## Overriding Inputs
 
 Inputs allow you to pass in values to the underlying module specified in the `include` block. This is where the envcommon pattern shows it convenience and helps to keep your code clean and DRY.
 
@@ -80,6 +80,6 @@ inputs = {
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "8476d824a6c4382b0f5dcecb7fd65b91"
+  "hash": "3d45bf88381893e476e03de0aede3c95"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/learning-center/envcommon/usage.md
+++ b/docs/learning-center/envcommon/usage.md
@@ -1,0 +1,88 @@
+# Using envcommon
+
+
+# Using envcommon in an infrastructure-unit
+
+### infrastructure-unit
+
+An infrastructure unit is the Gruntwork term for the deployment of an infrastructure as code module in a single environment. For example, deploying the [`vpc-app`](../../reference/modules/terraform-aws-vpc/vpc-app/) module in your development AWS account is a single infrastructure-unit.
+
+In this section, we'll walk through the approach we employ at Gruntwork for leveraging modules in envcommon as infrastructure-units. When you purchase a DevOps Foundation, the generated repository containing your infrastructure-as-code is automatically laid out to use this approach.
+
+### Terraform block
+
+Gruntwork recommends that infrastructure-unit definitions contain a `terraform` block, in addition the the `terraform` block in the underlying envcommon module. This allows users to change module versions granularly across environments, rather than changing a global value and updating all of your environments at once.
+
+To ensure that we're using the same module as the envcommon module, we can reference the `source_base_url` value from the envcommon `include` block (which we'll learn more about in the next section), then specify the release version after `ref`. In the example below, we reference the `base_source_url` from our envcommon module, then override the version to `v0.47.0`.
+
+```hcl
+terraform {
+  source = "${include.envcommon.locals.source_base_url}?ref=v0.47.0"
+}
+```
+
+### Include the envcommon module
+
+Including an envcommon module requires using an [`include`](https://terragrunt.gruntwork.io/docs/features/keep-your-terragrunt-architecture-dry/#using-exposed-includes-to-override-common-configurations) block. This allows you to use or override any default values and reference locals in the envcommon module.
+
+For example, this `include` block references an envcommon module in `_envcommon/networking/vpc-app.hcl`. We need to set `expose = true` in the block to allow referencing the `locals` block in the envcommon module.
+
+```hcl title=/dev/us-east-1/dev/networking/vpc/terragrunt.hcl
+include "envcommon" {
+  path = "${dirname(find_in_parent_folders())}/_envcommon/networking/vpc-app.hcl"
+  # We want to reference the variables from the included config in this configuration, so we expose it.
+  expose = true
+}
+```
+
+### Dependencies
+
+[Dependencies](https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#dependency) are a Terragrunt concept that allow you to specify that certain infrastructure-units must be applied before this infrastructure-unit. Dependencies can leveraged regardless of the source of the underlying module. This means that an infrastructure-unit that uses an envcommon module can reference dependencies the same way as an infrastructure-unit that does not use an envcommon module.
+
+For example, say you needed to add a dependency block that specified a KMS key that is defined in the parent directory of the vpc, must exist before we can apply our example infrastructure-unit.
+
+```hcl title=/dev/us-east-1/dev/networking/kms/terragrunt.hcl
+dependency "kms" {
+    config_path = "../kms"
+}
+```
+
+### Locals
+
+Like Dependencies, [Locals](https://terragrunt.gruntwork.io/docs/features/locals/) are a Terragrunt concept that allow you to bind a name to an expression. Locals are a useful tool when leveraging the envcommon pattern to set environment specific values, like CIDR blocks, resource name prefixes, and more. An infrastructure-unit that uses an envcommon module can reference dependencies the same way as an infrastructure-unit that does not use an envcommon module.
+
+Continuing our vpc-app example, we could specify the CIDR block in a local.
+
+```hcl title=/dev/us-east-1/dev/networking/vpc/terragrunt.hcl
+locals {
+  cidr_block = "10.0.0.0/16"
+}
+```
+
+### Inputs
+
+Inputs allow you to pass in values to the underlying module specified in the `include` block. This is where the envcommon pattern shows it convenience and helps to keep your code clean and DRY.
+
+Inputs specified in an input block are passed into the `include` block and override default values set in the underlying module. This allows you, a module consumer, to reduce the amount of code you need to use to leverage a module.
+
+Continuing our VPC app module example, say there were 20 required input variables to the Terraform module, but across all of your environments, there were only two input variables that needed to be set.
+
+Without envcommon, each time a consumer wanted to leverage your module, they'd need to specify all 20 input variables, increasing the likelihood of getting a value wrong.
+
+With envcommon, you can specify reasonable defaults for all values, then module consumers can override the two environment specific input variables. Not only does this reduce the amount of code consumers have to enter, it encourages code re-use, and reduces the likelihood of a user inputting the incorrect value for an input variable. For example, you may have an organization wide standard that a VPC always have at least three private and public subnets. With the envcommon you can specify the three private and public subnets in envcommon, then allow the user to override the CIDR block input variable per environment.
+
+Finishing out the vpc-app example, we override the CIDR block for an environment specific VPC by specifying the `cidr_block` input variable in the `inputs` block and provide the value we specified in the `locals` block.
+
+```hcl title=/dev/us-east-1/dev/networking/vpc/terragrunt.hcl
+inputs = {
+  cidr_block = local.cidr_block
+}
+```
+
+
+<!-- ##DOCS-SOURCER-START
+{
+  "sourcePlugin": "local-copier",
+  "hash": "e6a4dd5069f040f90a80492122cd988a"
+}
+##DOCS-SOURCER-END -->

--- a/docs/learning-center/index.md
+++ b/docs/learning-center/index.md
@@ -1,0 +1,11 @@
+# Learning Center
+
+Welcome to the Gruntwork Learning Center! In this category of documentation, you'll find information specific to patterns and practices Gruntwork use to simplify developing infrastructure as code. These patterns are leveraged in Gruntwork [products](../products.md), but we keep them documented separately because they can be applied generically outside of using Gruntwork products.
+
+
+<!-- ##DOCS-SOURCER-START
+{
+  "sourcePlugin": "local-copier",
+  "hash": "f324d5d2ce969711eea0f3af135d2df8"
+}
+##DOCS-SOURCER-END -->

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -138,6 +138,11 @@ const config = {
             label: "Library Reference",
             docId: "library/reference/index",
           },
+          {
+            type: "doc",
+            label: "Learning Center",
+            docId: "learning-center/index",
+          },
           { to: "/tools", label: "Tools", position: "left" },
           { to: "/courses", label: "Courses", position: "left" },
           {

--- a/sidebars.js
+++ b/sidebars.js
@@ -21,6 +21,7 @@ const patcherSidebars = require("./sidebars/patcher.js")
 const pipelinesSidebars = require("./sidebars/pipelines.js")
 const landingZoneSidebars = require("./sidebars/landing-zone.js")
 const refarchSidebar = require("./sidebars/refarch.js")
+const learningCenterSidebar = require("./sidebars/learning-center.js")
 
 // @ts-check
 
@@ -38,6 +39,7 @@ const sidebars = {
   landingZoneSidebars,
   refarchSidebar,
   libraryRefSidebars,
+  learningCenterSidebar,
 }
 
 module.exports = sidebars

--- a/sidebars/learning-center.js
+++ b/sidebars/learning-center.js
@@ -1,0 +1,33 @@
+const sidebar = [
+    {
+        label: "Learning Center",
+        type: "category",
+        collapsible: false,
+        items: [
+            {
+                label: "Welcome",
+                type: "doc",
+                id: "learning-center/index"
+            },
+            {
+                label: "envcommon",
+                type: "category",
+                collapsible: true,
+                items: [
+                    {
+                        label: "What is envcommon?",
+                        type: "doc",
+                        id: "learning-center/envcommon/index"
+                    },
+                    {
+                        label: "Using envcommon",
+                        type: "doc",
+                        id: "learning-center/envcommon/usage"
+                    }
+                ]
+            }
+        ]
+    }
+]
+
+module.exports = sidebar

--- a/sidebars/learning-center.js
+++ b/sidebars/learning-center.js
@@ -20,7 +20,12 @@ const sidebar = [
                         id: "learning-center/envcommon/index"
                     },
                     {
-                        label: "Using envcommon",
+                        label: "Defining an envcommon module",
+                        type: "doc",
+                        id: "learning-center/envcommon/defining"
+                    },
+                    {
+                        label: "Using an envcommon module",
                         type: "doc",
                         id: "learning-center/envcommon/usage"
                     }


### PR DESCRIPTION
## What it is

Adds docs to explain _what_ the envcommon pattern is and _how_ to use it as both a module developer and consumer.