### PR TITLE
chore: Getting rid of recent upgrade banner

### DIFF
--- a/_docs-sources/foundations/iac-foundations/initial-setup.md
+++ b/_docs-sources/foundations/iac-foundations/initial-setup.md
@@ -1,11 +1,5 @@
 # Initial setup
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/iac-foundations/initial-setup.md) to get the documentation for that version.
-:::
-
 To set up IaC Foundations, we use three pre-configured git repository templates that include best practices and also allow for customization.
 
 For each repository below, navigate to the template repository and select **Use this template** -> **Create a new Repository**. This will initiate repository creation. You should select your org as the owner, add a description if you like, make sure you are creating a **private** repo, and click **Create repository**.

--- a/_docs-sources/pipelines/architecture/index.md
+++ b/_docs-sources/pipelines/architecture/index.md
@@ -1,11 +1,5 @@
 # Architecture
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 There are two major components in pipelines - the orchestrator and the executor. The orchestrator determines the jobs to be executed and the executor actually executes the jobs and makes any necessary updates in AWS.
 
 ## Orchestrator

--- a/_docs-sources/pipelines/data-collection/index.md
+++ b/_docs-sources/pipelines/data-collection/index.md
@@ -1,9 +1,3 @@
 # Usage Data
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 Gruntwork Pipelines captures usage data to better understand how our customers use our products. This information includes the duration of pipelines runs, the number of jobs you run, customer name, and application errors that occur during execution. If you would like to disable telemetry, please set the environment variable `PIPELINES_TELEMETRY_OPT_OUT=1` in your CI job.

--- a/_docs-sources/pipelines/maintain/extending.md
+++ b/_docs-sources/pipelines/maintain/extending.md
@@ -1,11 +1,5 @@
 # Extending Your Pipeline
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 Gruntwork Pipelines is designed to be extensible. This means that you can add your own customizations to the GitHub Actions Workflows, and the underlying custom GitHub Actions to suit your organization's needs. This document will guide you through the process of extending your pipeline.
 
 

--- a/_docs-sources/pipelines/maintain/updating.md
+++ b/_docs-sources/pipelines/maintain/updating.md
@@ -1,11 +1,5 @@
 # Updating Your Pipeline
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 Staying up to date with the latest in Gruntwork Pipelines is fairly simple. We release new versions of the Pipelines CLI, the associated GitHub Actions Workflows and the underlying custom GitHub Actions regularly to provide the optimal experience for managing infrastructure changes at scale.
 
 To pull in the latest changes across all three of these dimensions, you can simply edit the `pipelines.yml` file found under `.github/workflows` in any repository integrated with Gruntwork Pipelines in order to select the latest version of the Pipelines GitHub Actions Workflow:

