### PR TITLE
Update tf_binary config description

### DIFF
--- a/docs/2.0/reference/pipelines/configurations-as-code/api.md
+++ b/docs/2.0/reference/pipelines/configurations-as-code/api.md
@@ -279,8 +279,8 @@ Whether or not Pipelines will consolidate deleted resources when running Terragr
 <HclListItemDescription>
 
 The Infrastructure as Code(Iac) binary that Pipelines will instruct Terragrunt to use. Valid values are:
-- `opentofu` (default): Use OpenTofu for managing infrastructure. Recommended for new projects.
-- `terraform`: Use Terraform for managing infrastructure. Consider this option for existing projects that already use Terraform and want features only available in Terraform but not OpenTofu.
+- `opentofu` (default): Use OpenTofu for managing infrastructure. Recommended for new projects
+- `terraform`: Use Terraform for managing infrastructure. Consider this option for existing projects that already use Terraform and want features only available in Terraform but not OpenTofu
 
   :::note
 

--- a/docs/2.0/reference/pipelines/configurations-as-code/api.md
+++ b/docs/2.0/reference/pipelines/configurations-as-code/api.md
@@ -280,7 +280,7 @@ Whether or not Pipelines will consolidate deleted resources when running Terragr
 
 The Infrastructure as Code(Iac) binary that Pipelines will instruct Terragrunt to use. Valid values are:
 - `opentofu` (default): Use OpenTofu for managing infrastructure. Recommended for new projects
-- `terraform`: Use Terraform for managing infrastructure. Consider this option for existing projects that already use Terraform and want features only available in Terraform but not OpenTofu
+- `terraform`: Use Terraform for managing infrastructure. 
 
   :::note
 

--- a/docs/2.0/reference/pipelines/configurations-as-code/api.md
+++ b/docs/2.0/reference/pipelines/configurations-as-code/api.md
@@ -278,7 +278,15 @@ Whether or not Pipelines will consolidate deleted resources when running Terragr
 <HclListItem name="tf_binary" requirement="optional" type="string">
 <HclListItemDescription>
 
-The IaC binary that Pipelines will instruct Terragrunt to use. Valid values are `opentofu` or `terraform`.
+The Infrastructure as Code(Iac) binary that Pipelines will instruct Terragrunt to use. Valid values are:
+- `opentofu` (default): Use OpenTofu for managing infrastructure. Recommended for new projects.
+- `terraform`: Use Terraform for managing infrastructure. Consider this option for existing projects that already use Terraform and want features only available in Terraform but not OpenTofu.
+
+  :::note
+
+  Changing this value for existing infrastructure may require additional steps to ensure a successful migration.
+
+  :::
 
 </HclListItemDescription>
 <HclListItemDefaultValue defaultValue="opentofu"/>


### PR DESCRIPTION
[Preview link](https://docs-git-update-tf-binary-docs-gruntwork.vercel.app/2.0/reference/pipelines/configurations-as-code/api#tf_binary)

<img width="1041" alt="Screenshot 2025-02-12 at 12 06 57 PM" src="https://github.com/user-attachments/assets/1c1d10ca-c46b-4f52-86d2-e1e30aae1767" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Revised the attribute description to detail valid IaC binary options ("opentofu" as the default and recommended for new projects; "terraform" for existing projects).
	- Enhanced formatting with bullet points and notes for improved clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->