### PR TITLE
Add basic drift detection install content

### DIFF
--- a/docs/2.0/docs/pipelines/configuration/driftdetection.md
+++ b/docs/2.0/docs/pipelines/configuration/driftdetection.md
@@ -1,8 +1,6 @@
 
 # Setting up Pipelines Drift Detection
 
-This page is under construction
-<!--
-## Already installed from infra-root boilerplate
-## Installing from scratch by adding the workflow file
--->
+If you're a Pipelines Enterprise customer and you installed Pipelines using our infrastructure-live-root repository template then Drift Detection is already installed and available as a GitHub workflow in your repository.
+
+If you installed Pipelines in a manner other than from the template and you're an enterprise customer and you want to add Drift Detection, see the [Installing Drift Detection Guide](../guides/installing-drift-detection.md).

--- a/docs/2.0/docs/pipelines/guides/installing-drift-detection.md
+++ b/docs/2.0/docs/pipelines/guides/installing-drift-detection.md
@@ -10,13 +10,13 @@ If you're creating new pipelines repositories using the latest version of Pipeli
 
 If you want to upgrade an older repository to add Drift Detection perform the following steps:
 
-### Step 1
+### Step 1 - Ensure the GitHub App is Installed
 
 Ensure you are using the [GitHub App](/2.0/docs/pipelines/installation/viagithubapp) in this repository. Drift Detection requires permissions from the GitHub App and is not available via machine user tokens.
 
 <PersistentCheckbox id="install-drift-1" label="GitHub App In Use" />
 
-### Step 2
+### Step 2 - Setup the Workflow file
 
 Create a new workflow file in your repository at `.github/workflows/pipelines-drift-detection.yml`
 
@@ -55,6 +55,6 @@ Commit the changes to the repository. If you are using [branch protection](/2.0/
 
 <PersistentCheckbox id="install-drift-2" label="Workflow File Created" />
 
-### Step 3
+### Step 3 - Run your first drift detection job
 
 Follow the instructions at [Running Drift Detection](/2.0/docs/pipelines/guides/running-drift-detection) to start using the new workflow.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -87,7 +87,7 @@ const config = {
         docs: {
           routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: "https://github.com/gruntwork-io/docs/edit/master/",
+          editUrl: "https://github.com/gruntwork-io/docs/edit/main/",
           exclude: [
             "guides/build-it-yourself/landing-zone/**",
             "guides/build-it-yourself/vpc/**",


### PR DESCRIPTION
We had a guide for drift detection install, but a blank placeholder page under install.  This has the install page send users to the guide.

I suppose the idea is that drift detection isn't a "day 1" need, so in general people won't mess with it during initial pipelines setup.  However, when they come back on "day 2" for drift detection they might look under setup for how to install it, or they might look under guides (with all the other day 2 content) -- this way regardless where they look they get what they want and the nav stays sensible.