### PR TITLE
DEV-454 Doc CI skips

### DIFF
--- a/_docs-sources/pipelines/overview/actions.md
+++ b/_docs-sources/pipelines/overview/actions.md
@@ -18,7 +18,7 @@ When a pull request is merged, Pipelines will automatically execute either `terr
 
 ## Skipping Runs
 
-Sometimes you find it necessary to make a change without going through the full pipelines process. This can be accomplished using GitHub's [built in method for skipping workflow runs](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs).
+Sometimes you find it necessary to make a change without going through the full pipelines process. This can be accomplished using GitHub's built in method for skipping workflow runs [by adding [skip ci] to your commit message](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs).
 
 ## Other Actions
 

--- a/_docs-sources/pipelines/overview/actions.md
+++ b/_docs-sources/pipelines/overview/actions.md
@@ -6,7 +6,7 @@ This documentation relates to the latest version of Gruntwork Pipelines released
 If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
 :::
 
-When a user opens a pull request, Pipelines runs a set of operations in response to the proposed [infrastructure changes](../overview/#infrastructure-change). We call these operations _pipelines actions_. Gruntwork Pipelines supports the following pipelines actions:
+When a user opens a pull request, Pipelines runs a set of operations as a Github Action Workflow in response to the proposed [infrastructure changes](../overview/#infrastructure-change). We call these operations _pipelines actions_. Gruntwork Pipelines supports the following pipelines actions:
 
 ## Terragrunt plan
 
@@ -15,6 +15,10 @@ When a pull request is created, Pipelines will automatically execute `terragrunt
 ## Terragrunt apply/destroy
 
 When a pull request is merged, Pipelines will automatically execute either `terragrunt apply` or `terragrunt destroy` on every infrastructure change, depending on the type of infrastructure change. For example, if the pull request deletes a `terragrunt.hcl` file, Pipelines will run `terragrunt destroy`.
+
+## Skipping Runs
+
+Sometimes you find it necessary to make a change without going through the full pipelines process. This can be accomplished using GitHub's [built in method for skipping workflow runs](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs).
 
 ## Other Actions
 

--- a/docs/pipelines/overview/actions.md
+++ b/docs/pipelines/overview/actions.md
@@ -18,7 +18,7 @@ When a pull request is merged, Pipelines will automatically execute either `terr
 
 ## Skipping Runs
 
-Sometimes you find it necessary to make a change without going through the full pipelines process. This can be accomplished using GitHub's [built in method for skipping workflow runs](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs).
+Sometimes you find it necessary to make a change without going through the full pipelines process. This can be accomplished using GitHub's built in method for skipping workflow runs [by adding [skip ci] to your commit message](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs).
 
 ## Other Actions
 

--- a/docs/pipelines/overview/actions.md
+++ b/docs/pipelines/overview/actions.md
@@ -28,6 +28,6 @@ If you'd like to request a new Pipelines action, please email us at <feedback@gr
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "08bff68a304a1c4ad67f8a54ffed55fb"
+  "hash": "076ffa02c765736e1055938abd15ab58"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/pipelines/overview/actions.md
+++ b/docs/pipelines/overview/actions.md
@@ -6,7 +6,7 @@ This documentation relates to the latest version of Gruntwork Pipelines released
 If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
 :::
 
-When a user opens a pull request, Pipelines runs a set of operations in response to the proposed [infrastructure changes](../overview/#infrastructure-change). We call these operations _pipelines actions_. Gruntwork Pipelines supports the following pipelines actions:
+When a user opens a pull request, Pipelines runs a set of operations as a Github Action Workflow in response to the proposed [infrastructure changes](../overview/#infrastructure-change). We call these operations _pipelines actions_. Gruntwork Pipelines supports the following pipelines actions:
 
 ## Terragrunt plan
 
@@ -15,6 +15,10 @@ When a pull request is created, Pipelines will automatically execute `terragrunt
 ## Terragrunt apply/destroy
 
 When a pull request is merged, Pipelines will automatically execute either `terragrunt apply` or `terragrunt destroy` on every infrastructure change, depending on the type of infrastructure change. For example, if the pull request deletes a `terragrunt.hcl` file, Pipelines will run `terragrunt destroy`.
+
+## Skipping Runs
+
+Sometimes you find it necessary to make a change without going through the full pipelines process. This can be accomplished using GitHub's [built in method for skipping workflow runs](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs).
 
 ## Other Actions
 

--- a/docs/pipelines/overview/actions.md
+++ b/docs/pipelines/overview/actions.md
@@ -28,6 +28,6 @@ If you'd like to request a new Pipelines action, please email us at <feedback@gr
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "f2f6558e306627b9ed19c3362929c75a"
+  "hash": "08bff68a304a1c4ad67f8a54ffed55fb"
 }
 ##DOCS-SOURCER-END -->


### PR DESCRIPTION
Annotate the fact that we can use workflow's built in ability to skip your ci run