### PR TITLE
Output from running patcher-changelogs plugin in docs-sourcer locally

### DIFF
--- a/static/patcher-changelogs/terraform-aws-asg/asg-instance-refresh.json
+++ b/static/patcher-changelogs/terraform-aws-asg/asg-instance-refresh.json
@@ -1,6 +1,39 @@
 {
   "module": "asg-instance-refresh",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.21.20": {
+      "contains_changes": false
+    },
+    "v0.21.19": {
+      "contains_changes": false
+    },
+    "v0.21.18": {
+      "contains_changes": false
+    },
+    "v0.21.17": {
+      "contains_changes": false
+    },
+    "v0.21.16": {
+      "contains_changes": false
+    },
+    "v0.21.15": {
+      "contains_changes": false
+    },
+    "v0.21.13": {
+      "contains_changes": false
+    },
+    "v0.21.12": {
+      "contains_changes": false
+    },
+    "v0.21.11": {
+      "contains_changes": true
+    },
+    "v0.21.10": {
+      "contains_changes": true
+    },
     "v0.21.9": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-asg/asg-rolling-deploy.json
+++ b/static/patcher-changelogs/terraform-aws-asg/asg-rolling-deploy.json
@@ -1,6 +1,39 @@
 {
   "module": "asg-rolling-deploy",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.21.20": {
+      "contains_changes": false
+    },
+    "v0.21.19": {
+      "contains_changes": false
+    },
+    "v0.21.18": {
+      "contains_changes": false
+    },
+    "v0.21.17": {
+      "contains_changes": true
+    },
+    "v0.21.16": {
+      "contains_changes": false
+    },
+    "v0.21.15": {
+      "contains_changes": true
+    },
+    "v0.21.13": {
+      "contains_changes": false
+    },
+    "v0.21.12": {
+      "contains_changes": false
+    },
+    "v0.21.11": {
+      "contains_changes": true
+    },
+    "v0.21.10": {
+      "contains_changes": true
+    },
     "v0.21.9": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-asg/server-group.json
+++ b/static/patcher-changelogs/terraform-aws-asg/server-group.json
@@ -1,6 +1,39 @@
 {
   "module": "server-group",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.21.20": {
+      "contains_changes": false
+    },
+    "v0.21.19": {
+      "contains_changes": false
+    },
+    "v0.21.18": {
+      "contains_changes": true
+    },
+    "v0.21.17": {
+      "contains_changes": false
+    },
+    "v0.21.16": {
+      "contains_changes": true
+    },
+    "v0.21.15": {
+      "contains_changes": true
+    },
+    "v0.21.13": {
+      "contains_changes": true
+    },
+    "v0.21.12": {
+      "contains_changes": true
+    },
+    "v0.21.11": {
+      "contains_changes": true
+    },
+    "v0.21.10": {
+      "contains_changes": true
+    },
     "v0.21.9": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cache/elastic-cache.json
+++ b/static/patcher-changelogs/terraform-aws-cache/elastic-cache.json
@@ -1,6 +1,45 @@
 {
   "module": "elastic-cache",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": true
+    },
+    "v0.22.9": {
+      "contains_changes": false
+    },
+    "v0.22.8": {
+      "contains_changes": true
+    },
+    "v0.22.7": {
+      "contains_changes": false
+    },
+    "v0.22.6": {
+      "contains_changes": false
+    },
+    "v0.22.5": {
+      "contains_changes": false
+    },
+    "v0.22.4": {
+      "contains_changes": true
+    },
+    "v0.22.3": {
+      "contains_changes": true
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": true
+    },
+    "v0.22.0": {
+      "contains_changes": true
+    },
     "v0.21.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cache/memcached.json
+++ b/static/patcher-changelogs/terraform-aws-cache/memcached.json
@@ -1,6 +1,45 @@
 {
   "module": "memcached",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.9": {
+      "contains_changes": false
+    },
+    "v0.22.8": {
+      "contains_changes": false
+    },
+    "v0.22.7": {
+      "contains_changes": false
+    },
+    "v0.22.6": {
+      "contains_changes": false
+    },
+    "v0.22.5": {
+      "contains_changes": false
+    },
+    "v0.22.4": {
+      "contains_changes": false
+    },
+    "v0.22.3": {
+      "contains_changes": true
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": true
+    },
+    "v0.22.0": {
+      "contains_changes": true
+    },
     "v0.21.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cache/redis.json
+++ b/static/patcher-changelogs/terraform-aws-cache/redis.json
@@ -1,6 +1,45 @@
 {
   "module": "redis",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": true
+    },
+    "v0.22.9": {
+      "contains_changes": true
+    },
+    "v0.22.8": {
+      "contains_changes": false
+    },
+    "v0.22.7": {
+      "contains_changes": true
+    },
+    "v0.22.6": {
+      "contains_changes": true
+    },
+    "v0.22.5": {
+      "contains_changes": true
+    },
+    "v0.22.4": {
+      "contains_changes": true
+    },
+    "v0.22.3": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": true
+    },
+    "v0.22.1": {
+      "contains_changes": true
+    },
+    "v0.22.0": {
+      "contains_changes": true
+    },
     "v0.21.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cache/redis_copy_snapshot.json
+++ b/static/patcher-changelogs/terraform-aws-cache/redis_copy_snapshot.json
@@ -1,6 +1,45 @@
 {
   "module": "redis_copy_snapshot",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.9": {
+      "contains_changes": false
+    },
+    "v0.22.8": {
+      "contains_changes": true
+    },
+    "v0.22.7": {
+      "contains_changes": false
+    },
+    "v0.22.6": {
+      "contains_changes": false
+    },
+    "v0.22.5": {
+      "contains_changes": false
+    },
+    "v0.22.4": {
+      "contains_changes": false
+    },
+    "v0.22.3": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": true
+    },
+    "v0.22.0": {
+      "contains_changes": true
+    },
     "v0.21.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cache/valkey.json
