### PR TITLE
chore: update the s3 update script with the new gtm id

### DIFF
--- a/scripts/push-to-s3-prod.sh
+++ b/scripts/push-to-s3-prod.sh
@@ -4,7 +4,7 @@ set -e
 
 export CONFIG_SITE_URL="https://docs.gruntwork.io"
 
-export CONFIG_GOOGLE_ANALYTICS_TRACKING_ID="GTM-5HV93CR"
+export CONFIG_GOOGLE_ANALYTICS_TRACKING_ID="GTM-5TTJJGTL"
 
 export ALGOLIA_INDEX_NAME="docs_site_prod"
 export ALGOLIA_API_KEY="49a495ba4c210780a28feed306d05522" # This is a search only key. It is safe to check in.


### PR DESCRIPTION
This is the actual source of truth for production GTM tag ID, the push-to-s3 script