### PR TITLE
Make gov cloud docs work with referenced templates

### DIFF
--- a/docs/2.0/docs/pipelines/installation/addinggitlabrepo.md
+++ b/docs/2.0/docs/pipelines/installation/addinggitlabrepo.md
@@ -116,7 +116,7 @@ First, you'll need to install [mise](https://mise.jdx.dev/), a powerful environm
 
 4. Edit the `vars.yaml` file to customize it for your environment. If using a custom GitLab instance, update any custom instance variables.
 
-5. `cd` to the root of <CustomizableValue id="REPOSITORY_NAME" /> where you wish to install Gruntwork Pipelines.  Run the boilerplate tool to generate your repository structure:
+5. `cd` to the root of <CustomizableValue id="REPOSITORY_NAME" /> where you wish to install Gruntwork Pipelines. Run the boilerplate tool to generate your repository structure:
    ```bash
    boilerplate --template-url "git@github.com:gruntwork-io/terraform-aws-architecture-catalog.git//templates/gitlab-pipelines-infrastructure-live-root/?ref=v3.1.0" --output-folder . --var-file vars.yaml --non-interactive
    ```

--- a/docs/2.0/docs/pipelines/tutorials/deploying-to-aws-gov-cloud.md
+++ b/docs/2.0/docs/pipelines/tutorials/deploying-to-aws-gov-cloud.md
@@ -47,18 +47,13 @@ Fundamentally, there are three places where the GovCloud partition must be set:
 
 This section covers the Pipelines configuration required to deploy an AWS S3 bucket to AWS GovCloud.
 
-1. Add the account configuration to the bottom of your root-folder `accounts.yml` file.
-
-    ```hcl title="accounts.yml"
-    $$ACCOUNT_NAME$$:
-      id: "$$ACCOUNT_ID$$"
-    ```
-2. Create a `vars.yaml` file on your local machine with the following content:
+1. Create a `vars.yaml` file on your local machine with the following content:
 
 <Tabs>
 <TabItem value="GitHub" label="GitHub" default>
     ```yaml title="vars.yaml"
     AccountName: "$$ACCOUNT_NAME$$"
+    AccountId: "$$ACCOUNT_ID$$"
     GitHubOrganization: "$$GITHUB_ORGANIZATION$$"
     GitHubRepository: "$$GITHUB_REPOSITORY$$"
     DeployBranchName: main # Change this to your default branch from which terragrunt apply should be run by pipelines
@@ -71,6 +66,7 @@ This section covers the Pipelines configuration required to deploy an AWS S3 buc
 <TabItem value="GitLab" label="GitLab">
     ```yaml title="vars.yaml"
     AccountName: "$$ACCOUNT_NAME$$"
+    AccountId: "$$ACCOUNT_ID$$"
     GitLabGroup: "$$GITLAB_GROUP$$"
     GitLabProject: "$$GITLAB_PROJECT$$"
     DeployBranchName: main # Change this to your default branch from which terragrunt apply should be run by pipelines
@@ -84,15 +80,17 @@ This section covers the Pipelines configuration required to deploy an AWS S3 buc
 
 3. We'll now use that `vars.yaml` file as input to [boilerplate](https://github.com/gruntwork-io/boilerplate) to generate the Terragrunt code for the OIDC Provider and IAM roles.  From the root of your repository, run the following command:
 
+<!-- TODO: Update the version of the architecture catalog templates below -->
+
 <Tabs>
 <TabItem value="GitHub" label="GitHub">
 ```bash
-boilerplate --template-url "git@github.com:gruntwork-io/terraform-aws-architecture-catalog.git//templates/github-actions-single-account-setup?ref=main" --output-folder . --var-file vars.yaml --non-interactive
+boilerplate --template-url "git@github.com:gruntwork-io/terraform-aws-architecture-catalog.git//templates/github-actions-single-account-setup?ref=X.Y.Z" --output-folder . --var-file vars.yaml --non-interactive
 ```
 </TabItem>
 <TabItem value="GitLab" label="GitLab">
 ```bash
-boilerplate --template-url "git@github.com:gruntwork-io/terraform-aws-architecture-catalog.git//templates/gitlab-pipelines-single-account-setup?ref=main" --output-folder . --var-file vars.yaml --non-interactive
+boilerplate --template-url "git@github.com:gruntwork-io/terraform-aws-architecture-catalog.git//templates/gitlab-pipelines-single-account-setup?ref=X.Y.Z" --output-folder . --var-file vars.yaml --non-interactive
 ```
 </TabItem>
 </Tabs>


### PR DESCRIPTION
These docs are being merged into a staging PR for "v4". Placeholder versions will be updated in that PR.