### PR TITLE
Update patcher changelogs as of 8. September

### DIFF
--- a/static/patcher-changelogs/terraform-aws-asg/asg-instance-refresh.json
+++ b/static/patcher-changelogs/terraform-aws-asg/asg-instance-refresh.json
@@ -1,6 +1,9 @@
 {
   "module": "asg-instance-refresh",
   "releases": {
+    "v0.21.9": {
+      "contains_changes": true
+    },
     "v0.21.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-asg/asg-rolling-deploy.json
+++ b/static/patcher-changelogs/terraform-aws-asg/asg-rolling-deploy.json
@@ -1,6 +1,9 @@
 {
   "module": "asg-rolling-deploy",
   "releases": {
+    "v0.21.9": {
+      "contains_changes": true
+    },
     "v0.21.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-asg/server-group.json
+++ b/static/patcher-changelogs/terraform-aws-asg/server-group.json
@@ -1,6 +1,9 @@
 {
   "module": "server-group",
   "releases": {
+    "v0.21.9": {
+      "contains_changes": true
+    },
     "v0.21.8": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cache/elastic-cache.json
+++ b/static/patcher-changelogs/terraform-aws-cache/elastic-cache.json
@@ -1,6 +1,9 @@
 {
   "module": "elastic-cache",
   "releases": {
+    "v0.21.0": {
+      "contains_changes": true
+    },
     "v0.20.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cache/memcached.json
+++ b/static/patcher-changelogs/terraform-aws-cache/memcached.json
@@ -1,6 +1,9 @@
 {
   "module": "memcached",
   "releases": {
+    "v0.21.0": {
+      "contains_changes": true
+    },
     "v0.20.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cache/redis.json
+++ b/static/patcher-changelogs/terraform-aws-cache/redis.json
@@ -1,6 +1,9 @@
 {
   "module": "redis",
   "releases": {
+    "v0.21.0": {
+      "contains_changes": true
+    },
     "v0.20.2": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cache/redis_copy_snapshot.json
+++ b/static/patcher-changelogs/terraform-aws-cache/redis_copy_snapshot.json
@@ -1,6 +1,9 @@
 {
   "module": "redis_copy_snapshot",
   "releases": {
+    "v0.21.0": {
+      "contains_changes": true
+    },
     "v0.20.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/aws-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/aws-helpers.json
@@ -1,6 +1,12 @@
 {
   "module": "aws-helpers",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": false
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
     "v0.52.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/build-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/build-helpers.json
@@ -1,6 +1,12 @@
 {
   "module": "build-helpers",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": false
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
     "v0.52.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/check-url.json
+++ b/static/patcher-changelogs/terraform-aws-ci/check-url.json
@@ -1,6 +1,12 @@
 {
   "module": "check-url",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": false
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
     "v0.52.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/circleci-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/circleci-helpers.json
@@ -1,6 +1,12 @@
 {
   "module": "circleci-helpers",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": false
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
     "v0.52.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/ec2-backup.json
+++ b/static/patcher-changelogs/terraform-aws-ci/ec2-backup.json
@@ -1,6 +1,12 @@
 {
   "module": "ec2-backup",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": true
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
     "v0.52.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/ecs-deploy-runner-invoke-iam-policy.json
+++ b/static/patcher-changelogs/terraform-aws-ci/ecs-deploy-runner-invoke-iam-policy.json
@@ -1,6 +1,12 @@
 {
   "module": "ecs-deploy-runner-invoke-iam-policy",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": true
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
     "v0.52.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/ecs-deploy-runner-standard-configuration.json
+++ b/static/patcher-changelogs/terraform-aws-ci/ecs-deploy-runner-standard-configuration.json
@@ -1,6 +1,12 @@
 {
   "module": "ecs-deploy-runner-standard-configuration",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": true
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
     "v0.52.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/ecs-deploy-runner.json
+++ b/static/patcher-changelogs/terraform-aws-ci/ecs-deploy-runner.json
@@ -1,6 +1,12 @@
 {
   "module": "ecs-deploy-runner",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": true
+    },
+    "v0.52.12": {
+      "contains_changes": true
+    },
     "v0.52.11": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-ci/git-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/git-helpers.json
@@ -1,6 +1,12 @@
 {
   "module": "git-helpers",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": false
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
     "v0.52.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/gruntwork-module-circleci-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/gruntwork-module-circleci-helpers.json
@@ -1,6 +1,12 @@
 {
   "module": "gruntwork-module-circleci-helpers",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": false
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
     "v0.52.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/iam-policies.json
+++ b/static/patcher-changelogs/terraform-aws-ci/iam-policies.json
@@ -1,6 +1,12 @@
 {
   "module": "iam-policies",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": true
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
     "v0.52.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/infrastructure-deploy-script.json
+++ b/static/patcher-changelogs/terraform-aws-ci/infrastructure-deploy-script.json
@@ -1,6 +1,12 @@
 {
   "module": "infrastructure-deploy-script",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": true
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
     "v0.52.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/infrastructure-deployer.json
+++ b/static/patcher-changelogs/terraform-aws-ci/infrastructure-deployer.json
@@ -1,6 +1,12 @@
 {
   "module": "infrastructure-deployer",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": false
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
     "v0.52.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/install-jenkins.json
+++ b/static/patcher-changelogs/terraform-aws-ci/install-jenkins.json
@@ -1,6 +1,12 @@
 {
   "module": "install-jenkins",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": false
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
     "v0.52.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/jenkins-server.json
+++ b/static/patcher-changelogs/terraform-aws-ci/jenkins-server.json
@@ -1,6 +1,12 @@
 {
   "module": "jenkins-server",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": true
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
     "v0.52.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/kubernetes-circleci-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/kubernetes-circleci-helpers.json
@@ -1,6 +1,12 @@
 {
   "module": "kubernetes-circleci-helpers",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": false
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
     "v0.52.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/monorepo-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/monorepo-helpers.json
@@ -1,6 +1,12 @@
 {
   "module": "monorepo-helpers",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": false
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
     "v0.52.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/sign-binary-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/sign-binary-helpers.json
@@ -1,6 +1,12 @@
 {
   "module": "sign-binary-helpers",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": false
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
     "v0.52.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/terraform-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/terraform-helpers.json
@@ -1,6 +1,12 @@
 {
   "module": "terraform-helpers",
   "releases": {
+    "v0.52.13": {
+      "contains_changes": false
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
     "v0.52.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/data-stores/efs.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/data-stores/efs.json
@@ -1,6 +1,12 @@
 {
   "module": "data-stores/efs",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/data-stores/rds.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/data-stores/rds.json
@@ -1,6 +1,12 @@
 {
   "module": "data-stores/rds",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/landingzone/account-baseline-app.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/landingzone/account-baseline-app.json
@@ -1,6 +1,12 @@
 {
   "module": "landingzone/account-baseline-app",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/landingzone/account-baseline-root.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/landingzone/account-baseline-root.json
@@ -1,6 +1,12 @@
 {
   "module": "landingzone/account-baseline-root",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/landingzone/account-baseline-security.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/landingzone/account-baseline-security.json
@@ -1,6 +1,12 @@
 {
   "module": "landingzone/account-baseline-security",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc-app-network-acls.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc-app-network-acls.json
@@ -1,6 +1,12 @@
 {
   "module": "networking/vpc-app-network-acls",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc-mgmt-network-acls.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc-mgmt-network-acls.json
@@ -1,6 +1,12 @@
 {
   "module": "networking/vpc-mgmt-network-acls",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc-mgmt.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc-mgmt.json
@@ -1,6 +1,12 @@
 {
   "module": "networking/vpc-mgmt",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc.json
@@ -1,6 +1,12 @@
 {
   "module": "networking/vpc",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/observability/aws-config-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/observability/aws-config-multi-region.json
@@ -1,6 +1,12 @@
 {
   "module": "observability/aws-config-multi-region",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/observability/cloudtrail.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/observability/cloudtrail.json
@@ -1,6 +1,12 @@
 {
   "module": "observability/cloudtrail",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/observability/cloudwatch-logs-metric-filters.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/observability/cloudwatch-logs-metric-filters.json
@@ -1,6 +1,12 @@
 {
   "module": "observability/cloudwatch-logs-metric-filters",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/aws-securityhub.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/aws-securityhub.json
@@ -1,6 +1,12 @@
 {
   "module": "security/aws-securityhub",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/cleanup-expired-certs.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/cleanup-expired-certs.json
@@ -1,6 +1,12 @@
 {
   "module": "security/cleanup-expired-certs",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/cross-account-iam-roles.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/cross-account-iam-roles.json
@@ -1,6 +1,12 @@
 {
   "module": "security/cross-account-iam-roles",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/custom-iam-entity.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/custom-iam-entity.json
@@ -1,6 +1,12 @@
 {
   "module": "security/custom-iam-entity",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/iam-groups.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/iam-groups.json
@@ -1,6 +1,12 @@
 {
   "module": "security/iam-groups",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/iam-password-policy.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/iam-password-policy.json
@@ -1,6 +1,12 @@
 {
   "module": "security/iam-password-policy",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/macie.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/macie.json
@@ -1,6 +1,12 @@
 {
   "module": "security/macie",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/revoke-unused-iam-credentials.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/revoke-unused-iam-credentials.json
@@ -1,6 +1,12 @@
 {
   "module": "security/revoke-unused-iam-credentials",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": false
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/saml-iam-roles.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/saml-iam-roles.json
@@ -1,6 +1,12 @@
 {
   "module": "security/saml-iam-roles",
   "releases": {
+    "v0.48.0": {
+      "contains_changes": true
+    },
+    "v0.47.9": {
+      "contains_changes": true
+    },
     "v0.47.8": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/aurora.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/aurora.json
@@ -1,6 +1,12 @@
 {
   "module": "aurora",
   "releases": {
+    "v0.30.0": {
+      "contains_changes": true
+    },
+    "v0.29.2": {
+      "contains_changes": false
+    },
     "v0.29.1": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/backup-plan.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/backup-plan.json
@@ -1,6 +1,12 @@
 {
   "module": "backup-plan",
   "releases": {
+    "v0.30.0": {
+      "contains_changes": true
+    },
+    "v0.29.2": {
+      "contains_changes": false
+    },
     "v0.29.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/backup-vault.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/backup-vault.json
@@ -1,6 +1,12 @@
 {
   "module": "backup-vault",
   "releases": {
+    "v0.30.0": {
+      "contains_changes": true
+    },
+    "v0.29.2": {
+      "contains_changes": false
+    },
     "v0.29.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/efs.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/efs.json
@@ -1,6 +1,12 @@
 {
   "module": "efs",
   "releases": {
+    "v0.30.0": {
+      "contains_changes": true
+    },
+    "v0.29.2": {
+      "contains_changes": false
+    },
     "v0.29.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/lambda-cleanup-snapshots.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/lambda-cleanup-snapshots.json
@@ -1,6 +1,12 @@
 {
   "module": "lambda-cleanup-snapshots",
   "releases": {
+    "v0.30.0": {
+      "contains_changes": true
+    },
+    "v0.29.2": {
+      "contains_changes": false
+    },
     "v0.29.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/lambda-copy-shared-snapshot.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/lambda-copy-shared-snapshot.json
@@ -1,6 +1,12 @@
 {
   "module": "lambda-copy-shared-snapshot",
   "releases": {
+    "v0.30.0": {
+      "contains_changes": true
+    },
+    "v0.29.2": {
+      "contains_changes": false
+    },
     "v0.29.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/lambda-create-snapshot.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/lambda-create-snapshot.json
@@ -1,6 +1,12 @@
 {
   "module": "lambda-create-snapshot",
   "releases": {
+    "v0.30.0": {
+      "contains_changes": true
+    },
+    "v0.29.2": {
+      "contains_changes": false
+    },
     "v0.29.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/lambda-share-snapshot.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/lambda-share-snapshot.json
@@ -1,6 +1,12 @@
 {
   "module": "lambda-share-snapshot",
   "releases": {
+    "v0.30.0": {
+      "contains_changes": true
+    },
+    "v0.29.2": {
+      "contains_changes": false
+    },
     "v0.29.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/rds-proxy.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/rds-proxy.json
@@ -1,6 +1,12 @@
 {
   "module": "rds-proxy",
   "releases": {
+    "v0.30.0": {
+      "contains_changes": true
+    },
+    "v0.29.2": {
+      "contains_changes": false
+    },
     "v0.29.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/rds-replicas.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/rds-replicas.json
@@ -1,6 +1,12 @@
 {
   "module": "rds-replicas",
   "releases": {
+    "v0.30.0": {
+      "contains_changes": true
+    },
+    "v0.29.2": {
+      "contains_changes": false
+    },
     "v0.29.1": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/rds.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/rds.json
@@ -1,6 +1,12 @@
 {
   "module": "rds",
   "releases": {
+    "v0.30.0": {
+      "contains_changes": true
+    },
+    "v0.29.2": {
+      "contains_changes": true
+    },
     "v0.29.1": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/redshift.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/redshift.json
@@ -1,6 +1,12 @@
 {
   "module": "redshift",
   "releases": {
+    "v0.30.0": {
+      "contains_changes": true
+    },
+    "v0.29.2": {
+      "contains_changes": false
+    },
     "v0.29.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-cluster.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-cluster.json
@@ -1,6 +1,9 @@
 {
   "module": "ecs-cluster",
   "releases": {
+    "v0.35.10": {
+      "contains_changes": true
+    },
     "v0.35.9": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-daemon-service.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-daemon-service.json
@@ -1,6 +1,9 @@
 {
   "module": "ecs-daemon-service",
   "releases": {
+    "v0.35.10": {
+      "contains_changes": true
+    },
     "v0.35.9": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-deploy-check-binaries.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-deploy-check-binaries.json
@@ -1,6 +1,9 @@
 {
   "module": "ecs-deploy-check-binaries",
   "releases": {
+    "v0.35.10": {
+      "contains_changes": false
+    },
     "v0.35.9": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-deploy.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-deploy.json
@@ -1,6 +1,9 @@
 {
   "module": "ecs-deploy",
   "releases": {
+    "v0.35.10": {
+      "contains_changes": false
+    },
     "v0.35.9": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-fargate.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-fargate.json
@@ -1,6 +1,9 @@
 {
   "module": "ecs-fargate",
   "releases": {
+    "v0.35.10": {
+      "contains_changes": false
+    },
     "v0.35.9": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-scripts.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-scripts.json
@@ -1,6 +1,9 @@
 {
   "module": "ecs-scripts",
   "releases": {
+    "v0.35.10": {
+      "contains_changes": false
+    },
     "v0.35.9": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-service-with-alb.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-service-with-alb.json
@@ -1,6 +1,9 @@
 {
   "module": "ecs-service-with-alb",
   "releases": {
+    "v0.35.10": {
+      "contains_changes": false
+    },
     "v0.35.9": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-service-with-discovery.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-service-with-discovery.json
@@ -1,6 +1,9 @@
 {
   "module": "ecs-service-with-discovery",
   "releases": {
+    "v0.35.10": {
+      "contains_changes": false
+    },
     "v0.35.9": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-service.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-service.json
@@ -1,6 +1,9 @@
 {
   "module": "ecs-service",
   "releases": {
+    "v0.35.10": {
+      "contains_changes": true
+    },
     "v0.35.9": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-task-scheduler.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-task-scheduler.json
@@ -1,6 +1,9 @@
 {
   "module": "ecs-task-scheduler",
   "releases": {
+    "v0.35.10": {
+      "contains_changes": false
+    },
     "v0.35.9": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-alb-ingress-controller-iam-policy.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-alb-ingress-controller-iam-policy.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-alb-ingress-controller-iam-policy",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": true
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
     "v0.61.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-alb-ingress-controller.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-alb-ingress-controller.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-alb-ingress-controller",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": true
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
     "v0.61.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-aws-auth-merger.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-aws-auth-merger.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-aws-auth-merger",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": true
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
     "v0.61.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-cloudwatch-agent.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-cloudwatch-agent.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-cloudwatch-agent",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": true
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
     "v0.61.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-cluster-control-plane.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-cluster-control-plane.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-cluster-control-plane",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": true
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
     "v0.61.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-cluster-managed-workers.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-cluster-managed-workers.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-cluster-managed-workers",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": true
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
     "v0.61.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-cluster-workers-cross-access.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-cluster-workers-cross-access.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-cluster-workers-cross-access",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": true
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
     "v0.61.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-cluster-workers.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-cluster-workers.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-cluster-workers",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": true
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
     "v0.61.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-container-logs.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-container-logs.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-container-logs",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": true
+    },
+    "v0.61.1": {
+      "contains_changes": true
+    },
     "v0.61.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-fargate-container-logs.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-fargate-container-logs.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-fargate-container-logs",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": true
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
     "v0.61.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-iam-role-assume-role-policy-for-service-account.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-iam-role-assume-role-policy-for-service-account.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-iam-role-assume-role-policy-for-service-account",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": true
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
     "v0.61.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-cluster-autoscaler-iam-policy.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-cluster-autoscaler-iam-policy.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-k8s-cluster-autoscaler-iam-policy",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": true
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
     "v0.61.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-cluster-autoscaler.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-cluster-autoscaler.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-k8s-cluster-autoscaler",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": true
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
     "v0.61.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-external-dns-iam-policy.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-external-dns-iam-policy.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-k8s-external-dns-iam-policy",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": true
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
     "v0.61.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-external-dns.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-external-dns.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-k8s-external-dns",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": true
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
     "v0.61.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-karpenter.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-karpenter.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-k8s-karpenter",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": true
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
     "v0.61.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-role-mapping.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-role-mapping.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-k8s-role-mapping",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": true
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
     "v0.61.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-scripts.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-scripts.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-scripts",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": false
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
     "v0.61.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-vpc-tags.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-vpc-tags.json
@@ -1,6 +1,12 @@
 {
   "module": "eks-vpc-tags",
   "releases": {
+    "v0.62.0": {
+      "contains_changes": true
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
     "v0.61.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/api-gateway-account-settings.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/api-gateway-account-settings.json
@@ -1,6 +1,9 @@
 {
   "module": "api-gateway-account-settings",
   "releases": {
+    "v0.21.13": {
+      "contains_changes": true
+    },
     "v0.21.12": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/api-gateway-proxy-methods.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/api-gateway-proxy-methods.json
@@ -1,6 +1,9 @@
 {
   "module": "api-gateway-proxy-methods",
   "releases": {
+    "v0.21.13": {
+      "contains_changes": false
+    },
     "v0.21.12": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/api-gateway-proxy.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/api-gateway-proxy.json
@@ -1,6 +1,9 @@
 {
   "module": "api-gateway-proxy",
   "releases": {
+    "v0.21.13": {
+      "contains_changes": true
+    },
     "v0.21.12": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/keep-warm.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/keep-warm.json
@@ -1,6 +1,9 @@
 {
   "module": "keep-warm",
   "releases": {
+    "v0.21.13": {
+      "contains_changes": true
+    },
     "v0.21.12": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/lambda-edge-log-group.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/lambda-edge-log-group.json
@@ -1,6 +1,9 @@
 {
   "module": "lambda-edge-log-group",
   "releases": {
+    "v0.21.13": {
+      "contains_changes": true
+    },
     "v0.21.12": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/lambda-edge-multi-region-log-groups.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/lambda-edge-multi-region-log-groups.json
@@ -1,6 +1,9 @@
 {
   "module": "lambda-edge-multi-region-log-groups",
   "releases": {
+    "v0.21.13": {
+      "contains_changes": true
+    },
     "v0.21.12": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/lambda-edge.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/lambda-edge.json
@@ -1,6 +1,9 @@
 {
   "module": "lambda-edge",
   "releases": {
+    "v0.21.13": {
+      "contains_changes": true
+    },
     "v0.21.12": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/lambda-http-api-gateway.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/lambda-http-api-gateway.json
@@ -1,6 +1,9 @@
 {
   "module": "lambda-http-api-gateway",
   "releases": {
+    "v0.21.13": {
+      "contains_changes": true
+    },
     "v0.21.12": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/lambda.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/lambda.json
@@ -1,6 +1,9 @@
 {
   "module": "lambda",
   "releases": {
+    "v0.21.13": {
+      "contains_changes": true
+    },
     "v0.21.12": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/run-lambda-entrypoint.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/run-lambda-entrypoint.json
@@ -1,6 +1,9 @@
 {
   "module": "run-lambda-entrypoint",
   "releases": {
+    "v0.21.13": {
+      "contains_changes": false
+    },
     "v0.21.12": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/scheduled-lambda-job.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/scheduled-lambda-job.json
@@ -1,6 +1,9 @@
 {
   "module": "scheduled-lambda-job",
   "releases": {
+    "v0.21.13": {
+      "contains_changes": true
+    },
     "v0.21.12": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-load-balancer/acm-tls-certificate.json
+++ b/static/patcher-changelogs/terraform-aws-load-balancer/acm-tls-certificate.json
@@ -1,6 +1,9 @@
 {
   "module": "acm-tls-certificate",
   "releases": {
+    "v0.29.11": {
+      "contains_changes": true
+    },
     "v0.29.10": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-load-balancer/alb.json
+++ b/static/patcher-changelogs/terraform-aws-load-balancer/alb.json
@@ -1,6 +1,9 @@
 {
   "module": "alb",
   "releases": {
+    "v0.29.11": {
+      "contains_changes": true
+    },
     "v0.29.10": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-load-balancer/lb-listener-rules.json
+++ b/static/patcher-changelogs/terraform-aws-load-balancer/lb-listener-rules.json
@@ -1,6 +1,9 @@
 {
   "module": "lb-listener-rules",
   "releases": {
+    "v0.29.11": {
+      "contains_changes": true
+    },
     "v0.29.10": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-load-balancer/nlb.json
+++ b/static/patcher-changelogs/terraform-aws-load-balancer/nlb.json
@@ -1,6 +1,9 @@
 {
   "module": "nlb",
   "releases": {
+    "v0.29.11": {
+      "contains_changes": false
+    },
     "v0.29.10": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-messaging/kinesis-firehose.json
+++ b/static/patcher-changelogs/terraform-aws-messaging/kinesis-firehose.json
@@ -1,6 +1,9 @@
 {
   "module": "kinesis-firehose",
   "releases": {
+    "v0.12.2": {
+      "contains_changes": true
+    },
     "v0.12.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-messaging/kinesis.json
+++ b/static/patcher-changelogs/terraform-aws-messaging/kinesis.json
@@ -1,6 +1,9 @@
 {
   "module": "kinesis",
   "releases": {
+    "v0.12.2": {
+      "contains_changes": true
+    },
     "v0.12.1": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-messaging/msk.json
+++ b/static/patcher-changelogs/terraform-aws-messaging/msk.json
@@ -1,6 +1,9 @@
 {
   "module": "msk",
   "releases": {
+    "v0.12.2": {
+      "contains_changes": true
+    },
     "v0.12.1": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-messaging/sns-sqs-connection.json
+++ b/static/patcher-changelogs/terraform-aws-messaging/sns-sqs-connection.json
@@ -1,6 +1,9 @@
 {
   "module": "sns-sqs-connection",
   "releases": {
+    "v0.12.2": {
+      "contains_changes": true
+    },
     "v0.12.1": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-messaging/sns.json
+++ b/static/patcher-changelogs/terraform-aws-messaging/sns.json
@@ -1,6 +1,9 @@
 {
   "module": "sns",
   "releases": {
+    "v0.12.2": {
+      "contains_changes": true
+    },
     "v0.12.1": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-messaging/sqs-lambda-connection.json
+++ b/static/patcher-changelogs/terraform-aws-messaging/sqs-lambda-connection.json
@@ -1,6 +1,9 @@
 {
   "module": "sqs-lambda-connection",
   "releases": {
+    "v0.12.2": {
+      "contains_changes": true
+    },
     "v0.12.1": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-messaging/sqs.json
+++ b/static/patcher-changelogs/terraform-aws-messaging/sqs.json
@@ -1,6 +1,9 @@
 {
   "module": "sqs",
   "releases": {
+    "v0.12.2": {
+      "contains_changes": true
+    },
     "v0.12.1": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/agents/cloudwatch-agent.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/agents/cloudwatch-agent.json
@@ -1,6 +1,9 @@
 {
   "module": "agents/cloudwatch-agent",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": false
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/alb-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/alb-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/alb-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/alb-target-group-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/alb-target-group-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/alb-target-group-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/asg-cpu-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/asg-cpu-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/asg-cpu-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/asg-disk-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/asg-disk-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/asg-disk-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/asg-memory-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/asg-memory-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/asg-memory-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/ec2-cpu-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/ec2-cpu-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/ec2-cpu-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/ec2-disk-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/ec2-disk-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/ec2-disk-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/ec2-memory-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/ec2-memory-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/ec2-memory-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/ecs-cluster-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/ecs-cluster-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/ecs-cluster-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/ecs-service-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/ecs-service-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/ecs-service-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/ecs-service-with-alb-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/ecs-service-with-alb-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/ecs-service-with-alb-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": false
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/elasticache-memcached-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/elasticache-memcached-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/elasticache-memcached-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/elasticache-redis-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/elasticache-redis-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/elasticache-redis-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/elasticsearch-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/elasticsearch-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/elasticsearch-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/elb-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/elb-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/elb-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/lambda-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/lambda-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/lambda-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/rds-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/rds-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/rds-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/route53-health-check-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/route53-health-check-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/route53-health-check-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/scheduled-job-alarm.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/scheduled-job-alarm.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/scheduled-job-alarm",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/sns-to-slack.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/sns-to-slack.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/sns-to-slack",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/sqs-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/sqs-alarms.json
@@ -1,6 +1,9 @@
 {
   "module": "alarms/sqs-alarms",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/logs/cloudwatch-log-aggregation-iam-policy.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/logs/cloudwatch-log-aggregation-iam-policy.json
@@ -1,6 +1,9 @@
 {
   "module": "logs/cloudwatch-log-aggregation-iam-policy",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/logs/cloudwatch-logs-metric-filters.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/logs/cloudwatch-logs-metric-filters.json
@@ -1,6 +1,9 @@
 {
   "module": "logs/cloudwatch-logs-metric-filters",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/logs/load-balancer-access-logs.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/logs/load-balancer-access-logs.json
@@ -1,6 +1,9 @@
 {
   "module": "logs/load-balancer-access-logs",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/logs/log-filter-to-slack.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/logs/log-filter-to-slack.json
@@ -1,6 +1,9 @@
 {
   "module": "logs/log-filter-to-slack",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/logs/syslog.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/logs/syslog.json
@@ -1,6 +1,9 @@
 {
   "module": "logs/syslog",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": false
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/metrics/cloudwatch-custom-metrics-iam-policy.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/metrics/cloudwatch-custom-metrics-iam-policy.json
@@ -1,6 +1,9 @@
 {
   "module": "metrics/cloudwatch-custom-metrics-iam-policy",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/metrics/cloudwatch-dashboard-metric-widget.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/metrics/cloudwatch-dashboard-metric-widget.json
@@ -1,6 +1,9 @@
 {
   "module": "metrics/cloudwatch-dashboard-metric-widget",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/metrics/cloudwatch-dashboard-text-widget.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/metrics/cloudwatch-dashboard-text-widget.json
@@ -1,6 +1,9 @@
 {
   "module": "metrics/cloudwatch-dashboard-text-widget",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/metrics/cloudwatch-dashboard.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/metrics/cloudwatch-dashboard.json
@@ -1,6 +1,9 @@
 {
   "module": "metrics/cloudwatch-dashboard",
   "releases": {
+    "v0.36.3": {
+      "contains_changes": true
+    },
     "v0.36.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-openvpn/backup-openvpn-pki.json
+++ b/static/patcher-changelogs/terraform-aws-openvpn/backup-openvpn-pki.json
@@ -1,6 +1,9 @@
 {
   "module": "backup-openvpn-pki",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
     "v0.26.4": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-openvpn/init-openvpn.json
+++ b/static/patcher-changelogs/terraform-aws-openvpn/init-openvpn.json
@@ -1,6 +1,9 @@
 {
   "module": "init-openvpn",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
     "v0.26.4": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-openvpn/install-openvpn.json
+++ b/static/patcher-changelogs/terraform-aws-openvpn/install-openvpn.json
@@ -1,6 +1,9 @@
 {
   "module": "install-openvpn",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
     "v0.26.4": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-openvpn/openvpn-admin.json
+++ b/static/patcher-changelogs/terraform-aws-openvpn/openvpn-admin.json
@@ -1,6 +1,9 @@
 {
   "module": "openvpn-admin",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
     "v0.26.4": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-openvpn/openvpn-server.json
+++ b/static/patcher-changelogs/terraform-aws-openvpn/openvpn-server.json
@@ -1,6 +1,9 @@
 {
   "module": "openvpn-server",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": true
+    },
     "v0.26.4": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-openvpn/start-openvpn-admin.json
+++ b/static/patcher-changelogs/terraform-aws-openvpn/start-openvpn-admin.json
@@ -1,6 +1,9 @@
 {
   "module": "start-openvpn-admin",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
     "v0.26.4": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/auto-update.json
+++ b/static/patcher-changelogs/terraform-aws-security/auto-update.json
@@ -1,6 +1,12 @@
 {
   "module": "auto-update",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/aws-auth.json
+++ b/static/patcher-changelogs/terraform-aws-security/aws-auth.json
@@ -1,6 +1,12 @@
 {
   "module": "aws-auth",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/aws-config-bucket.json
+++ b/static/patcher-changelogs/terraform-aws-security/aws-config-bucket.json
@@ -1,6 +1,12 @@
 {
   "module": "aws-config-bucket",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/aws-config-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-security/aws-config-multi-region.json
@@ -1,6 +1,12 @@
 {
   "module": "aws-config-multi-region",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/aws-config-rules.json
+++ b/static/patcher-changelogs/terraform-aws-security/aws-config-rules.json
@@ -1,6 +1,12 @@
 {
   "module": "aws-config-rules",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/aws-config.json
+++ b/static/patcher-changelogs/terraform-aws-security/aws-config.json
@@ -1,6 +1,12 @@
 {
   "module": "aws-config",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/aws-organizations.json
+++ b/static/patcher-changelogs/terraform-aws-security/aws-organizations.json
@@ -1,6 +1,12 @@
 {
   "module": "aws-organizations",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/cloudtrail-bucket.json
+++ b/static/patcher-changelogs/terraform-aws-security/cloudtrail-bucket.json
@@ -1,6 +1,12 @@
 {
   "module": "cloudtrail-bucket",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/cloudtrail.json
+++ b/static/patcher-changelogs/terraform-aws-security/cloudtrail.json
@@ -1,6 +1,12 @@
 {
   "module": "cloudtrail",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/cross-account-iam-roles.json
+++ b/static/patcher-changelogs/terraform-aws-security/cross-account-iam-roles.json
@@ -1,6 +1,12 @@
 {
   "module": "cross-account-iam-roles",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": true
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/custom-iam-entity.json
+++ b/static/patcher-changelogs/terraform-aws-security/custom-iam-entity.json
@@ -1,6 +1,12 @@
 {
   "module": "custom-iam-entity",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": true
+    },
+    "v0.68.6": {
+      "contains_changes": true
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ebs-encryption-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-security/ebs-encryption-multi-region.json
@@ -1,6 +1,12 @@
 {
   "module": "ebs-encryption-multi-region",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ebs-encryption.json
+++ b/static/patcher-changelogs/terraform-aws-security/ebs-encryption.json
@@ -1,6 +1,12 @@
 {
   "module": "ebs-encryption",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/fail2ban.json
+++ b/static/patcher-changelogs/terraform-aws-security/fail2ban.json
@@ -1,6 +1,12 @@
 {
   "module": "fail2ban",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/github-actions-iam-role.json
+++ b/static/patcher-changelogs/terraform-aws-security/github-actions-iam-role.json
@@ -1,6 +1,12 @@
 {
   "module": "github-actions-iam-role",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": true
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/guardduty-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-security/guardduty-multi-region.json
@@ -1,6 +1,12 @@
 {
   "module": "guardduty-multi-region",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/guardduty.json
+++ b/static/patcher-changelogs/terraform-aws-security/guardduty.json
@@ -1,6 +1,12 @@
 {
   "module": "guardduty",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/iam-access-analyzer-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-security/iam-access-analyzer-multi-region.json
@@ -1,6 +1,12 @@
 {
   "module": "iam-access-analyzer-multi-region",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/iam-groups.json
+++ b/static/patcher-changelogs/terraform-aws-security/iam-groups.json
@@ -1,6 +1,12 @@
 {
   "module": "iam-groups",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": true
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/iam-policies.json
+++ b/static/patcher-changelogs/terraform-aws-security/iam-policies.json
@@ -1,6 +1,12 @@
 {
   "module": "iam-policies",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": true
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/iam-user-password-policy.json
+++ b/static/patcher-changelogs/terraform-aws-security/iam-user-password-policy.json
@@ -1,6 +1,12 @@
 {
   "module": "iam-user-password-policy",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/iam-users.json
+++ b/static/patcher-changelogs/terraform-aws-security/iam-users.json
@@ -1,6 +1,12 @@
 {
   "module": "iam-users",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ip-lockdown.json
+++ b/static/patcher-changelogs/terraform-aws-security/ip-lockdown.json
@@ -1,6 +1,12 @@
 {
   "module": "ip-lockdown",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/kms-cmk-replica.json
+++ b/static/patcher-changelogs/terraform-aws-security/kms-cmk-replica.json
@@ -1,6 +1,12 @@
 {
   "module": "kms-cmk-replica",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/kms-grant-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-security/kms-grant-multi-region.json
@@ -1,6 +1,12 @@
 {
   "module": "kms-grant-multi-region",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/kms-master-key-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-security/kms-master-key-multi-region.json
@@ -1,6 +1,12 @@
 {
   "module": "kms-master-key-multi-region",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/kms-master-key.json
+++ b/static/patcher-changelogs/terraform-aws-security/kms-master-key.json
@@ -1,6 +1,12 @@
 {
   "module": "kms-master-key",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ntp.json
+++ b/static/patcher-changelogs/terraform-aws-security/ntp.json
@@ -1,6 +1,12 @@
 {
   "module": "ntp",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/os-hardening.json
+++ b/static/patcher-changelogs/terraform-aws-security/os-hardening.json
@@ -1,6 +1,12 @@
 {
   "module": "os-hardening",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/private-s3-bucket.json
+++ b/static/patcher-changelogs/terraform-aws-security/private-s3-bucket.json
@@ -1,6 +1,12 @@
 {
   "module": "private-s3-bucket",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-security/saml-iam-roles.json
+++ b/static/patcher-changelogs/terraform-aws-security/saml-iam-roles.json
@@ -1,6 +1,12 @@
 {
   "module": "saml-iam-roles",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": true
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/secrets-manager-resource-policies.json
+++ b/static/patcher-changelogs/terraform-aws-security/secrets-manager-resource-policies.json
@@ -1,6 +1,12 @@
 {
   "module": "secrets-manager-resource-policies",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": true
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ssh-grunt-selinux-policy.json
+++ b/static/patcher-changelogs/terraform-aws-security/ssh-grunt-selinux-policy.json
@@ -1,6 +1,12 @@
 {
   "module": "ssh-grunt-selinux-policy",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ssh-grunt.json
+++ b/static/patcher-changelogs/terraform-aws-security/ssh-grunt.json
@@ -1,6 +1,12 @@
 {
   "module": "ssh-grunt",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ssh-iam.json
+++ b/static/patcher-changelogs/terraform-aws-security/ssh-iam.json
@@ -1,6 +1,12 @@
 {
   "module": "ssh-iam",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ssm-healthchecks-iam-permissions.json
+++ b/static/patcher-changelogs/terraform-aws-security/ssm-healthchecks-iam-permissions.json
@@ -1,6 +1,12 @@
 {
   "module": "ssm-healthchecks-iam-permissions",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/tls-cert-private.json
+++ b/static/patcher-changelogs/terraform-aws-security/tls-cert-private.json
@@ -1,6 +1,12 @@
 {
   "module": "tls-cert-private",
   "releases": {
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
     "v0.68.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-server/attach-eni.json
+++ b/static/patcher-changelogs/terraform-aws-server/attach-eni.json
@@ -1,6 +1,9 @@
 {
   "module": "attach-eni",
   "releases": {
+    "v0.15.6": {
+      "contains_changes": false
+    },
     "v0.15.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-server/disable-instance-metadata.json
+++ b/static/patcher-changelogs/terraform-aws-server/disable-instance-metadata.json
@@ -1,6 +1,9 @@
 {
   "module": "disable-instance-metadata",
   "releases": {
+    "v0.15.6": {
+      "contains_changes": false
+    },
     "v0.15.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-server/ec2-backup.json
+++ b/static/patcher-changelogs/terraform-aws-server/ec2-backup.json
@@ -1,6 +1,9 @@
 {
   "module": "ec2-backup",
   "releases": {
+    "v0.15.6": {
+      "contains_changes": true
+    },
     "v0.15.5": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-server/persistent-ebs-volume.json
+++ b/static/patcher-changelogs/terraform-aws-server/persistent-ebs-volume.json
@@ -1,6 +1,9 @@
 {
   "module": "persistent-ebs-volume",
   "releases": {
+    "v0.15.6": {
+      "contains_changes": false
+    },
     "v0.15.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-server/require-instance-metadata-service-version.json
+++ b/static/patcher-changelogs/terraform-aws-server/require-instance-metadata-service-version.json
@@ -1,6 +1,9 @@
 {
   "module": "require-instance-metadata-service-version",
   "releases": {
+    "v0.15.6": {
+      "contains_changes": false
+    },
     "v0.15.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-server/route53-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-server/route53-helpers.json
@@ -1,6 +1,9 @@
 {
   "module": "route53-helpers",
   "releases": {
+    "v0.15.6": {
+      "contains_changes": false
+    },
     "v0.15.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-server/single-server.json
+++ b/static/patcher-changelogs/terraform-aws-server/single-server.json
@@ -1,6 +1,9 @@
 {
   "module": "single-server",
   "releases": {
+    "v0.15.6": {
+      "contains_changes": true
+    },
     "v0.15.5": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/base/ec2-baseline.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/base/ec2-baseline.json
@@ -1,6 +1,18 @@
 {
   "module": "base/ec2-baseline",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/aurora.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/aurora.json
@@ -1,6 +1,18 @@
 {
   "module": "data-stores/aurora",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/ecr-repos.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/ecr-repos.json
@@ -1,6 +1,18 @@
 {
   "module": "data-stores/ecr-repos",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/elasticsearch.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/elasticsearch.json
@@ -1,6 +1,18 @@
 {
   "module": "data-stores/elasticsearch",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/memcached.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/memcached.json
@@ -1,6 +1,18 @@
 {
   "module": "data-stores/memcached",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/rds-replica.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/rds-replica.json
@@ -1,6 +1,18 @@
 {
   "module": "data-stores/rds-replica",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/rds.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/rds.json
@@ -1,6 +1,18 @@
 {
   "module": "data-stores/rds",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/redis.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/redis.json
@@ -1,6 +1,18 @@
 {
   "module": "data-stores/redis",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/s3-bucket.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/s3-bucket.json
@@ -1,6 +1,18 @@
 {
   "module": "data-stores/s3-bucket",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-app.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-app.json
@@ -1,6 +1,18 @@
 {
   "module": "landingzone/account-baseline-app",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-root.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-root.json
@@ -1,6 +1,18 @@
 {
   "module": "landingzone/account-baseline-root",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-security.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-security.json
@@ -1,6 +1,18 @@
 {
   "module": "landingzone/account-baseline-security",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/gruntwork-access.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/gruntwork-access.json
@@ -1,6 +1,18 @@
 {
   "module": "landingzone/gruntwork-access",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/iam-users-and-groups.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/iam-users-and-groups.json
@@ -1,6 +1,18 @@
 {
   "module": "landingzone/iam-users-and-groups",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/bastion-host.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/bastion-host.json
@@ -1,6 +1,18 @@
 {
   "module": "mgmt/bastion-host",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/ecs-deploy-runner.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/ecs-deploy-runner.json
@@ -1,6 +1,18 @@
 {
   "module": "mgmt/ecs-deploy-runner",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/jenkins.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/jenkins.json
@@ -1,6 +1,18 @@
 {
   "module": "mgmt/jenkins",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/openvpn-server.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/openvpn-server.json
@@ -1,6 +1,18 @@
 {
   "module": "mgmt/openvpn-server",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/tailscale-subnet-router.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/tailscale-subnet-router.json
@@ -1,6 +1,18 @@
 {
   "module": "mgmt/tailscale-subnet-router",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/alb.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/alb.json
@@ -1,6 +1,18 @@
 {
   "module": "networking/alb",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/route53.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/route53.json
@@ -1,6 +1,18 @@
 {
   "module": "networking/route53",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/sns-topics.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/sns-topics.json
@@ -1,6 +1,18 @@
 {
   "module": "networking/sns-topics",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/vpc-mgmt.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/vpc-mgmt.json
@@ -1,6 +1,18 @@
 {
   "module": "networking/vpc-mgmt",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": true
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/vpc.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/vpc.json
@@ -1,6 +1,18 @@
 {
   "module": "networking/vpc",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": true
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/asg-service.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/asg-service.json
@@ -1,6 +1,18 @@
 {
   "module": "services/asg-service",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/ec2-instance.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/ec2-instance.json
@@ -1,6 +1,18 @@
 {
   "module": "services/ec2-instance",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-cluster.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-cluster.json
@@ -1,6 +1,18 @@
 {
   "module": "services/ecs-cluster",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-fargate-cluster.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-fargate-cluster.json
@@ -1,6 +1,18 @@
 {
   "module": "services/ecs-fargate-cluster",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-service.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-service.json
@@ -1,6 +1,18 @@
 {
   "module": "services/ecs-service",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-cluster.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-cluster.json
@@ -1,6 +1,18 @@
 {
   "module": "services/eks-cluster",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": true
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-core-services.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-core-services.json
@@ -1,6 +1,18 @@
 {
   "module": "services/eks-core-services",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-karpenter.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-karpenter.json
@@ -1,6 +1,18 @@
 {
   "module": "services/eks-karpenter",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-workers.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-workers.json
@@ -1,6 +1,18 @@
 {
   "module": "services/eks-workers",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/helm-service.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/helm-service.json
@@ -1,6 +1,18 @@
 {
   "module": "services/helm-service",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/k8s-namespace.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/k8s-namespace.json
@@ -1,6 +1,18 @@
 {
   "module": "services/k8s-namespace",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": false
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/k8s-service.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/k8s-service.json
@@ -1,6 +1,18 @@
 {
   "module": "services/k8s-service",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": true
+    },
+    "v0.104.17": {
+      "contains_changes": true
+    },
     "v0.104.16": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/lambda.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/lambda.json
@@ -1,6 +1,18 @@
 {
   "module": "services/lambda",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/public-static-website.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/public-static-website.json
@@ -1,6 +1,18 @@
 {
   "module": "services/public-static-website",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": true
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/Dockerfile.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/Dockerfile.json
@@ -1,6 +1,18 @@
 {
   "module": "tls-scripts/Dockerfile",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": false
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/core-concepts.md.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/core-concepts.md.json
@@ -1,6 +1,18 @@
 {
   "module": "tls-scripts/core-concepts.md",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": false
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/create-tls-cert.sh.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/create-tls-cert.sh.json
@@ -1,6 +1,18 @@
 {
   "module": "tls-scripts/create-tls-cert.sh",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": false
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/docker-compose.yml.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/docker-compose.yml.json
@@ -1,6 +1,18 @@
 {
   "module": "tls-scripts/docker-compose.yml",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": false
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/download-rds-ca-certs.sh.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/download-rds-ca-certs.sh.json
@@ -1,6 +1,18 @@
 {
   "module": "tls-scripts/download-rds-ca-certs.sh",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": false
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/generate-trust-stores.sh.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/generate-trust-stores.sh.json
@@ -1,6 +1,18 @@
 {
   "module": "tls-scripts/generate-trust-stores.sh",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": false
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/helpers.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/helpers.json
@@ -1,6 +1,18 @@
 {
   "module": "tls-scripts/helpers",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": false
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/install.sh.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/install.sh.json
@@ -1,6 +1,18 @@
 {
   "module": "tls-scripts/install.sh",
   "releases": {
+    "v0.105.0": {
+      "contains_changes": false
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
     "v0.104.16": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-static-assets/s3-cloudfront.json
+++ b/static/patcher-changelogs/terraform-aws-static-assets/s3-cloudfront.json
@@ -1,6 +1,9 @@
 {
   "module": "s3-cloudfront",
   "releases": {
+    "v0.17.2": {
+      "contains_changes": true
+    },
     "v0.17.1": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-static-assets/s3-static-website.json
+++ b/static/patcher-changelogs/terraform-aws-static-assets/s3-static-website.json
@@ -1,6 +1,9 @@
 {
   "module": "s3-static-website",
   "releases": {
+    "v0.17.2": {
+      "contains_changes": true
+    },
     "v0.17.1": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/executable-dependency.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/executable-dependency.json
@@ -1,6 +1,12 @@
 {
   "module": "executable-dependency",
   "releases": {
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
     "v0.9.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/instance-type.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/instance-type.json
@@ -1,6 +1,12 @@
 {
   "module": "instance-type",
   "releases": {
+    "v0.9.4": {
+      "contains_changes": true
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
     "v0.9.2": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/join-path.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/join-path.json
@@ -1,6 +1,12 @@
 {
   "module": "join-path",
   "releases": {
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
     "v0.9.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/list-remove.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/list-remove.json
@@ -1,6 +1,12 @@
 {
   "module": "list-remove",
   "releases": {
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
     "v0.9.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/operating-system.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/operating-system.json
@@ -1,6 +1,12 @@
 {
   "module": "operating-system",
   "releases": {
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
     "v0.9.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/prepare-pex-environment.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/prepare-pex-environment.json
@@ -1,6 +1,12 @@
 {
   "module": "prepare-pex-environment",
   "releases": {
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
     "v0.9.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/request-quota-increase.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/request-quota-increase.json
@@ -1,6 +1,12 @@
 {
   "module": "request-quota-increase",
   "releases": {
+    "v0.9.4": {
+      "contains_changes": true
+    },
+    "v0.9.3": {
+      "contains_changes": true
+    },
     "v0.9.2": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/require-executable.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/require-executable.json
@@ -1,6 +1,12 @@
 {
   "module": "require-executable",
   "releases": {
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
     "v0.9.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/run-pex-as-data-source.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/run-pex-as-data-source.json
@@ -1,6 +1,12 @@
 {
   "module": "run-pex-as-data-source",
   "releases": {
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
     "v0.9.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/run-pex-as-resource.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/run-pex-as-resource.json
@@ -1,6 +1,12 @@
 {
   "module": "run-pex-as-resource",
   "releases": {
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
     "v0.9.2": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/network-acl-inbound.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/network-acl-inbound.json
@@ -1,6 +1,18 @@
 {
   "module": "network-acl-inbound",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": false
+    },
     "v0.26.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/network-acl-outbound.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/network-acl-outbound.json
@@ -1,6 +1,18 @@
 {
   "module": "network-acl-outbound",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": false
+    },
     "v0.26.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/port-range-calculator.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/port-range-calculator.json
@@ -1,6 +1,18 @@
 {
   "module": "port-range-calculator",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": false
+    },
     "v0.26.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/transit-gateway-attachment.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/transit-gateway-attachment.json
@@ -1,0 +1,428 @@
+{
+  "module": "transit-gateway-attachment",
+  "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": true
+    },
+    "v0.26.1": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.8": {
+      "contains_changes": false
+    },
+    "v0.22.7": {
+      "contains_changes": false
+    },
+    "v0.22.6": {
+      "contains_changes": false
+    },
+    "v0.22.5": {
+      "contains_changes": false
+    },
+    "v0.22.4": {
+      "contains_changes": false
+    },
+    "v0.22.3": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.1": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.4": {
+      "contains_changes": false
+    },
+    "v0.20.3": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.12": {
+      "contains_changes": false
+    },
+    "v0.18.11": {
+      "contains_changes": false
+    },
+    "v0.18.10": {
+      "contains_changes": false
+    },
+    "v0.18.9": {
+      "contains_changes": false
+    },
+    "v0.18.8": {
+      "contains_changes": false
+    },
+    "v0.18.7": {
+      "contains_changes": false
+    },
+    "v0.18.6": {
+      "contains_changes": false
+    },
+    "v0.18.5": {
+      "contains_changes": false
+    },
+    "v0.18.4": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.9": {
+      "contains_changes": false
+    },
+    "v0.17.8": {
+      "contains_changes": false
+    },
+    "v0.17.7": {
+      "contains_changes": false
+    },
+    "v0.17.6": {
+      "contains_changes": false
+    },
+    "v0.17.5": {
+      "contains_changes": false
+    },
+    "v0.17.4": {
+      "contains_changes": false
+    },
+    "v0.17.3": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
+    "v0.15.6": {
+      "contains_changes": false
+    },
+    "v0.15.5": {
+      "contains_changes": false
+    },
+    "v0.15.4": {
+      "contains_changes": false
+    },
+    "v0.15.3": {
+      "contains_changes": false
+    },
+    "v0.15.2": {
+      "contains_changes": false
+    },
+    "v0.15.1": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.4": {
+      "contains_changes": false
+    },
+    "v0.14.3": {
+      "contains_changes": false
+    },
+    "v0.14.2": {
+      "contains_changes": false
+    },
+    "v0.14.1": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.1": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.5": {
+      "contains_changes": false
+    },
+    "v0.12.4": {
+      "contains_changes": false
+    },
+    "v0.12.3": {
+      "contains_changes": false
+    },
+    "v0.12.2": {
+      "contains_changes": false
+    },
+    "v0.12.1": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
+    "v0.9.2": {
+      "contains_changes": false
+    },
+    "v0.9.1": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.12": {
+      "contains_changes": false
+    },
+    "v0.8.11": {
+      "contains_changes": false
+    },
+    "v0.8.10": {
+      "contains_changes": false
+    },
+    "v0.8.9": {
+      "contains_changes": false
+    },
+    "v0.8.8": {
+      "contains_changes": false
+    },
+    "v0.8.7": {
+      "contains_changes": false
+    },
+    "v0.8.6": {
+      "contains_changes": false
+    },
+    "v0.8.5": {
+      "contains_changes": false
+    },
+    "v0.8.4": {
+      "contains_changes": false
+    },
+    "v0.8.3": {
+      "contains_changes": false
+    },
+    "v0.8.2": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.8": {
+      "contains_changes": false
+    },
+    "v0.7.7": {
+      "contains_changes": false
+    },
+    "v0.7.6": {
+      "contains_changes": false
+    },
+    "v0.7.5": {
+      "contains_changes": false
+    },
+    "v0.7.4": {
+      "contains_changes": false
+    },
+    "v0.7.3": {
+      "contains_changes": false
+    },
+    "v0.7.2": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.8": {
+      "contains_changes": false
+    },
+    "v0.5.7": {
+      "contains_changes": false
+    },
+    "v0.5.6": {
+      "contains_changes": false
+    },
+    "v0.5.5": {
+      "contains_changes": false
+    },
+    "v0.5.4": {
+      "contains_changes": false
+    },
+    "v0.5.3": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.1": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.2": {
+      "contains_changes": false
+    },
+    "v0.3.1": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.2": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.9": {
+      "contains_changes": false
+    },
+    "v0.1.8": {
+      "contains_changes": false
+    },
+    "v0.1.7": {
+      "contains_changes": false
+    },
+    "v0.1.6": {
+      "contains_changes": false
+    },
+    "v0.1.5": {
+      "contains_changes": false
+    },
+    "v0.1.4": {
+      "contains_changes": false
+    },
+    "v0.1.3": {
+      "contains_changes": false
+    },
+    "v0.1.2": {
+      "contains_changes": false
+    },
+    "v0.1.1": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.8": {
+      "contains_changes": false
+    },
+    "v0.0.7": {
+      "contains_changes": false
+    },
+    "v0.0.6": {
+      "contains_changes": false
+    },
+    "v0.0.5": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-vpc/transit-gateway-peering-attachment-accepter.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/transit-gateway-peering-attachment-accepter.json
@@ -1,0 +1,428 @@
+{
+  "module": "transit-gateway-peering-attachment-accepter",
+  "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": true
+    },
+    "v0.26.1": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.8": {
+      "contains_changes": false
+    },
+    "v0.22.7": {
+      "contains_changes": false
+    },
+    "v0.22.6": {
+      "contains_changes": false
+    },
+    "v0.22.5": {
+      "contains_changes": false
+    },
+    "v0.22.4": {
+      "contains_changes": false
+    },
+    "v0.22.3": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.1": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.4": {
+      "contains_changes": false
+    },
+    "v0.20.3": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.12": {
+      "contains_changes": false
+    },
+    "v0.18.11": {
+      "contains_changes": false
+    },
+    "v0.18.10": {
+      "contains_changes": false
+    },
+    "v0.18.9": {
+      "contains_changes": false
+    },
+    "v0.18.8": {
+      "contains_changes": false
+    },
+    "v0.18.7": {
+      "contains_changes": false
+    },
+    "v0.18.6": {
+      "contains_changes": false
+    },
+    "v0.18.5": {
+      "contains_changes": false
+    },
+    "v0.18.4": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.9": {
+      "contains_changes": false
+    },
+    "v0.17.8": {
+      "contains_changes": false
+    },
+    "v0.17.7": {
+      "contains_changes": false
+    },
+    "v0.17.6": {
+      "contains_changes": false
+    },
+    "v0.17.5": {
+      "contains_changes": false
+    },
+    "v0.17.4": {
+      "contains_changes": false
+    },
+    "v0.17.3": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
+    "v0.15.6": {
+      "contains_changes": false
+    },
+    "v0.15.5": {
+      "contains_changes": false
+    },
+    "v0.15.4": {
+      "contains_changes": false
+    },
+    "v0.15.3": {
+      "contains_changes": false
+    },
+    "v0.15.2": {
+      "contains_changes": false
+    },
+    "v0.15.1": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.4": {
+      "contains_changes": false
+    },
+    "v0.14.3": {
+      "contains_changes": false
+    },
+    "v0.14.2": {
+      "contains_changes": false
+    },
+    "v0.14.1": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.1": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.5": {
+      "contains_changes": false
+    },
+    "v0.12.4": {
+      "contains_changes": false
+    },
+    "v0.12.3": {
+      "contains_changes": false
+    },
+    "v0.12.2": {
+      "contains_changes": false
+    },
+    "v0.12.1": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
+    "v0.9.2": {
+      "contains_changes": false
+    },
+    "v0.9.1": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.12": {
+      "contains_changes": false
+    },
+    "v0.8.11": {
+      "contains_changes": false
+    },
+    "v0.8.10": {
+      "contains_changes": false
+    },
+    "v0.8.9": {
+      "contains_changes": false
+    },
+    "v0.8.8": {
+      "contains_changes": false
+    },
+    "v0.8.7": {
+      "contains_changes": false
+    },
+    "v0.8.6": {
+      "contains_changes": false
+    },
+    "v0.8.5": {
+      "contains_changes": false
+    },
+    "v0.8.4": {
+      "contains_changes": false
+    },
+    "v0.8.3": {
+      "contains_changes": false
+    },
+    "v0.8.2": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.8": {
+      "contains_changes": false
+    },
+    "v0.7.7": {
+      "contains_changes": false
+    },
+    "v0.7.6": {
+      "contains_changes": false
+    },
+    "v0.7.5": {
+      "contains_changes": false
+    },
+    "v0.7.4": {
+      "contains_changes": false
+    },
+    "v0.7.3": {
+      "contains_changes": false
+    },
+    "v0.7.2": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.8": {
+      "contains_changes": false
+    },
+    "v0.5.7": {
+      "contains_changes": false
+    },
+    "v0.5.6": {
+      "contains_changes": false
+    },
+    "v0.5.5": {
+      "contains_changes": false
+    },
+    "v0.5.4": {
+      "contains_changes": false
+    },
+    "v0.5.3": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.1": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.2": {
+      "contains_changes": false
+    },
+    "v0.3.1": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.2": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.9": {
+      "contains_changes": false
+    },
+    "v0.1.8": {
+      "contains_changes": false
+    },
+    "v0.1.7": {
+      "contains_changes": false
+    },
+    "v0.1.6": {
+      "contains_changes": false
+    },
+    "v0.1.5": {
+      "contains_changes": false
+    },
+    "v0.1.4": {
+      "contains_changes": false
+    },
+    "v0.1.3": {
+      "contains_changes": false
+    },
+    "v0.1.2": {
+      "contains_changes": false
+    },
+    "v0.1.1": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.8": {
+      "contains_changes": false
+    },
+    "v0.0.7": {
+      "contains_changes": false
+    },
+    "v0.0.6": {
+      "contains_changes": false
+    },
+    "v0.0.5": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-vpc/transit-gateway-peering-attachment.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/transit-gateway-peering-attachment.json
@@ -1,0 +1,428 @@
+{
+  "module": "transit-gateway-peering-attachment",
+  "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": true
+    },
+    "v0.26.1": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.8": {
+      "contains_changes": false
+    },
+    "v0.22.7": {
+      "contains_changes": false
+    },
+    "v0.22.6": {
+      "contains_changes": false
+    },
+    "v0.22.5": {
+      "contains_changes": false
+    },
+    "v0.22.4": {
+      "contains_changes": false
+    },
+    "v0.22.3": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.1": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.4": {
+      "contains_changes": false
+    },
+    "v0.20.3": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.12": {
+      "contains_changes": false
+    },
+    "v0.18.11": {
+      "contains_changes": false
+    },
+    "v0.18.10": {
+      "contains_changes": false
+    },
+    "v0.18.9": {
+      "contains_changes": false
+    },
+    "v0.18.8": {
+      "contains_changes": false
+    },
+    "v0.18.7": {
+      "contains_changes": false
+    },
+    "v0.18.6": {
+      "contains_changes": false
+    },
+    "v0.18.5": {
+      "contains_changes": false
+    },
+    "v0.18.4": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.9": {
+      "contains_changes": false
+    },
+    "v0.17.8": {
+      "contains_changes": false
+    },
+    "v0.17.7": {
+      "contains_changes": false
+    },
+    "v0.17.6": {
+      "contains_changes": false
+    },
+    "v0.17.5": {
+      "contains_changes": false
+    },
+    "v0.17.4": {
+      "contains_changes": false
+    },
+    "v0.17.3": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
+    "v0.15.6": {
+      "contains_changes": false
+    },
+    "v0.15.5": {
+      "contains_changes": false
+    },
+    "v0.15.4": {
+      "contains_changes": false
+    },
+    "v0.15.3": {
+      "contains_changes": false
+    },
+    "v0.15.2": {
+      "contains_changes": false
+    },
+    "v0.15.1": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.4": {
+      "contains_changes": false
+    },
+    "v0.14.3": {
+      "contains_changes": false
+    },
+    "v0.14.2": {
+      "contains_changes": false
+    },
+    "v0.14.1": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.1": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.5": {
+      "contains_changes": false
+    },
+    "v0.12.4": {
+      "contains_changes": false
+    },
+    "v0.12.3": {
+      "contains_changes": false
+    },
+    "v0.12.2": {
+      "contains_changes": false
+    },
+    "v0.12.1": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
+    "v0.9.2": {
+      "contains_changes": false
+    },
+    "v0.9.1": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.12": {
+      "contains_changes": false
+    },
+    "v0.8.11": {
+      "contains_changes": false
+    },
+    "v0.8.10": {
+      "contains_changes": false
+    },
+    "v0.8.9": {
+      "contains_changes": false
+    },
+    "v0.8.8": {
+      "contains_changes": false
+    },
+    "v0.8.7": {
+      "contains_changes": false
+    },
+    "v0.8.6": {
+      "contains_changes": false
+    },
+    "v0.8.5": {
+      "contains_changes": false
+    },
+    "v0.8.4": {
+      "contains_changes": false
+    },
+    "v0.8.3": {
+      "contains_changes": false
+    },
+    "v0.8.2": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.8": {
+      "contains_changes": false
+    },
+    "v0.7.7": {
+      "contains_changes": false
+    },
+    "v0.7.6": {
+      "contains_changes": false
+    },
+    "v0.7.5": {
+      "contains_changes": false
+    },
+    "v0.7.4": {
+      "contains_changes": false
+    },
+    "v0.7.3": {
+      "contains_changes": false
+    },
+    "v0.7.2": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.8": {
+      "contains_changes": false
+    },
+    "v0.5.7": {
+      "contains_changes": false
+    },
+    "v0.5.6": {
+      "contains_changes": false
+    },
+    "v0.5.5": {
+      "contains_changes": false
+    },
+    "v0.5.4": {
+      "contains_changes": false
+    },
+    "v0.5.3": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.1": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.2": {
+      "contains_changes": false
+    },
+    "v0.3.1": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.2": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.9": {
+      "contains_changes": false
+    },
+    "v0.1.8": {
+      "contains_changes": false
+    },
+    "v0.1.7": {
+      "contains_changes": false
+    },
+    "v0.1.6": {
+      "contains_changes": false
+    },
+    "v0.1.5": {
+      "contains_changes": false
+    },
+    "v0.1.4": {
+      "contains_changes": false
+    },
+    "v0.1.3": {
+      "contains_changes": false
+    },
+    "v0.1.2": {
+      "contains_changes": false
+    },
+    "v0.1.1": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.8": {
+      "contains_changes": false
+    },
+    "v0.0.7": {
+      "contains_changes": false
+    },
+    "v0.0.6": {
+      "contains_changes": false
+    },
+    "v0.0.5": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-vpc/transit-gateway-route.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/transit-gateway-route.json
@@ -1,0 +1,428 @@
+{
+  "module": "transit-gateway-route",
+  "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": true
+    },
+    "v0.26.1": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.8": {
+      "contains_changes": false
+    },
+    "v0.22.7": {
+      "contains_changes": false
+    },
+    "v0.22.6": {
+      "contains_changes": false
+    },
+    "v0.22.5": {
+      "contains_changes": false
+    },
+    "v0.22.4": {
+      "contains_changes": false
+    },
+    "v0.22.3": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.1": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.4": {
+      "contains_changes": false
+    },
+    "v0.20.3": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.12": {
+      "contains_changes": false
+    },
+    "v0.18.11": {
+      "contains_changes": false
+    },
+    "v0.18.10": {
+      "contains_changes": false
+    },
+    "v0.18.9": {
+      "contains_changes": false
+    },
+    "v0.18.8": {
+      "contains_changes": false
+    },
+    "v0.18.7": {
+      "contains_changes": false
+    },
+    "v0.18.6": {
+      "contains_changes": false
+    },
+    "v0.18.5": {
+      "contains_changes": false
+    },
+    "v0.18.4": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.9": {
+      "contains_changes": false
+    },
+    "v0.17.8": {
+      "contains_changes": false
+    },
+    "v0.17.7": {
+      "contains_changes": false
+    },
+    "v0.17.6": {
+      "contains_changes": false
+    },
+    "v0.17.5": {
+      "contains_changes": false
+    },
+    "v0.17.4": {
+      "contains_changes": false
+    },
+    "v0.17.3": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
+    "v0.15.6": {
+      "contains_changes": false
+    },
+    "v0.15.5": {
+      "contains_changes": false
+    },
+    "v0.15.4": {
+      "contains_changes": false
+    },
+    "v0.15.3": {
+      "contains_changes": false
+    },
+    "v0.15.2": {
+      "contains_changes": false
+    },
+    "v0.15.1": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.4": {
+      "contains_changes": false
+    },
+    "v0.14.3": {
+      "contains_changes": false
+    },
+    "v0.14.2": {
+      "contains_changes": false
+    },
+    "v0.14.1": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.1": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.5": {
+      "contains_changes": false
+    },
+    "v0.12.4": {
+      "contains_changes": false
+    },
+    "v0.12.3": {
+      "contains_changes": false
+    },
+    "v0.12.2": {
+      "contains_changes": false
+    },
+    "v0.12.1": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
+    "v0.9.2": {
+      "contains_changes": false
+    },
+    "v0.9.1": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.12": {
+      "contains_changes": false
+    },
+    "v0.8.11": {
+      "contains_changes": false
+    },
+    "v0.8.10": {
+      "contains_changes": false
+    },
+    "v0.8.9": {
+      "contains_changes": false
+    },
+    "v0.8.8": {
+      "contains_changes": false
+    },
+    "v0.8.7": {
+      "contains_changes": false
+    },
+    "v0.8.6": {
+      "contains_changes": false
+    },
+    "v0.8.5": {
+      "contains_changes": false
+    },
+    "v0.8.4": {
+      "contains_changes": false
+    },
+    "v0.8.3": {
+      "contains_changes": false
+    },
+    "v0.8.2": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.8": {
+      "contains_changes": false
+    },
+    "v0.7.7": {
+      "contains_changes": false
+    },
+    "v0.7.6": {
+      "contains_changes": false
+    },
+    "v0.7.5": {
+      "contains_changes": false
+    },
+    "v0.7.4": {
+      "contains_changes": false
+    },
+    "v0.7.3": {
+      "contains_changes": false
+    },
+    "v0.7.2": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.8": {
+      "contains_changes": false
+    },
+    "v0.5.7": {
+      "contains_changes": false
+    },
+    "v0.5.6": {
+      "contains_changes": false
+    },
+    "v0.5.5": {
+      "contains_changes": false
+    },
+    "v0.5.4": {
+      "contains_changes": false
+    },
+    "v0.5.3": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.1": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.2": {
+      "contains_changes": false
+    },
+    "v0.3.1": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.2": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.9": {
+      "contains_changes": false
+    },
+    "v0.1.8": {
+      "contains_changes": false
+    },
+    "v0.1.7": {
+      "contains_changes": false
+    },
+    "v0.1.6": {
+      "contains_changes": false
+    },
+    "v0.1.5": {
+      "contains_changes": false
+    },
+    "v0.1.4": {
+      "contains_changes": false
+    },
+    "v0.1.3": {
+      "contains_changes": false
+    },
+    "v0.1.2": {
+      "contains_changes": false
+    },
+    "v0.1.1": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.8": {
+      "contains_changes": false
+    },
+    "v0.0.7": {
+      "contains_changes": false
+    },
+    "v0.0.6": {
+      "contains_changes": false
+    },
+    "v0.0.5": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-vpc/transit-gateway.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/transit-gateway.json
@@ -1,0 +1,428 @@
+{
+  "module": "transit-gateway",
+  "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": true
+    },
+    "v0.26.1": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.8": {
+      "contains_changes": false
+    },
+    "v0.22.7": {
+      "contains_changes": false
+    },
+    "v0.22.6": {
+      "contains_changes": false
+    },
+    "v0.22.5": {
+      "contains_changes": false
+    },
+    "v0.22.4": {
+      "contains_changes": false
+    },
+    "v0.22.3": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.1": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.4": {
+      "contains_changes": false
+    },
+    "v0.20.3": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.12": {
+      "contains_changes": false
+    },
+    "v0.18.11": {
+      "contains_changes": false
+    },
+    "v0.18.10": {
+      "contains_changes": false
+    },
+    "v0.18.9": {
+      "contains_changes": false
+    },
+    "v0.18.8": {
+      "contains_changes": false
+    },
+    "v0.18.7": {
+      "contains_changes": false
+    },
+    "v0.18.6": {
+      "contains_changes": false
+    },
+    "v0.18.5": {
+      "contains_changes": false
+    },
+    "v0.18.4": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.9": {
+      "contains_changes": false
+    },
+    "v0.17.8": {
+      "contains_changes": false
+    },
+    "v0.17.7": {
+      "contains_changes": false
+    },
+    "v0.17.6": {
+      "contains_changes": false
+    },
+    "v0.17.5": {
+      "contains_changes": false
+    },
+    "v0.17.4": {
+      "contains_changes": false
+    },
+    "v0.17.3": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
+    "v0.15.6": {
+      "contains_changes": false
+    },
+    "v0.15.5": {
+      "contains_changes": false
+    },
+    "v0.15.4": {
+      "contains_changes": false
+    },
+    "v0.15.3": {
+      "contains_changes": false
+    },
+    "v0.15.2": {
+      "contains_changes": false
+    },
+    "v0.15.1": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.4": {
+      "contains_changes": false
+    },
+    "v0.14.3": {
+      "contains_changes": false
+    },
+    "v0.14.2": {
+      "contains_changes": false
+    },
+    "v0.14.1": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.1": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.5": {
+      "contains_changes": false
+    },
+    "v0.12.4": {
+      "contains_changes": false
+    },
+    "v0.12.3": {
+      "contains_changes": false
+    },
+    "v0.12.2": {
+      "contains_changes": false
+    },
+    "v0.12.1": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
+    "v0.9.2": {
+      "contains_changes": false
+    },
+    "v0.9.1": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.12": {
+      "contains_changes": false
+    },
+    "v0.8.11": {
+      "contains_changes": false
+    },
+    "v0.8.10": {
+      "contains_changes": false
+    },
+    "v0.8.9": {
+      "contains_changes": false
+    },
+    "v0.8.8": {
+      "contains_changes": false
+    },
+    "v0.8.7": {
+      "contains_changes": false
+    },
+    "v0.8.6": {
+      "contains_changes": false
+    },
+    "v0.8.5": {
+      "contains_changes": false
+    },
+    "v0.8.4": {
+      "contains_changes": false
+    },
+    "v0.8.3": {
+      "contains_changes": false
+    },
+    "v0.8.2": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.8": {
+      "contains_changes": false
+    },
+    "v0.7.7": {
+      "contains_changes": false
+    },
+    "v0.7.6": {
+      "contains_changes": false
+    },
+    "v0.7.5": {
+      "contains_changes": false
+    },
+    "v0.7.4": {
+      "contains_changes": false
+    },
+    "v0.7.3": {
+      "contains_changes": false
+    },
+    "v0.7.2": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.8": {
+      "contains_changes": false
+    },
+    "v0.5.7": {
+      "contains_changes": false
+    },
+    "v0.5.6": {
+      "contains_changes": false
+    },
+    "v0.5.5": {
+      "contains_changes": false
+    },
+    "v0.5.4": {
+      "contains_changes": false
+    },
+    "v0.5.3": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.1": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.2": {
+      "contains_changes": false
+    },
+    "v0.3.1": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.2": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.9": {
+      "contains_changes": false
+    },
+    "v0.1.8": {
+      "contains_changes": false
+    },
+    "v0.1.7": {
+      "contains_changes": false
+    },
+    "v0.1.6": {
+      "contains_changes": false
+    },
+    "v0.1.5": {
+      "contains_changes": false
+    },
+    "v0.1.4": {
+      "contains_changes": false
+    },
+    "v0.1.3": {
+      "contains_changes": false
+    },
+    "v0.1.2": {
+      "contains_changes": false
+    },
+    "v0.1.1": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.8": {
+      "contains_changes": false
+    },
+    "v0.0.7": {
+      "contains_changes": false
+    },
+    "v0.0.6": {
+      "contains_changes": false
+    },
+    "v0.0.5": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-app-network-acls.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-app-network-acls.json
@@ -1,6 +1,18 @@
 {
   "module": "vpc-app-network-acls",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": false
+    },
     "v0.26.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-app.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-app.json
@@ -1,6 +1,18 @@
 {
   "module": "vpc-app",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": false
+    },
     "v0.26.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-dns-forwarder-rules.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-dns-forwarder-rules.json
@@ -1,6 +1,18 @@
 {
   "module": "vpc-dns-forwarder-rules",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": false
+    },
     "v0.26.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-dns-forwarder.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-dns-forwarder.json
@@ -1,6 +1,18 @@
 {
   "module": "vpc-dns-forwarder",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": false
+    },
     "v0.26.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-flow-logs.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-flow-logs.json
@@ -1,6 +1,18 @@
 {
   "module": "vpc-flow-logs",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": false
+    },
     "v0.26.1": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-interface-endpoint.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-interface-endpoint.json
@@ -1,6 +1,18 @@
 {
   "module": "vpc-interface-endpoint",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": false
+    },
     "v0.26.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-mgmt-network-acls.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-mgmt-network-acls.json
@@ -1,6 +1,18 @@
 {
   "module": "vpc-mgmt-network-acls",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": false
+    },
     "v0.26.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-mgmt.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-mgmt.json
@@ -1,6 +1,18 @@
 {
   "module": "vpc-mgmt",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": false
+    },
     "v0.26.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-peering-cross-accounts-accepter.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-peering-cross-accounts-accepter.json
@@ -1,6 +1,18 @@
 {
   "module": "vpc-peering-cross-accounts-accepter",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": false
+    },
     "v0.26.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-peering-cross-accounts-requester.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-peering-cross-accounts-requester.json
@@ -1,6 +1,18 @@
 {
   "module": "vpc-peering-cross-accounts-requester",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": false
+    },
     "v0.26.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-peering-external.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-peering-external.json
@@ -1,6 +1,18 @@
 {
   "module": "vpc-peering-external",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": false
+    },
     "v0.26.1": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-peering.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-peering.json
@@ -1,6 +1,18 @@
 {
   "module": "vpc-peering",
   "releases": {
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": false
+    },
     "v0.26.1": {
       "contains_changes": false
     },


### PR DESCRIPTION
Data generated by running `DOCS_SITE_BASE_DIR="../docs/" yarn dev -p patcher-changelogs`.