### PR TITLE
fix: Updating broken links

### DIFF
--- a/_docs-sources/infrastructure-pipelines/overview/deprecation.md
+++ b/_docs-sources/infrastructure-pipelines/overview/deprecation.md
@@ -26,7 +26,7 @@ If you still need documentation for the previous version of Pipelines, you can f
 
 ## How Do I Migrate to the New Version?
 
-Follow the steps outlined in the [migration guide](../../pipelines/upgrading/upgrading-from-infrastructure-pipelines) to migrate to the new version of Pipelines.
+Follow the steps outlined in the [migration guide](../../pipelines/upgrading/upgrading-from-infrastructure-pipelines.md) to migrate to the new version of Pipelines.
 
 ## Why Was This Deprecation Necessary?
 
@@ -104,7 +104,7 @@ Customers now have two new capabilities to help them stay up to date with the la
      uses: gruntwork-io/pipelines-workflows/.github/workflows/pipelines-root.yml@v1
    ```
 
-More documentation on upgrading to the latest version of Pipelines can be found [here](../../pipelines/maintain/updating).
+More documentation on upgrading to the latest version of Pipelines can be found [here](../../pipelines/maintain/updating.md).
 
 ### Flexible
 
@@ -113,7 +113,7 @@ Customers are also free to customize their Pipelines configurations more easily,
 In addition, the underlying actions that make up the Pipelines configuration are also public, so customers can inject their own logic in between the steps taken by Pipelines to customize workflows to their specific use cases, without losing the ability to pull in upstream updates to those actions.
 
 :::tip
-If you intend on leveraging this functionality, make sure to read the documentation on [extending Pipelines](../../pipelines/maintain/extending) to understand how to structure your custom workflows.
+If you intend on leveraging this functionality, make sure to read the documentation on [extending Pipelines](../../pipelines/maintain/extending.md) to understand how to structure your custom workflows.
 :::
 
 ### Secure

--- a/_docs-sources/pipelines/maintain/extending.md
+++ b/_docs-sources/pipelines/maintain/extending.md
@@ -22,15 +22,15 @@ Common reasons that you might decide to do this include:
 :::caution
 This will result in a public fork of Gruntwork's `pipelines-workflows` in your GitHub organization. If you have concerns about this, you will need to create a manual private fork of the repository. Reach out to <support@gruntwork.io> if you need assistance with this.
 
-Do not include any sensitive information in your forked repository if hosted publicly.
+Do not include any sensitive information in your forked repository, especially if hosted publicly.
 :::
 
 ## Extending the GitHub Actions
 
 In addition to extending the top-level workflow, you can also extend the underlying custom GitHub Actions that the workflow uses, as they are made public as well. This allows you to customize the behavior of individual Actions to suit your organization's needs.
 
-:::warning
-Note that in order to customize the behavior of an Action, you will need to fork the repository that contains the Action, which might be another GitHub Action, or a Workflow.
+:::note
+In order to customize the behavior of an Action, you will need to fork the repository that contains the Action, which might be another GitHub Action, or a Workflow.
 :::
 
 ## How to Extend the Pipelines Workflow

--- a/docs/infrastructure-pipelines/overview/deprecation.md
+++ b/docs/infrastructure-pipelines/overview/deprecation.md
@@ -26,7 +26,7 @@ If you still need documentation for the previous version of Pipelines, you can f
 
 ## How Do I Migrate to the New Version?
 
-Follow the steps outlined in the [migration guide](../../pipelines/upgrading/upgrading-from-infrastructure-pipelines) to migrate to the new version of Pipelines.
+Follow the steps outlined in the [migration guide](../../pipelines/upgrading/upgrading-from-infrastructure-pipelines.md) to migrate to the new version of Pipelines.
 
 ## Why Was This Deprecation Necessary?
 
@@ -104,7 +104,7 @@ Customers now have two new capabilities to help them stay up to date with the la
      uses: gruntwork-io/pipelines-workflows/.github/workflows/pipelines-root.yml@v1
    ```
 
-More documentation on upgrading to the latest version of Pipelines can be found [here](../../pipelines/maintain/updating).
+More documentation on upgrading to the latest version of Pipelines can be found [here](../../pipelines/maintain/updating.md).
 
 ### Flexible
 
@@ -113,7 +113,7 @@ Customers are also free to customize their Pipelines configurations more easily,
 In addition, the underlying actions that make up the Pipelines configuration are also public, so customers can inject their own logic in between the steps taken by Pipelines to customize workflows to their specific use cases, without losing the ability to pull in upstream updates to those actions.
 
 :::tip
-If you intend on leveraging this functionality, make sure to read the documentation on [extending Pipelines](../../pipelines/maintain/extending) to understand how to structure your custom workflows.
+If you intend on leveraging this functionality, make sure to read the documentation on [extending Pipelines](../../pipelines/maintain/extending.md) to understand how to structure your custom workflows.
 :::
 
 ### Secure
@@ -145,6 +145,6 @@ Gruntwork is excited to bring you this new architecture for Pipelines, and we ho
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "9aa12f50c8a505365b5c49d904379967"
+  "hash": "a64aa0ed1799129e7c110b6f672a909d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/pipelines/maintain/extending.md
+++ b/docs/pipelines/maintain/extending.md
@@ -22,15 +22,15 @@ Common reasons that you might decide to do this include:
 :::caution
 This will result in a public fork of Gruntwork's `pipelines-workflows` in your GitHub organization. If you have concerns about this, you will need to create a manual private fork of the repository. Reach out to <support@gruntwork.io> if you need assistance with this.
 
-Do not include any sensitive information in your forked repository if hosted publicly.
+Do not include any sensitive information in your forked repository, especially if hosted publicly.
 :::
 
 ## Extending the GitHub Actions
 
 In addition to extending the top-level workflow, you can also extend the underlying custom GitHub Actions that the workflow uses, as they are made public as well. This allows you to customize the behavior of individual Actions to suit your organization's needs.
 
-:::warning
-Note that in order to customize the behavior of an Action, you will need to fork the repository that contains the Action, which might be another GitHub Action, or a Workflow.
+:::note
+In order to customize the behavior of an Action, you will need to fork the repository that contains the Action, which might be another GitHub Action, or a Workflow.
 :::
 
 ## How to Extend the Pipelines Workflow
@@ -45,6 +45,6 @@ If you are comfortable with us sharing your story, we would like to document you
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "4b405e9603b7b24760b29788f9a8676c"
+  "hash": "15cd39ec36706531e30624841921c0b3"
 }
 ##DOCS-SOURCER-END -->

--- a/sidebars/pipelines.js
+++ b/sidebars/pipelines.js
@@ -68,13 +68,12 @@ const sidebar = [
           },
         ],
       },
-      // TODO write these docs once we identify common cases
-      // {
-      //   label: "Maintain Pipelines",
-      //   type: "category",
-      //   collapsed: false,
-      //   items: ["pipelines/maintain/updating", "pipelines/maintain/extending"],
-      // },
+      {
+        label: "Maintain Pipelines",
+        type: "category",
+        collapsed: false,
+        items: ["pipelines/maintain/updating", "pipelines/maintain/extending"],
+      },
       {
         label: "Previous Versions",
         type: "category",


### PR DESCRIPTION
There were some broken links due to how Docusaurus handles links without trailing `.md` values. This fixes that.