--- a/_docs-sources/pipelines/overview/actions.md
+++ b/_docs-sources/pipelines/overview/actions.md
@@ -1,11 +1,5 @@
 # Pipelines Actions
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 When a user opens a pull request, Pipelines runs a set of operations as a Github Action Workflow in response to the proposed [infrastructure changes](../overview/#infrastructure-change). We call these operations _pipelines actions_. Gruntwork Pipelines supports the following pipelines actions:
 
 ## Terragrunt plan

--- a/_docs-sources/pipelines/overview/index.md
+++ b/_docs-sources/pipelines/overview/index.md
@@ -1,11 +1,5 @@
 # What is Gruntwork Pipelines?
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 **Gruntwork Pipelines is designed to enable your organization to deploy infrastructure changes to cloud environments with control and confidence.**
 
 Having worked with hundreds of organizations to help them improve DevOps, we've discovered two truths about making changes to infrastructure:
@@ -13,7 +7,7 @@ Having worked with hundreds of organizations to help them improve DevOps, we've 
 1. Teams want to control exactly how infrastructure change gets rolled out
 2. Deploying infrastructure changes is scary!
 
-To address your need for _control_, we've designed Gruntwork Pipelines to use [configuration as code](configurations-as-code), where you use HCL (a popular alternative to JSON and YAML) to set configuration values that apply to your entire git repo, to just one environment, or to a single deployable unit of infrastructure. For example, you can specify a unique AWS authentication strategy for each deployable unit of infrastructure, one per environment, or a single strategy for the entire git repo.
+To address your need for _control_, we've designed Gruntwork Pipelines to use [configuration as code](./configurations-as-code.md), where you use HCL (a popular alternative to JSON and YAML) to set configuration values that apply to your entire git repo, to just one environment, or to a single deployable unit of infrastructure. For example, you can specify a unique AWS authentication strategy for each deployable unit of infrastructure, one per environment, or a single strategy for the entire git repo.
 
 To address your need for _assurance_ that an infrastructure change is safe to apply, we include a thoughtfully formatted `terragrunt plan` user experience, and the ability to customize Gruntwork Pipelines to support arbitrary steps that your organization needs to establish confidence in a deployment. Building assurance also factors heavily into our roadmap.
 

--- a/_docs-sources/pipelines/security/audit-log.md
+++ b/_docs-sources/pipelines/security/audit-log.md
@@ -1,11 +1,5 @@
 # Audit logs
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 Gruntwork Pipelines provides an audit log of which GitHub user performed _what_ operation in your AWS accounts as a result of a [Pipelines Action](../overview/actions.md).
 
 Accessing AWS environments from a CI/CD system is commonly done by assuming temporary credentials using [OpenID Connect (OIDC)](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services). Usage of shared credentials complicates the task of maintaining an accurate log of who did what in your AWS accounts. Gruntwork Pipelines solves this issue by leveraging [AWS CloudTrail](https://aws.amazon.com/cloudtrail/) and a naming scheme based on context from the triggering Pipelines Action in GitHub. This setup associates every single API operation performed by Gruntwork Pipelines with a GitHub username and a pull request or branch. This allows your security team to quickly triage access related issues and perform analytics on usage patterns of individual users from your version control system in your AWS accounts.

--- a/_docs-sources/pipelines/security/branch-protection.md
+++ b/_docs-sources/pipelines/security/branch-protection.md
@@ -1,11 +1,5 @@
 # Branch Protection
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 Gruntwork Pipelines is designed to be used with a PR based workflow.
 This means an approval on a PR is an approval to deploy infrastructure, making the configuration of repository settings and branch protection especially important.
 

--- a/_docs-sources/pipelines/security/controls.md
+++ b/_docs-sources/pipelines/security/controls.md
@@ -1,11 +1,5 @@
 # Controls
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 Pipelines takes a defense in depth approach to securing workflows. This document provides an overview of the controls that Pipelines employs to ensure that only infrastructure that has been written in code and approved by a reviewer can be deployed in your AWS accounts.
 
 ## Least privilege principle

--- a/_docs-sources/pipelines/security/machine-users.mdx
+++ b/_docs-sources/pipelines/security/machine-users.mdx
@@ -3,12 +3,6 @@ import TabItem from "@theme/TabItem"
 
 # Machine users
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 Gruntwork recommends using CI users in Gruntwork Pipelines, separate from human users in your organization. Using a CI user ensures that a workflow won't break due to an employee leaving your company. Using CI users allows you to apply granular permissions that may normally be too restrictive for a normal employee to do their daily work.
 
 :::info

--- a/_docs-sources/pipelines/security/repository-access.md
+++ b/_docs-sources/pipelines/security/repository-access.md
@@ -1,11 +1,5 @@
 # Repository Access
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 Gruntwork recommends that you grant permissions to GitHub repositories by defining three [GitHub Teams](https://docs.github.com/en/organizations/organizing-members-into-teams/about-teams), which should map to three separate personas in your organization. Each team and its permissions are designed to apply the [_principle of least privilege_](https://en.wikipedia.org/wiki/Principle_of_least_privilege) to each individual (or machine user) in your organization for them to be able to perform changes to your infrastructure.
 
 - The `infrastructure-administrators` team is for engineers who likely work on the IaC codebase daily, but _do_ have administrative AWS permissions.

--- a/docs/foundations/iac-foundations/initial-setup.md
+++ b/docs/foundations/iac-foundations/initial-setup.md
@@ -1,11 +1,5 @@
 # Initial setup
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/iac-foundations/initial-setup.md) to get the documentation for that version.
-:::
-
 To set up IaC Foundations, we use three pre-configured git repository templates that include best practices and also allow for customization.
 
 For each repository below, navigate to the template repository and select **Use this template** -> **Create a new Repository**. This will initiate repository creation. You should select your org as the owner, add a description if you like, make sure you are creating a **private** repo, and click **Create repository**.
@@ -34,6 +28,6 @@ This template creates an empty infrastructure-modules repository that will be us
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "c727d1e5c94ef7864a331765302d032a"
+  "hash": "bf3eaeb6a4f922d46183237aeff5b4bf"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/pipelines/architecture/index.md
+++ b/docs/pipelines/architecture/index.md
@@ -1,11 +1,5 @@
 # Architecture
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 There are two major components in pipelines - the orchestrator and the executor. The orchestrator determines the jobs to be executed and the executor actually executes the jobs and makes any necessary updates in AWS.
 
 ## Orchestrator
@@ -32,6 +26,6 @@ In addition, each AWS IAM role provisioned as part of DevOps Foundations only tr
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "7849eafdb71da19971fc4621d286755c"
+  "hash": "eb42967758fa13106b6717c449375359"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/pipelines/data-collection/index.md
+++ b/docs/pipelines/data-collection/index.md
@@ -1,17 +1,11 @@
 # Usage Data
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 Gruntwork Pipelines captures usage data to better understand how our customers use our products. This information includes the duration of pipelines runs, the number of jobs you run, customer name, and application errors that occur during execution. If you would like to disable telemetry, please set the environment variable `PIPELINES_TELEMETRY_OPT_OUT=1` in your CI job.
 
 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "5c3ea3775309c450e49ff686c4b40647"
+  "hash": "e11a2efc43910b4a56e9e84188f0d871"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/pipelines/maintain/extending.md
+++ b/docs/pipelines/maintain/extending.md
@@ -1,11 +1,5 @@
 # Extending Your Pipeline
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 Gruntwork Pipelines is designed to be extensible. This means that you can add your own customizations to the GitHub Actions Workflows, and the underlying custom GitHub Actions to suit your organization's needs. This document will guide you through the process of extending your pipeline.
 
 
@@ -148,6 +142,6 @@ In order to customize the behavior of an Action, you will need to fork the repos
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "9429934fae8090b87320c9182262d5cd"
+  "hash": "4f00edc5308693e07f576d4d2a3d408d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/pipelines/maintain/updating.md
+++ b/docs/pipelines/maintain/updating.md
@@ -1,11 +1,5 @@
 # Updating Your Pipeline
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 Staying up to date with the latest in Gruntwork Pipelines is fairly simple. We release new versions of the Pipelines CLI, the associated GitHub Actions Workflows and the underlying custom GitHub Actions regularly to provide the optimal experience for managing infrastructure changes at scale.
 
 To pull in the latest changes across all three of these dimensions, you can simply edit the `pipelines.yml` file found under `.github/workflows` in any repository integrated with Gruntwork Pipelines in order to select the latest version of the Pipelines GitHub Actions Workflow:
@@ -26,6 +20,6 @@ Note that if you follow the instructions under [Extending Pipelines](/pipelines/
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "6d58ce75f6b3810e2c15e8eaadd2e96f"
+  "hash": "cc2c507bc56eb96c8e9766353fa2dac8"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/pipelines/overview/actions.md
+++ b/docs/pipelines/overview/actions.md
@@ -1,11 +1,5 @@
 # Pipelines Actions
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 When a user opens a pull request, Pipelines runs a set of operations as a Github Action Workflow in response to the proposed [infrastructure changes](../overview/#infrastructure-change). We call these operations _pipelines actions_. Gruntwork Pipelines supports the following pipelines actions:
 
 ## Terragrunt plan
@@ -28,6 +22,6 @@ If you'd like to request a new Pipelines action, please email us at [feedback@gr
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "14b565cd10511c47abd81b1a535431a8"
+  "hash": "6dfd5542e8e8cbe86eff0053b6d85a01"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/pipelines/overview/index.md
+++ b/docs/pipelines/overview/index.md
@@ -1,11 +1,5 @@
 # What is Gruntwork Pipelines?
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 **Gruntwork Pipelines is designed to enable your organization to deploy infrastructure changes to cloud environments with control and confidence.**
 
 Having worked with hundreds of organizations to help them improve DevOps, we've discovered two truths about making changes to infrastructure:
@@ -13,7 +7,7 @@ Having worked with hundreds of organizations to help them improve DevOps, we've 
 1. Teams want to control exactly how infrastructure change gets rolled out
 2. Deploying infrastructure changes is scary!
 
-To address your need for _control_, we've designed Gruntwork Pipelines to use [configuration as code](configurations-as-code), where you use HCL (a popular alternative to JSON and YAML) to set configuration values that apply to your entire git repo, to just one environment, or to a single deployable unit of infrastructure. For example, you can specify a unique AWS authentication strategy for each deployable unit of infrastructure, one per environment, or a single strategy for the entire git repo.
+To address your need for _control_, we've designed Gruntwork Pipelines to use [configuration as code](./configurations-as-code.md), where you use HCL (a popular alternative to JSON and YAML) to set configuration values that apply to your entire git repo, to just one environment, or to a single deployable unit of infrastructure. For example, you can specify a unique AWS authentication strategy for each deployable unit of infrastructure, one per environment, or a single strategy for the entire git repo.
 
 To address your need for _assurance_ that an infrastructure change is safe to apply, we include a thoughtfully formatted `terragrunt plan` user experience, and the ability to customize Gruntwork Pipelines to support arbitrary steps that your organization needs to establish confidence in a deployment. Building assurance also factors heavily into our roadmap.
 
@@ -59,6 +53,6 @@ Gruntwork is responsible for adding support for a growing library of Pipelines A
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "4a7a651db403c68be5bac7a77e06265d"
+  "hash": "fa078a0b4d9c9a327c2c95f1db75038f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/pipelines/security/audit-log.md
+++ b/docs/pipelines/security/audit-log.md
@@ -1,11 +1,5 @@
 # Audit logs
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 Gruntwork Pipelines provides an audit log of which GitHub user performed _what_ operation in your AWS accounts as a result of a [Pipelines Action](../overview/actions.md).
 
 Accessing AWS environments from a CI/CD system is commonly done by assuming temporary credentials using [OpenID Connect (OIDC)](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services). Usage of shared credentials complicates the task of maintaining an accurate log of who did what in your AWS accounts. Gruntwork Pipelines solves this issue by leveraging [AWS CloudTrail](https://aws.amazon.com/cloudtrail/) and a naming scheme based on context from the triggering Pipelines Action in GitHub. This setup associates every single API operation performed by Gruntwork Pipelines with a GitHub username and a pull request or branch. This allows your security team to quickly triage access related issues and perform analytics on usage patterns of individual users from your version control system in your AWS accounts.
@@ -79,6 +73,6 @@ CloudTrail can be configured to automatically store events in an S3 bucket of yo
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "e0ddaa37b7ec46c7ad1d5a4a18ce6d02"
+  "hash": "0ce77267cc0423e0a3dffaa4cce28c4b"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/pipelines/security/branch-protection.md
+++ b/docs/pipelines/security/branch-protection.md
@@ -1,11 +1,5 @@
 # Branch Protection
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 Gruntwork Pipelines is designed to be used with a PR based workflow.
 This means an approval on a PR is an approval to deploy infrastructure, making the configuration of repository settings and branch protection especially important.
 
@@ -59,6 +53,6 @@ The following is an example of the recommended settings for branch protection:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "eea67b29d9823c1fe72af383a27280a5"
+  "hash": "39d6e1e890312eda80c90eba7a172739"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/pipelines/security/controls.md
+++ b/docs/pipelines/security/controls.md
@@ -1,11 +1,5 @@
 # Controls
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 Pipelines takes a defense in depth approach to securing workflows. This document provides an overview of the controls that Pipelines employs to ensure that only infrastructure that has been written in code and approved by a reviewer can be deployed in your AWS accounts.
 
 ## Least privilege principle
@@ -183,6 +177,6 @@ It is up to the user provisioning these roles to ensure that this role has only 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "dcb29bbdabc00cf74cbcd68de7a535e3"
+  "hash": "e663d09612e345a027def347871ed66f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/pipelines/security/machine-users.mdx
+++ b/docs/pipelines/security/machine-users.mdx
@@ -3,12 +3,6 @@ import TabItem from "@theme/TabItem"
 
 # Machine users
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 Gruntwork recommends using CI users in Gruntwork Pipelines, separate from human users in your organization. Using a CI user ensures that a workflow won't break due to an employee leaving your company. Using CI users allows you to apply granular permissions that may normally be too restrictive for a normal employee to do their daily work.
 
 :::info
@@ -352,6 +346,6 @@ For additional information on creating and using Github Actions Repository secre
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "8f4f83938ef101f9181edc95b7269134"
+  "hash": "0fed0191f3d62a5f463e03c95d3d1af7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/pipelines/security/repository-access.md
+++ b/docs/pipelines/security/repository-access.md
@@ -1,11 +1,5 @@
 # Repository Access
 
-:::info Recent Upgrade
-This documentation relates to the latest version of Gruntwork Pipelines released in May 2024.
-
-If you are using the older version of Gruntwork Pipelines that includes the `infrastructure-pipelines` repository, click [here](../../infrastructure-pipelines/overview/deprecation.md) to learn more about the deprecation of that version.
-:::
-
 Gruntwork recommends that you grant permissions to GitHub repositories by defining three [GitHub Teams](https://docs.github.com/en/organizations/organizing-members-into-teams/about-teams), which should map to three separate personas in your organization. Each team and its permissions are designed to apply the [_principle of least privilege_](https://en.wikipedia.org/wiki/Principle_of_least_privilege) to each individual (or machine user) in your organization for them to be able to perform changes to your infrastructure.
 
 - The `infrastructure-administrators` team is for engineers who likely work on the IaC codebase daily, but _do_ have administrative AWS permissions.
@@ -48,6 +42,6 @@ This team is meant for engineers and a single machine user who can read relevant
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "local-copier",
-  "hash": "2220f40e5d77f080fddd99d93e119de4"
+  "hash": "2629db6b6d1bd8579ea58140ffc0239d"
 }
 ##DOCS-SOURCER-END -->


### PR DESCRIPTION
This gets rid of the banner that was added when shifting away from `infrastructure-pipelines`.

It is no longer a "recent upgrade", and is now the exception, rather than the rule for what users expect when they read the docs.

