### PR TITLE
Add Stacks documentation

### DIFF
--- a/docs/2.0/docs/pipelines/guides/stacks.md
+++ b/docs/2.0/docs/pipelines/guides/stacks.md
@@ -1,18 +1,33 @@
-# Running Pipelines with Terragrunt Stacks
+# Using Terragrunt Stacks
 
 ## Introduction
 
-Terragrunt Stacks provide a powerful way to organize and manage your infrastructure code. Gruntwork Pipelines automatically integrates with Terragrunt Stacks.
+Terragrunt Stacks provide a powerful way to organize and manage your infrastructure code. Stacks simplify your infrastructure management by allowing you to define and deploy collections of related infrastructure units with a single file, reducing repetition and enabling consistent patterns across environments, customers, or regions.
 
-Learn more about Terragrunt Stacks in the <span class="external-link"><a href="https://terragrunt.gruntwork.io/docs/features/stacks/">Terragrunt Stacks Documentation</a></span>.
+Learn more about Terragrunt Stacks in the <span class="external-link"><a href="https://terragrunt.gruntwork.io/docs/features/stacks/">Terragrunt Stacks Documentation</a></span> and the <span class="external-link"><a href="https://blog.gruntwork.io/the-road-to-terragrunt-1-0-stacks-cd97f11ef565">The Road to 1.0: Terragrunt Stacks</a></span> blog post.
+
+Gruntwork Pipelines has full support for Terragrunt Stacks without need for any additional configuration. When you include `terragrunt.stack.hcl` files in your IaC repository, Gruntwork Pipelines will automatically detect any relevant changes, and automatically generate the resulting unit configurations. You don't need to (and should not) commit the generated units to source control; commit only the stack configuration files and leave the rest to Gruntwork Pipelines.
 
 ## Prerequisites
 
-Pipelines automatically supports Terragrunt Stacks as long as you're using Terragrunt `v0.71.3` or higher. You can specify the Terragrunt binary version in the `mise.toml` file in your repository, see the [configuration reference](/2.0/reference/pipelines/configurations#example-mise-configuration).
+Pipelines v3 automatically supports Terragrunt Stacks as long as you're using Terragrunt `v0.71.3` or higher. You can specify the Terragrunt binary version in the `mise.toml` file in your repository, see the [configuration reference](/2.0/reference/pipelines/configurations#example-mise-configuration).
 
 See [Terragrunt Version Compatibility](/2.0/reference/pipelines/terragrunt-version-compatibility) for more details on specific Terragrunt versions and their compatibility with Pipelines.
 
 ## Terragrunt Stacks in Pipelines
+
+### Getting Started
+
+To get started, follow these steps:
+
+1. Create Terragrunt Stack definitions (`terragrunt.stack.hcl` files) in your live IaC repo for any units you wish to configure as stacks. When referencing units in your stack, use versioned sources (e.g. `git::git@github.com:my-org/my-catalog.git//units/foo?ref=v0.2.0`). This ensures that the stack can be updated to a specific version of the unit.
+
+2. If the stacks pertain to units which you’ve previously committed to your IaC repo, set the `no_dot_terragrunt_stack` flag to true so that generated stacks will appear at the same directory path as your current stacks (instead of a hidden one). You should then remove the unit directories encoded with stacks from source control — Gruntwork Pipelines will generate these automatically when you deploy new changes. See the <span class="external-link"><a href="https://terragrunt.gruntwork.io/docs/migrate/terragrunt-stacks/#step-4-re-define-existing-infrastructure-using-terragruntstackhcl-files">Migration Guide</a></span> for more details.
+
+3. You can run `terragrunt stack generate` locally to preview the units configured in your stacks. However, do not commit the generated files to source control. Gruntwork Pipelines will generate these automatically when you deploy new changes.
+
+4. Add, modify, or remove stacks as needed. Gruntwork Pipelines will detect relevant changes as described in more detail below.
+
 
 ### Detecting Stack Changes
 
@@ -22,23 +37,28 @@ When you create, update, or remove a `terragrunt.stack.hcl` file, Pipelines will
 2. Detect any changes to units and values defined in the stack
 3. Plan and apply the changes as part of your existing pipelines process
 
+::note
 Note that the stack will only be generated if there are changes to the stack file. If you make changes to the remote units defined in the stack, these changes will not be reflected in pipeline runs until the stack file is updated.
