### PR TITLE
Update Gruntwork Releases as of 2025-04-30

### DIFF
--- a/docs/guides/stay-up-to-date/index.md
+++ b/docs/guides/stay-up-to-date/index.md
@@ -17,6 +17,7 @@ import CardGroup from "/src/components/CardGroup"
 <CardGroup cols={1} gap="1rem" stacked equalHeightRows={false} commonCardProps={{padding: "1.25rem"}}>
 
 <!-- START_DOCS_SOURCER_DYNAMIC_CONTENT id=gruntwork-releases-cards -->
+<Card title="Update to 2025-04" href="/guides/stay-up-to-date/releases/2025-04" />
 <Card title="Update to 2025-03" href="/guides/stay-up-to-date/releases/2025-03" />
 <Card title="Update to 2025-02" href="/guides/stay-up-to-date/releases/2025-02" />
 <Card title="Update to 2025-01" href="/guides/stay-up-to-date/releases/2025-01" />
@@ -31,7 +32,6 @@ import CardGroup from "/src/components/CardGroup"
 <Card title="Update to 2024-04" href="/guides/stay-up-to-date/releases/2024-04" />
 <Card title="Update to 2024-03" href="/guides/stay-up-to-date/releases/2024-03" />
 <Card title="Update to 2024-02" href="/guides/stay-up-to-date/releases/2024-02" />
-<Card title="Update to 2024-01" href="/guides/stay-up-to-date/releases/2024-01" />
 <Card title="See older releases" href="/guides/stay-up-to-date/releases" />
 <!-- END_DOCS_SOURCER_DYNAMIC_CONTENT -->
 
@@ -115,6 +115,6 @@ href="/guides/stay-up-to-date/cis/cis-1.5.0"
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "3107dbcc5c4c5f98250d3080929388ed"
+  "hash": "90130699f7ae719ee3972d34b979cef8"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2024-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2024-09/index.md
@@ -332,7 +332,6 @@ This introduces a change in how tags are managed for AWS Accounts. Now, any tag 
         - Set the variables to empty strings which will override the default values set in the upstream.
         - Override the default Helm Chart version and use a newer version of the chart which resolves the issue. This can be accomplished by setting `aws_for_fluent_bit_chart_version` to `0.1.32`.
         - Upgrade to [v0.73.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.73.0) of the `terraform-aws-eks` library module which uses a newer chart version as well as contains several enhancements to the module.
-```yaml
 
 </div>
 

--- a/docs/guides/stay-up-to-date/releases/2024-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2024-09/index.md
@@ -328,10 +328,11 @@ This introduces a change in how tags are managed for AWS Accounts. Now, any tag 
   
 
 - Add support for new Cloudwatch Logs plugin
-- Bump github.com/hashicorp/go-getter from 1.7.1 to 1.7.5 in /test
-- Bump golang.org/x/net from 0.17.0 to 0.23.0 in /test
-
-
+    - **NOTE:** There is an [upstream issue ](https://github.com/aws/eks-charts/issues/931) with the default version of the `aws-for-fluent-bit` chart where default values are defined for `logGroupTemplate` and `logStreamTemplate` which cause these values to be set to the default values if not explicitly set. There are 3 main workarounds for this:
+        - Set the variables to empty strings which will override the default values set in the upstream.
+        - Override the default Helm Chart version and use a newer version of the chart which resolves the issue. This can be accomplished by setting `aws_for_fluent_bit_chart_version` to `0.1.32`.
+        - Upgrade to [v0.73.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.73.0) of the `terraform-aws-eks` library module which uses a newer chart version as well as contains several enhancements to the module.
+```yaml
 
 </div>
 
@@ -768,6 +769,6 @@ Default version of EKS is `1.30` with this release! Please see the links below f
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "8daac619c38acf75d556043a18fad6ad"
+  "hash": "5bc26fd397602b0654b8f6b5a4d34d13"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2025-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2025-03/index.md
@@ -365,10 +365,10 @@ If `pipelines-execute` exits with non-zero return code we now forward stderr to 
 ## terraform-aws-cis-service-catalog
 
 
