### PR TITLE
Resolve inconsistency in comments for style guide

### DIFF
--- a/docs/guides/style/terraform-style-guide.md
+++ b/docs/guides/style/terraform-style-guide.md
@@ -178,27 +178,27 @@ optional variables (with defaults) using block comments.
 Example:
 
 ```hcl
-## ---------------------------------------------------------------------------------------------------------------------
-## ENVIRONMENT VARIABLES
-## Define these secrets as environment variables
-## ---------------------------------------------------------------------------------------------------------------------
+# ---------------------------------------------------------------------------------------------------------------------
+# ENVIRONMENT VARIABLES
+# Define these secrets as environment variables
+# ---------------------------------------------------------------------------------------------------------------------
 
-## TF_VAR_master_password
+# TF_VAR_master_password
 
-## ---------------------------------------------------------------------------------------------------------------------
-## MODULE PARAMETERS
-## These variables are expected to be passed in by the operator
-## ---------------------------------------------------------------------------------------------------------------------
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These variables are expected to be passed in by the operator
+# ---------------------------------------------------------------------------------------------------------------------
 
 variable "required_var" {
   description = "This variable must be set in order to create the resource."
   type        = string
 }
 
-## ---------------------------------------------------------------------------------------------------------------------
-## OPTIONAL PARAMETERS
-## These variables have defaults and may be overridden
-## ---------------------------------------------------------------------------------------------------------------------
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These variables have defaults and may be overridden
+# ---------------------------------------------------------------------------------------------------------------------
 
 variable "optional_var" {
   description = "This variable has a sensible default so it is not necessary to set it explicitly for this module to work."
@@ -217,11 +217,11 @@ managed in the section.
 Example:
 
 ```hcl
-## ---------------------------------------------------------------------------------------------------------------------
-## ONE LINE SUMMARY DESCRIBING WHAT IS BEING MANAGED IN THIS SECTION IN ALL CAPS
-## The rest of the comments should be in standard casing. This section should contain an overall description of the
-## component that is being managed, and highlight any unconventional workarounds or configurations that are in place.
-## ---------------------------------------------------------------------------------------------------------------------
+# ---------------------------------------------------------------------------------------------------------------------
+# ONE LINE SUMMARY DESCRIBING WHAT IS BEING MANAGED IN THIS SECTION IN ALL CAPS
+# The rest of the comments should be in standard casing. This section should contain an overall description of the
+# component that is being managed, and highlight any unconventional workarounds or configurations that are in place.
+# ---------------------------------------------------------------------------------------------------------------------
 ```
 
 ### Testing: Terratest


### PR DESCRIPTION
The Style Guide indicate that a single `#` should be used, but then has examples with double `#`, which is confusing

https://github.com/KyleKing/docs/blame/89ba5ba2b1468f55bb77b9b7b1f418eb4af586fe/docs/guides/style/terraform-style-guide.md#L169-L171

Unless the `## --` is the intended guidance, I can also make that change

---

*The changes look correct in deployment: https://6581f385a7bf9a0008663549--pensive-meitner-faaeee.netlify.app/guides/style/terraform-style-guide*