### PR TITLE
Make the homepage the primary index content

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,0 +1,7 @@
+---
+title: ''
+---
+
+import { HomeContent } from '../src/pages/home';
+
+<HomeContent />

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -119,7 +119,7 @@ const config = {
             type: "doc",
             position: "left",
             label: "Docs",
-            docId: "2.0/docs",
+            docId: "index",
           },
           {
             type: "doc",

--- a/sidebars/docs.js
+++ b/sidebars/docs.js
@@ -15,9 +15,8 @@ const sidebar = [
     label: "Gruntwork Documentation",
     type: "category",
     link: {
-      type: "generated-index",
-      title: "Gruntwork Documentation",
-      slug: "2.0/docs",
+      type: "doc",
+      id: 'index',
     },
     collapsible: false,
     items: [

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -27,12 +27,12 @@ function HomepageHeader() {
   )
 }
 
-export default function Home(): JSX.Element {
+export const HomeContent = () => {
   const { siteConfig } = useDocusaurusContext()
   return (
-    <Layout description="Documentation and guides for Gruntwork's tools and services">
-      <HomepageHeader />
-      <main>
+    <>
+    <HomepageHeader />
+    <main>
         <section className={styles.features}>
           <div className="container">
             <CardGroup>
@@ -102,6 +102,14 @@ export default function Home(): JSX.Element {
           </div>
         </section>
       </main>
+       </>
+      );
+}
+
+export default function Home(): JSX.Element {
+  return (
+    <Layout description="Documentation and guides for Gruntwork's tools and services">
+      <HomeContent />
     </Layout>
   )
 }


### PR DESCRIPTION
Now that we have the majority of our docs under one sidebar it makes sense to me to have the homepage have the primary sidebar.  This also solves the problem of "what do we do for the primary generated-index page" for the top of the docs nav.  It's not perfect, but IMO it works

![image](https://github.com/user-attachments/assets/467c91a9-5115-4c89-9243-250a148751ae)
