### PR TITLE
Fixes bugs on stay-up-to-date index page

### DIFF
--- a/docs/guides/stay-up-to-date/index.md
+++ b/docs/guides/stay-up-to-date/index.md
@@ -16,6 +16,8 @@ import CardGroup from "/src/components/CardGroup"
 
 <CardGroup cols={1} gap="1rem" stacked equalHeightRows={false} commonCardProps={{padding: "1.25rem"}}>
 
+<!-- START_DOCS_SOURCER_DYNAMIC_CONTENT id=gruntwork-releases-cards -->
+<Card title="Update to 2024-11" href="/guides/stay-up-to-date/releases/2024-11" />
 <Card title="Update to 2024-10" href="/guides/stay-up-to-date/releases/2024-10" />
 <Card title="Update to 2024-09" href="/guides/stay-up-to-date/releases/2024-09" />
 <Card title="Update to 2024-08" href="/guides/stay-up-to-date/releases/2024-08" />
@@ -30,9 +32,8 @@ import CardGroup from "/src/components/CardGroup"
 <Card title="Update to 2023-11" href="/guides/stay-up-to-date/releases/2023-11" />
 <Card title="Update to 2023-10" href="/guides/stay-up-to-date/releases/2023-10" />
 <Card title="Update to 2023-09" href="/guides/stay-up-to-date/releases/2023-09" />
-<Card title="Update to 2023-08" href="/guides/stay-up-to-date/releases/2023-08" />
-<Card title="Update to 2023-07" href="/guides/stay-up-to-date/releases/2023-07" />
 <Card title="See older releases" href="/guides/stay-up-to-date/releases" />
+<!-- END_DOCS_SOURCER_DYNAMIC_CONTENT -->
 
 </CardGroup>
 
@@ -111,13 +112,9 @@ href="/guides/stay-up-to-date/cis/cis-1.5.0"
 
 </Grid>
 
-
-##DOCS-SOURCER-END -->
-
-
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "a0caca4ec28cda39ab7abc90efddbf9e"
+  "hash": "1cb8da7049693e1d1a779e4d89bcbfa7"
 }
 ##DOCS-SOURCER-END -->


### PR DESCRIPTION
Content generated fixes by running the releases plugin with the bug fix in [this docs-sourcer PR](https://github.com/gruntwork-io/docs-sourcer/pull/156).