+::
 
 ### Repository Structure
 
 We recommend using your `infrastructure-catalog` repository to define your reusable Terragrunt Units.
 
-Within your `infrastructure-live-root` repositories, add `terragrunt.stack.hcl` files to define your Terragrunt Stacks. You should not commit the generated `.terragrunt-stack` directories to source control, pipelines will generate these directories automatically during execution.
+Within your `infrastructure-live-root` repositories, add `terragrunt.stack.hcl` files to define your Terragrunt Stacks.
+
+::warning
+You should not commit the generated `.terragrunt-stack` directories to source control, pipelines will generate these directories automatically during execution.
+::
 
 #### Removing .terragrunt-stack directories
 
-If you have already committed a `.terragrunt-stack` directory to source control and want to remove it, we recommend adding `[skip-ci]` in your commit message to prevent unintended infrastructure destruction. If your changes remove tracked files, but do not modify the stack file, the stack will not be generated and Pipelines will assume that the infrastructure is being removed.
+::note
+The following is only necessary if you've accidentally committed `.terragrunt-stack` directories to source control, which should be avoided.
+::
+
+If you find yourself in the situation where `.terragrunt-stack` directories have been committed to your repository, you'll need to remove them carefully. When doing so, add `[skip-ci]` to your commit message to prevent unintended infrastructure destruction. Without this flag, if Pipelines detects removed tracked files but doesn't see corresponding stack file modifications, it may interpret this as infrastructure that should be destroyed.
 
 ### Migration from _envcommon
 
-If your repository currently uses the _envcommon pattern, you can gradually migrate to Terragrunt Stacks without disrupting your existing workflows. See the <span class="external-link"><a href="https://terragrunt.gruntwork.io/docs/migrate/terragrunt-stacks/">Terragrunt Migration Guide</a></span> for detailed instructions on transitioning from _envcommon to Stacks.
-
-## Best Practices
-
-- **Don't commit generated files**: The `.terragrunt-stack` directory should not be committed to source control
-- **Use versioned unit sources**: When referencing units in your stack, use versioned sources (e.g. `git::git@github.com:my-org/my-catalog.git//units/foo?ref=v0.2.0`). This ensures that the stack can be updated to a specific version of the unit.
+The _envcommon pattern can be gradually replaced with Terragrunt Stacks while maintaining your existing workflows. Stacks provide a more structured and version-controlled alternative to _envcommon. Instead of updating shared files that immediately affect all dependent units across your repository, Stacks enable incremental rollouts of infrastructure changes through explicit versioning. This allows you to deploy changes to development environments first, then progressively to staging and production environments as confidence builds. For step-by-step migration instructions, see the <span class="external-link"><a href="https://terragrunt.gruntwork.io/docs/migrate/terragrunt-stacks/">Terragrunt Migration Guide</a></span>.

--- a/docs/2.0/docs/pipelines/guides/stacks.md
+++ b/docs/2.0/docs/pipelines/guides/stacks.md
@@ -30,7 +30,9 @@ We recommend using your `infrastructure-catalog` repository to define your reusa
 
 Within your `infrastructure-live-root` repositories, add `terragrunt.stack.hcl` files to define your Terragrunt Stacks. You should not commit the generated `.terragrunt-stack` directories to source control, pipelines will generate these directories automatically during execution.
 
-If you have already committed the `.terragrunt-stack` directory to source control and want to remove it, we recommend adding `[skip-ci]` in your commit message to prevent unintended infrastructure destruction. If your changes remove tracked files, but do not modify the stack file, the stack will not be generated and Pipelines will assume that the infrastructure is being removed.
+#### Removing .terragrunt-stack directories
+
+If you have already committed a `.terragrunt-stack` directory to source control and want to remove it, we recommend adding `[skip-ci]` in your commit message to prevent unintended infrastructure destruction. If your changes remove tracked files, but do not modify the stack file, the stack will not be generated and Pipelines will assume that the infrastructure is being removed.
 
 ### Migration from _envcommon
 

--- a/docs/2.0/docs/pipelines/guides/stacks.md
+++ b/docs/2.0/docs/pipelines/guides/stacks.md
@@ -37,9 +37,11 @@ When you create, update, or remove a `terragrunt.stack.hcl` file, Pipelines will
 2. Detect any changes to units and values defined in the stack
 3. Plan and apply the changes as part of your existing pipelines process
 