-### [v0.57.0](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.56.2)
+### [v0.57.0](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.57.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 3/3/2025 | Modules affected: networking | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.56.2">Release notes</a></small>
+  <small>Published: 3/3/2025 | Modules affected: networking | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.57.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -539,7 +539,7 @@ If `pipelines-execute` exits with non-zero return code we now forward stderr to 
 
   
 
-- Updated SG name.
+- Updated EKS Security Group name to address potential issue with Security Group name collisions with other modules.
 
 
 
@@ -548,6 +548,32 @@ If `pipelines-execute` exits with non-zero return code we now forward stderr to 
 
 
 ## terraform-aws-security
+
+
+### [v0.75.15](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.75.15)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 3/31/2025 | Modules affected: gitlab-pipelines-openid-connect-provider | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.75.15">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+- `gitlab-pipelines-openid-connect-provider`
+
+
+
+
+- Add configurable GitLab URL for self-hosted GitLab instances
+
+
+
+- https://github.com/gruntwork-io/terraform-aws-security/pull/878
+
+
+
+
+</div>
 
 
 ### [v0.75.14](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.75.14)
@@ -865,6 +891,6 @@ If `pipelines-execute` exits with non-zero return code we now forward stderr to 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "eb8c101cd963b7022a86e67a26603141"
+  "hash": "1c9d9b56fc77ee5601d4ad80dbbb8114"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2025-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2025-04/index.md
@@ -1,0 +1,717 @@
+
+# Gruntwork release 2025-04
+
+<p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2025-04</small></p>
+
+This page is lists all the updates to the [Gruntwork Infrastructure as Code
+Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-04. For instructions
+on how to use these updates in your code, check out the [updating
+documentation](/library/stay-up-to-date/updating).
+
+Here are the repos that were updated:
+
+- [boilerplate](#boilerplate)
+- [patcher-cli](#patcher-cli)
+- [pipelines-actions](#pipelines-actions)
+- [pipelines-cli](#pipelines-cli)
+- [pipelines-workflows](#pipelines-workflows)
+- [terraform-aws-architecture-catalog](#terraform-aws-architecture-catalog)
+- [terraform-aws-cis-service-catalog](#terraform-aws-cis-service-catalog)
+- [terraform-aws-eks](#terraform-aws-eks)
+- [terraform-aws-security](#terraform-aws-security)
+- [terraform-aws-service-catalog](#terraform-aws-service-catalog)
+- [terraform-aws-static-assets](#terraform-aws-static-assets)
+- [terraform-aws-vpc](#terraform-aws-vpc)
+
+
+## boilerplate
+
+
+### [v0.6.1](https://github.com/gruntwork-io/boilerplate/releases/tag/v0.6.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/15/2025 | <a href="https://github.com/gruntwork-io/boilerplate/releases/tag/v0.6.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Bump golang.org/x/net from 0.30.0 to 0.33.0 by @dependabot in https://github.com/gruntwork-io/boilerplate/pull/207
+* Bumping crypto to `0.35.0` by @yhakbar in https://github.com/gruntwork-io/boilerplate/pull/217
+
+
+**Full Changelog**: https://github.com/gruntwork-io/boilerplate/compare/v0.6.0...v0.6.1
+
+</div>
+
+
+
+## patcher-cli
+
+
+### [v0.14.0](https://github.com/gruntwork-io/patcher-cli/releases/tag/v0.14.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/18/2025 | <a href="https://github.com/gruntwork-io/patcher-cli/releases/tag/v0.14.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  Release duplicated from https://github.com/gruntwork-io/patcher/releases/tag/v0.14.0
+
+</div>
+
+
+### [v0.13.2](https://github.com/gruntwork-io/patcher-cli/releases/tag/v0.13.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/10/2025 | <a href="https://github.com/gruntwork-io/patcher-cli/releases/tag/v0.13.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  Release duplicated from https://github.com/gruntwork-io/patcher/releases/tag/v0.13.2
+
+</div>
+
+
+### [v0.13.1](https://github.com/gruntwork-io/patcher-cli/releases/tag/v0.13.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/8/2025 | <a href="https://github.com/gruntwork-io/patcher-cli/releases/tag/v0.13.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  Release duplicated from https://github.com/gruntwork-io/patcher/releases/tag/v0.13.1
+
+</div>
+
+
+
+## pipelines-actions
+
+
+### [v3.6.2](https://github.com/gruntwork-io/pipelines-actions/releases/tag/v3.6.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/25/2025 | <a href="https://github.com/gruntwork-io/pipelines-actions/releases/tag/v3.6.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Fix get jobs url failure if multiple jobs match by @Resonance1584 in https://github.com/gruntwork-io/pipelines-actions/pull/121
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-actions/compare/v3.6.1...v3.6.2
+
+</div>
+
+
+### [v3.6.1](https://github.com/gruntwork-io/pipelines-actions/releases/tag/v3.6.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/16/2025 | <a href="https://github.com/gruntwork-io/pipelines-actions/releases/tag/v3.6.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Add preflight check for stacks configuration by @oredavids in https://github.com/gruntwork-io/pipelines-actions/pull/120
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-actions/compare/v3.6.0...v3.6.1
+
+</div>
+
+
+### [v3.6.0](https://github.com/gruntwork-io/pipelines-actions/releases/tag/v3.6.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/14/2025 | <a href="https://github.com/gruntwork-io/pipelines-actions/releases/tag/v3.6.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Extract code auth logic into separate action by @oredavids in https://github.com/gruntwork-io/pipelines-actions/pull/119
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-actions/compare/v3.5.1...v3.6.0
+
+</div>
+
+
+### [v3.5.1](https://github.com/gruntwork-io/pipelines-actions/releases/tag/v3.5.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/10/2025 | <a href="https://github.com/gruntwork-io/pipelines-actions/releases/tag/v3.5.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Authorize git before orchestrate by @Resonance1584 in https://github.com/gruntwork-io/pipelines-actions/pull/118
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-actions/compare/v3.5.0...v3.5.1
+
+</div>
+
+
+### [v3.5.0](https://github.com/gruntwork-io/pipelines-actions/releases/tag/v3.5.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/10/2025 | <a href="https://github.com/gruntwork-io/pipelines-actions/releases/tag/v3.5.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Use stack paths in pipelines-execute action by @oredavids in https://github.com/gruntwork-io/pipelines-actions/pull/117
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-actions/compare/v3.4.3...v3.5.0
+
+</div>
+
+
+
+## pipelines-cli
+
+
+### [v0.38.2](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.38.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/29/2025 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.38.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Set server url in telemetry by @oredavids in https://github.com/gruntwork-io/pipelines/pull/369
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines/compare/v0.38.1...v0.38.2
+
+
+</div>
+
+
+### [v0.38.1](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.38.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/29/2025 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.38.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Split out tests for different configurations by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/365
+* Fix duplicate jobs produced when stack values present by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/367
+* DEV-879: Add stack to e2e test by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/366
+* Run stacks generate for accountAdded infraChange type by @oredavids in https://github.com/gruntwork-io/pipelines/pull/368
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines/compare/v0.37.0...v0.38.1
+
+
+</div>
+
+
+### [v0.37.0](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.37.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/16/2025 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.37.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+This release of Pipelines CLI adds support for Terragrunt Stacks when the detected Terragrunt version is higher than v0.71.3.
+
+
+* Extract scm provider hosts by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/347
+* Add support for testing against newer terragrunt version by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/344
+* TG v0.77.5 by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/348
+* Run generate stacks before detecting infra-changes by @oredavids in https://github.com/gruntwork-io/pipelines/pull/346
+* chore: disable cgo in e2e build by @ZachGoldberg in https://github.com/gruntwork-io/pipelines/pull/350
+* Include origin in infra changes and Jobs by @oredavids in https://github.com/gruntwork-io/pipelines/pull/349
+* Use temporary directory for stack generate by @oredavids in https://github.com/gruntwork-io/pipelines/pull/352
+* Generate stacks in execute by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/351
+* Bump tg to v0.77.11 by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/355
+* Add change type to telemetry by @ZachGoldberg in https://github.com/gruntwork-io/pipelines/pull/354
+* Use temporary source and target repos for infra change processing by @oredavids in https://github.com/gruntwork-io/pipelines/pull/353
+* Enable tg stacks experiment in execute by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/358
+* Replace chdir logic when finding parent terragrunt files by @oredavids in https://github.com/gruntwork-io/pipelines/pull/356
+* DEV-833 Enable ModuleChanged for stack values by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/359
+* Add preflight check for generated stack directories by @oredavids in https://github.com/gruntwork-io/pipelines/pull/360
+* Add repo info to telemetry by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/361
+* Fix tracked files moving to stacks should not trigger module deleted by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/362
+* Update stacks preflight error format by @oredavids in https://github.com/gruntwork-io/pipelines/pull/363
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines/compare/v0.36.6...v0.37.0
+
+
+</div>
+
+
+
+## pipelines-workflows
+
+
+### [v3.8.1](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v3.8.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/29/2025 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v3.8.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+Account vending now supports Terragunt Stacks in the account template. Pipelines will generate stacks before plan and apply for new accounts.
+
+
+Fixed an issue where Pipelines Orchestrate would create duplicate jobs for stack units
+
+</div>
+
+
+### [v3.8.0](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v3.8.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/16/2025 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v3.8.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+Pipelines now supports [Terragrunt stacks](https://terragrunt.gruntwork.io/docs/features/stacks/). When you push updates involving `terragrunt.stack.hcl` files in your Pull/Merge Requests, Pipelines automatically evaluates the required changes and orchestrates the infrastructure updates. This process ensures:
+
+1. **Lowest Blast Radius:** Pipelines uses `terragrunt stack generate` to identify the minimum set of infrastructure units affected by your changes, avoiding unnecessary operations.
+2. **Complete Management:** All relevant infrastructure actions triggered by your `terragrunt.stack.hcl` updates (create, read, update, destroy) are handled automatically.
+3. **DAG Aware Execution:** Updates are applied respecting the dependency graph (DAG) order:
+    - **Adds:** New units are created *after* any dependencies that also need adding.
+    - **Changes:** Modified units are updated *after* any dependencies that also need changing.
+    - **Destroys:** Units marked for removal are destroyed *after* any resources depending on them are also destroyed.
+
+You can freely mix changes to `terragrunt.stack.hcl` and `terragrunt.hcl` files within the same Pull/Merge Request. Pipelines will process everything correctly.
+
+* Ore/dev-878-support-pipelines-unlock-on-stacks by @oredavids in https://github.com/gruntwork-io/pipelines-workflows/pull/116
+* Stacks support by @Resonance1584 in https://github.com/gruntwork-io/pipelines-workflows/pull/117
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v3...v3.8.0
+
+</div>
+
+
+### [v3.7.10](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v3.7.10)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/15/2025 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v3.7.10">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * When codebases have both pipelines config-as-code (HCL) and config.yml configs, we now prefer the HCL configs for deploy_branch_name and tf_binary
+* Pipelines no longer crashes if config.yml is missing when run in GitHub with only HCL based configuration.
+* Make preflight comments collapsible and link to logs
+* Adds GitLab log grouping
+* Errors are red now in GitLab logs
+
+* Use latest CLI v0.36.6 by @ZachGoldberg in https://github.com/gruntwork-io/pipelines-workflows/pull/119
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v3...v3.7.10
+
+</div>
+
+
+
+## terraform-aws-architecture-catalog
+
+
+### [v2.12.11](https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v2.12.11)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/28/2025 | <a href="https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v2.12.11">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Add default terragrunt performance tuning values for pipelines by @ZachGoldberg in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1142
+
+
+**Full Changelog**: https://github.com/gruntwork-io/terraform-aws-architecture-catalog/compare/v2.12.10...v2.12.11
+
+</div>
+
+
+
+## terraform-aws-cis-service-catalog
+
+
+### [v0.58.2](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.58.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/10/2025 | Modules affected: data-stores | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.58.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+- Removed duplicated description attribute
+
+
+
+</div>
+
+
+### [v0.58.1](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.58.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/8/2025 | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.58.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Replaced default VPC with Custom in EFS example
+
+
+</div>
+
+
+### [v0.58.0](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.58.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/3/2025 | Modules affected: landingzone | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.58.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Added account-level s3_account_public_access_block variable to control S3 public access.
+
+
+
+</div>
+
+
+
+## terraform-aws-eks
+
+
+### [v0.78.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.78.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/16/2025 | Modules affected: eks-aws-auth-merger, eks-cluster-control-plane, eks-ebs-csi-driver, eks-k8s-cluster-autoscaler | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.78.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Add Support for EKS 1.32
+
+Default EKS version is 1.32 with this release! Please see the links below for full details of the EKS 1.32 release including new features and any API changes.
+
+[Official AWS EKS 1.32 Announcement](https://aws.amazon.com/about-aws/whats-new/2025/01/amazon-eks-eks-distro-kubernetes-version-1-32/)
+[Kubernetes 1.32 Announcement](https://kubernetes.io/blog/2024/12/11/kubernetes-v1-32-release/)
+[Kubernetes 1.32 Release Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md)
+
+
+
+
+</div>
+
+
+### [v0.77.1](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.77.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/11/2025 | Modules affected: test | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.77.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Bump golang.org/x/net from 0.23.0 to 0.36.0 in /test
+
+
+
+</div>
+
+
+### [v0.77.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.77.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/2/2025 | Modules affected: eks-aws-auth-merger, eks-cluster-control-plane, eks-ebs-csi-driver, eks-k8s-cluster-autoscaler | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v0.77.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+Default EKS version is 1.31 with this release! Please see the links below for full details of the EKS 1.31 release including new features and any API changes.
+
+[Official AWS EKS 1.31 Announcement](https://aws.amazon.com/about-aws/whats-new/2024/09/amazon-eks-distro-kubernetes-version-1-31/)
+[Kubernetes 1.31 Announcement](https://kubernetes.io/blog/2024/08/13/kubernetes-v1-31-release/)
+[Kubernetes 1.31 Release Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md)
+
+
+
+</div>
+
+
+
+## terraform-aws-security
+
+
+### [v0.75.18](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.75.18)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/24/2025 | Modules affected: iam-users, private-s3-bucket | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.75.18">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- iam-users: fix lifecycle ignore_changes warning related to encrypted_secret
+- private-s3-bucket: expose var transition_default_minimum_object_size
+
+
+</div>
+
+
+### [v0.75.17](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.75.17)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/17/2025 | Modules affected: aws-config-multi-region, aws-config | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.75.17">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- `test`: Bump golang.org/x/net from 0.36.0 to 0.38.0 in /test
+- `aws-config` / `aws-config-multi-region`: Make var.recording_group not nullable
+
+
+
+</div>
+
+
+### [v0.75.16](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.75.16)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/10/2025 | Modules affected: aws-config-multi-region | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v0.75.16">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+Updated `aws-config-multi-region` to handle `var.recording_groups`
+
+
+
+
+</div>
+
+
+
+## terraform-aws-service-catalog
+
+
+### [v0.125.1](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.125.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/29/2025 | Modules affected: landingzone/account-baseline-app, landingzone/account-baseline-root, landingzone/account-baseline-security | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.125.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Add variables `config_recording_groups` and `recording_mode` to `account-baseline-*`
+
+
+
+</div>
+
+
+### [v0.125.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.125.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/17/2025 | Modules affected: networking | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.125.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Propagated changes from vpc module
+
+
+
+</div>
+
+
+### [v0.124.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.124.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/16/2025 | Modules affected: mgmt, networking, services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.124.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Add Default Support for EKS 1.31
+- Bump `terraform-aws-eks` library module to version from `v0.76.0` -&gt; `v0.77.0`
+
+Default EKS version is 1.31 with this release! Please see the links below for full details of the EKS 1.31 release including new features and any API changes.
+
+[Official AWS EKS 1.31 Announcement](https://aws.amazon.com/about-aws/whats-new/2024/09/amazon-eks-distro-kubernetes-version-1-31/)
+[Kubernetes 1.31 Announcement](https://kubernetes.io/blog/2024/08/13/kubernetes-v1-31-release/)
+[Kubernetes 1.31 Release Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md)
+
+
+
+</div>
+
+
+### [v0.123.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.123.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/11/2025 | Modules affected: networking, services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.123.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Bump Library Module `terraform-aws-eks` to `v0.76.0`
+    - This version upgrades the `eks-aws-auth-merger` Go version from `1.18` to `1.23`
+
+
+
+</div>
+
+
+### [v0.122.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.122.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/8/2025 | Modules affected: networking, services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.122.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Add support for AWS EKS Auto Mode feature.
+- Bump `terraform-aws-eks` to `v0.75.0` (this version of the library module contains support for the AWS EKS Auto Mode feature).
+
+
+
+</div>
+
+
+### [v0.121.3](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.121.3)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/4/2025 | Modules affected: networking, services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.121.3">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Update `terraform-aws-eks` library modules to `v0.74.2`
+
+
+
+</div>
+
+
+### [v0.121.2](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.121.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/3/2025 | Modules affected: landingzone | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v0.121.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- `modules/landingzone`: Added account-level S3 account access block
+
+
+
+</div>
+
+
+
+## terraform-aws-static-assets
+
+
+### [v0.20.5](https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.20.5)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/26/2025 | Modules affected: s3-static-website | <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.20.5">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- `s3-static-website`: Made condition optional in routing_rule
+
+
+
+</div>
+
+
+### [v0.20.4](https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.20.4)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/1/2025 | Modules affected: cloudfront | <a href="https://github.com/gruntwork-io/terraform-aws-static-assets/releases/tag/v0.20.4">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Bump golang.org/x/net from 0.33.0 to 0.36.0 in /test
+- Fixed CloudFront continuous deployment error, added usage examples.
+
+
+</div>
+
+
+
+## terraform-aws-vpc
+
+
+### [v0.28.5](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.28.5)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/20/2025 | Modules affected: vpc-interface-endpoint | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.28.5">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+-  vpc-endpoint-interface: Add optional Pinpoint Endpoint
+
+
+
+</div>
+
+<!-- ##DOCS-SOURCER-START
+{
+  "sourcePlugin": "releases",
+  "hash": "b1c2e9fa4f387bb16bd2f6a955f1fec4"
+}
+##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/index.md
+++ b/docs/guides/stay-up-to-date/releases/index.md
@@ -11,7 +11,8 @@ Library](https://gruntwork.io/infrastructure-as-code-library/), grouped by month
 updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 <CardGroup cols={1} gap="1rem" stacked equalHeightRows={false} commonCardProps={{padding: "1.25rem"}}>
-  <Card title="Gruntwork Release 2025-03" href="/guides/stay-up-to-date/releases/2025-03" />
+  <Card title="Gruntwork Release 2025-04" href="/guides/stay-up-to-date/releases/2025-04" />
+<Card title="Gruntwork Release 2025-03" href="/guides/stay-up-to-date/releases/2025-03" />
 <Card title="Gruntwork Release 2025-02" href="/guides/stay-up-to-date/releases/2025-02" />
 <Card title="Gruntwork Release 2025-01" href="/guides/stay-up-to-date/releases/2025-01" />
 <Card title="Gruntwork Release 2024-12" href="/guides/stay-up-to-date/releases/2024-12" />
@@ -122,6 +123,6 @@ updates in your code, check out the [updating documentation](/library/stay-up-to
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "0657838f2ee74021ecac04cf77b1041d"
+  "hash": "f266fb6bbd53f4479661b129c3ae74f5"
 }
 ##DOCS-SOURCER-END -->


### PR DESCRIPTION
Update Gruntwork releases as of 2025-04-30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive release notes for April 2025, detailing new features, bug fixes, and enhancements across multiple repositories.
  - Updated the release index and "Stay Up To Date" pages to include the April 2025 release and remove outdated entries.
  - Clarified and corrected previous release notes, including EKS module workarounds and changelog clarifications for recent releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->