+++ b/static/patcher-changelogs/terraform-aws-cache/valkey.json
@@ -1,0 +1,188 @@
+{
+  "module": "valkey",
+  "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": true
+    },
+    "v0.23.0": {
+      "contains_changes": true
+    },
+    "v0.22.9": {
+      "contains_changes": false
+    },
+    "v0.22.8": {
+      "contains_changes": false
+    },
+    "v0.22.7": {
+      "contains_changes": false
+    },
+    "v0.22.6": {
+      "contains_changes": false
+    },
+    "v0.22.5": {
+      "contains_changes": false
+    },
+    "v0.22.4": {
+      "contains_changes": false
+    },
+    "v0.22.3": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.3": {
+      "contains_changes": false
+    },
+    "v0.19.2": {
+      "contains_changes": false
+    },
+    "v0.19.1": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.2": {
+      "contains_changes": false
+    },
+    "v0.16.1": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.1": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
+    "v0.9.2": {
+      "contains_changes": false
+    },
+    "v0.9.1": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.1": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.4": {
+      "contains_changes": false
+    },
+    "v0.3.3": {
+      "contains_changes": false
+    },
+    "v0.3.2": {
+      "contains_changes": false
+    },
+    "v0.3.1": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.3": {
+      "contains_changes": false
+    },
+    "v0.1.2": {
+      "contains_changes": false
+    },
+    "v0.1.1": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-ci-steampipe/ecs-deploy-runner-steampipe-standard-configuration.json
+++ b/static/patcher-changelogs/terraform-aws-ci-steampipe/ecs-deploy-runner-steampipe-standard-configuration.json
@@ -1,6 +1,9 @@
 {
   "module": "ecs-deploy-runner-steampipe-standard-configuration",
   "releases": {
+    "v0.3.5": {
+      "contains_changes": false
+    },
     "v0.3.4": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci-steampipe/ecs-deploy-runner-with-steampipe-runner.json
+++ b/static/patcher-changelogs/terraform-aws-ci-steampipe/ecs-deploy-runner-with-steampipe-runner.json
@@ -1,6 +1,9 @@
 {
   "module": "ecs-deploy-runner-with-steampipe-runner",
   "releases": {
+    "v0.3.5": {
+      "contains_changes": false
+    },
     "v0.3.4": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-ci-steampipe/steampipe-runner.json
+++ b/static/patcher-changelogs/terraform-aws-ci-steampipe/steampipe-runner.json
@@ -1,6 +1,9 @@
 {
   "module": "steampipe-runner",
   "releases": {
+    "v0.3.5": {
+      "contains_changes": false
+    },
     "v0.3.4": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-ci/aws-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/aws-helpers.json
@@ -1,6 +1,117 @@
 {
   "module": "aws-helpers",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": false
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": false
+    },
+    "v0.52.17": {
+      "contains_changes": false
+    },
+    "v0.52.16": {
+      "contains_changes": false
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
     "v0.52.13": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/build-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/build-helpers.json
@@ -1,6 +1,117 @@
 {
   "module": "build-helpers",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": false
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": false
+    },
+    "v0.52.17": {
+      "contains_changes": false
+    },
+    "v0.52.16": {
+      "contains_changes": false
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
     "v0.52.13": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/check-url.json
+++ b/static/patcher-changelogs/terraform-aws-ci/check-url.json
@@ -1,6 +1,117 @@
 {
   "module": "check-url",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": false
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": false
+    },
+    "v0.52.17": {
+      "contains_changes": false
+    },
+    "v0.52.16": {
+      "contains_changes": false
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
     "v0.52.13": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/circleci-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/circleci-helpers.json
@@ -1,6 +1,117 @@
 {
   "module": "circleci-helpers",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": false
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": false
+    },
+    "v0.52.17": {
+      "contains_changes": false
+    },
+    "v0.52.16": {
+      "contains_changes": false
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
     "v0.52.13": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/ec2-backup.json
+++ b/static/patcher-changelogs/terraform-aws-ci/ec2-backup.json
@@ -1,6 +1,117 @@
 {
   "module": "ec2-backup",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": false
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": true
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": false
+    },
+    "v0.52.17": {
+      "contains_changes": true
+    },
+    "v0.52.16": {
+      "contains_changes": true
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
     "v0.52.13": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-ci/ecs-deploy-runner-invoke-iam-policy.json
+++ b/static/patcher-changelogs/terraform-aws-ci/ecs-deploy-runner-invoke-iam-policy.json
@@ -1,6 +1,117 @@
 {
   "module": "ecs-deploy-runner-invoke-iam-policy",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": false
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": false
+    },
+    "v0.52.17": {
+      "contains_changes": true
+    },
+    "v0.52.16": {
+      "contains_changes": true
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
     "v0.52.13": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-ci/ecs-deploy-runner-standard-configuration.json
+++ b/static/patcher-changelogs/terraform-aws-ci/ecs-deploy-runner-standard-configuration.json
@@ -1,6 +1,117 @@
 {
   "module": "ecs-deploy-runner-standard-configuration",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": false
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": false
+    },
+    "v0.52.17": {
+      "contains_changes": true
+    },
+    "v0.52.16": {
+      "contains_changes": true
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
     "v0.52.13": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-ci/ecs-deploy-runner.json
+++ b/static/patcher-changelogs/terraform-aws-ci/ecs-deploy-runner.json
@@ -1,6 +1,117 @@
 {
   "module": "ecs-deploy-runner",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": true
+    },
+    "v0.59.9": {
+      "contains_changes": true
+    },
+    "v0.59.8": {
+      "contains_changes": true
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": true
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": true
+    },
+    "v0.59.2": {
+      "contains_changes": true
+    },
+    "v0.59.1": {
+      "contains_changes": true
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": true
+    },
+    "v0.58.1": {
+      "contains_changes": true
+    },
+    "v0.58.0": {
+      "contains_changes": true
+    },
+    "v0.57.3": {
+      "contains_changes": true
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": true
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": true
+    },
+    "v0.54.3": {
+      "contains_changes": true
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": true
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": true
+    },
+    "v0.52.17": {
+      "contains_changes": true
+    },
+    "v0.52.16": {
+      "contains_changes": true
+    },
+    "v0.52.15": {
+      "contains_changes": true
+    },
+    "v0.52.14": {
+      "contains_changes": true
+    },
     "v0.52.13": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-ci/git-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/git-helpers.json
@@ -1,6 +1,117 @@
 {
   "module": "git-helpers",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": false
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": false
+    },
+    "v0.52.17": {
+      "contains_changes": false
+    },
+    "v0.52.16": {
+      "contains_changes": false
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
     "v0.52.13": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/github-release-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/github-release-helpers.json
@@ -1,0 +1,905 @@
+{
+  "module": "github-release-helpers",
+  "releases": {
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": false
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": true
+    },
+    "v0.58.0": {
+      "contains_changes": true
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": false
+    },
+    "v0.52.17": {
+      "contains_changes": false
+    },
+    "v0.52.16": {
+      "contains_changes": false
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
+    "v0.52.13": {
+      "contains_changes": false
+    },
+    "v0.52.12": {
+      "contains_changes": false
+    },
+    "v0.52.11": {
+      "contains_changes": false
+    },
+    "v0.52.10": {
+      "contains_changes": false
+    },
+    "v0.52.9": {
+      "contains_changes": false
+    },
+    "v0.52.8": {
+      "contains_changes": false
+    },
+    "v0.52.7": {
+      "contains_changes": false
+    },
+    "v0.52.6": {
+      "contains_changes": false
+    },
+    "v0.52.5": {
+      "contains_changes": false
+    },
+    "v0.52.4": {
+      "contains_changes": false
+    },
+    "v0.52.3": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.8": {
+      "contains_changes": false
+    },
+    "v0.51.7": {
+      "contains_changes": false
+    },
+    "v0.51.6": {
+      "contains_changes": false
+    },
+    "v0.51.5": {
+      "contains_changes": false
+    },
+    "v0.51.4": {
+      "contains_changes": false
+    },
+    "v0.51.3": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.12": {
+      "contains_changes": false
+    },
+    "v0.50.11": {
+      "contains_changes": false
+    },
+    "v0.50.10": {
+      "contains_changes": false
+    },
+    "v0.50.9": {
+      "contains_changes": false
+    },
+    "v0.50.8": {
+      "contains_changes": false
+    },
+    "v0.50.7": {
+      "contains_changes": false
+    },
+    "v0.50.6": {
+      "contains_changes": false
+    },
+    "v0.50.5": {
+      "contains_changes": false
+    },
+    "v0.50.4": {
+      "contains_changes": false
+    },
+    "v0.50.3": {
+      "contains_changes": false
+    },
+    "v0.50.2": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
+    "v0.48.0": {
+      "contains_changes": false
+    },
+    "v0.47.11": {
+      "contains_changes": false
+    },
+    "v0.47.10": {
+      "contains_changes": false
+    },
+    "v0.47.9": {
+      "contains_changes": false
+    },
+    "v0.47.8": {
+      "contains_changes": false
+    },
+    "v0.47.7": {
+      "contains_changes": false
+    },
+    "v0.47.6": {
+      "contains_changes": false
+    },
+    "v0.47.5": {
+      "contains_changes": false
+    },
+    "v0.47.4": {
+      "contains_changes": false
+    },
+    "v0.47.3": {
+      "contains_changes": false
+    },
+    "v0.47.2": {
+      "contains_changes": false
+    },
+    "v0.47.1": {
+      "contains_changes": false
+    },
+    "v0.47.0": {
+      "contains_changes": false
+    },
+    "v0.46.1": {
+      "contains_changes": false
+    },
+    "v0.46.0": {
+      "contains_changes": false
+    },
+    "v0.45.4": {
+      "contains_changes": false
+    },
+    "v0.45.3": {
+      "contains_changes": false
+    },
+    "v0.45.2": {
+      "contains_changes": false
+    },
+    "v0.45.1": {
+      "contains_changes": false
+    },
+    "v0.45.0": {
+      "contains_changes": false
+    },
+    "v0.44.0": {
+      "contains_changes": false
+    },
+    "v0.43.1": {
+      "contains_changes": false
+    },
+    "v0.43.0": {
+      "contains_changes": false
+    },
+    "v0.42.0": {
+      "contains_changes": false
+    },
+    "v0.41.1": {
+      "contains_changes": false
+    },
+    "v0.41.0": {
+      "contains_changes": false
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.7": {
+      "contains_changes": false
+    },
+    "v0.39.6": {
+      "contains_changes": false
+    },
+    "v0.39.5": {
+      "contains_changes": false
+    },
+    "v0.39.4": {
+      "contains_changes": false
+    },
+    "v0.39.3": {
+      "contains_changes": false
+    },
+    "v0.39.2": {
+      "contains_changes": false
+    },
+    "v0.39.1": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.14": {
+      "contains_changes": false
+    },
+    "v0.38.13": {
+      "contains_changes": false
+    },
+    "v0.38.12": {
+      "contains_changes": false
+    },
+    "v0.38.11": {
+      "contains_changes": false
+    },
+    "v0.38.10": {
+      "contains_changes": false
+    },
+    "v0.38.9": {
+      "contains_changes": false
+    },
+    "v0.38.8": {
+      "contains_changes": false
+    },
+    "v0.38.7": {
+      "contains_changes": false
+    },
+    "v0.38.6": {
+      "contains_changes": false
+    },
+    "v0.38.5": {
+      "contains_changes": false
+    },
+    "v0.38.4": {
+      "contains_changes": false
+    },
+    "v0.38.3": {
+      "contains_changes": false
+    },
+    "v0.38.2": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.8": {
+      "contains_changes": false
+    },
+    "v0.37.7": {
+      "contains_changes": false
+    },
+    "v0.37.6": {
+      "contains_changes": false
+    },
+    "v0.37.5": {
+      "contains_changes": false
+    },
+    "v0.37.4": {
+      "contains_changes": false
+    },
+    "v0.37.3": {
+      "contains_changes": false
+    },
+    "v0.37.2": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.1": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34.0": {
+      "contains_changes": false
+    },
+    "v0.33.3": {
+      "contains_changes": false
+    },
+    "v0.33.2": {
+      "contains_changes": false
+    },
+    "v0.33.1": {
+      "contains_changes": false
+    },
+    "v0.33.0": {
+      "contains_changes": false
+    },
+    "v0.32.0": {
+      "contains_changes": false
+    },
+    "v0.31.1": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
+    "v0.30.0": {
+      "contains_changes": false
+    },
+    "v0.29.14": {
+      "contains_changes": false
+    },
+    "v0.29.13": {
+      "contains_changes": false
+    },
+    "v0.29.12": {
+      "contains_changes": false
+    },
+    "v0.29.11": {
+      "contains_changes": false
+    },
+    "v0.29.10": {
+      "contains_changes": false
+    },
+    "v0.29.9": {
+      "contains_changes": false
+    },
+    "v0.29.8": {
+      "contains_changes": false
+    },
+    "v0.29.7": {
+      "contains_changes": false
+    },
+    "v0.29.6": {
+      "contains_changes": false
+    },
+    "v0.29.5": {
+      "contains_changes": false
+    },
+    "v0.29.4": {
+      "contains_changes": false
+    },
+    "v0.29.3": {
+      "contains_changes": false
+    },
+    "v0.29.2": {
+      "contains_changes": false
+    },
+    "v0.29.1": {
+      "contains_changes": false
+    },
+    "v0.29.0": {
+      "contains_changes": false
+    },
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.3": {
+      "contains_changes": false
+    },
+    "v0.27.2": {
+      "contains_changes": false
+    },
+    "v0.27.1": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.1": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.4": {
+      "contains_changes": false
+    },
+    "v0.24.3": {
+      "contains_changes": false
+    },
+    "v0.24.2": {
+      "contains_changes": false
+    },
+    "v0.24.1": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.4": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.6": {
+      "contains_changes": false
+    },
+    "v0.18.5": {
+      "contains_changes": false
+    },
+    "v0.18.4": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.6": {
+      "contains_changes": false
+    },
+    "v0.16.5": {
+      "contains_changes": false
+    },
+    "v0.16.4": {
+      "contains_changes": false
+    },
+    "v0.16.3": {
+      "contains_changes": false
+    },
+    "v0.16.2": {
+      "contains_changes": false
+    },
+    "v0.16.1": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.2": {
+      "contains_changes": false
+    },
+    "v0.14.1": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.16": {
+      "contains_changes": false
+    },
+    "v0.13.15": {
+      "contains_changes": false
+    },
+    "v0.13.14": {
+      "contains_changes": false
+    },
+    "v0.13.13": {
+      "contains_changes": false
+    },
+    "v0.13.12": {
+      "contains_changes": false
+    },
+    "v0.13.11": {
+      "contains_changes": false
+    },
+    "v0.13.10": {
+      "contains_changes": false
+    },
+    "v0.13.9": {
+      "contains_changes": false
+    },
+    "v0.13.8": {
+      "contains_changes": false
+    },
+    "v0.13.7": {
+      "contains_changes": false
+    },
+    "v0.13.6": {
+      "contains_changes": false
+    },
+    "v0.13.5": {
+      "contains_changes": false
+    },
+    "v0.13.4": {
+      "contains_changes": false
+    },
+    "v0.13.3": {
+      "contains_changes": false
+    },
+    "v0.13.2": {
+      "contains_changes": false
+    },
+    "v0.13.1": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.2": {
+      "contains_changes": false
+    },
+    "v0.12.1": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.2": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.1": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.21": {
+      "contains_changes": false
+    },
+    "v0.3.20": {
+      "contains_changes": false
+    },
+    "v0.3.19": {
+      "contains_changes": false
+    },
+    "v0.3.18": {
+      "contains_changes": false
+    },
+    "v0.3.17": {
+      "contains_changes": false
+    },
+    "v0.3.16": {
+      "contains_changes": false
+    },
+    "v0.3.15": {
+      "contains_changes": false
+    },
+    "v0.3.14": {
+      "contains_changes": false
+    },
+    "v0.3.13": {
+      "contains_changes": false
+    },
+    "v0.3.12": {
+      "contains_changes": false
+    },
+    "v0.3.11": {
+      "contains_changes": false
+    },
+    "v0.3.10": {
+      "contains_changes": false
+    },
+    "v0.3.9": {
+      "contains_changes": false
+    },
+    "v0.3.8": {
+      "contains_changes": false
+    },
+    "v0.3.7": {
+      "contains_changes": false
+    },
+    "v0.3.6": {
+      "contains_changes": false
+    },
+    "v0.3.5": {
+      "contains_changes": false
+    },
+    "v0.3.4": {
+      "contains_changes": false
+    },
+    "v0.3.3": {
+      "contains_changes": false
+    },
+    "v0.3.2": {
+      "contains_changes": false
+    },
+    "v0.3.1": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.2": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.25": {
+      "contains_changes": false
+    },
+    "v0.0.24": {
+      "contains_changes": false
+    },
+    "v0.0.23": {
+      "contains_changes": false
+    },
+    "v0.0.22": {
+      "contains_changes": false
+    },
+    "v0.0.21": {
+      "contains_changes": false
+    },
+    "v0.0.20": {
+      "contains_changes": false
+    },
+    "v0.0.19": {
+      "contains_changes": false
+    },
+    "v0.0.18": {
+      "contains_changes": false
+    },
+    "v0.0.17": {
+      "contains_changes": false
+    },
+    "v0.0.16": {
+      "contains_changes": false
+    },
+    "v0.0.15": {
+      "contains_changes": false
+    },
+    "v0.0.14": {
+      "contains_changes": false
+    },
+    "v0.0.13": {
+      "contains_changes": false
+    },
+    "v0.0.12": {
+      "contains_changes": false
+    },
+    "v0.0.11": {
+      "contains_changes": false
+    },
+    "v0.0.10": {
+      "contains_changes": false
+    },
+    "v0.0.9": {
+      "contains_changes": false
+    },
+    "v0.0.8": {
+      "contains_changes": false
+    },
+    "v0.0.7": {
+      "contains_changes": false
+    },
+    "v0.0.6": {
+      "contains_changes": false
+    },
+    "v0.0.5": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    },
+    "v0.0.0": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-ci/gruntwork-module-circleci-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/gruntwork-module-circleci-helpers.json
@@ -1,6 +1,117 @@
 {
   "module": "gruntwork-module-circleci-helpers",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": false
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": true
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": true
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": true
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": true
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": true
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": false
+    },
+    "v0.52.17": {
+      "contains_changes": false
+    },
+    "v0.52.16": {
+      "contains_changes": false
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
     "v0.52.13": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/iam-policies.json
+++ b/static/patcher-changelogs/terraform-aws-ci/iam-policies.json
@@ -1,6 +1,117 @@
 {
   "module": "iam-policies",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": false
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": false
+    },
+    "v0.52.17": {
+      "contains_changes": true
+    },
+    "v0.52.16": {
+      "contains_changes": true
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
     "v0.52.13": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-ci/infrastructure-deploy-script.json
+++ b/static/patcher-changelogs/terraform-aws-ci/infrastructure-deploy-script.json
@@ -1,6 +1,117 @@
 {
   "module": "infrastructure-deploy-script",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": true
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": true
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": false
+    },
+    "v0.52.17": {
+      "contains_changes": true
+    },
+    "v0.52.16": {
+      "contains_changes": true
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
     "v0.52.13": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-ci/infrastructure-deployer.json
+++ b/static/patcher-changelogs/terraform-aws-ci/infrastructure-deployer.json
@@ -1,6 +1,117 @@
 {
   "module": "infrastructure-deployer",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": true
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": true
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": true
+    },
+    "v0.59.4": {
+      "contains_changes": true
+    },
+    "v0.59.3": {
+      "contains_changes": true
+    },
+    "v0.59.2": {
+      "contains_changes": true
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": true
+    },
+    "v0.58.2": {
+      "contains_changes": true
+    },
+    "v0.58.1": {
+      "contains_changes": true
+    },
+    "v0.58.0": {
+      "contains_changes": true
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": true
+    },
+    "v0.52.17": {
+      "contains_changes": false
+    },
+    "v0.52.16": {
+      "contains_changes": false
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
     "v0.52.13": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/install-jenkins.json
+++ b/static/patcher-changelogs/terraform-aws-ci/install-jenkins.json
@@ -1,6 +1,117 @@
 {
   "module": "install-jenkins",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": false
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": true
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": false
+    },
+    "v0.52.17": {
+      "contains_changes": false
+    },
+    "v0.52.16": {
+      "contains_changes": false
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
     "v0.52.13": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/jenkins-server.json
+++ b/static/patcher-changelogs/terraform-aws-ci/jenkins-server.json
@@ -1,6 +1,117 @@
 {
   "module": "jenkins-server",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": false
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": true
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": true
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": true
+    },
+    "v0.53.4": {
+      "contains_changes": true
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": false
+    },
+    "v0.52.17": {
+      "contains_changes": true
+    },
+    "v0.52.16": {
+      "contains_changes": true
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
     "v0.52.13": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-ci/kubernetes-circleci-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/kubernetes-circleci-helpers.json
@@ -1,6 +1,117 @@
 {
   "module": "kubernetes-circleci-helpers",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": false
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": true
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": false
+    },
+    "v0.52.17": {
+      "contains_changes": false
+    },
+    "v0.52.16": {
+      "contains_changes": false
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
     "v0.52.13": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/monorepo-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/monorepo-helpers.json
@@ -1,6 +1,117 @@
 {
   "module": "monorepo-helpers",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": true
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": false
+    },
+    "v0.52.17": {
+      "contains_changes": false
+    },
+    "v0.52.16": {
+      "contains_changes": false
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
     "v0.52.13": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/sign-binary-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/sign-binary-helpers.json
@@ -1,6 +1,117 @@
 {
   "module": "sign-binary-helpers",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": false
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": true
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": true
+    },
+    "v0.53.2": {
+      "contains_changes": true
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": false
+    },
+    "v0.52.17": {
+      "contains_changes": false
+    },
+    "v0.52.16": {
+      "contains_changes": false
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
     "v0.52.13": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ci/terraform-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-ci/terraform-helpers.json
@@ -1,6 +1,117 @@
 {
   "module": "terraform-helpers",
   "releases": {
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.9": {
+      "contains_changes": false
+    },
+    "v0.59.8": {
+      "contains_changes": false
+    },
+    "v0.59.7": {
+      "contains_changes": false
+    },
+    "v0.59.6": {
+      "contains_changes": false
+    },
+    "v0.59.5": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.3": {
+      "contains_changes": false
+    },
+    "v0.54.2": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.19": {
+      "contains_changes": false
+    },
+    "v0.52.18": {
+      "contains_changes": false
+    },
+    "v0.52.17": {
+      "contains_changes": false
+    },
+    "v0.52.16": {
+      "contains_changes": false
+    },
+    "v0.52.15": {
+      "contains_changes": false
+    },
+    "v0.52.14": {
+      "contains_changes": false
+    },
     "v0.52.13": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/data-stores/efs.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/data-stores/efs.json
@@ -1,6 +1,93 @@
 {
   "module": "data-stores/efs",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/data-stores/rds.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/data-stores/rds.json
@@ -1,6 +1,93 @@
 {
   "module": "data-stores/rds",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": true
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": true
+    },
+    "v0.55.2": {
+      "contains_changes": true
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": true
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": true
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": true
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/landingzone/account-baseline-app.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/landingzone/account-baseline-app.json
@@ -1,6 +1,93 @@
 {
   "module": "landingzone/account-baseline-app",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": true
+    },
+    "v0.56.1": {
+      "contains_changes": true
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": true
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": true
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": true
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/landingzone/account-baseline-root.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/landingzone/account-baseline-root.json
@@ -1,6 +1,93 @@
 {
   "module": "landingzone/account-baseline-root",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": true
+    },
+    "v0.56.1": {
+      "contains_changes": true
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": true
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/landingzone/account-baseline-security.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/landingzone/account-baseline-security.json
@@ -1,6 +1,93 @@
 {
   "module": "landingzone/account-baseline-security",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": true
+    },
+    "v0.56.1": {
+      "contains_changes": true
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": true
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc-app-network-acls.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc-app-network-acls.json
@@ -1,6 +1,93 @@
 {
   "module": "networking/vpc-app-network-acls",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": true
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": true
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": true
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc-mgmt-network-acls.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc-mgmt-network-acls.json
@@ -1,6 +1,93 @@
 {
   "module": "networking/vpc-mgmt-network-acls",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": true
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": true
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc-mgmt.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc-mgmt.json
@@ -1,6 +1,93 @@
 {
   "module": "networking/vpc-mgmt",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": true
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": true
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/networking/vpc.json
@@ -1,6 +1,93 @@
 {
   "module": "networking/vpc",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": true
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": true
+    },
+    "v0.53.0": {
+      "contains_changes": true
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": true
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": true
+    },
+    "v0.50.0": {
+      "contains_changes": true
+    },
+    "v0.49.3": {
+      "contains_changes": true
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": true
+    },
+    "v0.49.0": {
+      "contains_changes": true
+    },
+    "v0.48.4": {
+      "contains_changes": true
+    },
+    "v0.48.3": {
+      "contains_changes": true
+    },
+    "v0.48.2": {
+      "contains_changes": true
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/observability/aws-config-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/observability/aws-config-multi-region.json
@@ -1,6 +1,93 @@
 {
   "module": "observability/aws-config-multi-region",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/observability/cloudtrail.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/observability/cloudtrail.json
@@ -1,6 +1,93 @@
 {
   "module": "observability/cloudtrail",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/observability/cloudwatch-logs-metric-filters.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/observability/cloudwatch-logs-metric-filters.json
@@ -1,6 +1,93 @@
 {
   "module": "observability/cloudwatch-logs-metric-filters",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/aws-securityhub.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/aws-securityhub.json
@@ -1,6 +1,93 @@
 {
   "module": "security/aws-securityhub",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": true
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": true
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/cleanup-expired-certs.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/cleanup-expired-certs.json
@@ -1,6 +1,93 @@
 {
   "module": "security/cleanup-expired-certs",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/cross-account-iam-roles.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/cross-account-iam-roles.json
@@ -1,6 +1,93 @@
 {
   "module": "security/cross-account-iam-roles",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/custom-iam-entity.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/custom-iam-entity.json
@@ -1,6 +1,93 @@
 {
   "module": "security/custom-iam-entity",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/iam-groups.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/iam-groups.json
@@ -1,6 +1,93 @@
 {
   "module": "security/iam-groups",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/iam-password-policy.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/iam-password-policy.json
@@ -1,6 +1,93 @@
 {
   "module": "security/iam-password-policy",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/macie.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/macie.json
@@ -1,6 +1,93 @@
 {
   "module": "security/macie",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": true
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": true
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": true
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": true
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/revoke-unused-iam-credentials.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/revoke-unused-iam-credentials.json
@@ -1,6 +1,93 @@
 {
   "module": "security/revoke-unused-iam-credentials",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/saml-iam-roles.json
+++ b/static/patcher-changelogs/terraform-aws-cis-service-catalog/security/saml-iam-roles.json
@@ -1,6 +1,93 @@
 {
   "module": "security/saml-iam-roles",
   "releases": {
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": true
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.1": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.2": {
+      "contains_changes": false
+    },
+    "v0.52.1": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
     "v0.48.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/aurora.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/aurora.json
@@ -1,6 +1,78 @@
 {
   "module": "aurora",
   "releases": {
+    "v0.40.6": {
+      "contains_changes": true
+    },
+    "v0.40.5": {
+      "contains_changes": false
+    },
+    "v0.40.4": {
+      "contains_changes": false
+    },
+    "v0.40.3": {
+      "contains_changes": false
+    },
+    "v0.40.2": {
+      "contains_changes": true
+    },
+    "v0.40.1": {
+      "contains_changes": true
+    },
+    "v0.40.0": {
+      "contains_changes": true
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.3": {
+      "contains_changes": false
+    },
+    "v0.37.2": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": true
+    },
+    "v0.34": {
+      "contains_changes": false
+    },
+    "v0.33": {
+      "contains_changes": false
+    },
+    "v0.32": {
+      "contains_changes": false
+    },
+    "v0.31.4": {
+      "contains_changes": true
+    },
+    "v0.31.3": {
+      "contains_changes": false
+    },
+    "v0.31.2": {
+      "contains_changes": true
+    },
+    "v0.31.1": {
+      "contains_changes": true
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
     "v0.30.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/backup-plan.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/backup-plan.json
@@ -1,6 +1,78 @@
 {
   "module": "backup-plan",
   "releases": {
+    "v0.40.6": {
+      "contains_changes": false
+    },
+    "v0.40.5": {
+      "contains_changes": false
+    },
+    "v0.40.4": {
+      "contains_changes": false
+    },
+    "v0.40.3": {
+      "contains_changes": false
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": true
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.3": {
+      "contains_changes": false
+    },
+    "v0.37.2": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34": {
+      "contains_changes": false
+    },
+    "v0.33": {
+      "contains_changes": false
+    },
+    "v0.32": {
+      "contains_changes": false
+    },
+    "v0.31.4": {
+      "contains_changes": true
+    },
+    "v0.31.3": {
+      "contains_changes": false
+    },
+    "v0.31.2": {
+      "contains_changes": true
+    },
+    "v0.31.1": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
     "v0.30.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/backup-vault.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/backup-vault.json
@@ -1,6 +1,78 @@
 {
   "module": "backup-vault",
   "releases": {
+    "v0.40.6": {
+      "contains_changes": false
+    },
+    "v0.40.5": {
+      "contains_changes": false
+    },
+    "v0.40.4": {
+      "contains_changes": false
+    },
+    "v0.40.3": {
+      "contains_changes": false
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": true
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.3": {
+      "contains_changes": false
+    },
+    "v0.37.2": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34": {
+      "contains_changes": false
+    },
+    "v0.33": {
+      "contains_changes": true
+    },
+    "v0.32": {
+      "contains_changes": false
+    },
+    "v0.31.4": {
+      "contains_changes": true
+    },
+    "v0.31.3": {
+      "contains_changes": false
+    },
+    "v0.31.2": {
+      "contains_changes": true
+    },
+    "v0.31.1": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
     "v0.30.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/dms.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/dms.json
@@ -1,0 +1,494 @@
+{
+  "module": "dms",
+  "releases": {
+    "v0.40.6": {
+      "contains_changes": false
+    },
+    "v0.40.5": {
+      "contains_changes": false
+    },
+    "v0.40.4": {
+      "contains_changes": false
+    },
+    "v0.40.3": {
+      "contains_changes": true
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.3": {
+      "contains_changes": false
+    },
+    "v0.37.2": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34": {
+      "contains_changes": false
+    },
+    "v0.33": {
+      "contains_changes": true
+    },
+    "v0.32": {
+      "contains_changes": true
+    },
+    "v0.31.4": {
+      "contains_changes": false
+    },
+    "v0.31.3": {
+      "contains_changes": false
+    },
+    "v0.31.2": {
+      "contains_changes": false
+    },
+    "v0.31.1": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
+    "v0.30.0": {
+      "contains_changes": false
+    },
+    "v0.29.2": {
+      "contains_changes": false
+    },
+    "v0.29.1": {
+      "contains_changes": false
+    },
+    "v0.29.0": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.2": {
+      "contains_changes": false
+    },
+    "v0.27.1": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.3": {
+      "contains_changes": false
+    },
+    "v0.24.2": {
+      "contains_changes": false
+    },
+    "v0.24.1": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.5": {
+      "contains_changes": false
+    },
+    "v0.23.4": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.6": {
+      "contains_changes": false
+    },
+    "v0.22.5": {
+      "contains_changes": false
+    },
+    "v0.22.4": {
+      "contains_changes": false
+    },
+    "v0.22.3": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.1": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.5": {
+      "contains_changes": false
+    },
+    "v0.20.4": {
+      "contains_changes": false
+    },
+    "v0.20.3": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.4": {
+      "contains_changes": false
+    },
+    "v0.17.3": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.3": {
+      "contains_changes": false
+    },
+    "v0.16.2": {
+      "contains_changes": false
+    },
+    "v0.16.1": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.1": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.21": {
+      "contains_changes": false
+    },
+    "v0.12.20": {
+      "contains_changes": false
+    },
+    "v0.12.19": {
+      "contains_changes": false
+    },
+    "v0.12.18": {
+      "contains_changes": false
+    },
+    "v0.12.17": {
+      "contains_changes": false
+    },
+    "v0.12.16": {
+      "contains_changes": false
+    },
+    "v0.12.15": {
+      "contains_changes": false
+    },
+    "v0.12.14": {
+      "contains_changes": false
+    },
+    "v0.12.13": {
+      "contains_changes": false
+    },
+    "v0.12.12": {
+      "contains_changes": false
+    },
+    "v0.12.11": {
+      "contains_changes": false
+    },
+    "v0.12.10": {
+      "contains_changes": false
+    },
+    "v0.12.9": {
+      "contains_changes": false
+    },
+    "v0.12.8": {
+      "contains_changes": false
+    },
+    "v0.12.7": {
+      "contains_changes": false
+    },
+    "v0.12.6": {
+      "contains_changes": false
+    },
+    "v0.12.5": {
+      "contains_changes": false
+    },
+    "v0.12.4": {
+      "contains_changes": false
+    },
+    "v0.12.3": {
+      "contains_changes": false
+    },
+    "v0.12.2": {
+      "contains_changes": false
+    },
+    "v0.12.1": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.5": {
+      "contains_changes": false
+    },
+    "v0.11.4": {
+      "contains_changes": false
+    },
+    "v0.11.3": {
+      "contains_changes": false
+    },
+    "v0.11.2": {
+      "contains_changes": false
+    },
+    "v0.11.1": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.3": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
+    "v0.9.2": {
+      "contains_changes": false
+    },
+    "v0.9.1": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.9": {
+      "contains_changes": false
+    },
+    "v0.8.8": {
+      "contains_changes": false
+    },
+    "v0.8.7": {
+      "contains_changes": false
+    },
+    "v0.8.6": {
+      "contains_changes": false
+    },
+    "v0.8.5": {
+      "contains_changes": false
+    },
+    "v0.8.4": {
+      "contains_changes": false
+    },
+    "v0.8.3": {
+      "contains_changes": false
+    },
+    "v0.8.2": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.8": {
+      "contains_changes": false
+    },
+    "v0.6.7": {
+      "contains_changes": false
+    },
+    "v0.6.6": {
+      "contains_changes": false
+    },
+    "v0.6.5": {
+      "contains_changes": false
+    },
+    "v0.6.4": {
+      "contains_changes": false
+    },
+    "v0.6.3": {
+      "contains_changes": false
+    },
+    "v0.6.2": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.1": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.2": {
+      "contains_changes": false
+    },
+    "v0.3.1": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.10": {
+      "contains_changes": false
+    },
+    "v0.2.9": {
+      "contains_changes": false
+    },
+    "v0.2.8": {
+      "contains_changes": false
+    },
+    "v0.2.7": {
+      "contains_changes": false
+    },
+    "v0.2.6": {
+      "contains_changes": false
+    },
+    "v0.2.5": {
+      "contains_changes": false
+    },
+    "v0.2.4": {
+      "contains_changes": false
+    },
+    "v0.2.3": {
+      "contains_changes": false
+    },
+    "v0.2.2": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.5": {
+      "contains_changes": false
+    },
+    "v0.1.4": {
+      "contains_changes": false
+    },
+    "v0.1.3": {
+      "contains_changes": false
+    },
+    "v0.1.2": {
+      "contains_changes": false
+    },
+    "v0.1.1": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.7": {
+      "contains_changes": false
+    },
+    "v0.0.6": {
+      "contains_changes": false
+    },
+    "v0.0.5": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-data-storage/efs.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/efs.json
@@ -1,6 +1,78 @@
 {
   "module": "efs",
   "releases": {
+    "v0.40.6": {
+      "contains_changes": false
+    },
+    "v0.40.5": {
+      "contains_changes": true
+    },
+    "v0.40.4": {
+      "contains_changes": false
+    },
+    "v0.40.3": {
+      "contains_changes": false
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.3": {
+      "contains_changes": false
+    },
+    "v0.37.2": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34": {
+      "contains_changes": false
+    },
+    "v0.33": {
+      "contains_changes": true
+    },
+    "v0.32": {
+      "contains_changes": false
+    },
+    "v0.31.4": {
+      "contains_changes": true
+    },
+    "v0.31.3": {
+      "contains_changes": false
+    },
+    "v0.31.2": {
+      "contains_changes": true
+    },
+    "v0.31.1": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
     "v0.30.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/lambda-cleanup-snapshots.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/lambda-cleanup-snapshots.json
@@ -1,6 +1,78 @@
 {
   "module": "lambda-cleanup-snapshots",
   "releases": {
+    "v0.40.6": {
+      "contains_changes": false
+    },
+    "v0.40.5": {
+      "contains_changes": false
+    },
+    "v0.40.4": {
+      "contains_changes": false
+    },
+    "v0.40.3": {
+      "contains_changes": false
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": true
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.3": {
+      "contains_changes": false
+    },
+    "v0.37.2": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34": {
+      "contains_changes": false
+    },
+    "v0.33": {
+      "contains_changes": false
+    },
+    "v0.32": {
+      "contains_changes": false
+    },
+    "v0.31.4": {
+      "contains_changes": true
+    },
+    "v0.31.3": {
+      "contains_changes": false
+    },
+    "v0.31.2": {
+      "contains_changes": true
+    },
+    "v0.31.1": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
     "v0.30.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/lambda-copy-shared-snapshot.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/lambda-copy-shared-snapshot.json
@@ -1,6 +1,78 @@
 {
   "module": "lambda-copy-shared-snapshot",
   "releases": {
+    "v0.40.6": {
+      "contains_changes": false
+    },
+    "v0.40.5": {
+      "contains_changes": false
+    },
+    "v0.40.4": {
+      "contains_changes": false
+    },
+    "v0.40.3": {
+      "contains_changes": false
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": true
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.3": {
+      "contains_changes": false
+    },
+    "v0.37.2": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34": {
+      "contains_changes": false
+    },
+    "v0.33": {
+      "contains_changes": false
+    },
+    "v0.32": {
+      "contains_changes": false
+    },
+    "v0.31.4": {
+      "contains_changes": true
+    },
+    "v0.31.3": {
+      "contains_changes": false
+    },
+    "v0.31.2": {
+      "contains_changes": true
+    },
+    "v0.31.1": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
     "v0.30.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/lambda-create-snapshot.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/lambda-create-snapshot.json
@@ -1,6 +1,78 @@
 {
   "module": "lambda-create-snapshot",
   "releases": {
+    "v0.40.6": {
+      "contains_changes": false
+    },
+    "v0.40.5": {
+      "contains_changes": true
+    },
+    "v0.40.4": {
+      "contains_changes": false
+    },
+    "v0.40.3": {
+      "contains_changes": false
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": true
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.3": {
+      "contains_changes": false
+    },
+    "v0.37.2": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": true
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34": {
+      "contains_changes": false
+    },
+    "v0.33": {
+      "contains_changes": false
+    },
+    "v0.32": {
+      "contains_changes": false
+    },
+    "v0.31.4": {
+      "contains_changes": true
+    },
+    "v0.31.3": {
+      "contains_changes": false
+    },
+    "v0.31.2": {
+      "contains_changes": true
+    },
+    "v0.31.1": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
     "v0.30.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/lambda-share-snapshot.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/lambda-share-snapshot.json
@@ -1,6 +1,78 @@
 {
   "module": "lambda-share-snapshot",
   "releases": {
+    "v0.40.6": {
+      "contains_changes": false
+    },
+    "v0.40.5": {
+      "contains_changes": false
+    },
+    "v0.40.4": {
+      "contains_changes": false
+    },
+    "v0.40.3": {
+      "contains_changes": false
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": true
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.3": {
+      "contains_changes": false
+    },
+    "v0.37.2": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34": {
+      "contains_changes": false
+    },
+    "v0.33": {
+      "contains_changes": false
+    },
+    "v0.32": {
+      "contains_changes": false
+    },
+    "v0.31.4": {
+      "contains_changes": true
+    },
+    "v0.31.3": {
+      "contains_changes": false
+    },
+    "v0.31.2": {
+      "contains_changes": true
+    },
+    "v0.31.1": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
     "v0.30.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/org-backup-policy.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/org-backup-policy.json
@@ -1,0 +1,494 @@
+{
+  "module": "org-backup-policy",
+  "releases": {
+    "v0.40.6": {
+      "contains_changes": false
+    },
+    "v0.40.5": {
+      "contains_changes": false
+    },
+    "v0.40.4": {
+      "contains_changes": false
+    },
+    "v0.40.3": {
+      "contains_changes": false
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.3": {
+      "contains_changes": false
+    },
+    "v0.37.2": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34": {
+      "contains_changes": false
+    },
+    "v0.33": {
+      "contains_changes": true
+    },
+    "v0.32": {
+      "contains_changes": false
+    },
+    "v0.31.4": {
+      "contains_changes": false
+    },
+    "v0.31.3": {
+      "contains_changes": false
+    },
+    "v0.31.2": {
+      "contains_changes": false
+    },
+    "v0.31.1": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
+    "v0.30.0": {
+      "contains_changes": false
+    },
+    "v0.29.2": {
+      "contains_changes": false
+    },
+    "v0.29.1": {
+      "contains_changes": false
+    },
+    "v0.29.0": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.2": {
+      "contains_changes": false
+    },
+    "v0.27.1": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.3": {
+      "contains_changes": false
+    },
+    "v0.24.2": {
+      "contains_changes": false
+    },
+    "v0.24.1": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.5": {
+      "contains_changes": false
+    },
+    "v0.23.4": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.6": {
+      "contains_changes": false
+    },
+    "v0.22.5": {
+      "contains_changes": false
+    },
+    "v0.22.4": {
+      "contains_changes": false
+    },
+    "v0.22.3": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.1": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.5": {
+      "contains_changes": false
+    },
+    "v0.20.4": {
+      "contains_changes": false
+    },
+    "v0.20.3": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.4": {
+      "contains_changes": false
+    },
+    "v0.17.3": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.3": {
+      "contains_changes": false
+    },
+    "v0.16.2": {
+      "contains_changes": false
+    },
+    "v0.16.1": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.1": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.21": {
+      "contains_changes": false
+    },
+    "v0.12.20": {
+      "contains_changes": false
+    },
+    "v0.12.19": {
+      "contains_changes": false
+    },
+    "v0.12.18": {
+      "contains_changes": false
+    },
+    "v0.12.17": {
+      "contains_changes": false
+    },
+    "v0.12.16": {
+      "contains_changes": false
+    },
+    "v0.12.15": {
+      "contains_changes": false
+    },
+    "v0.12.14": {
+      "contains_changes": false
+    },
+    "v0.12.13": {
+      "contains_changes": false
+    },
+    "v0.12.12": {
+      "contains_changes": false
+    },
+    "v0.12.11": {
+      "contains_changes": false
+    },
+    "v0.12.10": {
+      "contains_changes": false
+    },
+    "v0.12.9": {
+      "contains_changes": false
+    },
+    "v0.12.8": {
+      "contains_changes": false
+    },
+    "v0.12.7": {
+      "contains_changes": false
+    },
+    "v0.12.6": {
+      "contains_changes": false
+    },
+    "v0.12.5": {
+      "contains_changes": false
+    },
+    "v0.12.4": {
+      "contains_changes": false
+    },
+    "v0.12.3": {
+      "contains_changes": false
+    },
+    "v0.12.2": {
+      "contains_changes": false
+    },
+    "v0.12.1": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.5": {
+      "contains_changes": false
+    },
+    "v0.11.4": {
+      "contains_changes": false
+    },
+    "v0.11.3": {
+      "contains_changes": false
+    },
+    "v0.11.2": {
+      "contains_changes": false
+    },
+    "v0.11.1": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.3": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
+    "v0.9.2": {
+      "contains_changes": false
+    },
+    "v0.9.1": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.9": {
+      "contains_changes": false
+    },
+    "v0.8.8": {
+      "contains_changes": false
+    },
+    "v0.8.7": {
+      "contains_changes": false
+    },
+    "v0.8.6": {
+      "contains_changes": false
+    },
+    "v0.8.5": {
+      "contains_changes": false
+    },
+    "v0.8.4": {
+      "contains_changes": false
+    },
+    "v0.8.3": {
+      "contains_changes": false
+    },
+    "v0.8.2": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.8": {
+      "contains_changes": false
+    },
+    "v0.6.7": {
+      "contains_changes": false
+    },
+    "v0.6.6": {
+      "contains_changes": false
+    },
+    "v0.6.5": {
+      "contains_changes": false
+    },
+    "v0.6.4": {
+      "contains_changes": false
+    },
+    "v0.6.3": {
+      "contains_changes": false
+    },
+    "v0.6.2": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.1": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.2": {
+      "contains_changes": false
+    },
+    "v0.3.1": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.10": {
+      "contains_changes": false
+    },
+    "v0.2.9": {
+      "contains_changes": false
+    },
+    "v0.2.8": {
+      "contains_changes": false
+    },
+    "v0.2.7": {
+      "contains_changes": false
+    },
+    "v0.2.6": {
+      "contains_changes": false
+    },
+    "v0.2.5": {
+      "contains_changes": false
+    },
+    "v0.2.4": {
+      "contains_changes": false
+    },
+    "v0.2.3": {
+      "contains_changes": false
+    },
+    "v0.2.2": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.5": {
+      "contains_changes": false
+    },
+    "v0.1.4": {
+      "contains_changes": false
+    },
+    "v0.1.3": {
+      "contains_changes": false
+    },
+    "v0.1.2": {
+      "contains_changes": false
+    },
+    "v0.1.1": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.7": {
+      "contains_changes": false
+    },
+    "v0.0.6": {
+      "contains_changes": false
+    },
+    "v0.0.5": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-data-storage/rds-proxy.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/rds-proxy.json
@@ -1,6 +1,78 @@
 {
   "module": "rds-proxy",
   "releases": {
+    "v0.40.6": {
+      "contains_changes": true
+    },
+    "v0.40.5": {
+      "contains_changes": true
+    },
+    "v0.40.4": {
+      "contains_changes": false
+    },
+    "v0.40.3": {
+      "contains_changes": false
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": true
+    },
+    "v0.37.3": {
+      "contains_changes": true
+    },
+    "v0.37.2": {
+      "contains_changes": true
+    },
+    "v0.37.1": {
+      "contains_changes": true
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34": {
+      "contains_changes": true
+    },
+    "v0.33": {
+      "contains_changes": true
+    },
+    "v0.32": {
+      "contains_changes": false
+    },
+    "v0.31.4": {
+      "contains_changes": true
+    },
+    "v0.31.3": {
+      "contains_changes": false
+    },
+    "v0.31.2": {
+      "contains_changes": true
+    },
+    "v0.31.1": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
     "v0.30.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/rds-replicas.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/rds-replicas.json
@@ -1,6 +1,78 @@
 {
   "module": "rds-replicas",
   "releases": {
+    "v0.40.6": {
+      "contains_changes": true
+    },
+    "v0.40.5": {
+      "contains_changes": false
+    },
+    "v0.40.4": {
+      "contains_changes": false
+    },
+    "v0.40.3": {
+      "contains_changes": true
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": true
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.3": {
+      "contains_changes": false
+    },
+    "v0.37.2": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34": {
+      "contains_changes": false
+    },
+    "v0.33": {
+      "contains_changes": false
+    },
+    "v0.32": {
+      "contains_changes": false
+    },
+    "v0.31.4": {
+      "contains_changes": true
+    },
+    "v0.31.3": {
+      "contains_changes": false
+    },
+    "v0.31.2": {
+      "contains_changes": true
+    },
+    "v0.31.1": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": true
+    },
     "v0.30.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/rds.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/rds.json
@@ -1,6 +1,78 @@
 {
   "module": "rds",
   "releases": {
+    "v0.40.6": {
+      "contains_changes": false
+    },
+    "v0.40.5": {
+      "contains_changes": false
+    },
+    "v0.40.4": {
+      "contains_changes": true
+    },
+    "v0.40.3": {
+      "contains_changes": true
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": true
+    },
+    "v0.38.1": {
+      "contains_changes": true
+    },
+    "v0.38.0": {
+      "contains_changes": true
+    },
+    "v0.37.3": {
+      "contains_changes": false
+    },
+    "v0.37.2": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": true
+    },
+    "v0.37.0": {
+      "contains_changes": true
+    },
+    "v0.36.0": {
+      "contains_changes": true
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34": {
+      "contains_changes": false
+    },
+    "v0.33": {
+      "contains_changes": true
+    },
+    "v0.32": {
+      "contains_changes": true
+    },
+    "v0.31.4": {
+      "contains_changes": true
+    },
+    "v0.31.3": {
+      "contains_changes": true
+    },
+    "v0.31.2": {
+      "contains_changes": true
+    },
+    "v0.31.1": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": true
+    },
     "v0.30.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-data-storage/redshift.json
+++ b/static/patcher-changelogs/terraform-aws-data-storage/redshift.json
@@ -1,6 +1,78 @@
 {
   "module": "redshift",
   "releases": {
+    "v0.40.6": {
+      "contains_changes": false
+    },
+    "v0.40.5": {
+      "contains_changes": false
+    },
+    "v0.40.4": {
+      "contains_changes": false
+    },
+    "v0.40.3": {
+      "contains_changes": false
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": true
+    },
+    "v0.38.1": {
+      "contains_changes": true
+    },
+    "v0.38.0": {
+      "contains_changes": true
+    },
+    "v0.37.3": {
+      "contains_changes": false
+    },
+    "v0.37.2": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34": {
+      "contains_changes": false
+    },
+    "v0.33": {
+      "contains_changes": true
+    },
+    "v0.32": {
+      "contains_changes": false
+    },
+    "v0.31.4": {
+      "contains_changes": true
+    },
+    "v0.31.3": {
+      "contains_changes": false
+    },
+    "v0.31.2": {
+      "contains_changes": true
+    },
+    "v0.31.1": {
+      "contains_changes": true
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
     "v0.30.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-cluster.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-cluster.json
@@ -1,6 +1,69 @@
 {
   "module": "ecs-cluster",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.38.10": {
+      "contains_changes": false
+    },
+    "v0.38.9": {
+      "contains_changes": true
+    },
+    "v0.38.8": {
+      "contains_changes": true
+    },
+    "v0.38.7": {
+      "contains_changes": false
+    },
+    "v0.38.6": {
+      "contains_changes": true
+    },
+    "v0.38.5": {
+      "contains_changes": false
+    },
+    "v0.38.4": {
+      "contains_changes": true
+    },
+    "v0.38.3": {
+      "contains_changes": false
+    },
+    "v0.38.2": {
+      "contains_changes": true
+    },
+    "v0.38.1": {
+      "contains_changes": true
+    },
+    "v0.38.0": {
+      "contains_changes": true
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.1": {
+      "contains_changes": true
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.16": {
+      "contains_changes": true
+    },
+    "v0.35.15": {
+      "contains_changes": false
+    },
+    "v0.35.14": {
+      "contains_changes": true
+    },
+    "v0.35.13": {
+      "contains_changes": false
+    },
+    "v0.35.12": {
+      "contains_changes": true
+    },
+    "v0.35.11": {
+      "contains_changes": true
+    },
     "v0.35.10": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-daemon-service.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-daemon-service.json
@@ -1,6 +1,69 @@
 {
   "module": "ecs-daemon-service",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.38.10": {
+      "contains_changes": false
+    },
+    "v0.38.9": {
+      "contains_changes": false
+    },
+    "v0.38.8": {
+      "contains_changes": false
+    },
+    "v0.38.7": {
+      "contains_changes": true
+    },
+    "v0.38.6": {
+      "contains_changes": false
+    },
+    "v0.38.5": {
+      "contains_changes": false
+    },
+    "v0.38.4": {
+      "contains_changes": false
+    },
+    "v0.38.3": {
+      "contains_changes": false
+    },
+    "v0.38.2": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": true
+    },
+    "v0.38.0": {
+      "contains_changes": true
+    },
+    "v0.37.0": {
+      "contains_changes": true
+    },
+    "v0.36.1": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.16": {
+      "contains_changes": false
+    },
+    "v0.35.15": {
+      "contains_changes": false
+    },
+    "v0.35.14": {
+      "contains_changes": false
+    },
+    "v0.35.13": {
+      "contains_changes": false
+    },
+    "v0.35.12": {
+      "contains_changes": true
+    },
+    "v0.35.11": {
+      "contains_changes": true
+    },
     "v0.35.10": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-deploy.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-deploy.json
@@ -1,6 +1,69 @@
 {
   "module": "ecs-deploy",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.38.10": {
+      "contains_changes": false
+    },
+    "v0.38.9": {
+      "contains_changes": false
+    },
+    "v0.38.8": {
+      "contains_changes": false
+    },
+    "v0.38.7": {
+      "contains_changes": false
+    },
+    "v0.38.6": {
+      "contains_changes": false
+    },
+    "v0.38.5": {
+      "contains_changes": false
+    },
+    "v0.38.4": {
+      "contains_changes": false
+    },
+    "v0.38.3": {
+      "contains_changes": false
+    },
+    "v0.38.2": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.1": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.16": {
+      "contains_changes": false
+    },
+    "v0.35.15": {
+      "contains_changes": false
+    },
+    "v0.35.14": {
+      "contains_changes": false
+    },
+    "v0.35.13": {
+      "contains_changes": false
+    },
+    "v0.35.12": {
+      "contains_changes": false
+    },
+    "v0.35.11": {
+      "contains_changes": false
+    },
     "v0.35.10": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-fargate.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-fargate.json
@@ -1,6 +1,69 @@
 {
   "module": "ecs-fargate",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.38.10": {
+      "contains_changes": false
+    },
+    "v0.38.9": {
+      "contains_changes": false
+    },
+    "v0.38.8": {
+      "contains_changes": false
+    },
+    "v0.38.7": {
+      "contains_changes": false
+    },
+    "v0.38.6": {
+      "contains_changes": false
+    },
+    "v0.38.5": {
+      "contains_changes": false
+    },
+    "v0.38.4": {
+      "contains_changes": false
+    },
+    "v0.38.3": {
+      "contains_changes": false
+    },
+    "v0.38.2": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.1": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.16": {
+      "contains_changes": false
+    },
+    "v0.35.15": {
+      "contains_changes": false
+    },
+    "v0.35.14": {
+      "contains_changes": false
+    },
+    "v0.35.13": {
+      "contains_changes": false
+    },
+    "v0.35.12": {
+      "contains_changes": false
+    },
+    "v0.35.11": {
+      "contains_changes": false
+    },
     "v0.35.10": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-scripts.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-scripts.json
@@ -1,6 +1,69 @@
 {
   "module": "ecs-scripts",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.38.10": {
+      "contains_changes": false
+    },
+    "v0.38.9": {
+      "contains_changes": false
+    },
+    "v0.38.8": {
+      "contains_changes": false
+    },
+    "v0.38.7": {
+      "contains_changes": false
+    },
+    "v0.38.6": {
+      "contains_changes": false
+    },
+    "v0.38.5": {
+      "contains_changes": false
+    },
+    "v0.38.4": {
+      "contains_changes": false
+    },
+    "v0.38.3": {
+      "contains_changes": false
+    },
+    "v0.38.2": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.1": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.16": {
+      "contains_changes": false
+    },
+    "v0.35.15": {
+      "contains_changes": false
+    },
+    "v0.35.14": {
+      "contains_changes": false
+    },
+    "v0.35.13": {
+      "contains_changes": false
+    },
+    "v0.35.12": {
+      "contains_changes": false
+    },
+    "v0.35.11": {
+      "contains_changes": false
+    },
     "v0.35.10": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-service-with-alb.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-service-with-alb.json
@@ -1,6 +1,69 @@
 {
   "module": "ecs-service-with-alb",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.38.10": {
+      "contains_changes": false
+    },
+    "v0.38.9": {
+      "contains_changes": false
+    },
+    "v0.38.8": {
+      "contains_changes": false
+    },
+    "v0.38.7": {
+      "contains_changes": false
+    },
+    "v0.38.6": {
+      "contains_changes": false
+    },
+    "v0.38.5": {
+      "contains_changes": false
+    },
+    "v0.38.4": {
+      "contains_changes": false
+    },
+    "v0.38.3": {
+      "contains_changes": false
+    },
+    "v0.38.2": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.1": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.16": {
+      "contains_changes": false
+    },
+    "v0.35.15": {
+      "contains_changes": false
+    },
+    "v0.35.14": {
+      "contains_changes": false
+    },
+    "v0.35.13": {
+      "contains_changes": false
+    },
+    "v0.35.12": {
+      "contains_changes": false
+    },
+    "v0.35.11": {
+      "contains_changes": false
+    },
     "v0.35.10": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-service-with-discovery.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-service-with-discovery.json
@@ -1,6 +1,69 @@
 {
   "module": "ecs-service-with-discovery",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.38.10": {
+      "contains_changes": false
+    },
+    "v0.38.9": {
+      "contains_changes": false
+    },
+    "v0.38.8": {
+      "contains_changes": false
+    },
+    "v0.38.7": {
+      "contains_changes": false
+    },
+    "v0.38.6": {
+      "contains_changes": false
+    },
+    "v0.38.5": {
+      "contains_changes": false
+    },
+    "v0.38.4": {
+      "contains_changes": false
+    },
+    "v0.38.3": {
+      "contains_changes": false
+    },
+    "v0.38.2": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.1": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.16": {
+      "contains_changes": false
+    },
+    "v0.35.15": {
+      "contains_changes": false
+    },
+    "v0.35.14": {
+      "contains_changes": false
+    },
+    "v0.35.13": {
+      "contains_changes": false
+    },
+    "v0.35.12": {
+      "contains_changes": false
+    },
+    "v0.35.11": {
+      "contains_changes": false
+    },
     "v0.35.10": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-service.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-service.json
@@ -1,6 +1,69 @@
 {
   "module": "ecs-service",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.38.10": {
+      "contains_changes": false
+    },
+    "v0.38.9": {
+      "contains_changes": false
+    },
+    "v0.38.8": {
+      "contains_changes": false
+    },
+    "v0.38.7": {
+      "contains_changes": true
+    },
+    "v0.38.6": {
+      "contains_changes": false
+    },
+    "v0.38.5": {
+      "contains_changes": true
+    },
+    "v0.38.4": {
+      "contains_changes": true
+    },
+    "v0.38.3": {
+      "contains_changes": true
+    },
+    "v0.38.2": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": true
+    },
+    "v0.38.0": {
+      "contains_changes": true
+    },
+    "v0.37.0": {
+      "contains_changes": true
+    },
+    "v0.36.1": {
+      "contains_changes": true
+    },
+    "v0.36.0": {
+      "contains_changes": true
+    },
+    "v0.35.16": {
+      "contains_changes": true
+    },
+    "v0.35.15": {
+      "contains_changes": true
+    },
+    "v0.35.14": {
+      "contains_changes": false
+    },
+    "v0.35.13": {
+      "contains_changes": true
+    },
+    "v0.35.12": {
+      "contains_changes": true
+    },
+    "v0.35.11": {
+      "contains_changes": true
+    },
     "v0.35.10": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-ecs/ecs-task-scheduler.json
+++ b/static/patcher-changelogs/terraform-aws-ecs/ecs-task-scheduler.json
@@ -1,6 +1,69 @@
 {
   "module": "ecs-task-scheduler",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.38.10": {
+      "contains_changes": false
+    },
+    "v0.38.9": {
+      "contains_changes": false
+    },
+    "v0.38.8": {
+      "contains_changes": false
+    },
+    "v0.38.7": {
+      "contains_changes": false
+    },
+    "v0.38.6": {
+      "contains_changes": false
+    },
+    "v0.38.5": {
+      "contains_changes": false
+    },
+    "v0.38.4": {
+      "contains_changes": false
+    },
+    "v0.38.3": {
+      "contains_changes": false
+    },
+    "v0.38.2": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": true
+    },
+    "v0.37.0": {
+      "contains_changes": true
+    },
+    "v0.36.1": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.16": {
+      "contains_changes": false
+    },
+    "v0.35.15": {
+      "contains_changes": false
+    },
+    "v0.35.14": {
+      "contains_changes": false
+    },
+    "v0.35.13": {
+      "contains_changes": false
+    },
+    "v0.35.12": {
+      "contains_changes": false
+    },
+    "v0.35.11": {
+      "contains_changes": false
+    },
     "v0.35.10": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-alb-ingress-controller-iam-policy.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-alb-ingress-controller-iam-policy.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-alb-ingress-controller-iam-policy",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": true
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": true
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": true
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": true
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-alb-ingress-controller.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-alb-ingress-controller.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-alb-ingress-controller",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": true
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": true
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": true
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-aws-auth-merger.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-aws-auth-merger.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-aws-auth-merger",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": true
+    },
+    "v0.78.0": {
+      "contains_changes": true
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": true
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": true
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": true
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
+    "v0.69.0": {
+      "contains_changes": true
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": true
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": true
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": true
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": true
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": true
+    },
+    "v0.64.4": {
+      "contains_changes": true
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-cloudwatch-agent.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-cloudwatch-agent.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-cloudwatch-agent",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-cluster-control-plane.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-cluster-control-plane.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-cluster-control-plane",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": true
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": true
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": true
+    },
+    "v0.74.2": {
+      "contains_changes": true
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": true
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": true
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": true
+    },
+    "v0.71.0": {
+      "contains_changes": true
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": true
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
+    "v0.69.0": {
+      "contains_changes": true
+    },
+    "v0.68.1": {
+      "contains_changes": true
+    },
+    "v0.68.0": {
+      "contains_changes": true
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": true
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": true
+    },
+    "v0.67.6": {
+      "contains_changes": true
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": true
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": true
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": true
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": true
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": true
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-cluster-managed-workers.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-cluster-managed-workers.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-cluster-managed-workers",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": true
+    },
+    "v0.67.8": {
+      "contains_changes": true
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-cluster-workers-cross-access.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-cluster-workers-cross-access.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-cluster-workers-cross-access",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-cluster-workers.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-cluster-workers.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-cluster-workers",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": true
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": true
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-container-logs.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-container-logs.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-container-logs",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": true
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": true
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": true
+    },
+    "v0.67.6": {
+      "contains_changes": true
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": true
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": true
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-ebs-csi-driver.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-ebs-csi-driver.json
@@ -1,0 +1,773 @@
+{
+  "module": "eks-ebs-csi-driver",
+  "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": true
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": true
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": true
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": true
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": true
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": true
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": true
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
+    "v0.62.0": {
+      "contains_changes": false
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
+    "v0.61.0": {
+      "contains_changes": false
+    },
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.4": {
+      "contains_changes": false
+    },
+    "v0.58.3": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.4": {
+      "contains_changes": false
+    },
+    "v0.56.3": {
+      "contains_changes": false
+    },
+    "v0.56.2": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.6": {
+      "contains_changes": false
+    },
+    "v0.51.5": {
+      "contains_changes": false
+    },
+    "v0.51.4": {
+      "contains_changes": false
+    },
+    "v0.51.3": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.4": {
+      "contains_changes": false
+    },
+    "v0.50.3": {
+      "contains_changes": false
+    },
+    "v0.50.2": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
+    "v0.48.0": {
+      "contains_changes": false
+    },
+    "v0.47.3": {
+      "contains_changes": false
+    },
+    "v0.47.2": {
+      "contains_changes": false
+    },
+    "v0.47.1": {
+      "contains_changes": false
+    },
+    "v0.47.0": {
+      "contains_changes": false
+    },
+    "v0.46.10": {
+      "contains_changes": false
+    },
+    "v0.46.9": {
+      "contains_changes": false
+    },
+    "v0.46.8": {
+      "contains_changes": false
+    },
+    "v0.46.7": {
+      "contains_changes": false
+    },
+    "v0.46.6": {
+      "contains_changes": false
+    },
+    "v0.46.5": {
+      "contains_changes": false
+    },
+    "v0.46.4": {
+      "contains_changes": false
+    },
+    "v0.46.3": {
+      "contains_changes": false
+    },
+    "v0.46.2": {
+      "contains_changes": false
+    },
+    "v0.46.1": {
+      "contains_changes": false
+    },
+    "v0.46.0": {
+      "contains_changes": false
+    },
+    "v0.45.2": {
+      "contains_changes": false
+    },
+    "v0.45.1": {
+      "contains_changes": false
+    },
+    "v0.45.0": {
+      "contains_changes": false
+    },
+    "v0.44.8": {
+      "contains_changes": false
+    },
+    "v0.44.7": {
+      "contains_changes": false
+    },
+    "v0.44.6": {
+      "contains_changes": false
+    },
+    "v0.44.5": {
+      "contains_changes": false
+    },
+    "v0.44.4": {
+      "contains_changes": false
+    },
+    "v0.44.3": {
+      "contains_changes": false
+    },
+    "v0.44.2": {
+      "contains_changes": false
+    },
+    "v0.44.1": {
+      "contains_changes": false
+    },
+    "v0.44.0": {
+      "contains_changes": false
+    },
+    "v0.43.0": {
+      "contains_changes": false
+    },
+    "v0.42.3": {
+      "contains_changes": false
+    },
+    "v0.42.2": {
+      "contains_changes": false
+    },
+    "v0.42.1": {
+      "contains_changes": false
+    },
+    "v0.42.0": {
+      "contains_changes": false
+    },
+    "v0.41.1": {
+      "contains_changes": false
+    },
+    "v0.41.0": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.2": {
+      "contains_changes": false
+    },
+    "v0.39.1": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.2": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.1": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.2": {
+      "contains_changes": false
+    },
+    "v0.35.1": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34.0": {
+      "contains_changes": false
+    },
+    "v0.33.1": {
+      "contains_changes": false
+    },
+    "v0.33.0": {
+      "contains_changes": false
+    },
+    "v0.32.4": {
+      "contains_changes": false
+    },
+    "v0.32.3": {
+      "contains_changes": false
+    },
+    "v0.32.2": {
+      "contains_changes": false
+    },
+    "v0.32.1": {
+      "contains_changes": false
+    },
+    "v0.32.0": {
+      "contains_changes": false
+    },
+    "v0.31.3": {
+      "contains_changes": false
+    },
+    "v0.31.2": {
+      "contains_changes": false
+    },
+    "v0.31.1": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
+    "v0.30.0": {
+      "contains_changes": false
+    },
+    "v0.29.2": {
+      "contains_changes": false
+    },
+    "v0.29.1": {
+      "contains_changes": false
+    },
+    "v0.29.0": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.2": {
+      "contains_changes": false
+    },
+    "v0.27.1": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": false
+    },
+    "v0.26.1": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.4": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.2": {
+      "contains_changes": false
+    },
+    "v0.21.1": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.4": {
+      "contains_changes": false
+    },
+    "v0.20.3": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.9": {
+      "contains_changes": false
+    },
+    "v0.19.8": {
+      "contains_changes": false
+    },
+    "v0.19.7": {
+      "contains_changes": false
+    },
+    "v0.19.6": {
+      "contains_changes": false
+    },
+    "v0.19.5": {
+      "contains_changes": false
+    },
+    "v0.19.4": {
+      "contains_changes": false
+    },
+    "v0.19.3": {
+      "contains_changes": false
+    },
+    "v0.19.2": {
+      "contains_changes": false
+    },
+    "v0.19.1": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.1": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.5": {
+      "contains_changes": false
+    },
+    "v0.15.4": {
+      "contains_changes": false
+    },
+    "v0.15.3": {
+      "contains_changes": false
+    },
+    "v0.15.2": {
+      "contains_changes": false
+    },
+    "v0.15.1": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.2": {
+      "contains_changes": false
+    },
+    "v0.12.1": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.1": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.8": {
+      "contains_changes": false
+    },
+    "v0.9.7": {
+      "contains_changes": false
+    },
+    "v0.9.6": {
+      "contains_changes": false
+    },
+    "v0.9.5": {
+      "contains_changes": false
+    },
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
+    "v0.9.2": {
+      "contains_changes": false
+    },
+    "v0.9.1": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.2": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.5": {
+      "contains_changes": false
+    },
+    "v0.5.4": {
+      "contains_changes": false
+    },
+    "v0.5.3": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.1": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.3": {
+      "contains_changes": false
+    },
+    "v0.2.2": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.5": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-eks/eks-fargate-container-logs.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-fargate-container-logs.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-fargate-container-logs",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-iam-role-assume-role-policy-for-service-account.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-iam-role-assume-role-policy-for-service-account.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-iam-role-assume-role-policy-for-service-account",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-argocd.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-argocd.json
@@ -1,0 +1,773 @@
+{
+  "module": "eks-k8s-argocd",
+  "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": true
+    },
+    "v0.62.0": {
+      "contains_changes": false
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
+    "v0.61.0": {
+      "contains_changes": false
+    },
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.4": {
+      "contains_changes": false
+    },
+    "v0.58.3": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.4": {
+      "contains_changes": false
+    },
+    "v0.56.3": {
+      "contains_changes": false
+    },
+    "v0.56.2": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.6": {
+      "contains_changes": false
+    },
+    "v0.51.5": {
+      "contains_changes": false
+    },
+    "v0.51.4": {
+      "contains_changes": false
+    },
+    "v0.51.3": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.4": {
+      "contains_changes": false
+    },
+    "v0.50.3": {
+      "contains_changes": false
+    },
+    "v0.50.2": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
+    "v0.48.0": {
+      "contains_changes": false
+    },
+    "v0.47.3": {
+      "contains_changes": false
+    },
+    "v0.47.2": {
+      "contains_changes": false
+    },
+    "v0.47.1": {
+      "contains_changes": false
+    },
+    "v0.47.0": {
+      "contains_changes": false
+    },
+    "v0.46.10": {
+      "contains_changes": false
+    },
+    "v0.46.9": {
+      "contains_changes": false
+    },
+    "v0.46.8": {
+      "contains_changes": false
+    },
+    "v0.46.7": {
+      "contains_changes": false
+    },
+    "v0.46.6": {
+      "contains_changes": false
+    },
+    "v0.46.5": {
+      "contains_changes": false
+    },
+    "v0.46.4": {
+      "contains_changes": false
+    },
+    "v0.46.3": {
+      "contains_changes": false
+    },
+    "v0.46.2": {
+      "contains_changes": false
+    },
+    "v0.46.1": {
+      "contains_changes": false
+    },
+    "v0.46.0": {
+      "contains_changes": false
+    },
+    "v0.45.2": {
+      "contains_changes": false
+    },
+    "v0.45.1": {
+      "contains_changes": false
+    },
+    "v0.45.0": {
+      "contains_changes": false
+    },
+    "v0.44.8": {
+      "contains_changes": false
+    },
+    "v0.44.7": {
+      "contains_changes": false
+    },
+    "v0.44.6": {
+      "contains_changes": false
+    },
+    "v0.44.5": {
+      "contains_changes": false
+    },
+    "v0.44.4": {
+      "contains_changes": false
+    },
+    "v0.44.3": {
+      "contains_changes": false
+    },
+    "v0.44.2": {
+      "contains_changes": false
+    },
+    "v0.44.1": {
+      "contains_changes": false
+    },
+    "v0.44.0": {
+      "contains_changes": false
+    },
+    "v0.43.0": {
+      "contains_changes": false
+    },
+    "v0.42.3": {
+      "contains_changes": false
+    },
+    "v0.42.2": {
+      "contains_changes": false
+    },
+    "v0.42.1": {
+      "contains_changes": false
+    },
+    "v0.42.0": {
+      "contains_changes": false
+    },
+    "v0.41.1": {
+      "contains_changes": false
+    },
+    "v0.41.0": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.2": {
+      "contains_changes": false
+    },
+    "v0.39.1": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.2": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.1": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.2": {
+      "contains_changes": false
+    },
+    "v0.35.1": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34.0": {
+      "contains_changes": false
+    },
+    "v0.33.1": {
+      "contains_changes": false
+    },
+    "v0.33.0": {
+      "contains_changes": false
+    },
+    "v0.32.4": {
+      "contains_changes": false
+    },
+    "v0.32.3": {
+      "contains_changes": false
+    },
+    "v0.32.2": {
+      "contains_changes": false
+    },
+    "v0.32.1": {
+      "contains_changes": false
+    },
+    "v0.32.0": {
+      "contains_changes": false
+    },
+    "v0.31.3": {
+      "contains_changes": false
+    },
+    "v0.31.2": {
+      "contains_changes": false
+    },
+    "v0.31.1": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
+    "v0.30.0": {
+      "contains_changes": false
+    },
+    "v0.29.2": {
+      "contains_changes": false
+    },
+    "v0.29.1": {
+      "contains_changes": false
+    },
+    "v0.29.0": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.2": {
+      "contains_changes": false
+    },
+    "v0.27.1": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": false
+    },
+    "v0.26.1": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.4": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.2": {
+      "contains_changes": false
+    },
+    "v0.21.1": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.4": {
+      "contains_changes": false
+    },
+    "v0.20.3": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.9": {
+      "contains_changes": false
+    },
+    "v0.19.8": {
+      "contains_changes": false
+    },
+    "v0.19.7": {
+      "contains_changes": false
+    },
+    "v0.19.6": {
+      "contains_changes": false
+    },
+    "v0.19.5": {
+      "contains_changes": false
+    },
+    "v0.19.4": {
+      "contains_changes": false
+    },
+    "v0.19.3": {
+      "contains_changes": false
+    },
+    "v0.19.2": {
+      "contains_changes": false
+    },
+    "v0.19.1": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.1": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.5": {
+      "contains_changes": false
+    },
+    "v0.15.4": {
+      "contains_changes": false
+    },
+    "v0.15.3": {
+      "contains_changes": false
+    },
+    "v0.15.2": {
+      "contains_changes": false
+    },
+    "v0.15.1": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.2": {
+      "contains_changes": false
+    },
+    "v0.12.1": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.1": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.8": {
+      "contains_changes": false
+    },
+    "v0.9.7": {
+      "contains_changes": false
+    },
+    "v0.9.6": {
+      "contains_changes": false
+    },
+    "v0.9.5": {
+      "contains_changes": false
+    },
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
+    "v0.9.2": {
+      "contains_changes": false
+    },
+    "v0.9.1": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.2": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.5": {
+      "contains_changes": false
+    },
+    "v0.5.4": {
+      "contains_changes": false
+    },
+    "v0.5.3": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.1": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.3": {
+      "contains_changes": false
+    },
+    "v0.2.2": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.5": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-cluster-autoscaler-iam-policy.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-cluster-autoscaler-iam-policy.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-k8s-cluster-autoscaler-iam-policy",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": true
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": true
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": true
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-cluster-autoscaler.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-cluster-autoscaler.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-k8s-cluster-autoscaler",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": true
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": true
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": true
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": true
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": true
+    },
+    "v0.67.4": {
+      "contains_changes": true
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": true
+    },
+    "v0.66.2": {
+      "contains_changes": true
+    },
+    "v0.66.1": {
+      "contains_changes": true
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": true
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-external-dns-iam-policy.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-external-dns-iam-policy.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-k8s-external-dns-iam-policy",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-external-dns.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-external-dns.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-k8s-external-dns",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": true
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-karpenter.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-karpenter.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-k8s-karpenter",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": true
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": true
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": true
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": true
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": true
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": true
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": true
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": true
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": true
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": true
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": true
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-k8s-role-mapping.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-k8s-role-mapping.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-k8s-role-mapping",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-scripts.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-scripts.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-scripts",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": true
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": false
+    },
+    "v0.64.2": {
+      "contains_changes": false
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-eks/eks-vpc-tags.json
+++ b/static/patcher-changelogs/terraform-aws-eks/eks-vpc-tags.json
@@ -1,6 +1,192 @@
 {
   "module": "eks-vpc-tags",
   "releases": {
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.1": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.5": {
+      "contains_changes": false
+    },
+    "v0.72.4": {
+      "contains_changes": false
+    },
+    "v0.72.3": {
+      "contains_changes": false
+    },
+    "v0.72.2": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.12": {
+      "contains_changes": false
+    },
+    "v0.67.11": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.2": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.4": {
+      "contains_changes": false
+    },
+    "v0.64.3": {
+      "contains_changes": true
+    },
+    "v0.64.2": {
+      "contains_changes": true
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
     "v0.62.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/api-gateway-account-settings.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/api-gateway-account-settings.json
@@ -1,6 +1,42 @@
 {
   "module": "api-gateway-account-settings",
   "releases": {
+    "v1.1.0": {
+      "contains_changes": false
+    },
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.19": {
+      "contains_changes": false
+    },
+    "v0.21.18": {
+      "contains_changes": false
+    },
+    "v0.21.17": {
+      "contains_changes": false
+    },
+    "v0.21.16": {
+      "contains_changes": false
+    },
+    "v0.21.15": {
+      "contains_changes": true
+    },
+    "v0.21.14": {
+      "contains_changes": true
+    },
     "v0.21.13": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/api-gateway-proxy-methods.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/api-gateway-proxy-methods.json
@@ -1,6 +1,42 @@
 {
   "module": "api-gateway-proxy-methods",
   "releases": {
+    "v1.1.0": {
+      "contains_changes": false
+    },
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": true
+    },
+    "v0.21.19": {
+      "contains_changes": false
+    },
+    "v0.21.18": {
+      "contains_changes": false
+    },
+    "v0.21.17": {
+      "contains_changes": false
+    },
+    "v0.21.16": {
+      "contains_changes": false
+    },
+    "v0.21.15": {
+      "contains_changes": false
+    },
+    "v0.21.14": {
+      "contains_changes": false
+    },
     "v0.21.13": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/api-gateway-proxy.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/api-gateway-proxy.json
@@ -1,6 +1,42 @@
 {
   "module": "api-gateway-proxy",
   "releases": {
+    "v1.1.0": {
+      "contains_changes": false
+    },
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": true
+    },
+    "v0.21.19": {
+      "contains_changes": false
+    },
+    "v0.21.18": {
+      "contains_changes": true
+    },
+    "v0.21.17": {
+      "contains_changes": true
+    },
+    "v0.21.16": {
+      "contains_changes": false
+    },
+    "v0.21.15": {
+      "contains_changes": true
+    },
+    "v0.21.14": {
+      "contains_changes": true
+    },
     "v0.21.13": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/keep-warm.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/keep-warm.json
@@ -1,6 +1,42 @@
 {
   "module": "keep-warm",
   "releases": {
+    "v1.1.0": {
+      "contains_changes": true
+    },
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.19": {
+      "contains_changes": false
+    },
+    "v0.21.18": {
+      "contains_changes": false
+    },
+    "v0.21.17": {
+      "contains_changes": false
+    },
+    "v0.21.16": {
+      "contains_changes": true
+    },
+    "v0.21.15": {
+      "contains_changes": true
+    },
+    "v0.21.14": {
+      "contains_changes": true
+    },
     "v0.21.13": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/lambda-edge-log-group.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/lambda-edge-log-group.json
@@ -1,6 +1,42 @@
 {
   "module": "lambda-edge-log-group",
   "releases": {
+    "v1.1.0": {
+      "contains_changes": false
+    },
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": true
+    },
+    "v0.21.19": {
+      "contains_changes": false
+    },
+    "v0.21.18": {
+      "contains_changes": false
+    },
+    "v0.21.17": {
+      "contains_changes": false
+    },
+    "v0.21.16": {
+      "contains_changes": false
+    },
+    "v0.21.15": {
+      "contains_changes": true
+    },
+    "v0.21.14": {
+      "contains_changes": true
+    },
     "v0.21.13": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/lambda-edge-multi-region-log-groups.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/lambda-edge-multi-region-log-groups.json
@@ -1,6 +1,42 @@
 {
   "module": "lambda-edge-multi-region-log-groups",
   "releases": {
+    "v1.1.0": {
+      "contains_changes": false
+    },
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": true
+    },
+    "v0.22.0": {
+      "contains_changes": true
+    },
+    "v0.21.19": {
+      "contains_changes": false
+    },
+    "v0.21.18": {
+      "contains_changes": false
+    },
+    "v0.21.17": {
+      "contains_changes": false
+    },
+    "v0.21.16": {
+      "contains_changes": false
+    },
+    "v0.21.15": {
+      "contains_changes": true
+    },
+    "v0.21.14": {
+      "contains_changes": true
+    },
     "v0.21.13": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/lambda-edge.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/lambda-edge.json
@@ -1,6 +1,42 @@
 {
   "module": "lambda-edge",
   "releases": {
+    "v1.1.0": {
+      "contains_changes": true
+    },
+    "v1.0.2": {
+      "contains_changes": true
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": true
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": true
+    },
+    "v0.21.19": {
+      "contains_changes": false
+    },
+    "v0.21.18": {
+      "contains_changes": false
+    },
+    "v0.21.17": {
+      "contains_changes": false
+    },
+    "v0.21.16": {
+      "contains_changes": true
+    },
+    "v0.21.15": {
+      "contains_changes": true
+    },
+    "v0.21.14": {
+      "contains_changes": true
+    },
     "v0.21.13": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/lambda-function-url.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/lambda-function-url.json
@@ -1,0 +1,275 @@
+{
+  "module": "lambda-function-url",
+  "releases": {
+    "v1.1.0": {
+      "contains_changes": false
+    },
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": true
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": true
+    },
+    "v0.21.19": {
+      "contains_changes": false
+    },
+    "v0.21.18": {
+      "contains_changes": false
+    },
+    "v0.21.17": {
+      "contains_changes": false
+    },
+    "v0.21.16": {
+      "contains_changes": false
+    },
+    "v0.21.15": {
+      "contains_changes": false
+    },
+    "v0.21.14": {
+      "contains_changes": false
+    },
+    "v0.21.13": {
+      "contains_changes": false
+    },
+    "v0.21.12": {
+      "contains_changes": false
+    },
+    "v0.21.11": {
+      "contains_changes": false
+    },
+    "v0.21.10": {
+      "contains_changes": false
+    },
+    "v0.21.9": {
+      "contains_changes": false
+    },
+    "v0.21.8": {
+      "contains_changes": false
+    },
+    "v0.21.7": {
+      "contains_changes": false
+    },
+    "v0.21.6": {
+      "contains_changes": false
+    },
+    "v0.21.5": {
+      "contains_changes": false
+    },
+    "v0.21.4": {
+      "contains_changes": false
+    },
+    "v0.21.3": {
+      "contains_changes": false
+    },
+    "v0.21.2": {
+      "contains_changes": false
+    },
+    "v0.21.1": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.5": {
+      "contains_changes": false
+    },
+    "v0.20.4": {
+      "contains_changes": false
+    },
+    "v0.20.3": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.3": {
+      "contains_changes": false
+    },
+    "v0.19.2": {
+      "contains_changes": false
+    },
+    "v0.19.1": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.5": {
+      "contains_changes": false
+    },
+    "v0.18.4": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.3": {
+      "contains_changes": false
+    },
+    "v0.14.2": {
+      "contains_changes": false
+    },
+    "v0.14.1": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.3": {
+      "contains_changes": false
+    },
+    "v0.13.2": {
+      "contains_changes": false
+    },
+    "v0.13.1": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.2": {
+      "contains_changes": false
+    },
+    "v0.11.1": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
+    "v0.9.2": {
+      "contains_changes": false
+    },
+    "v0.9.1": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.7": {
+      "contains_changes": false
+    },
+    "v0.7.6": {
+      "contains_changes": false
+    },
+    "v0.7.5": {
+      "contains_changes": false
+    },
+    "v0.7.4": {
+      "contains_changes": false
+    },
+    "v0.7.3": {
+      "contains_changes": false
+    },
+    "v0.7.2": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.3": {
+      "contains_changes": false
+    },
+    "v0.2.2": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.1": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-lambda/lambda-http-api-gateway.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/lambda-http-api-gateway.json
@@ -1,6 +1,42 @@
 {
   "module": "lambda-http-api-gateway",
   "releases": {
+    "v1.1.0": {
+      "contains_changes": false
+    },
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": true
+    },
+    "v0.21.19": {
+      "contains_changes": true
+    },
+    "v0.21.18": {
+      "contains_changes": false
+    },
+    "v0.21.17": {
+      "contains_changes": true
+    },
+    "v0.21.16": {
+      "contains_changes": false
+    },
+    "v0.21.15": {
+      "contains_changes": true
+    },
+    "v0.21.14": {
+      "contains_changes": true
+    },
     "v0.21.13": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/lambda.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/lambda.json
@@ -1,6 +1,42 @@
 {
   "module": "lambda",
   "releases": {
+    "v1.1.0": {
+      "contains_changes": false
+    },
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": true
+    },
+    "v1.0.0": {
+      "contains_changes": true
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.19": {
+      "contains_changes": false
+    },
+    "v0.21.18": {
+      "contains_changes": false
+    },
+    "v0.21.17": {
+      "contains_changes": true
+    },
+    "v0.21.16": {
+      "contains_changes": false
+    },
+    "v0.21.15": {
+      "contains_changes": true
+    },
+    "v0.21.14": {
+      "contains_changes": true
+    },
     "v0.21.13": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/run-lambda-entrypoint.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/run-lambda-entrypoint.json
@@ -1,6 +1,42 @@
 {
   "module": "run-lambda-entrypoint",
   "releases": {
+    "v1.1.0": {
+      "contains_changes": false
+    },
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.19": {
+      "contains_changes": false
+    },
+    "v0.21.18": {
+      "contains_changes": false
+    },
+    "v0.21.17": {
+      "contains_changes": false
+    },
+    "v0.21.16": {
+      "contains_changes": false
+    },
+    "v0.21.15": {
+      "contains_changes": false
+    },
+    "v0.21.14": {
+      "contains_changes": false
+    },
     "v0.21.13": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-lambda/scheduled-lambda-job.json
+++ b/static/patcher-changelogs/terraform-aws-lambda/scheduled-lambda-job.json
@@ -1,6 +1,42 @@
 {
   "module": "scheduled-lambda-job",
   "releases": {
+    "v1.1.0": {
+      "contains_changes": false
+    },
+    "v1.0.2": {
+      "contains_changes": false
+    },
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.19": {
+      "contains_changes": false
+    },
+    "v0.21.18": {
+      "contains_changes": false
+    },
+    "v0.21.17": {
+      "contains_changes": false
+    },
+    "v0.21.16": {
+      "contains_changes": false
+    },
+    "v0.21.15": {
+      "contains_changes": true
+    },
+    "v0.21.14": {
+      "contains_changes": true
+    },
     "v0.21.13": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-load-balancer/acm-tls-certificate.json
+++ b/static/patcher-changelogs/terraform-aws-load-balancer/acm-tls-certificate.json
@@ -1,6 +1,72 @@
 {
   "module": "acm-tls-certificate",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.30.5": {
+      "contains_changes": false
+    },
+    "v0.30.4": {
+      "contains_changes": false
+    },
+    "v0.30.3": {
+      "contains_changes": false
+    },
+    "v0.30.2": {
+      "contains_changes": false
+    },
+    "v0.30.1": {
+      "contains_changes": false
+    },
+    "v0.30.0": {
+      "contains_changes": false
+    },
+    "v0.29.26": {
+      "contains_changes": false
+    },
+    "v0.29.25": {
+      "contains_changes": false
+    },
+    "v0.29.24": {
+      "contains_changes": false
+    },
+    "v0.29.23": {
+      "contains_changes": false
+    },
+    "v0.29.22": {
+      "contains_changes": false
+    },
+    "v0.29.21": {
+      "contains_changes": false
+    },
+    "v0.29.20": {
+      "contains_changes": true
+    },
+    "v0.29.19": {
+      "contains_changes": true
+    },
+    "v0.29.18": {
+      "contains_changes": true
+    },
+    "v0.29.17": {
+      "contains_changes": true
+    },
+    "v0.29.16": {
+      "contains_changes": true
+    },
+    "v0.29.15": {
+      "contains_changes": true
+    },
+    "v0.29.14": {
+      "contains_changes": true
+    },
+    "v0.29.13": {
+      "contains_changes": false
+    },
+    "v0.29.12": {
+      "contains_changes": false
+    },
     "v0.29.11": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-load-balancer/alb.json
+++ b/static/patcher-changelogs/terraform-aws-load-balancer/alb.json
@@ -1,6 +1,72 @@
 {
   "module": "alb",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.30.5": {
+      "contains_changes": true
+    },
+    "v0.30.4": {
+      "contains_changes": false
+    },
+    "v0.30.3": {
+      "contains_changes": false
+    },
+    "v0.30.2": {
+      "contains_changes": true
+    },
+    "v0.30.1": {
+      "contains_changes": false
+    },
+    "v0.30.0": {
+      "contains_changes": true
+    },
+    "v0.29.26": {
+      "contains_changes": true
+    },
+    "v0.29.25": {
+      "contains_changes": true
+    },
+    "v0.29.24": {
+      "contains_changes": false
+    },
+    "v0.29.23": {
+      "contains_changes": false
+    },
+    "v0.29.22": {
+      "contains_changes": false
+    },
+    "v0.29.21": {
+      "contains_changes": true
+    },
+    "v0.29.20": {
+      "contains_changes": false
+    },
+    "v0.29.19": {
+      "contains_changes": false
+    },
+    "v0.29.18": {
+      "contains_changes": false
+    },
+    "v0.29.17": {
+      "contains_changes": true
+    },
+    "v0.29.16": {
+      "contains_changes": true
+    },
+    "v0.29.15": {
+      "contains_changes": false
+    },
+    "v0.29.14": {
+      "contains_changes": true
+    },
+    "v0.29.13": {
+      "contains_changes": true
+    },
+    "v0.29.12": {
+      "contains_changes": true
+    },
     "v0.29.11": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-load-balancer/lb-listener-rules.json
+++ b/static/patcher-changelogs/terraform-aws-load-balancer/lb-listener-rules.json
@@ -1,6 +1,72 @@
 {
   "module": "lb-listener-rules",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.30.5": {
+      "contains_changes": false
+    },
+    "v0.30.4": {
+      "contains_changes": false
+    },
+    "v0.30.3": {
+      "contains_changes": true
+    },
+    "v0.30.2": {
+      "contains_changes": false
+    },
+    "v0.30.1": {
+      "contains_changes": false
+    },
+    "v0.30.0": {
+      "contains_changes": false
+    },
+    "v0.29.26": {
+      "contains_changes": false
+    },
+    "v0.29.25": {
+      "contains_changes": false
+    },
+    "v0.29.24": {
+      "contains_changes": true
+    },
+    "v0.29.23": {
+      "contains_changes": false
+    },
+    "v0.29.22": {
+      "contains_changes": true
+    },
+    "v0.29.21": {
+      "contains_changes": false
+    },
+    "v0.29.20": {
+      "contains_changes": false
+    },
+    "v0.29.19": {
+      "contains_changes": false
+    },
+    "v0.29.18": {
+      "contains_changes": false
+    },
+    "v0.29.17": {
+      "contains_changes": true
+    },
+    "v0.29.16": {
+      "contains_changes": true
+    },
+    "v0.29.15": {
+      "contains_changes": false
+    },
+    "v0.29.14": {
+      "contains_changes": true
+    },
+    "v0.29.13": {
+      "contains_changes": false
+    },
+    "v0.29.12": {
+      "contains_changes": true
+    },
     "v0.29.11": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-load-balancer/nlb.json
+++ b/static/patcher-changelogs/terraform-aws-load-balancer/nlb.json
@@ -1,6 +1,72 @@
 {
   "module": "nlb",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.30.5": {
+      "contains_changes": false
+    },
+    "v0.30.4": {
+      "contains_changes": false
+    },
+    "v0.30.3": {
+      "contains_changes": false
+    },
+    "v0.30.2": {
+      "contains_changes": false
+    },
+    "v0.30.1": {
+      "contains_changes": false
+    },
+    "v0.30.0": {
+      "contains_changes": false
+    },
+    "v0.29.26": {
+      "contains_changes": false
+    },
+    "v0.29.25": {
+      "contains_changes": false
+    },
+    "v0.29.24": {
+      "contains_changes": false
+    },
+    "v0.29.23": {
+      "contains_changes": false
+    },
+    "v0.29.22": {
+      "contains_changes": false
+    },
+    "v0.29.21": {
+      "contains_changes": false
+    },
+    "v0.29.20": {
+      "contains_changes": false
+    },
+    "v0.29.19": {
+      "contains_changes": false
+    },
+    "v0.29.18": {
+      "contains_changes": false
+    },
+    "v0.29.17": {
+      "contains_changes": false
+    },
+    "v0.29.16": {
+      "contains_changes": false
+    },
+    "v0.29.15": {
+      "contains_changes": false
+    },
+    "v0.29.14": {
+      "contains_changes": false
+    },
+    "v0.29.13": {
+      "contains_changes": false
+    },
+    "v0.29.12": {
+      "contains_changes": false
+    },
     "v0.29.11": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-messaging/kinesis-firehose.json
+++ b/static/patcher-changelogs/terraform-aws-messaging/kinesis-firehose.json
@@ -1,6 +1,18 @@
 {
   "module": "kinesis-firehose",
   "releases": {
+    "v0.13.0": {
+      "contains_changes": true
+    },
+    "v0.12.5": {
+      "contains_changes": false
+    },
+    "v0.12.4": {
+      "contains_changes": true
+    },
+    "v0.12.3": {
+      "contains_changes": true
+    },
     "v0.12.2": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-messaging/kinesis.json
+++ b/static/patcher-changelogs/terraform-aws-messaging/kinesis.json
@@ -1,6 +1,18 @@
 {
   "module": "kinesis",
   "releases": {
+    "v0.13.0": {
+      "contains_changes": true
+    },
+    "v0.12.5": {
+      "contains_changes": false
+    },
+    "v0.12.4": {
+      "contains_changes": true
+    },
+    "v0.12.3": {
+      "contains_changes": true
+    },
     "v0.12.2": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-messaging/msk.json
+++ b/static/patcher-changelogs/terraform-aws-messaging/msk.json
@@ -1,6 +1,18 @@
 {
   "module": "msk",
   "releases": {
+    "v0.13.0": {
+      "contains_changes": true
+    },
+    "v0.12.5": {
+      "contains_changes": false
+    },
+    "v0.12.4": {
+      "contains_changes": true
+    },
+    "v0.12.3": {
+      "contains_changes": true
+    },
     "v0.12.2": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-messaging/sns-sqs-connection.json
+++ b/static/patcher-changelogs/terraform-aws-messaging/sns-sqs-connection.json
@@ -1,6 +1,18 @@
 {
   "module": "sns-sqs-connection",
   "releases": {
+    "v0.13.0": {
+      "contains_changes": true
+    },
+    "v0.12.5": {
+      "contains_changes": false
+    },
+    "v0.12.4": {
+      "contains_changes": true
+    },
+    "v0.12.3": {
+      "contains_changes": true
+    },
     "v0.12.2": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-messaging/sns.json
+++ b/static/patcher-changelogs/terraform-aws-messaging/sns.json
@@ -1,6 +1,18 @@
 {
   "module": "sns",
   "releases": {
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.5": {
+      "contains_changes": true
+    },
+    "v0.12.4": {
+      "contains_changes": true
+    },
+    "v0.12.3": {
+      "contains_changes": true
+    },
     "v0.12.2": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-messaging/sqs-lambda-connection.json
+++ b/static/patcher-changelogs/terraform-aws-messaging/sqs-lambda-connection.json
@@ -1,6 +1,18 @@
 {
   "module": "sqs-lambda-connection",
   "releases": {
+    "v0.13.0": {
+      "contains_changes": true
+    },
+    "v0.12.5": {
+      "contains_changes": false
+    },
+    "v0.12.4": {
+      "contains_changes": true
+    },
+    "v0.12.3": {
+      "contains_changes": true
+    },
     "v0.12.2": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-messaging/sqs.json
+++ b/static/patcher-changelogs/terraform-aws-messaging/sqs.json
@@ -1,6 +1,18 @@
 {
   "module": "sqs",
   "releases": {
+    "v0.13.0": {
+      "contains_changes": true
+    },
+    "v0.12.5": {
+      "contains_changes": false
+    },
+    "v0.12.4": {
+      "contains_changes": true
+    },
+    "v0.12.3": {
+      "contains_changes": true
+    },
     "v0.12.2": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/agents/cloudwatch-agent.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/agents/cloudwatch-agent.json
@@ -1,6 +1,87 @@
 {
   "module": "agents/cloudwatch-agent",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": true
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": true
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": true
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": true
+    },
+    "v0.36.17": {
+      "contains_changes": true
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": true
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": false
+    },
+    "v0.36.5": {
+      "contains_changes": false
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/alb-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/alb-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/alb-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/alb-target-group-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/alb-target-group-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/alb-target-group-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": true
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/asg-cpu-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/asg-cpu-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/asg-cpu-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/asg-disk-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/asg-disk-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/asg-disk-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/asg-memory-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/asg-memory-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/asg-memory-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/ec2-cpu-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/ec2-cpu-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/ec2-cpu-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/ec2-disk-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/ec2-disk-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/ec2-disk-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": false
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/ec2-memory-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/ec2-memory-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/ec2-memory-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/ecs-cluster-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/ecs-cluster-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/ecs-cluster-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/ecs-service-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/ecs-service-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/ecs-service-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/ecs-service-with-alb-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/ecs-service-with-alb-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/ecs-service-with-alb-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": false
+    },
+    "v0.36.5": {
+      "contains_changes": false
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/elasticache-memcached-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/elasticache-memcached-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/elasticache-memcached-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/elasticache-redis-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/elasticache-redis-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/elasticache-redis-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/elasticsearch-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/elasticsearch-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/elasticsearch-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/elb-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/elb-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/elb-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/lambda-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/lambda-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/lambda-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": true
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/rds-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/rds-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/rds-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": true
+    },
+    "v0.36.19": {
+      "contains_changes": true
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/route53-health-check-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/route53-health-check-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/route53-health-check-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": true
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": true
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": true
+    },
+    "v0.36.8": {
+      "contains_changes": true
+    },
+    "v0.36.7": {
+      "contains_changes": true
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/scheduled-job-alarm.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/scheduled-job-alarm.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/scheduled-job-alarm",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/sns-to-slack.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/sns-to-slack.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/sns-to-slack",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": true
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/alarms/sqs-alarms.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/alarms/sqs-alarms.json
@@ -1,6 +1,87 @@
 {
   "module": "alarms/sqs-alarms",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/logs/cloudwatch-log-aggregation-iam-policy.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/logs/cloudwatch-log-aggregation-iam-policy.json
@@ -1,6 +1,87 @@
 {
   "module": "logs/cloudwatch-log-aggregation-iam-policy",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": true
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/logs/cloudwatch-logs-metric-filters.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/logs/cloudwatch-logs-metric-filters.json
@@ -1,6 +1,87 @@
 {
   "module": "logs/cloudwatch-logs-metric-filters",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": false
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/logs/load-balancer-access-logs.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/logs/load-balancer-access-logs.json
@@ -1,6 +1,87 @@
 {
   "module": "logs/load-balancer-access-logs",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": true
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": true
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": true
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/logs/log-filter-to-slack.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/logs/log-filter-to-slack.json
@@ -1,6 +1,87 @@
 {
   "module": "logs/log-filter-to-slack",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": true
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": true
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/logs/syslog.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/logs/syslog.json
@@ -1,6 +1,87 @@
 {
   "module": "logs/syslog",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": true
+    },
+    "v0.36.23": {
+      "contains_changes": true
+    },
+    "v0.36.22": {
+      "contains_changes": true
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": true
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": true
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": false
+    },
+    "v0.36.5": {
+      "contains_changes": false
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/metrics/cloudwatch-custom-metrics-iam-policy.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/metrics/cloudwatch-custom-metrics-iam-policy.json
@@ -1,6 +1,87 @@
 {
   "module": "metrics/cloudwatch-custom-metrics-iam-policy",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/metrics/cloudwatch-dashboard-metric-widget.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/metrics/cloudwatch-dashboard-metric-widget.json
@@ -1,6 +1,87 @@
 {
   "module": "metrics/cloudwatch-dashboard-metric-widget",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/metrics/cloudwatch-dashboard-text-widget.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/metrics/cloudwatch-dashboard-text-widget.json
@@ -1,6 +1,87 @@
 {
   "module": "metrics/cloudwatch-dashboard-text-widget",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-monitoring/metrics/cloudwatch-dashboard.json
+++ b/static/patcher-changelogs/terraform-aws-monitoring/metrics/cloudwatch-dashboard.json
@@ -1,6 +1,87 @@
 {
   "module": "metrics/cloudwatch-dashboard",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.36.29": {
+      "contains_changes": false
+    },
+    "v0.36.28": {
+      "contains_changes": false
+    },
+    "v0.36.27": {
+      "contains_changes": false
+    },
+    "v0.36.26": {
+      "contains_changes": false
+    },
+    "v0.36.25": {
+      "contains_changes": false
+    },
+    "v0.36.24": {
+      "contains_changes": false
+    },
+    "v0.36.23": {
+      "contains_changes": false
+    },
+    "v0.36.22": {
+      "contains_changes": false
+    },
+    "v0.36.21": {
+      "contains_changes": false
+    },
+    "v0.36.20": {
+      "contains_changes": false
+    },
+    "v0.36.19": {
+      "contains_changes": false
+    },
+    "v0.36.18": {
+      "contains_changes": false
+    },
+    "v0.36.17": {
+      "contains_changes": false
+    },
+    "v0.36.16": {
+      "contains_changes": false
+    },
+    "v0.36.15": {
+      "contains_changes": false
+    },
+    "v0.36.14": {
+      "contains_changes": false
+    },
+    "v0.36.13": {
+      "contains_changes": false
+    },
+    "v0.36.12": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": true
+    },
+    "v0.36.5": {
+      "contains_changes": true
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
     "v0.36.3": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-openvpn/backup-openvpn-pki.json
+++ b/static/patcher-changelogs/terraform-aws-openvpn/backup-openvpn-pki.json
@@ -1,6 +1,42 @@
 {
   "module": "backup-openvpn-pki",
   "releases": {
+    "v0.27.10": {
+      "contains_changes": false
+    },
+    "v0.27.9": {
+      "contains_changes": false
+    },
+    "v0.27.8": {
+      "contains_changes": false
+    },
+    "v0.27.7": {
+      "contains_changes": false
+    },
+    "v0.27.6": {
+      "contains_changes": false
+    },
+    "v0.27.5": {
+      "contains_changes": false
+    },
+    "v0.27.4": {
+      "contains_changes": false
+    },
+    "v0.27.3": {
+      "contains_changes": false
+    },
+    "v0.27.2": {
+      "contains_changes": false
+    },
+    "v0.27.1": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": false
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-openvpn/init-openvpn.json
+++ b/static/patcher-changelogs/terraform-aws-openvpn/init-openvpn.json
@@ -1,6 +1,42 @@
 {
   "module": "init-openvpn",
   "releases": {
+    "v0.27.10": {
+      "contains_changes": false
+    },
+    "v0.27.9": {
+      "contains_changes": false
+    },
+    "v0.27.8": {
+      "contains_changes": false
+    },
+    "v0.27.7": {
+      "contains_changes": false
+    },
+    "v0.27.6": {
+      "contains_changes": false
+    },
+    "v0.27.5": {
+      "contains_changes": false
+    },
+    "v0.27.4": {
+      "contains_changes": false
+    },
+    "v0.27.3": {
+      "contains_changes": false
+    },
+    "v0.27.2": {
+      "contains_changes": false
+    },
+    "v0.27.1": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": false
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-openvpn/install-openvpn.json
+++ b/static/patcher-changelogs/terraform-aws-openvpn/install-openvpn.json
@@ -1,6 +1,42 @@
 {
   "module": "install-openvpn",
   "releases": {
+    "v0.27.10": {
+      "contains_changes": false
+    },
+    "v0.27.9": {
+      "contains_changes": false
+    },
+    "v0.27.8": {
+      "contains_changes": false
+    },
+    "v0.27.7": {
+      "contains_changes": false
+    },
+    "v0.27.6": {
+      "contains_changes": false
+    },
+    "v0.27.5": {
+      "contains_changes": false
+    },
+    "v0.27.4": {
+      "contains_changes": true
+    },
+    "v0.27.3": {
+      "contains_changes": false
+    },
+    "v0.27.2": {
+      "contains_changes": false
+    },
+    "v0.27.1": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": false
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-openvpn/openvpn-admin.json
+++ b/static/patcher-changelogs/terraform-aws-openvpn/openvpn-admin.json
@@ -1,6 +1,42 @@
 {
   "module": "openvpn-admin",
   "releases": {
+    "v0.27.10": {
+      "contains_changes": false
+    },
+    "v0.27.9": {
+      "contains_changes": false
+    },
+    "v0.27.8": {
+      "contains_changes": true
+    },
+    "v0.27.7": {
+      "contains_changes": false
+    },
+    "v0.27.6": {
+      "contains_changes": true
+    },
+    "v0.27.5": {
+      "contains_changes": false
+    },
+    "v0.27.4": {
+      "contains_changes": false
+    },
+    "v0.27.3": {
+      "contains_changes": true
+    },
+    "v0.27.2": {
+      "contains_changes": false
+    },
+    "v0.27.1": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": false
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-openvpn/openvpn-server.json
+++ b/static/patcher-changelogs/terraform-aws-openvpn/openvpn-server.json
@@ -1,6 +1,42 @@
 {
   "module": "openvpn-server",
   "releases": {
+    "v0.27.10": {
+      "contains_changes": false
+    },
+    "v0.27.9": {
+      "contains_changes": false
+    },
+    "v0.27.8": {
+      "contains_changes": true
+    },
+    "v0.27.7": {
+      "contains_changes": true
+    },
+    "v0.27.6": {
+      "contains_changes": false
+    },
+    "v0.27.5": {
+      "contains_changes": false
+    },
+    "v0.27.4": {
+      "contains_changes": false
+    },
+    "v0.27.3": {
+      "contains_changes": true
+    },
+    "v0.27.2": {
+      "contains_changes": true
+    },
+    "v0.27.1": {
+      "contains_changes": true
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": true
+    },
     "v0.26.5": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-openvpn/start-openvpn-admin.json
+++ b/static/patcher-changelogs/terraform-aws-openvpn/start-openvpn-admin.json
@@ -1,6 +1,42 @@
 {
   "module": "start-openvpn-admin",
   "releases": {
+    "v0.27.10": {
+      "contains_changes": false
+    },
+    "v0.27.9": {
+      "contains_changes": false
+    },
+    "v0.27.8": {
+      "contains_changes": false
+    },
+    "v0.27.7": {
+      "contains_changes": false
+    },
+    "v0.27.6": {
+      "contains_changes": false
+    },
+    "v0.27.5": {
+      "contains_changes": false
+    },
+    "v0.27.4": {
+      "contains_changes": false
+    },
+    "v0.27.3": {
+      "contains_changes": true
+    },
+    "v0.27.2": {
+      "contains_changes": false
+    },
+    "v0.27.1": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": false
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/auto-update.json
+++ b/static/patcher-changelogs/terraform-aws-security/auto-update.json
@@ -1,6 +1,141 @@
 {
   "module": "auto-update",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": true
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": true
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": true
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": true
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/aws-auth.json
+++ b/static/patcher-changelogs/terraform-aws-security/aws-auth.json
@@ -1,6 +1,141 @@
 {
   "module": "aws-auth",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/aws-config-bucket.json
+++ b/static/patcher-changelogs/terraform-aws-security/aws-config-bucket.json
@@ -1,6 +1,141 @@
 {
   "module": "aws-config-bucket",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": true
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/aws-config-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-security/aws-config-multi-region.json
@@ -1,6 +1,141 @@
 {
   "module": "aws-config-multi-region",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": true
+    },
+    "v0.75.16": {
+      "contains_changes": true
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": true
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": true
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": true
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": true
+    },
+    "v0.74.0": {
+      "contains_changes": true
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": true
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": true
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": true
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/aws-config-rules.json
+++ b/static/patcher-changelogs/terraform-aws-security/aws-config-rules.json
@@ -1,6 +1,141 @@
 {
   "module": "aws-config-rules",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": true
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/aws-config.json
+++ b/static/patcher-changelogs/terraform-aws-security/aws-config.json
@@ -1,6 +1,141 @@
 {
   "module": "aws-config",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": true
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": true
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": true
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": true
+    },
+    "v0.74.1": {
+      "contains_changes": true
+    },
+    "v0.74.0": {
+      "contains_changes": true
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": true
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": true
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/aws-organizations.json
+++ b/static/patcher-changelogs/terraform-aws-security/aws-organizations.json
@@ -1,6 +1,141 @@
 {
   "module": "aws-organizations",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": true
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": true
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/cloudtrail-bucket.json
+++ b/static/patcher-changelogs/terraform-aws-security/cloudtrail-bucket.json
@@ -1,6 +1,141 @@
 {
   "module": "cloudtrail-bucket",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/cloudtrail.json
+++ b/static/patcher-changelogs/terraform-aws-security/cloudtrail.json
@@ -1,6 +1,141 @@
 {
   "module": "cloudtrail",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": true
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": true
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/cross-account-iam-roles.json
+++ b/static/patcher-changelogs/terraform-aws-security/cross-account-iam-roles.json
@@ -1,6 +1,141 @@
 {
   "module": "cross-account-iam-roles",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-security/custom-iam-entity.json
+++ b/static/patcher-changelogs/terraform-aws-security/custom-iam-entity.json
@@ -1,6 +1,141 @@
 {
   "module": "custom-iam-entity",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": true
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-security/ebs-encryption-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-security/ebs-encryption-multi-region.json
@@ -1,6 +1,141 @@
 {
   "module": "ebs-encryption-multi-region",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": true
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": true
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": true
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": true
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ebs-encryption.json
+++ b/static/patcher-changelogs/terraform-aws-security/ebs-encryption.json
@@ -1,6 +1,141 @@
 {
   "module": "ebs-encryption",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/fail2ban.json
+++ b/static/patcher-changelogs/terraform-aws-security/fail2ban.json
@@ -1,6 +1,141 @@
 {
   "module": "fail2ban",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": true
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": true
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": true
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": true
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/github-actions-iam-role.json
+++ b/static/patcher-changelogs/terraform-aws-security/github-actions-iam-role.json
@@ -1,6 +1,141 @@
 {
   "module": "github-actions-iam-role",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": true
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": true
+    },
+    "v0.70.1": {
+      "contains_changes": true
+    },
+    "v0.70.0": {
+      "contains_changes": true
+    },
+    "v0.69.3": {
+      "contains_changes": true
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-security/github-actions-openid-connect-provider.json
+++ b/static/patcher-changelogs/terraform-aws-security/github-actions-openid-connect-provider.json
@@ -1,0 +1,995 @@
+{
+  "module": "github-actions-openid-connect-provider",
+  "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": true
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": true
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": true
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
+    "v0.68.5": {
+      "contains_changes": false
+    },
+    "v0.68.4": {
+      "contains_changes": false
+    },
+    "v0.68.3": {
+      "contains_changes": false
+    },
+    "v0.68.2": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.10": {
+      "contains_changes": false
+    },
+    "v0.65.9": {
+      "contains_changes": false
+    },
+    "v0.65.8": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.1": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
+    "v0.62.5": {
+      "contains_changes": false
+    },
+    "v0.62.4": {
+      "contains_changes": false
+    },
+    "v0.62.3": {
+      "contains_changes": false
+    },
+    "v0.62.2": {
+      "contains_changes": false
+    },
+    "v0.62.1": {
+      "contains_changes": false
+    },
+    "v0.62.0": {
+      "contains_changes": false
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
+    "v0.61.0": {
+      "contains_changes": false
+    },
+    "v0.60.3": {
+      "contains_changes": false
+    },
+    "v0.60.2": {
+      "contains_changes": false
+    },
+    "v0.60.1": {
+      "contains_changes": false
+    },
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.4": {
+      "contains_changes": false
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.7": {
+      "contains_changes": false
+    },
+    "v0.53.6": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.4": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.5": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
+    "v0.48.0": {
+      "contains_changes": false
+    },
+    "v0.47.0": {
+      "contains_changes": false
+    },
+    "v0.46.8": {
+      "contains_changes": false
+    },
+    "v0.46.7": {
+      "contains_changes": false
+    },
+    "v0.46.6": {
+      "contains_changes": false
+    },
+    "v0.46.5": {
+      "contains_changes": false
+    },
+    "v0.46.4": {
+      "contains_changes": false
+    },
+    "v0.46.3": {
+      "contains_changes": false
+    },
+    "v0.46.2": {
+      "contains_changes": false
+    },
+    "v0.46.1": {
+      "contains_changes": false
+    },
+    "v0.46.0": {
+      "contains_changes": false
+    },
+    "v0.45.8": {
+      "contains_changes": false
+    },
+    "v0.45.7": {
+      "contains_changes": false
+    },
+    "v0.45.6": {
+      "contains_changes": false
+    },
+    "v0.45.5": {
+      "contains_changes": false
+    },
+    "v0.45.4": {
+      "contains_changes": false
+    },
+    "v0.45.3": {
+      "contains_changes": false
+    },
+    "v0.45.2": {
+      "contains_changes": false
+    },
+    "v0.45.1": {
+      "contains_changes": false
+    },
+    "v0.45.0": {
+      "contains_changes": false
+    },
+    "v0.44.10": {
+      "contains_changes": false
+    },
+    "v0.44.9": {
+      "contains_changes": false
+    },
+    "v0.44.8": {
+      "contains_changes": false
+    },
+    "v0.44.7": {
+      "contains_changes": false
+    },
+    "v0.44.6": {
+      "contains_changes": false
+    },
+    "v0.44.5": {
+      "contains_changes": false
+    },
+    "v0.44.4": {
+      "contains_changes": false
+    },
+    "v0.44.3": {
+      "contains_changes": false
+    },
+    "v0.44.2": {
+      "contains_changes": false
+    },
+    "v0.44.1": {
+      "contains_changes": false
+    },
+    "v0.44.0": {
+      "contains_changes": false
+    },
+    "v0.43.0": {
+      "contains_changes": false
+    },
+    "v0.42.0": {
+      "contains_changes": false
+    },
+    "v0.41.3": {
+      "contains_changes": false
+    },
+    "v0.41.2": {
+      "contains_changes": false
+    },
+    "v0.41.1": {
+      "contains_changes": false
+    },
+    "v0.41.0": {
+      "contains_changes": false
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.2": {
+      "contains_changes": false
+    },
+    "v0.39.1": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.4": {
+      "contains_changes": false
+    },
+    "v0.38.3": {
+      "contains_changes": false
+    },
+    "v0.38.2": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": false
+    },
+    "v0.36.5": {
+      "contains_changes": false
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
+    "v0.36.3": {
+      "contains_changes": false
+    },
+    "v0.36.2": {
+      "contains_changes": false
+    },
+    "v0.36.1": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34.5": {
+      "contains_changes": false
+    },
+    "v0.34.4": {
+      "contains_changes": false
+    },
+    "v0.34.3": {
+      "contains_changes": false
+    },
+    "v0.34.2": {
+      "contains_changes": false
+    },
+    "v0.34.1": {
+      "contains_changes": false
+    },
+    "v0.34.0": {
+      "contains_changes": false
+    },
+    "v0.33.2": {
+      "contains_changes": false
+    },
+    "v0.33.1": {
+      "contains_changes": false
+    },
+    "v0.33.0": {
+      "contains_changes": false
+    },
+    "v0.32.5": {
+      "contains_changes": false
+    },
+    "v0.32.4": {
+      "contains_changes": false
+    },
+    "v0.32.3": {
+      "contains_changes": false
+    },
+    "v0.32.2": {
+      "contains_changes": false
+    },
+    "v0.32.1": {
+      "contains_changes": false
+    },
+    "v0.32.0": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
+    "v0.30.0": {
+      "contains_changes": false
+    },
+    "v0.29.1": {
+      "contains_changes": false
+    },
+    "v0.29.0": {
+      "contains_changes": false
+    },
+    "v0.28.7": {
+      "contains_changes": false
+    },
+    "v0.28.6": {
+      "contains_changes": false
+    },
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.2": {
+      "contains_changes": false
+    },
+    "v0.27.1": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": false
+    },
+    "v0.26.1": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.1": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.1": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.4": {
+      "contains_changes": false
+    },
+    "v0.21.3": {
+      "contains_changes": false
+    },
+    "v0.21.2": {
+      "contains_changes": false
+    },
+    "v0.21.1": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.3": {
+      "contains_changes": false
+    },
+    "v0.19.2": {
+      "contains_changes": false
+    },
+    "v0.19.1": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.6": {
+      "contains_changes": false
+    },
+    "v0.18.5": {
+      "contains_changes": false
+    },
+    "v0.18.4": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.6": {
+      "contains_changes": false
+    },
+    "v0.16.5": {
+      "contains_changes": false
+    },
+    "v0.16.4": {
+      "contains_changes": false
+    },
+    "v0.16.3": {
+      "contains_changes": false
+    },
+    "v0.16.2": {
+      "contains_changes": false
+    },
+    "v0.16.1": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.8": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
+    "v0.15.6": {
+      "contains_changes": false
+    },
+    "v0.15.5": {
+      "contains_changes": false
+    },
+    "v0.15.4": {
+      "contains_changes": false
+    },
+    "v0.15.3": {
+      "contains_changes": false
+    },
+    "v0.15.2": {
+      "contains_changes": false
+    },
+    "v0.15.1": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.1": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.2": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.3": {
+      "contains_changes": false
+    },
+    "v0.7.2": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.6": {
+      "contains_changes": false
+    },
+    "v0.6.5": {
+      "contains_changes": false
+    },
+    "v0.6.4": {
+      "contains_changes": false
+    },
+    "v0.6.3": {
+      "contains_changes": false
+    },
+    "v0.6.2": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.4": {
+      "contains_changes": false
+    },
+    "v0.5.3": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.20": {
+      "contains_changes": false
+    },
+    "v0.4.19": {
+      "contains_changes": false
+    },
+    "v0.4.18": {
+      "contains_changes": false
+    },
+    "v0.4.17": {
+      "contains_changes": false
+    },
+    "v0.4.16": {
+      "contains_changes": false
+    },
+    "v0.4.15": {
+      "contains_changes": false
+    },
+    "v0.4.14": {
+      "contains_changes": false
+    },
+    "v0.4.13": {
+      "contains_changes": false
+    },
+    "v0.4.12": {
+      "contains_changes": false
+    },
+    "v0.4.11": {
+      "contains_changes": false
+    },
+    "v0.4.10": {
+      "contains_changes": false
+    },
+    "v0.4.9": {
+      "contains_changes": false
+    },
+    "v0.4.8": {
+      "contains_changes": false
+    },
+    "v0.4.7": {
+      "contains_changes": false
+    },
+    "v0.4.6": {
+      "contains_changes": false
+    },
+    "v0.4.5": {
+      "contains_changes": false
+    },
+    "v0.4.4": {
+      "contains_changes": false
+    },
+    "v0.4.3": {
+      "contains_changes": false
+    },
+    "v0.4.2": {
+      "contains_changes": false
+    },
+    "v0.4.1": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.2": {
+      "contains_changes": false
+    },
+    "v0.1.1": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    },
+    "v0.0.1": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-security/gitlab-pipelines-iam-role.json
+++ b/static/patcher-changelogs/terraform-aws-security/gitlab-pipelines-iam-role.json
@@ -1,0 +1,995 @@
+{
+  "module": "gitlab-pipelines-iam-role",
+  "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": true
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
+    "v0.68.5": {
+      "contains_changes": false
+    },
+    "v0.68.4": {
+      "contains_changes": false
+    },
+    "v0.68.3": {
+      "contains_changes": false
+    },
+    "v0.68.2": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.10": {
+      "contains_changes": false
+    },
+    "v0.65.9": {
+      "contains_changes": false
+    },
+    "v0.65.8": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.1": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
+    "v0.62.5": {
+      "contains_changes": false
+    },
+    "v0.62.4": {
+      "contains_changes": false
+    },
+    "v0.62.3": {
+      "contains_changes": false
+    },
+    "v0.62.2": {
+      "contains_changes": false
+    },
+    "v0.62.1": {
+      "contains_changes": false
+    },
+    "v0.62.0": {
+      "contains_changes": false
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
+    "v0.61.0": {
+      "contains_changes": false
+    },
+    "v0.60.3": {
+      "contains_changes": false
+    },
+    "v0.60.2": {
+      "contains_changes": false
+    },
+    "v0.60.1": {
+      "contains_changes": false
+    },
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.4": {
+      "contains_changes": false
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.7": {
+      "contains_changes": false
+    },
+    "v0.53.6": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.4": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.5": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
+    "v0.48.0": {
+      "contains_changes": false
+    },
+    "v0.47.0": {
+      "contains_changes": false
+    },
+    "v0.46.8": {
+      "contains_changes": false
+    },
+    "v0.46.7": {
+      "contains_changes": false
+    },
+    "v0.46.6": {
+      "contains_changes": false
+    },
+    "v0.46.5": {
+      "contains_changes": false
+    },
+    "v0.46.4": {
+      "contains_changes": false
+    },
+    "v0.46.3": {
+      "contains_changes": false
+    },
+    "v0.46.2": {
+      "contains_changes": false
+    },
+    "v0.46.1": {
+      "contains_changes": false
+    },
+    "v0.46.0": {
+      "contains_changes": false
+    },
+    "v0.45.8": {
+      "contains_changes": false
+    },
+    "v0.45.7": {
+      "contains_changes": false
+    },
+    "v0.45.6": {
+      "contains_changes": false
+    },
+    "v0.45.5": {
+      "contains_changes": false
+    },
+    "v0.45.4": {
+      "contains_changes": false
+    },
+    "v0.45.3": {
+      "contains_changes": false
+    },
+    "v0.45.2": {
+      "contains_changes": false
+    },
+    "v0.45.1": {
+      "contains_changes": false
+    },
+    "v0.45.0": {
+      "contains_changes": false
+    },
+    "v0.44.10": {
+      "contains_changes": false
+    },
+    "v0.44.9": {
+      "contains_changes": false
+    },
+    "v0.44.8": {
+      "contains_changes": false
+    },
+    "v0.44.7": {
+      "contains_changes": false
+    },
+    "v0.44.6": {
+      "contains_changes": false
+    },
+    "v0.44.5": {
+      "contains_changes": false
+    },
+    "v0.44.4": {
+      "contains_changes": false
+    },
+    "v0.44.3": {
+      "contains_changes": false
+    },
+    "v0.44.2": {
+      "contains_changes": false
+    },
+    "v0.44.1": {
+      "contains_changes": false
+    },
+    "v0.44.0": {
+      "contains_changes": false
+    },
+    "v0.43.0": {
+      "contains_changes": false
+    },
+    "v0.42.0": {
+      "contains_changes": false
+    },
+    "v0.41.3": {
+      "contains_changes": false
+    },
+    "v0.41.2": {
+      "contains_changes": false
+    },
+    "v0.41.1": {
+      "contains_changes": false
+    },
+    "v0.41.0": {
+      "contains_changes": false
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.2": {
+      "contains_changes": false
+    },
+    "v0.39.1": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.4": {
+      "contains_changes": false
+    },
+    "v0.38.3": {
+      "contains_changes": false
+    },
+    "v0.38.2": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": false
+    },
+    "v0.36.5": {
+      "contains_changes": false
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
+    "v0.36.3": {
+      "contains_changes": false
+    },
+    "v0.36.2": {
+      "contains_changes": false
+    },
+    "v0.36.1": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34.5": {
+      "contains_changes": false
+    },
+    "v0.34.4": {
+      "contains_changes": false
+    },
+    "v0.34.3": {
+      "contains_changes": false
+    },
+    "v0.34.2": {
+      "contains_changes": false
+    },
+    "v0.34.1": {
+      "contains_changes": false
+    },
+    "v0.34.0": {
+      "contains_changes": false
+    },
+    "v0.33.2": {
+      "contains_changes": false
+    },
+    "v0.33.1": {
+      "contains_changes": false
+    },
+    "v0.33.0": {
+      "contains_changes": false
+    },
+    "v0.32.5": {
+      "contains_changes": false
+    },
+    "v0.32.4": {
+      "contains_changes": false
+    },
+    "v0.32.3": {
+      "contains_changes": false
+    },
+    "v0.32.2": {
+      "contains_changes": false
+    },
+    "v0.32.1": {
+      "contains_changes": false
+    },
+    "v0.32.0": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
+    "v0.30.0": {
+      "contains_changes": false
+    },
+    "v0.29.1": {
+      "contains_changes": false
+    },
+    "v0.29.0": {
+      "contains_changes": false
+    },
+    "v0.28.7": {
+      "contains_changes": false
+    },
+    "v0.28.6": {
+      "contains_changes": false
+    },
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.2": {
+      "contains_changes": false
+    },
+    "v0.27.1": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": false
+    },
+    "v0.26.1": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.1": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.1": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.4": {
+      "contains_changes": false
+    },
+    "v0.21.3": {
+      "contains_changes": false
+    },
+    "v0.21.2": {
+      "contains_changes": false
+    },
+    "v0.21.1": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.3": {
+      "contains_changes": false
+    },
+    "v0.19.2": {
+      "contains_changes": false
+    },
+    "v0.19.1": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.6": {
+      "contains_changes": false
+    },
+    "v0.18.5": {
+      "contains_changes": false
+    },
+    "v0.18.4": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.6": {
+      "contains_changes": false
+    },
+    "v0.16.5": {
+      "contains_changes": false
+    },
+    "v0.16.4": {
+      "contains_changes": false
+    },
+    "v0.16.3": {
+      "contains_changes": false
+    },
+    "v0.16.2": {
+      "contains_changes": false
+    },
+    "v0.16.1": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.8": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
+    "v0.15.6": {
+      "contains_changes": false
+    },
+    "v0.15.5": {
+      "contains_changes": false
+    },
+    "v0.15.4": {
+      "contains_changes": false
+    },
+    "v0.15.3": {
+      "contains_changes": false
+    },
+    "v0.15.2": {
+      "contains_changes": false
+    },
+    "v0.15.1": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.1": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.2": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.3": {
+      "contains_changes": false
+    },
+    "v0.7.2": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.6": {
+      "contains_changes": false
+    },
+    "v0.6.5": {
+      "contains_changes": false
+    },
+    "v0.6.4": {
+      "contains_changes": false
+    },
+    "v0.6.3": {
+      "contains_changes": false
+    },
+    "v0.6.2": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.4": {
+      "contains_changes": false
+    },
+    "v0.5.3": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.20": {
+      "contains_changes": false
+    },
+    "v0.4.19": {
+      "contains_changes": false
+    },
+    "v0.4.18": {
+      "contains_changes": false
+    },
+    "v0.4.17": {
+      "contains_changes": false
+    },
+    "v0.4.16": {
+      "contains_changes": false
+    },
+    "v0.4.15": {
+      "contains_changes": false
+    },
+    "v0.4.14": {
+      "contains_changes": false
+    },
+    "v0.4.13": {
+      "contains_changes": false
+    },
+    "v0.4.12": {
+      "contains_changes": false
+    },
+    "v0.4.11": {
+      "contains_changes": false
+    },
+    "v0.4.10": {
+      "contains_changes": false
+    },
+    "v0.4.9": {
+      "contains_changes": false
+    },
+    "v0.4.8": {
+      "contains_changes": false
+    },
+    "v0.4.7": {
+      "contains_changes": false
+    },
+    "v0.4.6": {
+      "contains_changes": false
+    },
+    "v0.4.5": {
+      "contains_changes": false
+    },
+    "v0.4.4": {
+      "contains_changes": false
+    },
+    "v0.4.3": {
+      "contains_changes": false
+    },
+    "v0.4.2": {
+      "contains_changes": false
+    },
+    "v0.4.1": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.2": {
+      "contains_changes": false
+    },
+    "v0.1.1": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    },
+    "v0.0.1": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-security/gitlab-pipelines-openid-connect-provider.json
+++ b/static/patcher-changelogs/terraform-aws-security/gitlab-pipelines-openid-connect-provider.json
@@ -1,0 +1,995 @@
+{
+  "module": "gitlab-pipelines-openid-connect-provider",
+  "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": true
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": true
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": true
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
+    "v0.68.5": {
+      "contains_changes": false
+    },
+    "v0.68.4": {
+      "contains_changes": false
+    },
+    "v0.68.3": {
+      "contains_changes": false
+    },
+    "v0.68.2": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.10": {
+      "contains_changes": false
+    },
+    "v0.65.9": {
+      "contains_changes": false
+    },
+    "v0.65.8": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.1": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
+    "v0.62.5": {
+      "contains_changes": false
+    },
+    "v0.62.4": {
+      "contains_changes": false
+    },
+    "v0.62.3": {
+      "contains_changes": false
+    },
+    "v0.62.2": {
+      "contains_changes": false
+    },
+    "v0.62.1": {
+      "contains_changes": false
+    },
+    "v0.62.0": {
+      "contains_changes": false
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
+    "v0.61.0": {
+      "contains_changes": false
+    },
+    "v0.60.3": {
+      "contains_changes": false
+    },
+    "v0.60.2": {
+      "contains_changes": false
+    },
+    "v0.60.1": {
+      "contains_changes": false
+    },
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.4": {
+      "contains_changes": false
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.7": {
+      "contains_changes": false
+    },
+    "v0.53.6": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.4": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.5": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
+    "v0.48.0": {
+      "contains_changes": false
+    },
+    "v0.47.0": {
+      "contains_changes": false
+    },
+    "v0.46.8": {
+      "contains_changes": false
+    },
+    "v0.46.7": {
+      "contains_changes": false
+    },
+    "v0.46.6": {
+      "contains_changes": false
+    },
+    "v0.46.5": {
+      "contains_changes": false
+    },
+    "v0.46.4": {
+      "contains_changes": false
+    },
+    "v0.46.3": {
+      "contains_changes": false
+    },
+    "v0.46.2": {
+      "contains_changes": false
+    },
+    "v0.46.1": {
+      "contains_changes": false
+    },
+    "v0.46.0": {
+      "contains_changes": false
+    },
+    "v0.45.8": {
+      "contains_changes": false
+    },
+    "v0.45.7": {
+      "contains_changes": false
+    },
+    "v0.45.6": {
+      "contains_changes": false
+    },
+    "v0.45.5": {
+      "contains_changes": false
+    },
+    "v0.45.4": {
+      "contains_changes": false
+    },
+    "v0.45.3": {
+      "contains_changes": false
+    },
+    "v0.45.2": {
+      "contains_changes": false
+    },
+    "v0.45.1": {
+      "contains_changes": false
+    },
+    "v0.45.0": {
+      "contains_changes": false
+    },
+    "v0.44.10": {
+      "contains_changes": false
+    },
+    "v0.44.9": {
+      "contains_changes": false
+    },
+    "v0.44.8": {
+      "contains_changes": false
+    },
+    "v0.44.7": {
+      "contains_changes": false
+    },
+    "v0.44.6": {
+      "contains_changes": false
+    },
+    "v0.44.5": {
+      "contains_changes": false
+    },
+    "v0.44.4": {
+      "contains_changes": false
+    },
+    "v0.44.3": {
+      "contains_changes": false
+    },
+    "v0.44.2": {
+      "contains_changes": false
+    },
+    "v0.44.1": {
+      "contains_changes": false
+    },
+    "v0.44.0": {
+      "contains_changes": false
+    },
+    "v0.43.0": {
+      "contains_changes": false
+    },
+    "v0.42.0": {
+      "contains_changes": false
+    },
+    "v0.41.3": {
+      "contains_changes": false
+    },
+    "v0.41.2": {
+      "contains_changes": false
+    },
+    "v0.41.1": {
+      "contains_changes": false
+    },
+    "v0.41.0": {
+      "contains_changes": false
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.2": {
+      "contains_changes": false
+    },
+    "v0.39.1": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.4": {
+      "contains_changes": false
+    },
+    "v0.38.3": {
+      "contains_changes": false
+    },
+    "v0.38.2": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": false
+    },
+    "v0.36.5": {
+      "contains_changes": false
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
+    "v0.36.3": {
+      "contains_changes": false
+    },
+    "v0.36.2": {
+      "contains_changes": false
+    },
+    "v0.36.1": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34.5": {
+      "contains_changes": false
+    },
+    "v0.34.4": {
+      "contains_changes": false
+    },
+    "v0.34.3": {
+      "contains_changes": false
+    },
+    "v0.34.2": {
+      "contains_changes": false
+    },
+    "v0.34.1": {
+      "contains_changes": false
+    },
+    "v0.34.0": {
+      "contains_changes": false
+    },
+    "v0.33.2": {
+      "contains_changes": false
+    },
+    "v0.33.1": {
+      "contains_changes": false
+    },
+    "v0.33.0": {
+      "contains_changes": false
+    },
+    "v0.32.5": {
+      "contains_changes": false
+    },
+    "v0.32.4": {
+      "contains_changes": false
+    },
+    "v0.32.3": {
+      "contains_changes": false
+    },
+    "v0.32.2": {
+      "contains_changes": false
+    },
+    "v0.32.1": {
+      "contains_changes": false
+    },
+    "v0.32.0": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
+    "v0.30.0": {
+      "contains_changes": false
+    },
+    "v0.29.1": {
+      "contains_changes": false
+    },
+    "v0.29.0": {
+      "contains_changes": false
+    },
+    "v0.28.7": {
+      "contains_changes": false
+    },
+    "v0.28.6": {
+      "contains_changes": false
+    },
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.2": {
+      "contains_changes": false
+    },
+    "v0.27.1": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": false
+    },
+    "v0.26.1": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.1": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.1": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.4": {
+      "contains_changes": false
+    },
+    "v0.21.3": {
+      "contains_changes": false
+    },
+    "v0.21.2": {
+      "contains_changes": false
+    },
+    "v0.21.1": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.3": {
+      "contains_changes": false
+    },
+    "v0.19.2": {
+      "contains_changes": false
+    },
+    "v0.19.1": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.6": {
+      "contains_changes": false
+    },
+    "v0.18.5": {
+      "contains_changes": false
+    },
+    "v0.18.4": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.6": {
+      "contains_changes": false
+    },
+    "v0.16.5": {
+      "contains_changes": false
+    },
+    "v0.16.4": {
+      "contains_changes": false
+    },
+    "v0.16.3": {
+      "contains_changes": false
+    },
+    "v0.16.2": {
+      "contains_changes": false
+    },
+    "v0.16.1": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.8": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
+    "v0.15.6": {
+      "contains_changes": false
+    },
+    "v0.15.5": {
+      "contains_changes": false
+    },
+    "v0.15.4": {
+      "contains_changes": false
+    },
+    "v0.15.3": {
+      "contains_changes": false
+    },
+    "v0.15.2": {
+      "contains_changes": false
+    },
+    "v0.15.1": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.1": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.2": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.3": {
+      "contains_changes": false
+    },
+    "v0.7.2": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.6": {
+      "contains_changes": false
+    },
+    "v0.6.5": {
+      "contains_changes": false
+    },
+    "v0.6.4": {
+      "contains_changes": false
+    },
+    "v0.6.3": {
+      "contains_changes": false
+    },
+    "v0.6.2": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.4": {
+      "contains_changes": false
+    },
+    "v0.5.3": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.20": {
+      "contains_changes": false
+    },
+    "v0.4.19": {
+      "contains_changes": false
+    },
+    "v0.4.18": {
+      "contains_changes": false
+    },
+    "v0.4.17": {
+      "contains_changes": false
+    },
+    "v0.4.16": {
+      "contains_changes": false
+    },
+    "v0.4.15": {
+      "contains_changes": false
+    },
+    "v0.4.14": {
+      "contains_changes": false
+    },
+    "v0.4.13": {
+      "contains_changes": false
+    },
+    "v0.4.12": {
+      "contains_changes": false
+    },
+    "v0.4.11": {
+      "contains_changes": false
+    },
+    "v0.4.10": {
+      "contains_changes": false
+    },
+    "v0.4.9": {
+      "contains_changes": false
+    },
+    "v0.4.8": {
+      "contains_changes": false
+    },
+    "v0.4.7": {
+      "contains_changes": false
+    },
+    "v0.4.6": {
+      "contains_changes": false
+    },
+    "v0.4.5": {
+      "contains_changes": false
+    },
+    "v0.4.4": {
+      "contains_changes": false
+    },
+    "v0.4.3": {
+      "contains_changes": false
+    },
+    "v0.4.2": {
+      "contains_changes": false
+    },
+    "v0.4.1": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.2": {
+      "contains_changes": false
+    },
+    "v0.1.1": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    },
+    "v0.0.1": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-security/guardduty-bucket.json
+++ b/static/patcher-changelogs/terraform-aws-security/guardduty-bucket.json
@@ -1,0 +1,995 @@
+{
+  "module": "guardduty-bucket",
+  "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": true
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": true
+    },
+    "v0.71.2": {
+      "contains_changes": true
+    },
+    "v0.71.1": {
+      "contains_changes": true
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
+    "v0.68.5": {
+      "contains_changes": false
+    },
+    "v0.68.4": {
+      "contains_changes": false
+    },
+    "v0.68.3": {
+      "contains_changes": false
+    },
+    "v0.68.2": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.10": {
+      "contains_changes": false
+    },
+    "v0.67.9": {
+      "contains_changes": false
+    },
+    "v0.67.8": {
+      "contains_changes": false
+    },
+    "v0.67.7": {
+      "contains_changes": false
+    },
+    "v0.67.6": {
+      "contains_changes": false
+    },
+    "v0.67.5": {
+      "contains_changes": false
+    },
+    "v0.67.4": {
+      "contains_changes": false
+    },
+    "v0.67.3": {
+      "contains_changes": false
+    },
+    "v0.67.2": {
+      "contains_changes": false
+    },
+    "v0.67.1": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.10": {
+      "contains_changes": false
+    },
+    "v0.65.9": {
+      "contains_changes": false
+    },
+    "v0.65.8": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.1": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
+    "v0.62.5": {
+      "contains_changes": false
+    },
+    "v0.62.4": {
+      "contains_changes": false
+    },
+    "v0.62.3": {
+      "contains_changes": false
+    },
+    "v0.62.2": {
+      "contains_changes": false
+    },
+    "v0.62.1": {
+      "contains_changes": false
+    },
+    "v0.62.0": {
+      "contains_changes": false
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
+    "v0.61.0": {
+      "contains_changes": false
+    },
+    "v0.60.3": {
+      "contains_changes": false
+    },
+    "v0.60.2": {
+      "contains_changes": false
+    },
+    "v0.60.1": {
+      "contains_changes": false
+    },
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.3": {
+      "contains_changes": false
+    },
+    "v0.57.2": {
+      "contains_changes": false
+    },
+    "v0.57.1": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.4": {
+      "contains_changes": false
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.7": {
+      "contains_changes": false
+    },
+    "v0.53.6": {
+      "contains_changes": false
+    },
+    "v0.53.5": {
+      "contains_changes": false
+    },
+    "v0.53.4": {
+      "contains_changes": false
+    },
+    "v0.53.3": {
+      "contains_changes": false
+    },
+    "v0.53.2": {
+      "contains_changes": false
+    },
+    "v0.53.1": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.49.4": {
+      "contains_changes": false
+    },
+    "v0.49.3": {
+      "contains_changes": false
+    },
+    "v0.49.2": {
+      "contains_changes": false
+    },
+    "v0.49.1": {
+      "contains_changes": false
+    },
+    "v0.49.0": {
+      "contains_changes": false
+    },
+    "v0.48.5": {
+      "contains_changes": false
+    },
+    "v0.48.4": {
+      "contains_changes": false
+    },
+    "v0.48.3": {
+      "contains_changes": false
+    },
+    "v0.48.2": {
+      "contains_changes": false
+    },
+    "v0.48.1": {
+      "contains_changes": false
+    },
+    "v0.48.0": {
+      "contains_changes": false
+    },
+    "v0.47.0": {
+      "contains_changes": false
+    },
+    "v0.46.8": {
+      "contains_changes": false
+    },
+    "v0.46.7": {
+      "contains_changes": false
+    },
+    "v0.46.6": {
+      "contains_changes": false
+    },
+    "v0.46.5": {
+      "contains_changes": false
+    },
+    "v0.46.4": {
+      "contains_changes": false
+    },
+    "v0.46.3": {
+      "contains_changes": false
+    },
+    "v0.46.2": {
+      "contains_changes": false
+    },
+    "v0.46.1": {
+      "contains_changes": false
+    },
+    "v0.46.0": {
+      "contains_changes": false
+    },
+    "v0.45.8": {
+      "contains_changes": false
+    },
+    "v0.45.7": {
+      "contains_changes": false
+    },
+    "v0.45.6": {
+      "contains_changes": false
+    },
+    "v0.45.5": {
+      "contains_changes": false
+    },
+    "v0.45.4": {
+      "contains_changes": false
+    },
+    "v0.45.3": {
+      "contains_changes": false
+    },
+    "v0.45.2": {
+      "contains_changes": false
+    },
+    "v0.45.1": {
+      "contains_changes": false
+    },
+    "v0.45.0": {
+      "contains_changes": false
+    },
+    "v0.44.10": {
+      "contains_changes": false
+    },
+    "v0.44.9": {
+      "contains_changes": false
+    },
+    "v0.44.8": {
+      "contains_changes": false
+    },
+    "v0.44.7": {
+      "contains_changes": false
+    },
+    "v0.44.6": {
+      "contains_changes": false
+    },
+    "v0.44.5": {
+      "contains_changes": false
+    },
+    "v0.44.4": {
+      "contains_changes": false
+    },
+    "v0.44.3": {
+      "contains_changes": false
+    },
+    "v0.44.2": {
+      "contains_changes": false
+    },
+    "v0.44.1": {
+      "contains_changes": false
+    },
+    "v0.44.0": {
+      "contains_changes": false
+    },
+    "v0.43.0": {
+      "contains_changes": false
+    },
+    "v0.42.0": {
+      "contains_changes": false
+    },
+    "v0.41.3": {
+      "contains_changes": false
+    },
+    "v0.41.2": {
+      "contains_changes": false
+    },
+    "v0.41.1": {
+      "contains_changes": false
+    },
+    "v0.41.0": {
+      "contains_changes": false
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.2": {
+      "contains_changes": false
+    },
+    "v0.39.1": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.4": {
+      "contains_changes": false
+    },
+    "v0.38.3": {
+      "contains_changes": false
+    },
+    "v0.38.2": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.1": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.11": {
+      "contains_changes": false
+    },
+    "v0.36.10": {
+      "contains_changes": false
+    },
+    "v0.36.9": {
+      "contains_changes": false
+    },
+    "v0.36.8": {
+      "contains_changes": false
+    },
+    "v0.36.7": {
+      "contains_changes": false
+    },
+    "v0.36.6": {
+      "contains_changes": false
+    },
+    "v0.36.5": {
+      "contains_changes": false
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
+    "v0.36.3": {
+      "contains_changes": false
+    },
+    "v0.36.2": {
+      "contains_changes": false
+    },
+    "v0.36.1": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34.5": {
+      "contains_changes": false
+    },
+    "v0.34.4": {
+      "contains_changes": false
+    },
+    "v0.34.3": {
+      "contains_changes": false
+    },
+    "v0.34.2": {
+      "contains_changes": false
+    },
+    "v0.34.1": {
+      "contains_changes": false
+    },
+    "v0.34.0": {
+      "contains_changes": false
+    },
+    "v0.33.2": {
+      "contains_changes": false
+    },
+    "v0.33.1": {
+      "contains_changes": false
+    },
+    "v0.33.0": {
+      "contains_changes": false
+    },
+    "v0.32.5": {
+      "contains_changes": false
+    },
+    "v0.32.4": {
+      "contains_changes": false
+    },
+    "v0.32.3": {
+      "contains_changes": false
+    },
+    "v0.32.2": {
+      "contains_changes": false
+    },
+    "v0.32.1": {
+      "contains_changes": false
+    },
+    "v0.32.0": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
+    "v0.30.0": {
+      "contains_changes": false
+    },
+    "v0.29.1": {
+      "contains_changes": false
+    },
+    "v0.29.0": {
+      "contains_changes": false
+    },
+    "v0.28.7": {
+      "contains_changes": false
+    },
+    "v0.28.6": {
+      "contains_changes": false
+    },
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.2": {
+      "contains_changes": false
+    },
+    "v0.27.1": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": false
+    },
+    "v0.26.1": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.1": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.1": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.4": {
+      "contains_changes": false
+    },
+    "v0.21.3": {
+      "contains_changes": false
+    },
+    "v0.21.2": {
+      "contains_changes": false
+    },
+    "v0.21.1": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.3": {
+      "contains_changes": false
+    },
+    "v0.19.2": {
+      "contains_changes": false
+    },
+    "v0.19.1": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.6": {
+      "contains_changes": false
+    },
+    "v0.18.5": {
+      "contains_changes": false
+    },
+    "v0.18.4": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.6": {
+      "contains_changes": false
+    },
+    "v0.16.5": {
+      "contains_changes": false
+    },
+    "v0.16.4": {
+      "contains_changes": false
+    },
+    "v0.16.3": {
+      "contains_changes": false
+    },
+    "v0.16.2": {
+      "contains_changes": false
+    },
+    "v0.16.1": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.8": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
+    "v0.15.6": {
+      "contains_changes": false
+    },
+    "v0.15.5": {
+      "contains_changes": false
+    },
+    "v0.15.4": {
+      "contains_changes": false
+    },
+    "v0.15.3": {
+      "contains_changes": false
+    },
+    "v0.15.2": {
+      "contains_changes": false
+    },
+    "v0.15.1": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.1": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.2": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.3": {
+      "contains_changes": false
+    },
+    "v0.7.2": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.6": {
+      "contains_changes": false
+    },
+    "v0.6.5": {
+      "contains_changes": false
+    },
+    "v0.6.4": {
+      "contains_changes": false
+    },
+    "v0.6.3": {
+      "contains_changes": false
+    },
+    "v0.6.2": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.4": {
+      "contains_changes": false
+    },
+    "v0.5.3": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.20": {
+      "contains_changes": false
+    },
+    "v0.4.19": {
+      "contains_changes": false
+    },
+    "v0.4.18": {
+      "contains_changes": false
+    },
+    "v0.4.17": {
+      "contains_changes": false
+    },
+    "v0.4.16": {
+      "contains_changes": false
+    },
+    "v0.4.15": {
+      "contains_changes": false
+    },
+    "v0.4.14": {
+      "contains_changes": false
+    },
+    "v0.4.13": {
+      "contains_changes": false
+    },
+    "v0.4.12": {
+      "contains_changes": false
+    },
+    "v0.4.11": {
+      "contains_changes": false
+    },
+    "v0.4.10": {
+      "contains_changes": false
+    },
+    "v0.4.9": {
+      "contains_changes": false
+    },
+    "v0.4.8": {
+      "contains_changes": false
+    },
+    "v0.4.7": {
+      "contains_changes": false
+    },
+    "v0.4.6": {
+      "contains_changes": false
+    },
+    "v0.4.5": {
+      "contains_changes": false
+    },
+    "v0.4.4": {
+      "contains_changes": false
+    },
+    "v0.4.3": {
+      "contains_changes": false
+    },
+    "v0.4.2": {
+      "contains_changes": false
+    },
+    "v0.4.1": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.2": {
+      "contains_changes": false
+    },
+    "v0.1.1": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    },
+    "v0.0.1": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-security/guardduty-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-security/guardduty-multi-region.json
@@ -1,6 +1,141 @@
 {
   "module": "guardduty-multi-region",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": true
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": true
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": true
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": true
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": true
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": true
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/guardduty.json
+++ b/static/patcher-changelogs/terraform-aws-security/guardduty.json
@@ -1,6 +1,141 @@
 {
   "module": "guardduty",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": true
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": true
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": true
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": true
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/iam-access-analyzer-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-security/iam-access-analyzer-multi-region.json
@@ -1,6 +1,141 @@
 {
   "module": "iam-access-analyzer-multi-region",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": true
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": true
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": true
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": true
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/iam-groups.json
+++ b/static/patcher-changelogs/terraform-aws-security/iam-groups.json
@@ -1,6 +1,141 @@
 {
   "module": "iam-groups",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-security/iam-policies.json
+++ b/static/patcher-changelogs/terraform-aws-security/iam-policies.json
@@ -1,6 +1,141 @@
 {
   "module": "iam-policies",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-security/iam-user-password-policy.json
+++ b/static/patcher-changelogs/terraform-aws-security/iam-user-password-policy.json
@@ -1,6 +1,141 @@
 {
   "module": "iam-user-password-policy",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": true
+    },
+    "v0.74.2": {
+      "contains_changes": true
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/iam-users.json
+++ b/static/patcher-changelogs/terraform-aws-security/iam-users.json
@@ -1,6 +1,141 @@
 {
   "module": "iam-users",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": true
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": true
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": true
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ip-lockdown.json
+++ b/static/patcher-changelogs/terraform-aws-security/ip-lockdown.json
@@ -1,6 +1,141 @@
 {
   "module": "ip-lockdown",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/kms-cmk-replica.json
+++ b/static/patcher-changelogs/terraform-aws-security/kms-cmk-replica.json
@@ -1,6 +1,141 @@
 {
   "module": "kms-cmk-replica",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": true
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/kms-grant-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-security/kms-grant-multi-region.json
@@ -1,6 +1,141 @@
 {
   "module": "kms-grant-multi-region",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": true
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": true
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": true
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": true
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/kms-master-key-multi-region.json
+++ b/static/patcher-changelogs/terraform-aws-security/kms-master-key-multi-region.json
@@ -1,6 +1,141 @@
 {
   "module": "kms-master-key-multi-region",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": true
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": true
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": true
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": true
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/kms-master-key.json
+++ b/static/patcher-changelogs/terraform-aws-security/kms-master-key.json
@@ -1,6 +1,141 @@
 {
   "module": "kms-master-key",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": true
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": true
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ntp.json
+++ b/static/patcher-changelogs/terraform-aws-security/ntp.json
@@ -1,6 +1,141 @@
 {
   "module": "ntp",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": true
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/os-hardening.json
+++ b/static/patcher-changelogs/terraform-aws-security/os-hardening.json
@@ -1,6 +1,141 @@
 {
   "module": "os-hardening",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": true
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/private-s3-bucket.json
+++ b/static/patcher-changelogs/terraform-aws-security/private-s3-bucket.json
@@ -1,6 +1,141 @@
 {
   "module": "private-s3-bucket",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": true
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": true
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": true
+    },
+    "v0.74.5": {
+      "contains_changes": true
+    },
+    "v0.74.4": {
+      "contains_changes": true
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": true
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/saml-iam-roles.json
+++ b/static/patcher-changelogs/terraform-aws-security/saml-iam-roles.json
@@ -1,6 +1,141 @@
 {
   "module": "saml-iam-roles",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-security/secrets-manager-resource-policies.json
+++ b/static/patcher-changelogs/terraform-aws-security/secrets-manager-resource-policies.json
@@ -1,6 +1,141 @@
 {
   "module": "secrets-manager-resource-policies",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ssh-grunt-selinux-policy.json
+++ b/static/patcher-changelogs/terraform-aws-security/ssh-grunt-selinux-policy.json
@@ -1,6 +1,141 @@
 {
   "module": "ssh-grunt-selinux-policy",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ssh-grunt.json
+++ b/static/patcher-changelogs/terraform-aws-security/ssh-grunt.json
@@ -1,6 +1,141 @@
 {
   "module": "ssh-grunt",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": true
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": true
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ssh-iam.json
+++ b/static/patcher-changelogs/terraform-aws-security/ssh-iam.json
@@ -1,6 +1,141 @@
 {
   "module": "ssh-iam",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/ssm-healthchecks-iam-permissions.json
+++ b/static/patcher-changelogs/terraform-aws-security/ssm-healthchecks-iam-permissions.json
@@ -1,6 +1,141 @@
 {
   "module": "ssm-healthchecks-iam-permissions",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": false
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": true
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": true
+    },
+    "v0.69.1": {
+      "contains_changes": true
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-security/tls-cert-private.json
+++ b/static/patcher-changelogs/terraform-aws-security/tls-cert-private.json
@@ -1,6 +1,141 @@
 {
   "module": "tls-cert-private",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.75.18": {
+      "contains_changes": false
+    },
+    "v0.75.17": {
+      "contains_changes": false
+    },
+    "v0.75.16": {
+      "contains_changes": false
+    },
+    "v0.75.15": {
+      "contains_changes": false
+    },
+    "v0.75.14": {
+      "contains_changes": false
+    },
+    "v0.75.13": {
+      "contains_changes": false
+    },
+    "v0.75.12": {
+      "contains_changes": false
+    },
+    "v0.75.11": {
+      "contains_changes": false
+    },
+    "v0.75.10": {
+      "contains_changes": false
+    },
+    "v0.75.9": {
+      "contains_changes": false
+    },
+    "v0.75.8": {
+      "contains_changes": false
+    },
+    "v0.75.7": {
+      "contains_changes": false
+    },
+    "v0.75.6": {
+      "contains_changes": false
+    },
+    "v0.75.5": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.6": {
+      "contains_changes": false
+    },
+    "v0.74.5": {
+      "contains_changes": false
+    },
+    "v0.74.4": {
+      "contains_changes": false
+    },
+    "v0.74.3": {
+      "contains_changes": false
+    },
+    "v0.74.2": {
+      "contains_changes": true
+    },
+    "v0.74.1": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.6": {
+      "contains_changes": false
+    },
+    "v0.71.5": {
+      "contains_changes": false
+    },
+    "v0.71.4": {
+      "contains_changes": false
+    },
+    "v0.71.3": {
+      "contains_changes": false
+    },
+    "v0.71.2": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.3": {
+      "contains_changes": false
+    },
+    "v0.69.2": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
     "v0.69.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-server/attach-eni.json
+++ b/static/patcher-changelogs/terraform-aws-server/attach-eni.json
@@ -1,6 +1,51 @@
 {
   "module": "attach-eni",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.16.3": {
+      "contains_changes": false
+    },
+    "v0.16.2": {
+      "contains_changes": false
+    },
+    "v0.16.1": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.16": {
+      "contains_changes": false
+    },
+    "v0.15.15": {
+      "contains_changes": false
+    },
+    "v0.15.14": {
+      "contains_changes": false
+    },
+    "v0.15.13": {
+      "contains_changes": false
+    },
+    "v0.15.12": {
+      "contains_changes": false
+    },
+    "v0.15.11": {
+      "contains_changes": false
+    },
+    "v0.15.10": {
+      "contains_changes": false
+    },
+    "v0.15.9": {
+      "contains_changes": false
+    },
+    "v0.15.8": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
     "v0.15.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-server/disable-instance-metadata.json
+++ b/static/patcher-changelogs/terraform-aws-server/disable-instance-metadata.json
@@ -1,6 +1,51 @@
 {
   "module": "disable-instance-metadata",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.16.3": {
+      "contains_changes": false
+    },
+    "v0.16.2": {
+      "contains_changes": false
+    },
+    "v0.16.1": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.16": {
+      "contains_changes": false
+    },
+    "v0.15.15": {
+      "contains_changes": false
+    },
+    "v0.15.14": {
+      "contains_changes": false
+    },
+    "v0.15.13": {
+      "contains_changes": false
+    },
+    "v0.15.12": {
+      "contains_changes": false
+    },
+    "v0.15.11": {
+      "contains_changes": false
+    },
+    "v0.15.10": {
+      "contains_changes": false
+    },
+    "v0.15.9": {
+      "contains_changes": false
+    },
+    "v0.15.8": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
     "v0.15.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-server/ec2-backup.json
+++ b/static/patcher-changelogs/terraform-aws-server/ec2-backup.json
@@ -1,6 +1,51 @@
 {
   "module": "ec2-backup",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.16.3": {
+      "contains_changes": false
+    },
+    "v0.16.2": {
+      "contains_changes": false
+    },
+    "v0.16.1": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.16": {
+      "contains_changes": false
+    },
+    "v0.15.15": {
+      "contains_changes": false
+    },
+    "v0.15.14": {
+      "contains_changes": false
+    },
+    "v0.15.13": {
+      "contains_changes": false
+    },
+    "v0.15.12": {
+      "contains_changes": false
+    },
+    "v0.15.11": {
+      "contains_changes": false
+    },
+    "v0.15.10": {
+      "contains_changes": true
+    },
+    "v0.15.9": {
+      "contains_changes": true
+    },
+    "v0.15.8": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
     "v0.15.6": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-server/persistent-ebs-volume.json
+++ b/static/patcher-changelogs/terraform-aws-server/persistent-ebs-volume.json
@@ -1,6 +1,51 @@
 {
   "module": "persistent-ebs-volume",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.16.3": {
+      "contains_changes": false
+    },
+    "v0.16.2": {
+      "contains_changes": false
+    },
+    "v0.16.1": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.16": {
+      "contains_changes": false
+    },
+    "v0.15.15": {
+      "contains_changes": false
+    },
+    "v0.15.14": {
+      "contains_changes": false
+    },
+    "v0.15.13": {
+      "contains_changes": false
+    },
+    "v0.15.12": {
+      "contains_changes": false
+    },
+    "v0.15.11": {
+      "contains_changes": false
+    },
+    "v0.15.10": {
+      "contains_changes": false
+    },
+    "v0.15.9": {
+      "contains_changes": false
+    },
+    "v0.15.8": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
     "v0.15.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-server/require-instance-metadata-service-version.json
+++ b/static/patcher-changelogs/terraform-aws-server/require-instance-metadata-service-version.json
@@ -1,6 +1,51 @@
 {
   "module": "require-instance-metadata-service-version",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.16.3": {
+      "contains_changes": false
+    },
+    "v0.16.2": {
+      "contains_changes": false
+    },
+    "v0.16.1": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.16": {
+      "contains_changes": false
+    },
+    "v0.15.15": {
+      "contains_changes": false
+    },
+    "v0.15.14": {
+      "contains_changes": false
+    },
+    "v0.15.13": {
+      "contains_changes": false
+    },
+    "v0.15.12": {
+      "contains_changes": false
+    },
+    "v0.15.11": {
+      "contains_changes": false
+    },
+    "v0.15.10": {
+      "contains_changes": false
+    },
+    "v0.15.9": {
+      "contains_changes": false
+    },
+    "v0.15.8": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
     "v0.15.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-server/route53-helpers.json
+++ b/static/patcher-changelogs/terraform-aws-server/route53-helpers.json
@@ -1,6 +1,51 @@
 {
   "module": "route53-helpers",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.16.3": {
+      "contains_changes": false
+    },
+    "v0.16.2": {
+      "contains_changes": false
+    },
+    "v0.16.1": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.16": {
+      "contains_changes": false
+    },
+    "v0.15.15": {
+      "contains_changes": false
+    },
+    "v0.15.14": {
+      "contains_changes": false
+    },
+    "v0.15.13": {
+      "contains_changes": false
+    },
+    "v0.15.12": {
+      "contains_changes": false
+    },
+    "v0.15.11": {
+      "contains_changes": false
+    },
+    "v0.15.10": {
+      "contains_changes": false
+    },
+    "v0.15.9": {
+      "contains_changes": false
+    },
+    "v0.15.8": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
     "v0.15.6": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-server/single-server.json
+++ b/static/patcher-changelogs/terraform-aws-server/single-server.json
@@ -1,6 +1,51 @@
 {
   "module": "single-server",
   "releases": {
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.16.3": {
+      "contains_changes": false
+    },
+    "v0.16.2": {
+      "contains_changes": false
+    },
+    "v0.16.1": {
+      "contains_changes": true
+    },
+    "v0.16.0": {
+      "contains_changes": true
+    },
+    "v0.15.16": {
+      "contains_changes": false
+    },
+    "v0.15.15": {
+      "contains_changes": true
+    },
+    "v0.15.14": {
+      "contains_changes": true
+    },
+    "v0.15.13": {
+      "contains_changes": true
+    },
+    "v0.15.12": {
+      "contains_changes": true
+    },
+    "v0.15.11": {
+      "contains_changes": true
+    },
+    "v0.15.10": {
+      "contains_changes": true
+    },
+    "v0.15.9": {
+      "contains_changes": true
+    },
+    "v0.15.8": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": true
+    },
     "v0.15.6": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/base/ec2-baseline.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/base/ec2-baseline.json
@@ -1,6 +1,387 @@
 {
   "module": "base/ec2-baseline",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": true
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": true
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": true
+    },
+    "v0.118.16": {
+      "contains_changes": true
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": true
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": true
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": true
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": true
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/aurora.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/aurora.json
@@ -1,6 +1,387 @@
 {
   "module": "data-stores/aurora",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": true
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": true
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": true
+    },
+    "v0.112.12": {
+      "contains_changes": true
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": true
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": true
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": true
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": true
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/ecr-repos.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/ecr-repos.json
@@ -1,6 +1,387 @@
 {
   "module": "data-stores/ecr-repos",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": true
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": true
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": true
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/elasticsearch.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/elasticsearch.json
@@ -1,6 +1,387 @@
 {
   "module": "data-stores/elasticsearch",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/memcached.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/memcached.json
@@ -1,6 +1,387 @@
 {
   "module": "data-stores/memcached",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": true
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": true
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/rds-replica.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/rds-replica.json
@@ -1,6 +1,387 @@
 {
   "module": "data-stores/rds-replica",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": true
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": true
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": true
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/rds.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/rds.json
@@ -1,6 +1,387 @@
 {
   "module": "data-stores/rds",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": true
+    },
+    "v0.118.18": {
+      "contains_changes": true
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": true
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": true
+    },
+    "v0.118.11": {
+      "contains_changes": true
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": true
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": true
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": true
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": true
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": true
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": true
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": true
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": true
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": true
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/redis.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/redis.json
@@ -1,6 +1,387 @@
 {
   "module": "data-stores/redis",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": true
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": true
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/s3-bucket.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/data-stores/s3-bucket.json
@@ -1,6 +1,387 @@
 {
   "module": "data-stores/s3-bucket",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": true
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": true
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": true
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": true
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": true
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-app.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-app.json
@@ -1,6 +1,387 @@
 {
   "module": "landingzone/account-baseline-app",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": true
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": true
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": true
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": true
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": true
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": true
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": true
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": true
+    },
+    "v0.112.7": {
+      "contains_changes": true
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": true
+    },
+    "v0.111.1": {
+      "contains_changes": true
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": true
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": true
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": true
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": true
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-root.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-root.json
@@ -1,6 +1,387 @@
 {
   "module": "landingzone/account-baseline-root",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": true
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": true
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": true
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": true
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": true
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": true
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": true
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": true
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": true
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": true
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": true
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": true
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-security.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/account-baseline-security.json
@@ -1,6 +1,387 @@
 {
   "module": "landingzone/account-baseline-security",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": true
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": true
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": true
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": true
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": true
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": true
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": true
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": true
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": true
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": true
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": true
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": true
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/gruntwork-access.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/gruntwork-access.json
@@ -1,6 +1,387 @@
 {
   "module": "landingzone/gruntwork-access",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": false
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/iam-users-and-groups.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/landingzone/iam-users-and-groups.json
@@ -1,6 +1,387 @@
 {
   "module": "landingzone/iam-users-and-groups",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": true
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": true
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/bastion-host.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/bastion-host.json
@@ -1,6 +1,387 @@
 {
   "module": "mgmt/bastion-host",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": true
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/ecs-deploy-runner.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/ecs-deploy-runner.json
@@ -1,6 +1,387 @@
 {
   "module": "mgmt/ecs-deploy-runner",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": true
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": true
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/jenkins.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/jenkins.json
@@ -1,6 +1,387 @@
 {
   "module": "mgmt/jenkins",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": true
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": true
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": true
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": true
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": true
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": true
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": true
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": true
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": true
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": true
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": true
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": true
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/openvpn-server.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/openvpn-server.json
@@ -1,6 +1,387 @@
 {
   "module": "mgmt/openvpn-server",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": true
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": true
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": true
+    },
+    "v0.107.4": {
+      "contains_changes": true
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": true
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/tailscale-subnet-router-v2.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/tailscale-subnet-router-v2.json
@@ -1,0 +1,1454 @@
+{
+  "module": "mgmt/tailscale-subnet-router-v2",
+  "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": true
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": false
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
+    "v0.105.0": {
+      "contains_changes": false
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
+    "v0.104.16": {
+      "contains_changes": false
+    },
+    "v0.104.15": {
+      "contains_changes": false
+    },
+    "v0.104.14": {
+      "contains_changes": false
+    },
+    "v0.104.13": {
+      "contains_changes": false
+    },
+    "v0.104.12": {
+      "contains_changes": false
+    },
+    "v0.104.11": {
+      "contains_changes": false
+    },
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": false
+    },
+    "v0.104.8": {
+      "contains_changes": false
+    },
+    "v0.104.7": {
+      "contains_changes": false
+    },
+    "v0.104.6": {
+      "contains_changes": false
+    },
+    "v0.104.5": {
+      "contains_changes": false
+    },
+    "v0.104.4": {
+      "contains_changes": false
+    },
+    "v0.104.3": {
+      "contains_changes": false
+    },
+    "v0.104.2": {
+      "contains_changes": false
+    },
+    "v0.104.1": {
+      "contains_changes": false
+    },
+    "v0.104.0": {
+      "contains_changes": false
+    },
+    "v0.103.2": {
+      "contains_changes": false
+    },
+    "v0.103.1": {
+      "contains_changes": false
+    },
+    "v0.103.0": {
+      "contains_changes": false
+    },
+    "v0.102.16": {
+      "contains_changes": false
+    },
+    "v0.102.15": {
+      "contains_changes": false
+    },
+    "v0.102.14": {
+      "contains_changes": false
+    },
+    "v0.102.13": {
+      "contains_changes": false
+    },
+    "v0.102.12": {
+      "contains_changes": false
+    },
+    "v0.102.11": {
+      "contains_changes": false
+    },
+    "v0.102.10": {
+      "contains_changes": false
+    },
+    "v0.102.9": {
+      "contains_changes": false
+    },
+    "v0.102.8": {
+      "contains_changes": false
+    },
+    "v0.102.7": {
+      "contains_changes": false
+    },
+    "v0.102.6": {
+      "contains_changes": false
+    },
+    "v0.102.5": {
+      "contains_changes": false
+    },
+    "v0.102.4": {
+      "contains_changes": false
+    },
+    "v0.102.3": {
+      "contains_changes": false
+    },
+    "v0.102.2": {
+      "contains_changes": false
+    },
+    "v0.102.1": {
+      "contains_changes": false
+    },
+    "v0.102.0": {
+      "contains_changes": false
+    },
+    "v0.101.0": {
+      "contains_changes": false
+    },
+    "v0.100.6": {
+      "contains_changes": false
+    },
+    "v0.100.5": {
+      "contains_changes": false
+    },
+    "v0.100.4": {
+      "contains_changes": false
+    },
+    "v0.100.3": {
+      "contains_changes": false
+    },
+    "v0.100.2": {
+      "contains_changes": false
+    },
+    "v0.100.1": {
+      "contains_changes": false
+    },
+    "v0.100.0": {
+      "contains_changes": false
+    },
+    "v0.99.2": {
+      "contains_changes": false
+    },
+    "v0.99.1": {
+      "contains_changes": false
+    },
+    "v0.99.0": {
+      "contains_changes": false
+    },
+    "v0.98.0": {
+      "contains_changes": false
+    },
+    "v0.97.0": {
+      "contains_changes": false
+    },
+    "v0.96.9": {
+      "contains_changes": false
+    },
+    "v0.96.8": {
+      "contains_changes": false
+    },
+    "v0.96.7": {
+      "contains_changes": false
+    },
+    "v0.96.6": {
+      "contains_changes": false
+    },
+    "v0.96.5": {
+      "contains_changes": false
+    },
+    "v0.96.4": {
+      "contains_changes": false
+    },
+    "v0.96.3": {
+      "contains_changes": false
+    },
+    "v0.96.2": {
+      "contains_changes": false
+    },
+    "v0.96.1": {
+      "contains_changes": false
+    },
+    "v0.96.0": {
+      "contains_changes": false
+    },
+    "v0.95.1": {
+      "contains_changes": false
+    },
+    "v0.95.0": {
+      "contains_changes": false
+    },
+    "v0.94.2": {
+      "contains_changes": false
+    },
+    "v0.94.1": {
+      "contains_changes": false
+    },
+    "v0.94.0": {
+      "contains_changes": false
+    },
+    "v0.93.2": {
+      "contains_changes": false
+    },
+    "v0.93.1": {
+      "contains_changes": false
+    },
+    "v0.93.0": {
+      "contains_changes": false
+    },
+    "v0.92.1": {
+      "contains_changes": false
+    },
+    "v0.92.0": {
+      "contains_changes": false
+    },
+    "v0.91.0": {
+      "contains_changes": false
+    },
+    "v0.90.8": {
+      "contains_changes": false
+    },
+    "v0.90.7": {
+      "contains_changes": false
+    },
+    "v0.90.6": {
+      "contains_changes": false
+    },
+    "v0.90.5": {
+      "contains_changes": false
+    },
+    "v0.90.4": {
+      "contains_changes": false
+    },
+    "v0.90.3": {
+      "contains_changes": false
+    },
+    "v0.90.2": {
+      "contains_changes": false
+    },
+    "v0.90.1": {
+      "contains_changes": false
+    },
+    "v0.90.0": {
+      "contains_changes": false
+    },
+    "v0.89.4": {
+      "contains_changes": false
+    },
+    "v0.89.3": {
+      "contains_changes": false
+    },
+    "v0.89.2": {
+      "contains_changes": false
+    },
+    "v0.89.1": {
+      "contains_changes": false
+    },
+    "v0.89.0": {
+      "contains_changes": false
+    },
+    "v0.88.2": {
+      "contains_changes": false
+    },
+    "v0.88.1": {
+      "contains_changes": false
+    },
+    "v0.88.0": {
+      "contains_changes": false
+    },
+    "v0.87.0": {
+      "contains_changes": false
+    },
+    "v0.86.2": {
+      "contains_changes": false
+    },
+    "v0.86.1": {
+      "contains_changes": false
+    },
+    "v0.86.0": {
+      "contains_changes": false
+    },
+    "v0.85.11": {
+      "contains_changes": false
+    },
+    "v0.85.10": {
+      "contains_changes": false
+    },
+    "v0.85.9": {
+      "contains_changes": false
+    },
+    "v0.85.8": {
+      "contains_changes": false
+    },
+    "v0.85.7": {
+      "contains_changes": false
+    },
+    "v0.85.6": {
+      "contains_changes": false
+    },
+    "v0.85.5": {
+      "contains_changes": false
+    },
+    "v0.85.4": {
+      "contains_changes": false
+    },
+    "v0.85.3": {
+      "contains_changes": false
+    },
+    "v0.85.2": {
+      "contains_changes": false
+    },
+    "v0.85.1": {
+      "contains_changes": false
+    },
+    "v0.85.0": {
+      "contains_changes": false
+    },
+    "v0.84.4": {
+      "contains_changes": false
+    },
+    "v0.84.3": {
+      "contains_changes": false
+    },
+    "v0.84.2": {
+      "contains_changes": false
+    },
+    "v0.84.1": {
+      "contains_changes": false
+    },
+    "v0.84.0": {
+      "contains_changes": false
+    },
+    "v0.83.0": {
+      "contains_changes": false
+    },
+    "v0.82.1": {
+      "contains_changes": false
+    },
+    "v0.82.0": {
+      "contains_changes": false
+    },
+    "v0.81.0": {
+      "contains_changes": false
+    },
+    "v0.80.3": {
+      "contains_changes": false
+    },
+    "v0.80.2": {
+      "contains_changes": false
+    },
+    "v0.80.1": {
+      "contains_changes": false
+    },
+    "v0.80.0": {
+      "contains_changes": false
+    },
+    "v0.79.1": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.8": {
+      "contains_changes": false
+    },
+    "v0.68.7": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
+    "v0.68.5": {
+      "contains_changes": false
+    },
+    "v0.68.4": {
+      "contains_changes": false
+    },
+    "v0.68.3": {
+      "contains_changes": false
+    },
+    "v0.68.2": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.4": {
+      "contains_changes": false
+    },
+    "v0.63.3": {
+      "contains_changes": false
+    },
+    "v0.63.2": {
+      "contains_changes": false
+    },
+    "v0.63.1": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
+    "v0.62.6": {
+      "contains_changes": false
+    },
+    "v0.62.5": {
+      "contains_changes": false
+    },
+    "v0.62.4": {
+      "contains_changes": false
+    },
+    "v0.62.3": {
+      "contains_changes": false
+    },
+    "v0.62.2": {
+      "contains_changes": false
+    },
+    "v0.62.1": {
+      "contains_changes": false
+    },
+    "v0.62.0": {
+      "contains_changes": false
+    },
+    "v0.61.2": {
+      "contains_changes": false
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
+    "v0.61.0": {
+      "contains_changes": false
+    },
+    "v0.60.2": {
+      "contains_changes": false
+    },
+    "v0.60.1": {
+      "contains_changes": false
+    },
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.5": {
+      "contains_changes": false
+    },
+    "v0.58.4": {
+      "contains_changes": false
+    },
+    "v0.58.3": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.2": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.4": {
+      "contains_changes": false
+    },
+    "v0.51.3": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.8": {
+      "contains_changes": false
+    },
+    "v0.50.7": {
+      "contains_changes": false
+    },
+    "v0.50.6": {
+      "contains_changes": false
+    },
+    "v0.50.5": {
+      "contains_changes": false
+    },
+    "v0.50.4": {
+      "contains_changes": false
+    },
+    "v0.50.3": {
+      "contains_changes": false
+    },
+    "v0.50.2": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.44.7": {
+      "contains_changes": false
+    },
+    "v0.44.6": {
+      "contains_changes": false
+    },
+    "v0.44.5": {
+      "contains_changes": false
+    },
+    "v0.44.4": {
+      "contains_changes": false
+    },
+    "v0.44.3": {
+      "contains_changes": false
+    },
+    "v0.44.2": {
+      "contains_changes": false
+    },
+    "v0.44.1": {
+      "contains_changes": false
+    },
+    "v0.44.0": {
+      "contains_changes": false
+    },
+    "v0.43.0": {
+      "contains_changes": false
+    },
+    "v0.42.1": {
+      "contains_changes": false
+    },
+    "v0.42.0": {
+      "contains_changes": false
+    },
+    "v0.41.4": {
+      "contains_changes": false
+    },
+    "v0.41.3": {
+      "contains_changes": false
+    },
+    "v0.41.2": {
+      "contains_changes": false
+    },
+    "v0.41.1": {
+      "contains_changes": false
+    },
+    "v0.41.0": {
+      "contains_changes": false
+    },
+    "v0.40.5": {
+      "contains_changes": false
+    },
+    "v0.40.4": {
+      "contains_changes": false
+    },
+    "v0.40.3": {
+      "contains_changes": false
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.5": {
+      "contains_changes": false
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
+    "v0.36.3": {
+      "contains_changes": false
+    },
+    "v0.36.2": {
+      "contains_changes": false
+    },
+    "v0.36.1": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.5": {
+      "contains_changes": false
+    },
+    "v0.35.4": {
+      "contains_changes": false
+    },
+    "v0.35.3": {
+      "contains_changes": false
+    },
+    "v0.35.2": {
+      "contains_changes": false
+    },
+    "v0.35.1": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34.2": {
+      "contains_changes": false
+    },
+    "v0.34.1": {
+      "contains_changes": false
+    },
+    "v0.34.0": {
+      "contains_changes": false
+    },
+    "v0.33.0": {
+      "contains_changes": false
+    },
+    "v0.32.0": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
+    "v0.30.0": {
+      "contains_changes": false
+    },
+    "v0.29.0": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.3": {
+      "contains_changes": false
+    },
+    "v0.27.2": {
+      "contains_changes": false
+    },
+    "v0.27.1": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.2": {
+      "contains_changes": false
+    },
+    "v0.24.1": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.6": {
+      "contains_changes": false
+    },
+    "v0.20.5": {
+      "contains_changes": false
+    },
+    "v0.20.4": {
+      "contains_changes": false
+    },
+    "v0.20.3": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.12": {
+      "contains_changes": false
+    },
+    "v0.18.11": {
+      "contains_changes": false
+    },
+    "v0.18.10": {
+      "contains_changes": false
+    },
+    "v0.18.9": {
+      "contains_changes": false
+    },
+    "v0.18.8": {
+      "contains_changes": false
+    },
+    "v0.18.7": {
+      "contains_changes": false
+    },
+    "v0.18.6": {
+      "contains_changes": false
+    },
+    "v0.18.5": {
+      "contains_changes": false
+    },
+    "v0.18.4": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.4": {
+      "contains_changes": false
+    },
+    "v0.15.3": {
+      "contains_changes": false
+    },
+    "v0.15.2": {
+      "contains_changes": false
+    },
+    "v0.15.1": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.1": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.1": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.2": {
+      "contains_changes": false
+    },
+    "v0.11.1": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
+    "v0.9.2": {
+      "contains_changes": false
+    },
+    "v0.9.1": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.2": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.4": {
+      "contains_changes": false
+    },
+    "v0.3.3": {
+      "contains_changes": false
+    },
+    "v0.3.2": {
+      "contains_changes": false
+    },
+    "v0.3.1": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.8": {
+      "contains_changes": false
+    },
+    "v0.2.7": {
+      "contains_changes": false
+    },
+    "v0.2.6": {
+      "contains_changes": false
+    },
+    "v0.2.5": {
+      "contains_changes": false
+    },
+    "v0.2.4": {
+      "contains_changes": false
+    },
+    "v0.2.3": {
+      "contains_changes": false
+    },
+    "v0.2.2": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.5": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/tailscale-subnet-router.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/mgmt/tailscale-subnet-router.json
@@ -1,6 +1,387 @@
 {
   "module": "mgmt/tailscale-subnet-router",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/alb.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/alb.json
@@ -1,6 +1,387 @@
 {
   "module": "networking/alb",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": true
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": true
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": true
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/route53.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/route53.json
@@ -1,6 +1,387 @@
 {
   "module": "networking/route53",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": true
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": true
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": false
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/sns-topics.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/sns-topics.json
@@ -1,6 +1,387 @@
 {
   "module": "networking/sns-topics",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/vpc-mgmt.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/vpc-mgmt.json
@@ -1,6 +1,387 @@
 {
   "module": "networking/vpc-mgmt",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": true
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": true
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": true
+    },
+    "v0.107.8": {
+      "contains_changes": true
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/networking/vpc.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/networking/vpc.json
@@ -1,6 +1,387 @@
 {
   "module": "networking/vpc",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": true
+    },
+    "v0.127.0": {
+      "contains_changes": true
+    },
+    "v0.126.0": {
+      "contains_changes": true
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": true
+    },
+    "v0.124.0": {
+      "contains_changes": true
+    },
+    "v0.123.0": {
+      "contains_changes": true
+    },
+    "v0.122.0": {
+      "contains_changes": true
+    },
+    "v0.121.3": {
+      "contains_changes": true
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": true
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": true
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": true
+    },
+    "v0.118.20": {
+      "contains_changes": true
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": true
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": true
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": true
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": true
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": true
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": true
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": true
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": true
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": true
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": true
+    },
+    "v0.110.2": {
+      "contains_changes": true
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": true
+    },
+    "v0.109.7": {
+      "contains_changes": true
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": true
+    },
+    "v0.109.4": {
+      "contains_changes": true
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": true
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": true
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": true
+    },
+    "v0.107.12": {
+      "contains_changes": true
+    },
+    "v0.107.11": {
+      "contains_changes": true
+    },
+    "v0.107.10": {
+      "contains_changes": true
+    },
+    "v0.107.9": {
+      "contains_changes": true
+    },
+    "v0.107.8": {
+      "contains_changes": true
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": true
+    },
+    "v0.107.2": {
+      "contains_changes": true
+    },
+    "v0.107.1": {
+      "contains_changes": true
+    },
+    "v0.107.0": {
+      "contains_changes": true
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/asg-service.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/asg-service.json
@@ -1,6 +1,387 @@
 {
   "module": "services/asg-service",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": true
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": true
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": true
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": true
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/ec2-instance.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/ec2-instance.json
@@ -1,6 +1,387 @@
 {
   "module": "services/ec2-instance",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": true
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": true
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": true
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": true
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": true
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-cluster.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-cluster.json
@@ -1,6 +1,387 @@
 {
   "module": "services/ecs-cluster",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": true
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": true
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": true
+    },
+    "v0.114.2": {
+      "contains_changes": true
+    },
+    "v0.114.1": {
+      "contains_changes": true
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": true
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": true
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": true
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": true
+    },
+    "v0.106.1": {
+      "contains_changes": true
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-fargate-cluster.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-fargate-cluster.json
@@ -1,6 +1,387 @@
 {
   "module": "services/ecs-fargate-cluster",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": false
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-service.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/ecs-service.json
@@ -1,6 +1,387 @@
 {
   "module": "services/ecs-service",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": true
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": true
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": true
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": true
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": true
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": true
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": true
+    },
+    "v0.109.1": {
+      "contains_changes": true
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": true
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": true
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": true
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-argocd.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-argocd.json
@@ -1,0 +1,1454 @@
+{
+  "module": "services/eks-argocd",
+  "releases": {
+    "v0.127.1": {
+      "contains_changes": true
+    },
+    "v0.127.0": {
+      "contains_changes": true
+    },
+    "v0.126.0": {
+      "contains_changes": true
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": true
+    },
+    "v0.123.0": {
+      "contains_changes": true
+    },
+    "v0.122.0": {
+      "contains_changes": true
+    },
+    "v0.121.3": {
+      "contains_changes": true
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": true
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": true
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": true
+    },
+    "v0.118.20": {
+      "contains_changes": true
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": true
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": true
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": true
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": true
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": true
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": true
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": true
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": true
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": true
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": true
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": true
+    },
+    "v0.107.2": {
+      "contains_changes": true
+    },
+    "v0.107.1": {
+      "contains_changes": true
+    },
+    "v0.107.0": {
+      "contains_changes": true
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
+    "v0.105.0": {
+      "contains_changes": false
+    },
+    "v0.104.19": {
+      "contains_changes": false
+    },
+    "v0.104.18": {
+      "contains_changes": false
+    },
+    "v0.104.17": {
+      "contains_changes": false
+    },
+    "v0.104.16": {
+      "contains_changes": false
+    },
+    "v0.104.15": {
+      "contains_changes": false
+    },
+    "v0.104.14": {
+      "contains_changes": false
+    },
+    "v0.104.13": {
+      "contains_changes": false
+    },
+    "v0.104.12": {
+      "contains_changes": false
+    },
+    "v0.104.11": {
+      "contains_changes": false
+    },
+    "v0.104.10": {
+      "contains_changes": false
+    },
+    "v0.104.9": {
+      "contains_changes": false
+    },
+    "v0.104.8": {
+      "contains_changes": false
+    },
+    "v0.104.7": {
+      "contains_changes": false
+    },
+    "v0.104.6": {
+      "contains_changes": false
+    },
+    "v0.104.5": {
+      "contains_changes": false
+    },
+    "v0.104.4": {
+      "contains_changes": false
+    },
+    "v0.104.3": {
+      "contains_changes": false
+    },
+    "v0.104.2": {
+      "contains_changes": false
+    },
+    "v0.104.1": {
+      "contains_changes": false
+    },
+    "v0.104.0": {
+      "contains_changes": false
+    },
+    "v0.103.2": {
+      "contains_changes": false
+    },
+    "v0.103.1": {
+      "contains_changes": false
+    },
+    "v0.103.0": {
+      "contains_changes": false
+    },
+    "v0.102.16": {
+      "contains_changes": false
+    },
+    "v0.102.15": {
+      "contains_changes": false
+    },
+    "v0.102.14": {
+      "contains_changes": false
+    },
+    "v0.102.13": {
+      "contains_changes": false
+    },
+    "v0.102.12": {
+      "contains_changes": false
+    },
+    "v0.102.11": {
+      "contains_changes": false
+    },
+    "v0.102.10": {
+      "contains_changes": false
+    },
+    "v0.102.9": {
+      "contains_changes": false
+    },
+    "v0.102.8": {
+      "contains_changes": false
+    },
+    "v0.102.7": {
+      "contains_changes": false
+    },
+    "v0.102.6": {
+      "contains_changes": false
+    },
+    "v0.102.5": {
+      "contains_changes": false
+    },
+    "v0.102.4": {
+      "contains_changes": false
+    },
+    "v0.102.3": {
+      "contains_changes": false
+    },
+    "v0.102.2": {
+      "contains_changes": false
+    },
+    "v0.102.1": {
+      "contains_changes": false
+    },
+    "v0.102.0": {
+      "contains_changes": false
+    },
+    "v0.101.0": {
+      "contains_changes": false
+    },
+    "v0.100.6": {
+      "contains_changes": false
+    },
+    "v0.100.5": {
+      "contains_changes": false
+    },
+    "v0.100.4": {
+      "contains_changes": false
+    },
+    "v0.100.3": {
+      "contains_changes": false
+    },
+    "v0.100.2": {
+      "contains_changes": false
+    },
+    "v0.100.1": {
+      "contains_changes": false
+    },
+    "v0.100.0": {
+      "contains_changes": false
+    },
+    "v0.99.2": {
+      "contains_changes": false
+    },
+    "v0.99.1": {
+      "contains_changes": false
+    },
+    "v0.99.0": {
+      "contains_changes": false
+    },
+    "v0.98.0": {
+      "contains_changes": false
+    },
+    "v0.97.0": {
+      "contains_changes": false
+    },
+    "v0.96.9": {
+      "contains_changes": false
+    },
+    "v0.96.8": {
+      "contains_changes": false
+    },
+    "v0.96.7": {
+      "contains_changes": false
+    },
+    "v0.96.6": {
+      "contains_changes": false
+    },
+    "v0.96.5": {
+      "contains_changes": false
+    },
+    "v0.96.4": {
+      "contains_changes": false
+    },
+    "v0.96.3": {
+      "contains_changes": false
+    },
+    "v0.96.2": {
+      "contains_changes": false
+    },
+    "v0.96.1": {
+      "contains_changes": false
+    },
+    "v0.96.0": {
+      "contains_changes": false
+    },
+    "v0.95.1": {
+      "contains_changes": false
+    },
+    "v0.95.0": {
+      "contains_changes": false
+    },
+    "v0.94.2": {
+      "contains_changes": false
+    },
+    "v0.94.1": {
+      "contains_changes": false
+    },
+    "v0.94.0": {
+      "contains_changes": false
+    },
+    "v0.93.2": {
+      "contains_changes": false
+    },
+    "v0.93.1": {
+      "contains_changes": false
+    },
+    "v0.93.0": {
+      "contains_changes": false
+    },
+    "v0.92.1": {
+      "contains_changes": false
+    },
+    "v0.92.0": {
+      "contains_changes": false
+    },
+    "v0.91.0": {
+      "contains_changes": false
+    },
+    "v0.90.8": {
+      "contains_changes": false
+    },
+    "v0.90.7": {
+      "contains_changes": false
+    },
+    "v0.90.6": {
+      "contains_changes": false
+    },
+    "v0.90.5": {
+      "contains_changes": false
+    },
+    "v0.90.4": {
+      "contains_changes": false
+    },
+    "v0.90.3": {
+      "contains_changes": false
+    },
+    "v0.90.2": {
+      "contains_changes": false
+    },
+    "v0.90.1": {
+      "contains_changes": false
+    },
+    "v0.90.0": {
+      "contains_changes": false
+    },
+    "v0.89.4": {
+      "contains_changes": false
+    },
+    "v0.89.3": {
+      "contains_changes": false
+    },
+    "v0.89.2": {
+      "contains_changes": false
+    },
+    "v0.89.1": {
+      "contains_changes": false
+    },
+    "v0.89.0": {
+      "contains_changes": false
+    },
+    "v0.88.2": {
+      "contains_changes": false
+    },
+    "v0.88.1": {
+      "contains_changes": false
+    },
+    "v0.88.0": {
+      "contains_changes": false
+    },
+    "v0.87.0": {
+      "contains_changes": false
+    },
+    "v0.86.2": {
+      "contains_changes": false
+    },
+    "v0.86.1": {
+      "contains_changes": false
+    },
+    "v0.86.0": {
+      "contains_changes": false
+    },
+    "v0.85.11": {
+      "contains_changes": false
+    },
+    "v0.85.10": {
+      "contains_changes": false
+    },
+    "v0.85.9": {
+      "contains_changes": false
+    },
+    "v0.85.8": {
+      "contains_changes": false
+    },
+    "v0.85.7": {
+      "contains_changes": false
+    },
+    "v0.85.6": {
+      "contains_changes": false
+    },
+    "v0.85.5": {
+      "contains_changes": false
+    },
+    "v0.85.4": {
+      "contains_changes": false
+    },
+    "v0.85.3": {
+      "contains_changes": false
+    },
+    "v0.85.2": {
+      "contains_changes": false
+    },
+    "v0.85.1": {
+      "contains_changes": false
+    },
+    "v0.85.0": {
+      "contains_changes": false
+    },
+    "v0.84.4": {
+      "contains_changes": false
+    },
+    "v0.84.3": {
+      "contains_changes": false
+    },
+    "v0.84.2": {
+      "contains_changes": false
+    },
+    "v0.84.1": {
+      "contains_changes": false
+    },
+    "v0.84.0": {
+      "contains_changes": false
+    },
+    "v0.83.0": {
+      "contains_changes": false
+    },
+    "v0.82.1": {
+      "contains_changes": false
+    },
+    "v0.82.0": {
+      "contains_changes": false
+    },
+    "v0.81.0": {
+      "contains_changes": false
+    },
+    "v0.80.3": {
+      "contains_changes": false
+    },
+    "v0.80.2": {
+      "contains_changes": false
+    },
+    "v0.80.1": {
+      "contains_changes": false
+    },
+    "v0.80.0": {
+      "contains_changes": false
+    },
+    "v0.79.1": {
+      "contains_changes": false
+    },
+    "v0.79.0": {
+      "contains_changes": false
+    },
+    "v0.78.1": {
+      "contains_changes": false
+    },
+    "v0.78.0": {
+      "contains_changes": false
+    },
+    "v0.77.1": {
+      "contains_changes": false
+    },
+    "v0.77.0": {
+      "contains_changes": false
+    },
+    "v0.76.0": {
+      "contains_changes": false
+    },
+    "v0.75.4": {
+      "contains_changes": false
+    },
+    "v0.75.3": {
+      "contains_changes": false
+    },
+    "v0.75.2": {
+      "contains_changes": false
+    },
+    "v0.75.1": {
+      "contains_changes": false
+    },
+    "v0.75.0": {
+      "contains_changes": false
+    },
+    "v0.74.0": {
+      "contains_changes": false
+    },
+    "v0.73.2": {
+      "contains_changes": false
+    },
+    "v0.73.1": {
+      "contains_changes": false
+    },
+    "v0.73.0": {
+      "contains_changes": false
+    },
+    "v0.72.1": {
+      "contains_changes": false
+    },
+    "v0.72.0": {
+      "contains_changes": false
+    },
+    "v0.71.1": {
+      "contains_changes": false
+    },
+    "v0.71.0": {
+      "contains_changes": false
+    },
+    "v0.70.2": {
+      "contains_changes": false
+    },
+    "v0.70.1": {
+      "contains_changes": false
+    },
+    "v0.70.0": {
+      "contains_changes": false
+    },
+    "v0.69.1": {
+      "contains_changes": false
+    },
+    "v0.69.0": {
+      "contains_changes": false
+    },
+    "v0.68.8": {
+      "contains_changes": false
+    },
+    "v0.68.7": {
+      "contains_changes": false
+    },
+    "v0.68.6": {
+      "contains_changes": false
+    },
+    "v0.68.5": {
+      "contains_changes": false
+    },
+    "v0.68.4": {
+      "contains_changes": false
+    },
+    "v0.68.3": {
+      "contains_changes": false
+    },
+    "v0.68.2": {
+      "contains_changes": false
+    },
+    "v0.68.1": {
+      "contains_changes": false
+    },
+    "v0.68.0": {
+      "contains_changes": false
+    },
+    "v0.67.0": {
+      "contains_changes": false
+    },
+    "v0.66.1": {
+      "contains_changes": false
+    },
+    "v0.66.0": {
+      "contains_changes": false
+    },
+    "v0.65.7": {
+      "contains_changes": false
+    },
+    "v0.65.6": {
+      "contains_changes": false
+    },
+    "v0.65.5": {
+      "contains_changes": false
+    },
+    "v0.65.4": {
+      "contains_changes": false
+    },
+    "v0.65.3": {
+      "contains_changes": false
+    },
+    "v0.65.2": {
+      "contains_changes": false
+    },
+    "v0.65.1": {
+      "contains_changes": false
+    },
+    "v0.65.0": {
+      "contains_changes": false
+    },
+    "v0.64.1": {
+      "contains_changes": false
+    },
+    "v0.64.0": {
+      "contains_changes": false
+    },
+    "v0.63.4": {
+      "contains_changes": false
+    },
+    "v0.63.3": {
+      "contains_changes": false
+    },
+    "v0.63.2": {
+      "contains_changes": false
+    },
+    "v0.63.1": {
+      "contains_changes": false
+    },
+    "v0.63.0": {
+      "contains_changes": false
+    },
+    "v0.62.6": {
+      "contains_changes": false
+    },
+    "v0.62.5": {
+      "contains_changes": false
+    },
+    "v0.62.4": {
+      "contains_changes": false
+    },
+    "v0.62.3": {
+      "contains_changes": false
+    },
+    "v0.62.2": {
+      "contains_changes": false
+    },
+    "v0.62.1": {
+      "contains_changes": false
+    },
+    "v0.62.0": {
+      "contains_changes": false
+    },
+    "v0.61.2": {
+      "contains_changes": false
+    },
+    "v0.61.1": {
+      "contains_changes": false
+    },
+    "v0.61.0": {
+      "contains_changes": false
+    },
+    "v0.60.2": {
+      "contains_changes": false
+    },
+    "v0.60.1": {
+      "contains_changes": false
+    },
+    "v0.60.0": {
+      "contains_changes": false
+    },
+    "v0.59.4": {
+      "contains_changes": false
+    },
+    "v0.59.3": {
+      "contains_changes": false
+    },
+    "v0.59.2": {
+      "contains_changes": false
+    },
+    "v0.59.1": {
+      "contains_changes": false
+    },
+    "v0.59.0": {
+      "contains_changes": false
+    },
+    "v0.58.5": {
+      "contains_changes": false
+    },
+    "v0.58.4": {
+      "contains_changes": false
+    },
+    "v0.58.3": {
+      "contains_changes": false
+    },
+    "v0.58.2": {
+      "contains_changes": false
+    },
+    "v0.58.1": {
+      "contains_changes": false
+    },
+    "v0.58.0": {
+      "contains_changes": false
+    },
+    "v0.57.0": {
+      "contains_changes": false
+    },
+    "v0.56.2": {
+      "contains_changes": false
+    },
+    "v0.56.1": {
+      "contains_changes": false
+    },
+    "v0.56.0": {
+      "contains_changes": false
+    },
+    "v0.55.3": {
+      "contains_changes": false
+    },
+    "v0.55.2": {
+      "contains_changes": false
+    },
+    "v0.55.1": {
+      "contains_changes": false
+    },
+    "v0.55.0": {
+      "contains_changes": false
+    },
+    "v0.54.0": {
+      "contains_changes": false
+    },
+    "v0.53.0": {
+      "contains_changes": false
+    },
+    "v0.52.0": {
+      "contains_changes": false
+    },
+    "v0.51.4": {
+      "contains_changes": false
+    },
+    "v0.51.3": {
+      "contains_changes": false
+    },
+    "v0.51.2": {
+      "contains_changes": false
+    },
+    "v0.51.1": {
+      "contains_changes": false
+    },
+    "v0.51.0": {
+      "contains_changes": false
+    },
+    "v0.50.8": {
+      "contains_changes": false
+    },
+    "v0.50.7": {
+      "contains_changes": false
+    },
+    "v0.50.6": {
+      "contains_changes": false
+    },
+    "v0.50.5": {
+      "contains_changes": false
+    },
+    "v0.50.4": {
+      "contains_changes": false
+    },
+    "v0.50.3": {
+      "contains_changes": false
+    },
+    "v0.50.2": {
+      "contains_changes": false
+    },
+    "v0.50.1": {
+      "contains_changes": false
+    },
+    "v0.50.0": {
+      "contains_changes": false
+    },
+    "v0.44.7": {
+      "contains_changes": false
+    },
+    "v0.44.6": {
+      "contains_changes": false
+    },
+    "v0.44.5": {
+      "contains_changes": false
+    },
+    "v0.44.4": {
+      "contains_changes": false
+    },
+    "v0.44.3": {
+      "contains_changes": false
+    },
+    "v0.44.2": {
+      "contains_changes": false
+    },
+    "v0.44.1": {
+      "contains_changes": false
+    },
+    "v0.44.0": {
+      "contains_changes": false
+    },
+    "v0.43.0": {
+      "contains_changes": false
+    },
+    "v0.42.1": {
+      "contains_changes": false
+    },
+    "v0.42.0": {
+      "contains_changes": false
+    },
+    "v0.41.4": {
+      "contains_changes": false
+    },
+    "v0.41.3": {
+      "contains_changes": false
+    },
+    "v0.41.2": {
+      "contains_changes": false
+    },
+    "v0.41.1": {
+      "contains_changes": false
+    },
+    "v0.41.0": {
+      "contains_changes": false
+    },
+    "v0.40.5": {
+      "contains_changes": false
+    },
+    "v0.40.4": {
+      "contains_changes": false
+    },
+    "v0.40.3": {
+      "contains_changes": false
+    },
+    "v0.40.2": {
+      "contains_changes": false
+    },
+    "v0.40.1": {
+      "contains_changes": false
+    },
+    "v0.40.0": {
+      "contains_changes": false
+    },
+    "v0.39.0": {
+      "contains_changes": false
+    },
+    "v0.38.1": {
+      "contains_changes": false
+    },
+    "v0.38.0": {
+      "contains_changes": false
+    },
+    "v0.37.0": {
+      "contains_changes": false
+    },
+    "v0.36.5": {
+      "contains_changes": false
+    },
+    "v0.36.4": {
+      "contains_changes": false
+    },
+    "v0.36.3": {
+      "contains_changes": false
+    },
+    "v0.36.2": {
+      "contains_changes": false
+    },
+    "v0.36.1": {
+      "contains_changes": false
+    },
+    "v0.36.0": {
+      "contains_changes": false
+    },
+    "v0.35.5": {
+      "contains_changes": false
+    },
+    "v0.35.4": {
+      "contains_changes": false
+    },
+    "v0.35.3": {
+      "contains_changes": false
+    },
+    "v0.35.2": {
+      "contains_changes": false
+    },
+    "v0.35.1": {
+      "contains_changes": false
+    },
+    "v0.35.0": {
+      "contains_changes": false
+    },
+    "v0.34.2": {
+      "contains_changes": false
+    },
+    "v0.34.1": {
+      "contains_changes": false
+    },
+    "v0.34.0": {
+      "contains_changes": false
+    },
+    "v0.33.0": {
+      "contains_changes": false
+    },
+    "v0.32.0": {
+      "contains_changes": false
+    },
+    "v0.31.0": {
+      "contains_changes": false
+    },
+    "v0.30.0": {
+      "contains_changes": false
+    },
+    "v0.29.0": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.3": {
+      "contains_changes": false
+    },
+    "v0.27.2": {
+      "contains_changes": false
+    },
+    "v0.27.1": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.2": {
+      "contains_changes": false
+    },
+    "v0.24.1": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.6": {
+      "contains_changes": false
+    },
+    "v0.20.5": {
+      "contains_changes": false
+    },
+    "v0.20.4": {
+      "contains_changes": false
+    },
+    "v0.20.3": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.12": {
+      "contains_changes": false
+    },
+    "v0.18.11": {
+      "contains_changes": false
+    },
+    "v0.18.10": {
+      "contains_changes": false
+    },
+    "v0.18.9": {
+      "contains_changes": false
+    },
+    "v0.18.8": {
+      "contains_changes": false
+    },
+    "v0.18.7": {
+      "contains_changes": false
+    },
+    "v0.18.6": {
+      "contains_changes": false
+    },
+    "v0.18.5": {
+      "contains_changes": false
+    },
+    "v0.18.4": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.4": {
+      "contains_changes": false
+    },
+    "v0.15.3": {
+      "contains_changes": false
+    },
+    "v0.15.2": {
+      "contains_changes": false
+    },
+    "v0.15.1": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.1": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.1": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.2": {
+      "contains_changes": false
+    },
+    "v0.11.1": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
+    "v0.9.2": {
+      "contains_changes": false
+    },
+    "v0.9.1": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.2": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.4": {
+      "contains_changes": false
+    },
+    "v0.3.3": {
+      "contains_changes": false
+    },
+    "v0.3.2": {
+      "contains_changes": false
+    },
+    "v0.3.1": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.8": {
+      "contains_changes": false
+    },
+    "v0.2.7": {
+      "contains_changes": false
+    },
+    "v0.2.6": {
+      "contains_changes": false
+    },
+    "v0.2.5": {
+      "contains_changes": false
+    },
+    "v0.2.4": {
+      "contains_changes": false
+    },
+    "v0.2.3": {
+      "contains_changes": false
+    },
+    "v0.2.2": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.5": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-cluster.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-cluster.json
@@ -1,6 +1,387 @@
 {
   "module": "services/eks-cluster",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": true
+    },
+    "v0.127.0": {
+      "contains_changes": true
+    },
+    "v0.126.0": {
+      "contains_changes": true
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": true
+    },
+    "v0.123.0": {
+      "contains_changes": true
+    },
+    "v0.122.0": {
+      "contains_changes": true
+    },
+    "v0.121.3": {
+      "contains_changes": true
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": true
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": true
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": true
+    },
+    "v0.118.20": {
+      "contains_changes": true
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": true
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": true
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": true
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": true
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": true
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": true
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": true
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": true
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": true
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": true
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": true
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": true
+    },
+    "v0.107.2": {
+      "contains_changes": true
+    },
+    "v0.107.1": {
+      "contains_changes": true
+    },
+    "v0.107.0": {
+      "contains_changes": true
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-core-services.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-core-services.json
@@ -1,6 +1,387 @@
 {
   "module": "services/eks-core-services",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": true
+    },
+    "v0.127.0": {
+      "contains_changes": true
+    },
+    "v0.126.0": {
+      "contains_changes": true
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": true
+    },
+    "v0.123.0": {
+      "contains_changes": true
+    },
+    "v0.122.0": {
+      "contains_changes": true
+    },
+    "v0.121.3": {
+      "contains_changes": true
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": true
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": true
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": true
+    },
+    "v0.118.20": {
+      "contains_changes": true
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": true
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": true
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": true
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": true
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": true
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": true
+    },
+    "v0.111.8": {
+      "contains_changes": true
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": true
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": true
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": true
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": true
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": true
+    },
+    "v0.107.2": {
+      "contains_changes": true
+    },
+    "v0.107.1": {
+      "contains_changes": true
+    },
+    "v0.107.0": {
+      "contains_changes": true
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-karpenter.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-karpenter.json
@@ -1,6 +1,387 @@
 {
   "module": "services/eks-karpenter",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": true
+    },
+    "v0.127.0": {
+      "contains_changes": true
+    },
+    "v0.126.0": {
+      "contains_changes": true
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": true
+    },
+    "v0.123.0": {
+      "contains_changes": true
+    },
+    "v0.122.0": {
+      "contains_changes": true
+    },
+    "v0.121.3": {
+      "contains_changes": true
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": true
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": true
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": true
+    },
+    "v0.118.20": {
+      "contains_changes": true
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": true
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": true
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": true
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": true
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": true
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": true
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": true
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": true
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": true
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": true
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": true
+    },
+    "v0.107.2": {
+      "contains_changes": true
+    },
+    "v0.107.1": {
+      "contains_changes": true
+    },
+    "v0.107.0": {
+      "contains_changes": true
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-workers.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/eks-workers.json
@@ -1,6 +1,387 @@
 {
   "module": "services/eks-workers",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": true
+    },
+    "v0.127.0": {
+      "contains_changes": true
+    },
+    "v0.126.0": {
+      "contains_changes": true
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": true
+    },
+    "v0.123.0": {
+      "contains_changes": true
+    },
+    "v0.122.0": {
+      "contains_changes": true
+    },
+    "v0.121.3": {
+      "contains_changes": true
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": true
+    },
+    "v0.121.0": {
+      "contains_changes": true
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": true
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": true
+    },
+    "v0.118.20": {
+      "contains_changes": true
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": true
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": true
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": true
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": true
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": true
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": true
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": true
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": true
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": true
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": true
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": true
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": true
+    },
+    "v0.107.2": {
+      "contains_changes": true
+    },
+    "v0.107.1": {
+      "contains_changes": true
+    },
+    "v0.107.0": {
+      "contains_changes": true
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/helm-service.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/helm-service.json
@@ -1,6 +1,387 @@
 {
   "module": "services/helm-service",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": true
+    },
+    "v0.127.0": {
+      "contains_changes": true
+    },
+    "v0.126.0": {
+      "contains_changes": true
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": true
+    },
+    "v0.123.0": {
+      "contains_changes": true
+    },
+    "v0.122.0": {
+      "contains_changes": true
+    },
+    "v0.121.3": {
+      "contains_changes": true
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": true
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": true
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": true
+    },
+    "v0.118.20": {
+      "contains_changes": true
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": true
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": true
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": true
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": true
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": true
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": true
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": true
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": true
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": true
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": true
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": true
+    },
+    "v0.107.2": {
+      "contains_changes": true
+    },
+    "v0.107.1": {
+      "contains_changes": true
+    },
+    "v0.107.0": {
+      "contains_changes": true
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/k8s-namespace.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/k8s-namespace.json
@@ -1,6 +1,387 @@
 {
   "module": "services/k8s-namespace",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": false
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/k8s-service.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/k8s-service.json
@@ -1,6 +1,387 @@
 {
   "module": "services/k8s-service",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": true
+    },
+    "v0.127.0": {
+      "contains_changes": true
+    },
+    "v0.126.0": {
+      "contains_changes": true
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": true
+    },
+    "v0.123.0": {
+      "contains_changes": true
+    },
+    "v0.122.0": {
+      "contains_changes": true
+    },
+    "v0.121.3": {
+      "contains_changes": true
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": true
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": true
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": true
+    },
+    "v0.118.20": {
+      "contains_changes": true
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": true
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": true
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": true
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": true
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": true
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": true
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": true
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": true
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": true
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": true
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": true
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": true
+    },
+    "v0.107.2": {
+      "contains_changes": true
+    },
+    "v0.107.1": {
+      "contains_changes": true
+    },
+    "v0.107.0": {
+      "contains_changes": true
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/lambda.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/lambda.json
@@ -1,6 +1,387 @@
 {
   "module": "services/lambda",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": true
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": true
+    },
+    "v0.112.3": {
+      "contains_changes": true
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": true
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": true
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/services/public-static-website.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/services/public-static-website.json
@@ -1,6 +1,387 @@
 {
   "module": "services/public-static-website",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": true
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": true
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": true
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": true
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/Dockerfile.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/Dockerfile.json
@@ -1,6 +1,387 @@
 {
   "module": "tls-scripts/Dockerfile",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": false
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/core-concepts.md.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/core-concepts.md.json
@@ -1,6 +1,387 @@
 {
   "module": "tls-scripts/core-concepts.md",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": false
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/create-tls-cert.sh.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/create-tls-cert.sh.json
@@ -1,6 +1,387 @@
 {
   "module": "tls-scripts/create-tls-cert.sh",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": false
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/docker-compose.yml.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/docker-compose.yml.json
@@ -1,6 +1,387 @@
 {
   "module": "tls-scripts/docker-compose.yml",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": false
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/download-rds-ca-certs.sh.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/download-rds-ca-certs.sh.json
@@ -1,6 +1,387 @@
 {
   "module": "tls-scripts/download-rds-ca-certs.sh",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": false
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/generate-trust-stores.sh.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/generate-trust-stores.sh.json
@@ -1,6 +1,387 @@
 {
   "module": "tls-scripts/generate-trust-stores.sh",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": false
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/helpers.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/helpers.json
@@ -1,6 +1,387 @@
 {
   "module": "tls-scripts/helpers",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": false
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/install.sh.json
+++ b/static/patcher-changelogs/terraform-aws-service-catalog/tls-scripts/install.sh.json
@@ -1,6 +1,387 @@
 {
   "module": "tls-scripts/install.sh",
   "releases": {
+    "v0.127.1": {
+      "contains_changes": false
+    },
+    "v0.127.0": {
+      "contains_changes": false
+    },
+    "v0.126.0": {
+      "contains_changes": false
+    },
+    "v0.125.5": {
+      "contains_changes": false
+    },
+    "v0.125.4": {
+      "contains_changes": false
+    },
+    "v0.125.3": {
+      "contains_changes": false
+    },
+    "v0.125.2": {
+      "contains_changes": false
+    },
+    "v0.125.1": {
+      "contains_changes": false
+    },
+    "v0.125.0": {
+      "contains_changes": false
+    },
+    "v0.124.0": {
+      "contains_changes": false
+    },
+    "v0.123.0": {
+      "contains_changes": false
+    },
+    "v0.122.0": {
+      "contains_changes": false
+    },
+    "v0.121.3": {
+      "contains_changes": false
+    },
+    "v0.121.2": {
+      "contains_changes": false
+    },
+    "v0.121.1": {
+      "contains_changes": false
+    },
+    "v0.121.0": {
+      "contains_changes": false
+    },
+    "v0.120.1": {
+      "contains_changes": false
+    },
+    "v0.120.0": {
+      "contains_changes": false
+    },
+    "v0.119.2": {
+      "contains_changes": false
+    },
+    "v0.119.1": {
+      "contains_changes": false
+    },
+    "v0.119.0": {
+      "contains_changes": false
+    },
+    "v0.118.22": {
+      "contains_changes": false
+    },
+    "v0.118.21": {
+      "contains_changes": false
+    },
+    "v0.118.20": {
+      "contains_changes": false
+    },
+    "v0.118.19": {
+      "contains_changes": false
+    },
+    "v0.118.18": {
+      "contains_changes": false
+    },
+    "v0.118.17": {
+      "contains_changes": false
+    },
+    "v0.118.16": {
+      "contains_changes": false
+    },
+    "v0.118.15": {
+      "contains_changes": false
+    },
+    "v0.118.14": {
+      "contains_changes": false
+    },
+    "v0.118.13": {
+      "contains_changes": false
+    },
+    "v0.118.12": {
+      "contains_changes": false
+    },
+    "v0.118.11": {
+      "contains_changes": false
+    },
+    "v0.118.10": {
+      "contains_changes": false
+    },
+    "v0.118.9": {
+      "contains_changes": false
+    },
+    "v0.118.8": {
+      "contains_changes": false
+    },
+    "v0.118.7": {
+      "contains_changes": false
+    },
+    "v0.118.6": {
+      "contains_changes": false
+    },
+    "v0.118.5": {
+      "contains_changes": false
+    },
+    "v0.118.4": {
+      "contains_changes": false
+    },
+    "v0.118.3": {
+      "contains_changes": false
+    },
+    "v0.118.2": {
+      "contains_changes": false
+    },
+    "v0.118.1": {
+      "contains_changes": false
+    },
+    "v0.118.0": {
+      "contains_changes": false
+    },
+    "v0.117.0": {
+      "contains_changes": false
+    },
+    "v0.116.1": {
+      "contains_changes": false
+    },
+    "v0.116.0": {
+      "contains_changes": false
+    },
+    "v0.115.6": {
+      "contains_changes": false
+    },
+    "v0.115.5": {
+      "contains_changes": false
+    },
+    "v0.115.4": {
+      "contains_changes": false
+    },
+    "v0.115.3": {
+      "contains_changes": false
+    },
+    "v0.115.2": {
+      "contains_changes": false
+    },
+    "v0.115.1": {
+      "contains_changes": false
+    },
+    "v0.115.0": {
+      "contains_changes": false
+    },
+    "v0.114.4": {
+      "contains_changes": false
+    },
+    "v0.114.3": {
+      "contains_changes": false
+    },
+    "v0.114.2": {
+      "contains_changes": false
+    },
+    "v0.114.1": {
+      "contains_changes": false
+    },
+    "v0.114.0": {
+      "contains_changes": false
+    },
+    "v0.113.0": {
+      "contains_changes": false
+    },
+    "v0.112.20": {
+      "contains_changes": false
+    },
+    "v0.112.19": {
+      "contains_changes": false
+    },
+    "v0.112.18": {
+      "contains_changes": false
+    },
+    "v0.112.17": {
+      "contains_changes": false
+    },
+    "v0.112.16": {
+      "contains_changes": false
+    },
+    "v0.112.15": {
+      "contains_changes": false
+    },
+    "v0.112.14": {
+      "contains_changes": false
+    },
+    "v0.112.13": {
+      "contains_changes": false
+    },
+    "v0.112.12": {
+      "contains_changes": false
+    },
+    "v0.112.11": {
+      "contains_changes": false
+    },
+    "v0.112.10": {
+      "contains_changes": false
+    },
+    "v0.112.9": {
+      "contains_changes": false
+    },
+    "v0.112.8": {
+      "contains_changes": false
+    },
+    "v0.112.7": {
+      "contains_changes": false
+    },
+    "v0.112.6": {
+      "contains_changes": false
+    },
+    "v0.112.5": {
+      "contains_changes": false
+    },
+    "v0.112.4": {
+      "contains_changes": false
+    },
+    "v0.112.3": {
+      "contains_changes": false
+    },
+    "v0.112.2": {
+      "contains_changes": false
+    },
+    "v0.112.1": {
+      "contains_changes": false
+    },
+    "v0.112.0": {
+      "contains_changes": false
+    },
+    "v0.111.8": {
+      "contains_changes": false
+    },
+    "v0.111.7": {
+      "contains_changes": false
+    },
+    "v0.111.6": {
+      "contains_changes": false
+    },
+    "v0.111.5": {
+      "contains_changes": false
+    },
+    "v0.111.4": {
+      "contains_changes": false
+    },
+    "v0.111.3": {
+      "contains_changes": false
+    },
+    "v0.111.2": {
+      "contains_changes": false
+    },
+    "v0.111.1": {
+      "contains_changes": false
+    },
+    "v0.111.0": {
+      "contains_changes": false
+    },
+    "v0.110.5": {
+      "contains_changes": false
+    },
+    "v0.110.4": {
+      "contains_changes": false
+    },
+    "v0.110.3": {
+      "contains_changes": false
+    },
+    "v0.110.2": {
+      "contains_changes": false
+    },
+    "v0.110.1": {
+      "contains_changes": false
+    },
+    "v0.110.0": {
+      "contains_changes": false
+    },
+    "v0.109.7": {
+      "contains_changes": false
+    },
+    "v0.109.6": {
+      "contains_changes": false
+    },
+    "v0.109.5": {
+      "contains_changes": false
+    },
+    "v0.109.4": {
+      "contains_changes": false
+    },
+    "v0.109.3": {
+      "contains_changes": false
+    },
+    "v0.109.2": {
+      "contains_changes": false
+    },
+    "v0.109.1": {
+      "contains_changes": false
+    },
+    "v0.109.0": {
+      "contains_changes": false
+    },
+    "v0.108.6": {
+      "contains_changes": false
+    },
+    "v0.108.5": {
+      "contains_changes": false
+    },
+    "v0.108.4": {
+      "contains_changes": false
+    },
+    "v0.108.3": {
+      "contains_changes": false
+    },
+    "v0.108.2": {
+      "contains_changes": false
+    },
+    "v0.108.1": {
+      "contains_changes": false
+    },
+    "v0.108.0": {
+      "contains_changes": false
+    },
+    "v0.107.12": {
+      "contains_changes": false
+    },
+    "v0.107.11": {
+      "contains_changes": false
+    },
+    "v0.107.10": {
+      "contains_changes": false
+    },
+    "v0.107.9": {
+      "contains_changes": false
+    },
+    "v0.107.8": {
+      "contains_changes": false
+    },
+    "v0.107.7": {
+      "contains_changes": false
+    },
+    "v0.107.6": {
+      "contains_changes": false
+    },
+    "v0.107.5": {
+      "contains_changes": false
+    },
+    "v0.107.4": {
+      "contains_changes": false
+    },
+    "v0.107.3": {
+      "contains_changes": false
+    },
+    "v0.107.2": {
+      "contains_changes": false
+    },
+    "v0.107.1": {
+      "contains_changes": false
+    },
+    "v0.107.0": {
+      "contains_changes": false
+    },
+    "v0.106.1": {
+      "contains_changes": false
+    },
+    "v0.106.0": {
+      "contains_changes": false
+    },
+    "v0.105.1": {
+      "contains_changes": false
+    },
     "v0.105.0": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-static-assets/cloudfront.json
+++ b/static/patcher-changelogs/terraform-aws-static-assets/cloudfront.json
@@ -1,0 +1,245 @@
+{
+  "module": "cloudfront",
+  "releases": {
+    "v1.0.1": {
+      "contains_changes": true
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.20.5": {
+      "contains_changes": false
+    },
+    "v0.20.4": {
+      "contains_changes": true
+    },
+    "v0.20.3": {
+      "contains_changes": true
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": true
+    },
+    "v0.20.0": {
+      "contains_changes": true
+    },
+    "v0.19.2": {
+      "contains_changes": false
+    },
+    "v0.19.1": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": true
+    },
+    "v0.18.5": {
+      "contains_changes": false
+    },
+    "v0.18.4": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.5": {
+      "contains_changes": false
+    },
+    "v0.17.4": {
+      "contains_changes": false
+    },
+    "v0.17.3": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.1": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.9": {
+      "contains_changes": false
+    },
+    "v0.15.8": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
+    "v0.15.6": {
+      "contains_changes": false
+    },
+    "v0.15.5": {
+      "contains_changes": false
+    },
+    "v0.15.4": {
+      "contains_changes": false
+    },
+    "v0.15.3": {
+      "contains_changes": false
+    },
+    "v0.15.2": {
+      "contains_changes": false
+    },
+    "v0.15.1": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.1": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.2": {
+      "contains_changes": false
+    },
+    "v0.13.1": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.3": {
+      "contains_changes": false
+    },
+    "v0.12.2": {
+      "contains_changes": false
+    },
+    "v0.12.1": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.1": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.5": {
+      "contains_changes": false
+    },
+    "v0.6.4": {
+      "contains_changes": false
+    },
+    "v0.6.3": {
+      "contains_changes": false
+    },
+    "v0.6.2": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.8": {
+      "contains_changes": false
+    },
+    "v0.5.7": {
+      "contains_changes": false
+    },
+    "v0.5.6": {
+      "contains_changes": false
+    },
+    "v0.5.5": {
+      "contains_changes": false
+    },
+    "v0.5.4": {
+      "contains_changes": false
+    },
+    "v0.5.3": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.4.4": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.3": {
+      "contains_changes": false
+    },
+    "v0.4.2": {
+      "contains_changes": false
+    },
+    "v0.4.1": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.4": {
+      "contains_changes": false
+    },
+    "v0.3.3": {
+      "contains_changes": false
+    },
+    "v0.3.2": {
+      "contains_changes": false
+    },
+    "v0.3.1": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-static-assets/s3-cloudfront.json
+++ b/static/patcher-changelogs/terraform-aws-static-assets/s3-cloudfront.json
@@ -1,6 +1,66 @@
 {
   "module": "s3-cloudfront",
   "releases": {
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.20.5": {
+      "contains_changes": false
+    },
+    "v0.20.4": {
+      "contains_changes": false
+    },
+    "v0.20.3": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.2": {
+      "contains_changes": false
+    },
+    "v0.19.1": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.5": {
+      "contains_changes": true
+    },
+    "v0.18.4": {
+      "contains_changes": true
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": true
+    },
+    "v0.18.1": {
+      "contains_changes": true
+    },
+    "v0.18.0": {
+      "contains_changes": true
+    },
+    "v0.17.5": {
+      "contains_changes": true
+    },
+    "v0.17.4": {
+      "contains_changes": true
+    },
+    "v0.17.3": {
+      "contains_changes": true
+    },
     "v0.17.2": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-static-assets/s3-static-website.json
+++ b/static/patcher-changelogs/terraform-aws-static-assets/s3-static-website.json
@@ -1,6 +1,66 @@
 {
   "module": "s3-static-website",
   "releases": {
+    "v1.0.1": {
+      "contains_changes": false
+    },
+    "v1.0.0": {
+      "contains_changes": false
+    },
+    "v0.20.5": {
+      "contains_changes": true
+    },
+    "v0.20.4": {
+      "contains_changes": false
+    },
+    "v0.20.3": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": true
+    },
+    "v0.20.1": {
+      "contains_changes": true
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.2": {
+      "contains_changes": false
+    },
+    "v0.19.1": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.5": {
+      "contains_changes": true
+    },
+    "v0.18.4": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": true
+    },
+    "v0.17.5": {
+      "contains_changes": false
+    },
+    "v0.17.4": {
+      "contains_changes": true
+    },
+    "v0.17.3": {
+      "contains_changes": true
+    },
     "v0.17.2": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/executable-dependency.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/executable-dependency.json
@@ -1,6 +1,33 @@
 {
   "module": "executable-dependency",
   "releases": {
+    "v0.10.6": {
+      "contains_changes": false
+    },
+    "v0.10.5": {
+      "contains_changes": true
+    },
+    "v0.10.4": {
+      "contains_changes": false
+    },
+    "v0.10.3": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.6": {
+      "contains_changes": true
+    },
+    "v0.9.5": {
+      "contains_changes": true
+    },
     "v0.9.4": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/instance-type.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/instance-type.json
@@ -1,6 +1,33 @@
 {
   "module": "instance-type",
   "releases": {
+    "v0.10.6": {
+      "contains_changes": false
+    },
+    "v0.10.5": {
+      "contains_changes": false
+    },
+    "v0.10.4": {
+      "contains_changes": false
+    },
+    "v0.10.3": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.6": {
+      "contains_changes": true
+    },
+    "v0.9.5": {
+      "contains_changes": true
+    },
     "v0.9.4": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/join-path.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/join-path.json
@@ -1,6 +1,33 @@
 {
   "module": "join-path",
   "releases": {
+    "v0.10.6": {
+      "contains_changes": false
+    },
+    "v0.10.5": {
+      "contains_changes": false
+    },
+    "v0.10.4": {
+      "contains_changes": false
+    },
+    "v0.10.3": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.6": {
+      "contains_changes": true
+    },
+    "v0.9.5": {
+      "contains_changes": true
+    },
     "v0.9.4": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/list-remove.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/list-remove.json
@@ -1,6 +1,33 @@
 {
   "module": "list-remove",
   "releases": {
+    "v0.10.6": {
+      "contains_changes": false
+    },
+    "v0.10.5": {
+      "contains_changes": false
+    },
+    "v0.10.4": {
+      "contains_changes": false
+    },
+    "v0.10.3": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.6": {
+      "contains_changes": true
+    },
+    "v0.9.5": {
+      "contains_changes": true
+    },
     "v0.9.4": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/operating-system.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/operating-system.json
@@ -1,6 +1,33 @@
 {
   "module": "operating-system",
   "releases": {
+    "v0.10.6": {
+      "contains_changes": false
+    },
+    "v0.10.5": {
+      "contains_changes": false
+    },
+    "v0.10.4": {
+      "contains_changes": false
+    },
+    "v0.10.3": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.6": {
+      "contains_changes": true
+    },
+    "v0.9.5": {
+      "contains_changes": true
+    },
     "v0.9.4": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/patcher-test.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/patcher-test.json
@@ -1,0 +1,131 @@
+{
+  "module": "patcher-test",
+  "releases": {
+    "v0.10.6": {
+      "contains_changes": false
+    },
+    "v0.10.5": {
+      "contains_changes": false
+    },
+    "v0.10.4": {
+      "contains_changes": true
+    },
+    "v0.10.3": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": true
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.6": {
+      "contains_changes": false
+    },
+    "v0.9.5": {
+      "contains_changes": false
+    },
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
+    "v0.9.2": {
+      "contains_changes": false
+    },
+    "v0.9.1": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.2": {
+      "contains_changes": false
+    },
+    "v0.3.1": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.8": {
+      "contains_changes": false
+    },
+    "v0.1.7": {
+      "contains_changes": false
+    },
+    "v0.1.6": {
+      "contains_changes": false
+    },
+    "v0.1.5": {
+      "contains_changes": false
+    },
+    "v0.1.4": {
+      "contains_changes": false
+    },
+    "v0.1.3": {
+      "contains_changes": false
+    },
+    "v0.1.2": {
+      "contains_changes": false
+    },
+    "v0.1.1": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.8": {
+      "contains_changes": false
+    },
+    "v0.0.7": {
+      "contains_changes": false
+    },
+    "v0.0.6": {
+      "contains_changes": false
+    },
+    "v0.0.5": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-utilities/prepare-pex-environment.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/prepare-pex-environment.json
@@ -1,6 +1,33 @@
 {
   "module": "prepare-pex-environment",
   "releases": {
+    "v0.10.6": {
+      "contains_changes": false
+    },
+    "v0.10.5": {
+      "contains_changes": false
+    },
+    "v0.10.4": {
+      "contains_changes": false
+    },
+    "v0.10.3": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.6": {
+      "contains_changes": true
+    },
+    "v0.9.5": {
+      "contains_changes": true
+    },
     "v0.9.4": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/request-quota-increase.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/request-quota-increase.json
@@ -1,6 +1,33 @@
 {
   "module": "request-quota-increase",
   "releases": {
+    "v0.10.6": {
+      "contains_changes": false
+    },
+    "v0.10.5": {
+      "contains_changes": false
+    },
+    "v0.10.4": {
+      "contains_changes": false
+    },
+    "v0.10.3": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": true
+    },
+    "v0.9.6": {
+      "contains_changes": true
+    },
+    "v0.9.5": {
+      "contains_changes": true
+    },
     "v0.9.4": {
       "contains_changes": true
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/require-executable.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/require-executable.json
@@ -1,6 +1,33 @@
 {
   "module": "require-executable",
   "releases": {
+    "v0.10.6": {
+      "contains_changes": false
+    },
+    "v0.10.5": {
+      "contains_changes": true
+    },
+    "v0.10.4": {
+      "contains_changes": false
+    },
+    "v0.10.3": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.6": {
+      "contains_changes": true
+    },
+    "v0.9.5": {
+      "contains_changes": true
+    },
     "v0.9.4": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/run-pex-as-data-source.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/run-pex-as-data-source.json
@@ -1,6 +1,33 @@
 {
   "module": "run-pex-as-data-source",
   "releases": {
+    "v0.10.6": {
+      "contains_changes": false
+    },
+    "v0.10.5": {
+      "contains_changes": false
+    },
+    "v0.10.4": {
+      "contains_changes": false
+    },
+    "v0.10.3": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.6": {
+      "contains_changes": true
+    },
+    "v0.9.5": {
+      "contains_changes": true
+    },
     "v0.9.4": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-utilities/run-pex-as-resource.json
+++ b/static/patcher-changelogs/terraform-aws-utilities/run-pex-as-resource.json
@@ -1,6 +1,33 @@
 {
   "module": "run-pex-as-resource",
   "releases": {
+    "v0.10.6": {
+      "contains_changes": false
+    },
+    "v0.10.5": {
+      "contains_changes": false
+    },
+    "v0.10.4": {
+      "contains_changes": false
+    },
+    "v0.10.3": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.6": {
+      "contains_changes": true
+    },
+    "v0.9.5": {
+      "contains_changes": true
+    },
     "v0.9.4": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/network-acl-inbound.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/network-acl-inbound.json
@@ -1,6 +1,93 @@
 {
   "module": "network-acl-inbound",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": true
+    },
+    "v0.26.7": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/network-acl-outbound.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/network-acl-outbound.json
@@ -1,6 +1,93 @@
 {
   "module": "network-acl-outbound",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": true
+    },
+    "v0.26.7": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/network-firewall.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/network-firewall.json
@@ -1,0 +1,515 @@
+{
+  "module": "network-firewall",
+  "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": true
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": false
+    },
+    "v0.26.7": {
+      "contains_changes": false
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": false
+    },
+    "v0.26.1": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.8": {
+      "contains_changes": false
+    },
+    "v0.22.7": {
+      "contains_changes": false
+    },
+    "v0.22.6": {
+      "contains_changes": false
+    },
+    "v0.22.5": {
+      "contains_changes": false
+    },
+    "v0.22.4": {
+      "contains_changes": false
+    },
+    "v0.22.3": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.1": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.4": {
+      "contains_changes": false
+    },
+    "v0.20.3": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.12": {
+      "contains_changes": false
+    },
+    "v0.18.11": {
+      "contains_changes": false
+    },
+    "v0.18.10": {
+      "contains_changes": false
+    },
+    "v0.18.9": {
+      "contains_changes": false
+    },
+    "v0.18.8": {
+      "contains_changes": false
+    },
+    "v0.18.7": {
+      "contains_changes": false
+    },
+    "v0.18.6": {
+      "contains_changes": false
+    },
+    "v0.18.5": {
+      "contains_changes": false
+    },
+    "v0.18.4": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.9": {
+      "contains_changes": false
+    },
+    "v0.17.8": {
+      "contains_changes": false
+    },
+    "v0.17.7": {
+      "contains_changes": false
+    },
+    "v0.17.6": {
+      "contains_changes": false
+    },
+    "v0.17.5": {
+      "contains_changes": false
+    },
+    "v0.17.4": {
+      "contains_changes": false
+    },
+    "v0.17.3": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
+    "v0.15.6": {
+      "contains_changes": false
+    },
+    "v0.15.5": {
+      "contains_changes": false
+    },
+    "v0.15.4": {
+      "contains_changes": false
+    },
+    "v0.15.3": {
+      "contains_changes": false
+    },
+    "v0.15.2": {
+      "contains_changes": false
+    },
+    "v0.15.1": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.4": {
+      "contains_changes": false
+    },
+    "v0.14.3": {
+      "contains_changes": false
+    },
+    "v0.14.2": {
+      "contains_changes": false
+    },
+    "v0.14.1": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.1": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.5": {
+      "contains_changes": false
+    },
+    "v0.12.4": {
+      "contains_changes": false
+    },
+    "v0.12.3": {
+      "contains_changes": false
+    },
+    "v0.12.2": {
+      "contains_changes": false
+    },
+    "v0.12.1": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
+    "v0.9.2": {
+      "contains_changes": false
+    },
+    "v0.9.1": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.12": {
+      "contains_changes": false
+    },
+    "v0.8.11": {
+      "contains_changes": false
+    },
+    "v0.8.10": {
+      "contains_changes": false
+    },
+    "v0.8.9": {
+      "contains_changes": false
+    },
+    "v0.8.8": {
+      "contains_changes": false
+    },
+    "v0.8.7": {
+      "contains_changes": false
+    },
+    "v0.8.6": {
+      "contains_changes": false
+    },
+    "v0.8.5": {
+      "contains_changes": false
+    },
+    "v0.8.4": {
+      "contains_changes": false
+    },
+    "v0.8.3": {
+      "contains_changes": false
+    },
+    "v0.8.2": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.8": {
+      "contains_changes": false
+    },
+    "v0.7.7": {
+      "contains_changes": false
+    },
+    "v0.7.6": {
+      "contains_changes": false
+    },
+    "v0.7.5": {
+      "contains_changes": false
+    },
+    "v0.7.4": {
+      "contains_changes": false
+    },
+    "v0.7.3": {
+      "contains_changes": false
+    },
+    "v0.7.2": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.8": {
+      "contains_changes": false
+    },
+    "v0.5.7": {
+      "contains_changes": false
+    },
+    "v0.5.6": {
+      "contains_changes": false
+    },
+    "v0.5.5": {
+      "contains_changes": false
+    },
+    "v0.5.4": {
+      "contains_changes": false
+    },
+    "v0.5.3": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.1": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.2": {
+      "contains_changes": false
+    },
+    "v0.3.1": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.2": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.9": {
+      "contains_changes": false
+    },
+    "v0.1.8": {
+      "contains_changes": false
+    },
+    "v0.1.7": {
+      "contains_changes": false
+    },
+    "v0.1.6": {
+      "contains_changes": false
+    },
+    "v0.1.5": {
+      "contains_changes": false
+    },
+    "v0.1.4": {
+      "contains_changes": false
+    },
+    "v0.1.3": {
+      "contains_changes": false
+    },
+    "v0.1.2": {
+      "contains_changes": false
+    },
+    "v0.1.1": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.8": {
+      "contains_changes": false
+    },
+    "v0.0.7": {
+      "contains_changes": false
+    },
+    "v0.0.6": {
+      "contains_changes": false
+    },
+    "v0.0.5": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-vpc/port-range-calculator.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/port-range-calculator.json
@@ -1,6 +1,93 @@
 {
   "module": "port-range-calculator",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": false
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": false
+    },
+    "v0.26.7": {
+      "contains_changes": false
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/route.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/route.json
@@ -1,0 +1,515 @@
+{
+  "module": "route",
+  "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": true
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": false
+    },
+    "v0.26.7": {
+      "contains_changes": false
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": false
+    },
+    "v0.26.1": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.8": {
+      "contains_changes": false
+    },
+    "v0.22.7": {
+      "contains_changes": false
+    },
+    "v0.22.6": {
+      "contains_changes": false
+    },
+    "v0.22.5": {
+      "contains_changes": false
+    },
+    "v0.22.4": {
+      "contains_changes": false
+    },
+    "v0.22.3": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.1": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.4": {
+      "contains_changes": false
+    },
+    "v0.20.3": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.12": {
+      "contains_changes": false
+    },
+    "v0.18.11": {
+      "contains_changes": false
+    },
+    "v0.18.10": {
+      "contains_changes": false
+    },
+    "v0.18.9": {
+      "contains_changes": false
+    },
+    "v0.18.8": {
+      "contains_changes": false
+    },
+    "v0.18.7": {
+      "contains_changes": false
+    },
+    "v0.18.6": {
+      "contains_changes": false
+    },
+    "v0.18.5": {
+      "contains_changes": false
+    },
+    "v0.18.4": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.9": {
+      "contains_changes": false
+    },
+    "v0.17.8": {
+      "contains_changes": false
+    },
+    "v0.17.7": {
+      "contains_changes": false
+    },
+    "v0.17.6": {
+      "contains_changes": false
+    },
+    "v0.17.5": {
+      "contains_changes": false
+    },
+    "v0.17.4": {
+      "contains_changes": false
+    },
+    "v0.17.3": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
+    "v0.15.6": {
+      "contains_changes": false
+    },
+    "v0.15.5": {
+      "contains_changes": false
+    },
+    "v0.15.4": {
+      "contains_changes": false
+    },
+    "v0.15.3": {
+      "contains_changes": false
+    },
+    "v0.15.2": {
+      "contains_changes": false
+    },
+    "v0.15.1": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.4": {
+      "contains_changes": false
+    },
+    "v0.14.3": {
+      "contains_changes": false
+    },
+    "v0.14.2": {
+      "contains_changes": false
+    },
+    "v0.14.1": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.1": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.5": {
+      "contains_changes": false
+    },
+    "v0.12.4": {
+      "contains_changes": false
+    },
+    "v0.12.3": {
+      "contains_changes": false
+    },
+    "v0.12.2": {
+      "contains_changes": false
+    },
+    "v0.12.1": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
+    "v0.9.2": {
+      "contains_changes": false
+    },
+    "v0.9.1": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.12": {
+      "contains_changes": false
+    },
+    "v0.8.11": {
+      "contains_changes": false
+    },
+    "v0.8.10": {
+      "contains_changes": false
+    },
+    "v0.8.9": {
+      "contains_changes": false
+    },
+    "v0.8.8": {
+      "contains_changes": false
+    },
+    "v0.8.7": {
+      "contains_changes": false
+    },
+    "v0.8.6": {
+      "contains_changes": false
+    },
+    "v0.8.5": {
+      "contains_changes": false
+    },
+    "v0.8.4": {
+      "contains_changes": false
+    },
+    "v0.8.3": {
+      "contains_changes": false
+    },
+    "v0.8.2": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.8": {
+      "contains_changes": false
+    },
+    "v0.7.7": {
+      "contains_changes": false
+    },
+    "v0.7.6": {
+      "contains_changes": false
+    },
+    "v0.7.5": {
+      "contains_changes": false
+    },
+    "v0.7.4": {
+      "contains_changes": false
+    },
+    "v0.7.3": {
+      "contains_changes": false
+    },
+    "v0.7.2": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.8": {
+      "contains_changes": false
+    },
+    "v0.5.7": {
+      "contains_changes": false
+    },
+    "v0.5.6": {
+      "contains_changes": false
+    },
+    "v0.5.5": {
+      "contains_changes": false
+    },
+    "v0.5.4": {
+      "contains_changes": false
+    },
+    "v0.5.3": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.1": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.2": {
+      "contains_changes": false
+    },
+    "v0.3.1": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.2": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.9": {
+      "contains_changes": false
+    },
+    "v0.1.8": {
+      "contains_changes": false
+    },
+    "v0.1.7": {
+      "contains_changes": false
+    },
+    "v0.1.6": {
+      "contains_changes": false
+    },
+    "v0.1.5": {
+      "contains_changes": false
+    },
+    "v0.1.4": {
+      "contains_changes": false
+    },
+    "v0.1.3": {
+      "contains_changes": false
+    },
+    "v0.1.2": {
+      "contains_changes": false
+    },
+    "v0.1.1": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.8": {
+      "contains_changes": false
+    },
+    "v0.0.7": {
+      "contains_changes": false
+    },
+    "v0.0.6": {
+      "contains_changes": false
+    },
+    "v0.0.5": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-vpc/transit-gateway-attachment.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/transit-gateway-attachment.json
@@ -1,6 +1,93 @@
 {
   "module": "transit-gateway-attachment",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": true
+    },
+    "v0.26.7": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/transit-gateway-peering-attachment-accepter.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/transit-gateway-peering-attachment-accepter.json
@@ -1,6 +1,93 @@
 {
   "module": "transit-gateway-peering-attachment-accepter",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": true
+    },
+    "v0.26.7": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/transit-gateway-peering-attachment.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/transit-gateway-peering-attachment.json
@@ -1,6 +1,93 @@
 {
   "module": "transit-gateway-peering-attachment",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": true
+    },
+    "v0.26.7": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/transit-gateway-route.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/transit-gateway-route.json
@@ -1,6 +1,93 @@
 {
   "module": "transit-gateway-route",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": true
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": true
+    },
+    "v0.26.7": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/transit-gateway.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/transit-gateway.json
@@ -1,6 +1,93 @@
 {
   "module": "transit-gateway",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": true
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": true
+    },
+    "v0.26.7": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-app-lookup.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-app-lookup.json
@@ -1,0 +1,515 @@
+{
+  "module": "vpc-app-lookup",
+  "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": false
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": true
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": true
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": true
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": false
+    },
+    "v0.26.7": {
+      "contains_changes": false
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
+    "v0.26.5": {
+      "contains_changes": false
+    },
+    "v0.26.4": {
+      "contains_changes": false
+    },
+    "v0.26.3": {
+      "contains_changes": false
+    },
+    "v0.26.2": {
+      "contains_changes": false
+    },
+    "v0.26.1": {
+      "contains_changes": false
+    },
+    "v0.26.0": {
+      "contains_changes": false
+    },
+    "v0.25.0": {
+      "contains_changes": false
+    },
+    "v0.24.0": {
+      "contains_changes": false
+    },
+    "v0.23.3": {
+      "contains_changes": false
+    },
+    "v0.23.2": {
+      "contains_changes": false
+    },
+    "v0.23.1": {
+      "contains_changes": false
+    },
+    "v0.23.0": {
+      "contains_changes": false
+    },
+    "v0.22.8": {
+      "contains_changes": false
+    },
+    "v0.22.7": {
+      "contains_changes": false
+    },
+    "v0.22.6": {
+      "contains_changes": false
+    },
+    "v0.22.5": {
+      "contains_changes": false
+    },
+    "v0.22.4": {
+      "contains_changes": false
+    },
+    "v0.22.3": {
+      "contains_changes": false
+    },
+    "v0.22.2": {
+      "contains_changes": false
+    },
+    "v0.22.1": {
+      "contains_changes": false
+    },
+    "v0.22.0": {
+      "contains_changes": false
+    },
+    "v0.21.1": {
+      "contains_changes": false
+    },
+    "v0.21.0": {
+      "contains_changes": false
+    },
+    "v0.20.4": {
+      "contains_changes": false
+    },
+    "v0.20.3": {
+      "contains_changes": false
+    },
+    "v0.20.2": {
+      "contains_changes": false
+    },
+    "v0.20.1": {
+      "contains_changes": false
+    },
+    "v0.20.0": {
+      "contains_changes": false
+    },
+    "v0.19.0": {
+      "contains_changes": false
+    },
+    "v0.18.12": {
+      "contains_changes": false
+    },
+    "v0.18.11": {
+      "contains_changes": false
+    },
+    "v0.18.10": {
+      "contains_changes": false
+    },
+    "v0.18.9": {
+      "contains_changes": false
+    },
+    "v0.18.8": {
+      "contains_changes": false
+    },
+    "v0.18.7": {
+      "contains_changes": false
+    },
+    "v0.18.6": {
+      "contains_changes": false
+    },
+    "v0.18.5": {
+      "contains_changes": false
+    },
+    "v0.18.4": {
+      "contains_changes": false
+    },
+    "v0.18.3": {
+      "contains_changes": false
+    },
+    "v0.18.2": {
+      "contains_changes": false
+    },
+    "v0.18.1": {
+      "contains_changes": false
+    },
+    "v0.18.0": {
+      "contains_changes": false
+    },
+    "v0.17.9": {
+      "contains_changes": false
+    },
+    "v0.17.8": {
+      "contains_changes": false
+    },
+    "v0.17.7": {
+      "contains_changes": false
+    },
+    "v0.17.6": {
+      "contains_changes": false
+    },
+    "v0.17.5": {
+      "contains_changes": false
+    },
+    "v0.17.4": {
+      "contains_changes": false
+    },
+    "v0.17.3": {
+      "contains_changes": false
+    },
+    "v0.17.2": {
+      "contains_changes": false
+    },
+    "v0.17.1": {
+      "contains_changes": false
+    },
+    "v0.17.0": {
+      "contains_changes": false
+    },
+    "v0.16.0": {
+      "contains_changes": false
+    },
+    "v0.15.7": {
+      "contains_changes": false
+    },
+    "v0.15.6": {
+      "contains_changes": false
+    },
+    "v0.15.5": {
+      "contains_changes": false
+    },
+    "v0.15.4": {
+      "contains_changes": false
+    },
+    "v0.15.3": {
+      "contains_changes": false
+    },
+    "v0.15.2": {
+      "contains_changes": false
+    },
+    "v0.15.1": {
+      "contains_changes": false
+    },
+    "v0.15.0": {
+      "contains_changes": false
+    },
+    "v0.14.4": {
+      "contains_changes": false
+    },
+    "v0.14.3": {
+      "contains_changes": false
+    },
+    "v0.14.2": {
+      "contains_changes": false
+    },
+    "v0.14.1": {
+      "contains_changes": false
+    },
+    "v0.14.0": {
+      "contains_changes": false
+    },
+    "v0.13.1": {
+      "contains_changes": false
+    },
+    "v0.13.0": {
+      "contains_changes": false
+    },
+    "v0.12.5": {
+      "contains_changes": false
+    },
+    "v0.12.4": {
+      "contains_changes": false
+    },
+    "v0.12.3": {
+      "contains_changes": false
+    },
+    "v0.12.2": {
+      "contains_changes": false
+    },
+    "v0.12.1": {
+      "contains_changes": false
+    },
+    "v0.12.0": {
+      "contains_changes": false
+    },
+    "v0.11.0": {
+      "contains_changes": false
+    },
+    "v0.10.2": {
+      "contains_changes": false
+    },
+    "v0.10.1": {
+      "contains_changes": false
+    },
+    "v0.10.0": {
+      "contains_changes": false
+    },
+    "v0.9.4": {
+      "contains_changes": false
+    },
+    "v0.9.3": {
+      "contains_changes": false
+    },
+    "v0.9.2": {
+      "contains_changes": false
+    },
+    "v0.9.1": {
+      "contains_changes": false
+    },
+    "v0.9.0": {
+      "contains_changes": false
+    },
+    "v0.8.12": {
+      "contains_changes": false
+    },
+    "v0.8.11": {
+      "contains_changes": false
+    },
+    "v0.8.10": {
+      "contains_changes": false
+    },
+    "v0.8.9": {
+      "contains_changes": false
+    },
+    "v0.8.8": {
+      "contains_changes": false
+    },
+    "v0.8.7": {
+      "contains_changes": false
+    },
+    "v0.8.6": {
+      "contains_changes": false
+    },
+    "v0.8.5": {
+      "contains_changes": false
+    },
+    "v0.8.4": {
+      "contains_changes": false
+    },
+    "v0.8.3": {
+      "contains_changes": false
+    },
+    "v0.8.2": {
+      "contains_changes": false
+    },
+    "v0.8.1": {
+      "contains_changes": false
+    },
+    "v0.8.0": {
+      "contains_changes": false
+    },
+    "v0.7.8": {
+      "contains_changes": false
+    },
+    "v0.7.7": {
+      "contains_changes": false
+    },
+    "v0.7.6": {
+      "contains_changes": false
+    },
+    "v0.7.5": {
+      "contains_changes": false
+    },
+    "v0.7.4": {
+      "contains_changes": false
+    },
+    "v0.7.3": {
+      "contains_changes": false
+    },
+    "v0.7.2": {
+      "contains_changes": false
+    },
+    "v0.7.1": {
+      "contains_changes": false
+    },
+    "v0.7.0": {
+      "contains_changes": false
+    },
+    "v0.6.1": {
+      "contains_changes": false
+    },
+    "v0.6.0": {
+      "contains_changes": false
+    },
+    "v0.5.8": {
+      "contains_changes": false
+    },
+    "v0.5.7": {
+      "contains_changes": false
+    },
+    "v0.5.6": {
+      "contains_changes": false
+    },
+    "v0.5.5": {
+      "contains_changes": false
+    },
+    "v0.5.4": {
+      "contains_changes": false
+    },
+    "v0.5.3": {
+      "contains_changes": false
+    },
+    "v0.5.2": {
+      "contains_changes": false
+    },
+    "v0.5.1": {
+      "contains_changes": false
+    },
+    "v0.5.0": {
+      "contains_changes": false
+    },
+    "v0.4.1": {
+      "contains_changes": false
+    },
+    "v0.4.0": {
+      "contains_changes": false
+    },
+    "v0.3.2": {
+      "contains_changes": false
+    },
+    "v0.3.1": {
+      "contains_changes": false
+    },
+    "v0.3.0": {
+      "contains_changes": false
+    },
+    "v0.2.2": {
+      "contains_changes": false
+    },
+    "v0.2.1": {
+      "contains_changes": false
+    },
+    "v0.2.0": {
+      "contains_changes": false
+    },
+    "v0.1.9": {
+      "contains_changes": false
+    },
+    "v0.1.8": {
+      "contains_changes": false
+    },
+    "v0.1.7": {
+      "contains_changes": false
+    },
+    "v0.1.6": {
+      "contains_changes": false
+    },
+    "v0.1.5": {
+      "contains_changes": false
+    },
+    "v0.1.4": {
+      "contains_changes": false
+    },
+    "v0.1.3": {
+      "contains_changes": false
+    },
+    "v0.1.2": {
+      "contains_changes": false
+    },
+    "v0.1.1": {
+      "contains_changes": false
+    },
+    "v0.1.0": {
+      "contains_changes": false
+    },
+    "v0.0.8": {
+      "contains_changes": false
+    },
+    "v0.0.7": {
+      "contains_changes": false
+    },
+    "v0.0.6": {
+      "contains_changes": false
+    },
+    "v0.0.5": {
+      "contains_changes": false
+    },
+    "v0.0.4": {
+      "contains_changes": false
+    },
+    "v0.0.3": {
+      "contains_changes": false
+    },
+    "v0.0.2": {
+      "contains_changes": false
+    }
+  }
+}

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-app-network-acls.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-app-network-acls.json
@@ -1,6 +1,93 @@
 {
   "module": "vpc-app-network-acls",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": true
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": true
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": true
+    },
+    "v0.26.7": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-app.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-app.json
@@ -1,6 +1,93 @@
 {
   "module": "vpc-app",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": true
+    },
+    "v0.28.2": {
+      "contains_changes": true
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": true
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": true
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": true
+    },
+    "v0.26.19": {
+      "contains_changes": true
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": true
+    },
+    "v0.26.16": {
+      "contains_changes": true
+    },
+    "v0.26.15": {
+      "contains_changes": true
+    },
+    "v0.26.14": {
+      "contains_changes": true
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": true
+    },
+    "v0.26.10": {
+      "contains_changes": true
+    },
+    "v0.26.9": {
+      "contains_changes": true
+    },
+    "v0.26.8": {
+      "contains_changes": true
+    },
+    "v0.26.7": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-dns-forwarder-rules.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-dns-forwarder-rules.json
@@ -1,6 +1,93 @@
 {
   "module": "vpc-dns-forwarder-rules",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": true
+    },
+    "v0.26.7": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-dns-forwarder.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-dns-forwarder.json
@@ -1,6 +1,93 @@
 {
   "module": "vpc-dns-forwarder",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": true
+    },
+    "v0.26.7": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-flow-logs.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-flow-logs.json
@@ -1,6 +1,93 @@
 {
   "module": "vpc-flow-logs",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": true
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": true
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": false
+    },
+    "v0.26.7": {
+      "contains_changes": false
+    },
+    "v0.26.6": {
+      "contains_changes": true
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-interface-endpoint.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-interface-endpoint.json
@@ -1,6 +1,93 @@
 {
   "module": "vpc-interface-endpoint",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": true
+    },
+    "v0.28.4": {
+      "contains_changes": true
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": true
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": true
+    },
+    "v0.26.7": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-mgmt-network-acls.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-mgmt-network-acls.json
@@ -1,6 +1,93 @@
 {
   "module": "vpc-mgmt-network-acls",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": true
+    },
+    "v0.26.7": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-mgmt.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-mgmt.json
@@ -1,6 +1,93 @@
 {
   "module": "vpc-mgmt",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": true
+    },
+    "v0.26.25": {
+      "contains_changes": true
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": true
+    },
+    "v0.26.7": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-peering-cross-accounts-accepter.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-peering-cross-accounts-accepter.json
@@ -1,6 +1,93 @@
 {
   "module": "vpc-peering-cross-accounts-accepter",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": true
+    },
+    "v0.26.7": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-peering-cross-accounts-requester.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-peering-cross-accounts-requester.json
@@ -1,6 +1,93 @@
 {
   "module": "vpc-peering-cross-accounts-requester",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": true
+    },
+    "v0.26.7": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-peering-external.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-peering-external.json
@@ -1,6 +1,93 @@
 {
   "module": "vpc-peering-external",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": true
+    },
+    "v0.26.7": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },

--- a/static/patcher-changelogs/terraform-aws-vpc/vpc-peering.json
+++ b/static/patcher-changelogs/terraform-aws-vpc/vpc-peering.json
@@ -1,6 +1,93 @@
 {
   "module": "vpc-peering",
   "releases": {
+    "v0.28.5": {
+      "contains_changes": false
+    },
+    "v0.28.4": {
+      "contains_changes": false
+    },
+    "v0.28.3": {
+      "contains_changes": false
+    },
+    "v0.28.2": {
+      "contains_changes": false
+    },
+    "v0.28.1": {
+      "contains_changes": false
+    },
+    "v0.28.0": {
+      "contains_changes": false
+    },
+    "v0.27.0": {
+      "contains_changes": true
+    },
+    "v0.26.27": {
+      "contains_changes": false
+    },
+    "v0.26.26": {
+      "contains_changes": false
+    },
+    "v0.26.25": {
+      "contains_changes": false
+    },
+    "v0.26.24": {
+      "contains_changes": false
+    },
+    "v0.26.23": {
+      "contains_changes": false
+    },
+    "v0.26.22": {
+      "contains_changes": false
+    },
+    "v0.26.21": {
+      "contains_changes": false
+    },
+    "v0.26.20": {
+      "contains_changes": false
+    },
+    "v0.26.19": {
+      "contains_changes": false
+    },
+    "v0.26.18": {
+      "contains_changes": false
+    },
+    "v0.26.17": {
+      "contains_changes": false
+    },
+    "v0.26.16": {
+      "contains_changes": false
+    },
+    "v0.26.15": {
+      "contains_changes": false
+    },
+    "v0.26.14": {
+      "contains_changes": false
+    },
+    "v0.26.13": {
+      "contains_changes": false
+    },
+    "v0.26.12": {
+      "contains_changes": false
+    },
+    "v0.26.11": {
+      "contains_changes": false
+    },
+    "v0.26.10": {
+      "contains_changes": false
+    },
+    "v0.26.9": {
+      "contains_changes": false
+    },
+    "v0.26.8": {
+      "contains_changes": true
+    },
+    "v0.26.7": {
+      "contains_changes": true
+    },
+    "v0.26.6": {
+      "contains_changes": false
+    },
     "v0.26.5": {
       "contains_changes": false
     },


### PR DESCRIPTION
[Previous run for reference](https://github.com/gruntwork-io/docs/pull/732)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Successful Patcher update pointed at localhost without warning
<img width="1215" alt="Screenshot 2025-05-27 at 1 02 15 PM" src="https://github.com/user-attachments/assets/76b82432-0ae0-48cd-8b0e-6887cac29603" />



## Summary by CodeRabbit

- **Documentation**
  - Expanded and updated changelog files across multiple modules to include detailed version histories, with each release now indicating whether it contains changes or not. This provides users with clearer visibility into the change status of each version for improved release tracking and transparency. No impact on functionality or user experience beyond enhanced documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->