-::note
+:::note
+
 Note that the stack will only be generated if there are changes to the stack file. If you make changes to the remote units defined in the stack, these changes will not be reflected in pipeline runs until the stack file is updated.
-::
+
+:::
 
 ### Repository Structure
 
@@ -47,18 +49,26 @@ We recommend using your `infrastructure-catalog` repository to define your reusa
 
 Within your `infrastructure-live-root` repositories, add `terragrunt.stack.hcl` files to define your Terragrunt Stacks.
 
-::warning
+:::warning
+
 You should not commit the generated `.terragrunt-stack` directories to source control, pipelines will generate these directories automatically during execution.
-::
+
+:::
 
 #### Removing .terragrunt-stack directories
 
-::note
+:::note
+
 The following is only necessary if you've accidentally committed `.terragrunt-stack` directories to source control, which should be avoided.
-::
+
+:::
 
 If you find yourself in the situation where `.terragrunt-stack` directories have been committed to your repository, you'll need to remove them carefully. When doing so, add `[skip-ci]` to your commit message to prevent unintended infrastructure destruction. Without this flag, if Pipelines detects removed tracked files but doesn't see corresponding stack file modifications, it may interpret this as infrastructure that should be destroyed.
 
 ### Migration from _envcommon
 
-The _envcommon pattern can be gradually replaced with Terragrunt Stacks while maintaining your existing workflows. Stacks provide a more structured and version-controlled alternative to _envcommon. Instead of updating shared files that immediately affect all dependent units across your repository, Stacks enable incremental rollouts of infrastructure changes through explicit versioning. This allows you to deploy changes to development environments first, then progressively to staging and production environments as confidence builds. For step-by-step migration instructions, see the <span class="external-link"><a href="https://terragrunt.gruntwork.io/docs/migrate/terragrunt-stacks/">Terragrunt Migration Guide</a></span>.
+Terragrunt Stacks provide a more structured and version-controlled alternative to `_envcommon`. Instead of updating shared files that immediately affect all dependent units across your repository, Terragrunt Stacks enable incremental rollouts of infrastructure changes through explicit versioning. This allows you to deploy changes to development environments first, then progressively to staging and production environments as confidence builds.
+
+The `_envcommon` pattern can be gradually replaced with Terragrunt Stacks while maintaining your existing workflows.
+
+For step-by-step migration instructions, see the <span class="external-link"><a href="https://terragrunt.gruntwork.io/docs/migrate/terragrunt-stacks/">Terragrunt Migration Guide</a></span>.

--- a/docs/2.0/docs/pipelines/guides/stacks.md
+++ b/docs/2.0/docs/pipelines/guides/stacks.md
@@ -1,0 +1,42 @@
+# Running Pipelines with Terragrunt Stacks
+
+## Introduction
+
+Terragrunt Stacks provide a powerful way to organize and manage your infrastructure code. Gruntwork Pipelines automatically integrates with Terragrunt Stacks.
+
+Learn more about Terragrunt Stacks in the <span class="external-link"><a href="https://terragrunt.gruntwork.io/docs/features/stacks/">Terragrunt Stacks Documentation</a></span>.
+
+## Prerequisites
+
+Pipelines automatically supports Terragrunt Stacks as long as you're using Terragrunt `v0.71.3` or higher. You can specify the Terragrunt binary version in the `mise.toml` file in your repository, see the [configuration reference](/2.0/reference/pipelines/configurations#example-mise-configuration).
+
+See [Terragrunt Version Compatibility](/2.0/reference/pipelines/terragrunt-version-compatibility) for more details on specific Terragrunt versions and their compatibility with Pipelines.
+
+## Terragrunt Stacks in Pipelines
+
+### Detecting Stack Changes
+
+When you create, update, or remove a `terragrunt.stack.hcl` file, Pipelines will automatically:
+
+1. Generate the stack during orchestration 
+2. Detect any changes to units and values defined in the stack
+3. Plan and apply the changes as part of your existing pipelines process
+
+Note that the stack will only be generated if there are changes to the stack file. If you make changes to the remote units defined in the stack, these changes will not be reflected in pipeline runs until the stack file is updated.
+
+### Repository Structure
+
+We recommend using your `infrastructure-catalog` repository to define your reusable Terragrunt Units.
+
+Within your `infrastructure-live-root` repositories, add `terragrunt.stack.hcl` files to define your Terragrunt Stacks. You should not commit the generated `.terragrunt-stack` directories to source control, pipelines will generate these directories automatically during execution.
+
+If you have already committed the `.terragrunt-stack` directory to source control and want to remove it, we recommend adding `[skip-ci]` in your commit message to prevent unintended infrastructure destruction. If your changes remove tracked files, but do not modify the stack file, the stack will not be generated and Pipelines will assume that the infrastructure is being removed.
+
+### Migration from _envcommon
+
+If your repository currently uses the _envcommon pattern, you can gradually migrate to Terragrunt Stacks without disrupting your existing workflows. See the <span class="external-link"><a href="https://terragrunt.gruntwork.io/docs/migrate/terragrunt-stacks/">Terragrunt Migration Guide</a></span> for detailed instructions on transitioning from _envcommon to Stacks.
+
+## Best Practices
+
+- **Don't commit generated files**: The `.terragrunt-stack` directory should not be committed to source control
+- **Use versioned unit sources**: When referencing units in your stack, use versioned sources (e.g. `git::git@github.com:my-org/my-catalog.git//units/foo?ref=v0.2.0`). This ensures that the stack can be updated to a specific version of the unit.

