### PR TITLE
remove docs around patcher report being interactive

### DIFF
--- a/docs/2.0/docs/patcher/guides/report.md
+++ b/docs/2.0/docs/patcher/guides/report.md
@@ -1,36 +1,8 @@
 # Patcher Report
 
-Starting in `0.4.2`, Patcher supports two modes: **interactive mode** and **non-interactive mode**.
-
-In interactive mode, the user can browse the discovered module dependencies.
+Patcher supports **non-interactive mode** for `patcher report`.
 
 In non-interactive mode, Patcher outputs a list of module dependencies in JSON format.
-
-## Interactive Mode (Default)
-Example usage:
-```
-patcher report prod
-```
-
-The `patcher report` command is a read-only version of Patcher that shows the changelog per module and its usages.
-
-After scanning for dependencies, Patcher will show you the 'Modules View', similar to the screenshot below.
-
-![Patcher report screenshot](/img/guides/stay-up-to-date/patcher/patcher-report-overview-futd.png)
-
-### Navigation commands
-
-1. While in the modules view, press `u` to see the usages. It shows all places where module is being used:
-
-![Patcher usages screenshot](/img/guides/stay-up-to-date/patcher/patcher-report-usages.png)
-
-2. While in the modules view, press `v` to see the changelogs from a module. Press `o` to open the page in the browser.
-
-![Patcher changelogs screenshot](/img/guides/stay-up-to-date/patcher/patcher-report-changelog.png)
-
-Some modules including third party modules may not have a CHANGELOGS.md file. In this case, press `o` to open the releases page for that repository.
-
-![Patcher no changelogs screenshot](/img/guides/stay-up-to-date/patcher/patcher-report-no-changelog.png)
 
 ## Non-Interactive Mode
 Example usage:

--- a/docs/2.0/docs/patcher/guides/report.md
+++ b/docs/2.0/docs/patcher/guides/report.md
@@ -1,13 +1,11 @@
 # Patcher Report
 
-Patcher supports **non-interactive mode** for `patcher report`.
-
-In non-interactive mode, Patcher outputs a list of module dependencies in JSON format.
+Patcher `report` outputs a list of module dependencies in JSON format.
 
 ## Non-Interactive Mode
 Example usage:
 ```
-patcher report --non-interactive prod
+patcher report prod
 ```
 
 The report command outpust a list of module dependencies in JSON format to `stdout`, for example:


### PR DESCRIPTION
## description

we're thisclose to not supporting `patcher report --non-interactive=false`. we should just remove the docs so folks don't get confused. that work is tracked [here](https://linear.app/gruntwork/issue/PAT-21/[report]-report-command-always-outputs-json)

there's potential here about examples for how to use `patcher report`'s JSON output to track dependency management within a codebase, but that's not the purpose of this PR. 