--- a/docs/2.0/reference/pipelines/terragrunt-version-compatibility.md
+++ b/docs/2.0/reference/pipelines/terragrunt-version-compatibility.md
@@ -1,7 +1,9 @@
 # Terragrunt Version Compatibility
 
-| Type        | Terragrunt Version | Pipelines Version | Comments                                                                                                                                                                        |
-| ----------- | ------------------ | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Recommended | 0.68.13+           | v3.y.z            | Pipelines uses new features in Terragrunt to provide enhanced logging, and the [File Dependency](https://docs.gruntwork.io/2.0/docs/pipelines/guides/file-dependencies) feature |
-| Minimum     | 0.59.7             | v3.y.z            | This is the absolute minimum version of terragrunt for pipelines v3                                                                                                             |
-| Minimum     | 0.59.7             | v2.y.z            |                                                                                                                                                                                 |
+| Type | Terragrunt Ver | Pipelines Ver | Comments |
+| ---- | -------------- | ------------- | -------- |
+| Recommended | 0.77.11 | v3.y.z | Pipelines is actively tested with this version of Terragrunt |
+| | 0.71.3+ | v3.y.z | Pipelines automatically supports [Terragrunt Stacks](/2.0/docs/pipelines/guides/stacks) |
+| | 0.68.13+ | v3.y.z | Pipelines uses new features in Terragrunt to provide enhanced logging, and the [File Dependency](https://docs.gruntwork.io/2.0/docs/pipelines/guides/file-dependencies) feature |
+| Minimum | 0.59.7 | v3.y.z | This is the absolute minimum version of terragrunt for pipelines v3 |
+| Minimum | 0.59.7 | v2.y.z | |

--- a/sidebars/docs.js
+++ b/sidebars/docs.js
@@ -364,7 +364,7 @@ const sidebar = [
         id: "2.0/docs/pipelines/guides/handling-broken-iac",
       },
       {
-        label: "Running Pipelines with Terragrunt Stacks",
+        label: "Using Terragrunt Stacks",
         type: "doc",
         id: "2.0/docs/pipelines/guides/stacks",
       },

--- a/sidebars/docs.js
+++ b/sidebars/docs.js
@@ -363,6 +363,11 @@ const sidebar = [
         type: "doc",
         id: "2.0/docs/pipelines/guides/handling-broken-iac",
       },
+      {
+        label: "Running Pipelines with Terragrunt Stacks",
+        type: "doc",
+        id: "2.0/docs/pipelines/guides/stacks",
+      },
     ],
   },
   {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Introduced a new guide on using Terragrunt Stacks for organizing and managing infrastructure code with pipelines.
  - Updated Terragrunt version compatibility with streamlined headers and revised recommended versions, highlighting support for Terragrunt Stacks.
  - Added the new guide to the documentation sidebar for easier access and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->