### PR TITLE
docs: Breaking down installation guide to void assuming AWS

### DIFF
--- a/docs/2.0/docs/accountfactory/installation/addingnewrepo.md
+++ b/docs/2.0/docs/accountfactory/installation/addingnewrepo.md
@@ -1,0 +1,51 @@
+# Adding Account Factory to a new repository
+
+To configure Gruntwork Account Factory in a new GitHub repository, the following steps are required (and will be explained in detail below):
+
+1. Create your `infrastructure-live-root` repository using Gruntwork's GitHub template.
+2. Configure the Gruntwork.io GitHub App to authorize your `infrastructure-live-root` repository, or ensure that the appropriate machine user tokens are set up as repository or organization secrets.
+3. Update the Bootstrap Workflow to configure your AWS settings.
+4. Execute the Bootstrap Workflow in your `infrastructure-live-root` repository to generate pull requests and additional repositories.
+
+## Creating the infrastructure-live-root repository
+
+Gruntwork provides a pre-configured git repository template that incorporates best practices while allowing for customization.
+
+[infrastructure-live-root-template](https://github.com/gruntwork-io/infrastructure-live-root-template)
+
+This template generates an `infrastructure-live-root` repository with a bootstrap workflow designed to scaffold a best-practices Terragrunt configuration. It includes patterns for module defaults, global variables, and account baselines. Additionally, it integrates Gruntwork Pipelines, which can be removed if not required.
+
+The workflow can optionally scaffold the `infrastructure-live-access-control` and `infrastructure-catalog` repositories.
+
+Navigate to the template repository and select **Use this template** -> **Create a new Repository**. Choose your organization as the owner, add a description if desired, set the repository to **private**, and click **Create repository**.
+
+## Configuring Gruntwork app settings
+
+Use the Gruntwork.io GitHub App to [add the repository as an Infra Root repository](/2.0/docs/pipelines/installation/viagithubapp#configuration).
+
+If using the [machine user model](/2.0/docs/pipelines/installation/viamachineusers.md), ensure the `INFRA_ROOT_WRITE_TOKEN` (and `ORG_REPO_ADMIN_TOKEN` for enterprise customers) is added to the repository as a secret or configured as an organization secret.
+
+## Updating the Bootstrap Workflow
+
+Return to your `infrastructure-live-root` repository and follow the `README` instructions to update the bootstrap workflow for IaC Foundations. Provide details about your AWS organization, accounts, and default values for new account provisioning.
+
+## Running the workflow
+
+Follow the instructions in your `infrastructure-live-root` repository to execute the Bootstrap Workflow. Gruntwork support is available to address any questions that arise. During the workflow execution, you can choose to create the `infrastructure-live-access-control` and `infrastructure-catalog` repositories. These repositories will be created in your GitHub organization using values defined in the workflow configuration.
+
+### Infrastructure live access control
+
+This repository is primarily for Enterprise customers but is recommended for all users. When running the Bootstrap Workflow in your `infrastructure-live-root` repository, select the option to "Bootstrap the infrastructure-access-control repository."
+
+### Infrastructure catalog
+
+The Bootstrap Workflow also creates an empty `infrastructure-catalog` repository. This repository is used to store Terraform/OpenTofu modules authored by your organization for internal use. During the Bootstrap Workflow execution in your `infrastructure-live-root` repository, select the option to "Bootstrap the infrastructure-catalog repository."
+
+## Completing instructions in Bootstrap Pull Requests
+
+Each of your repositories will contain a Bootstrap Pull Request. Follow the instructions in these Pull Requests to finalize the setup of your IaC repositories.
+
+:::info
+
+The bootstrapping pull requests include pre-configured files, such as a `.mise.toml` file that specifies versions of OpenTofu and Terragrunt. Ensure you review and update these configurations to align with your organization's requirements.
+:::

--- a/docs/2.0/docs/accountfactory/installation/index.md
+++ b/docs/2.0/docs/accountfactory/installation/index.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Account Factory is automatically integrated into [new Pipelines root repositories](/2.0/docs/pipelines/installation/addingnewrepo) during the bootstrapping process.
+Account Factory is automatically integrated into [new Pipelines root repositories](/2.0/docs/accountfactory/installation/addingnewrepo) during the bootstrapping process.
 
 By default, Account Factory includes the following components:
 

--- a/docs/2.0/docs/accountfactory/installation/index.md
+++ b/docs/2.0/docs/accountfactory/installation/index.md
@@ -7,11 +7,11 @@ Account Factory is automatically integrated into [new Pipelines root repositorie
 By default, Account Factory includes the following components:
 
 - 📋 An HTML form for generating workflow inputs: `.github/workflows/account-factory-inputs.html`
-  
+
 - 🏭 A workflow for generating new requests: `.github/workflows/account-factory.yml`
-  
+
 - 🗃️ A root directory for tracking account requests: `_new-account-requests`
-  
+
 - ⚙️ A YAML file for tracking account names and IDs: `accounts.yml`
 
 For detailed instructions on using these components, refer to the [Vending a New AWS Account Guide](/2.0/docs/accountfactory/guides/vend-aws-account).
@@ -19,6 +19,3 @@ For detailed instructions on using these components, refer to the [Vending a New
 ## Configuring account factory
 
 Account Factory is fully operational for vending new accounts without requiring any configuration changes. However, a [comprehensive reference for all configuration options is available here](/2.0/reference/accountfactory/configurations), allowing you to customize values and templates for generating Infrastructure as Code (IaC) for new accounts.
-
- 
-

--- a/docs/2.0/docs/accountfactory/prerequisites/awslandingzone.md
+++ b/docs/2.0/docs/accountfactory/prerequisites/awslandingzone.md
@@ -1,11 +1,10 @@
 import CustomizableValue from '/src/components/CustomizableValue';
 
- 
 # Landing Zone
 
 ## Overview
 
-The Landing Zone component establishes an initial best-practice AWS multi-account setup.
+The Landing Zone component establishes an initial best-practice AWS multi-account setup for use with Gruntwork Account Factory.
 
 ## Extending AWS Control Tower
 
@@ -242,16 +241,15 @@ Complete the following steps to prepare for Gruntwork Account Factory:
 
       3. Switch to the `Users` tab, select your management user from the list and click **Next**
 
-      4.  Select `AWSAdministratorAccess` from the list of Permission Sets, then click **Next**
+      4. Select `AWSAdministratorAccess` from the list of Permission Sets, then click **Next**
 
-      5.  Click `Submit` to finish assigning access to your user
+      5. Click `Submit` to finish assigning access to your user
 
 ## Next steps
 
 Now that Control Tower is configured, consider these next steps:
+
 - [Set up IAM Identity Center](https://docs.aws.amazon.com/singlesignon/latest/userguide/get-started-choose-identity-source.html) for access control.
 - [Apply required controls or SCPs](https://docs.aws.amazon.com/controltower/latest/userguide/controls.html).
 - [Install Gruntwork Pipelines](/2.0/docs/pipelines/installation/viagithubapp).
 - [Set up Gruntwork Account Factory](/2.0/docs/accountfactory/installation).
-
-

--- a/docs/2.0/docs/pipelines/installation/addingnewrepo.md
+++ b/docs/2.0/docs/pipelines/installation/addingnewrepo.md
@@ -1,23 +1,47 @@
 # Initial Setup
 
-To configure Gruntwork Pipelines in a new GitHub repository, complete the following steps:
+To configure Gruntwork Pipelines in a new GitHub repository, complete the following steps (which are explained in detail below):
 
-1. Create your `infrastructure-live-root` repository using Gruntwork's GitHub template.
-2. Configure the Gruntwork.io GitHub App to authorize your `infrastructure-live-root` repository, or ensure that the appropriate machine user tokens are set up as repository or organization secrets.
-3. Update the Bootstrap Workflow to configure your AWS settings.
-4. Execute the Bootstrap Workflow in your `infrastructure-live-root` repository to generate pull requests and additional repositories.
+1. Create an `infrastructure-live` repository.
+2. Configure the Gruntwork.io GitHub App to authorize your `infrastructure-live` repository, or ensure that the appropriate machine user tokens are set up as repository or organization secrets.
+3. Create `.gruntwork` HCL configurations to tell Pipelines how to authenticate in your environments.
+4. Create `.github/workflows/pipelines.yml` to tell your GitHub Actions workflow how to run your pipelines.
+5. Commit and push your changes to your repository.
 
-## Creating the infrastructure-live-root repository
+## Creating the infrastructure-live repository
 
-Gruntwork provides a pre-configured git repository template that incorporates best practices while allowing for customization.
+Creating an `infrastructure-live` repository is fairly straightforward. First, create a new repository using the official GitHub documentation for [creating repositories](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository). Name the repository something like `infrastructure-live` and make it private (or internal).
 
-[infrastructure-live-root-template](https://github.com/gruntwork-io/infrastructure-live-root-template)
+Clone the repository to your local machine using [Git](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository).
 
-This template generates an `infrastructure-live-root` repository with a bootstrap workflow designed to scaffold a best-practices Terragrunt configuration. It includes patterns for module defaults, global variables, and account baselines. Additionally, it integrates Gruntwork Pipelines, which can be removed if not required.
+For example:
 
-The workflow can optionally scaffold the `infrastructure-live-access-control` and `infrastructure-catalog` repositories.
+```bash
+git clone git@github.com:acme/infrastructure-live.git
+```
 
-Navigate to the template repository and select **Use this template** -> **Create a new Repository**. Choose your organization as the owner, add a description if desired, set the repository to **private**, and click **Create repository**.
+Once the repository is created, you'll want to create a `.mise.toml` file in the root of the repository to tell Pipelines what version of Terragrunt and OpenTofu to use.
+
+For example:
+
+```toml title=".mise.toml"
+[tools]
+terragrunt = "0.87.6"
+opentofu = "1.10.6"
+```
+
+:::tip
+
+You can get `mise` to lookup the versions available for a given tool by using the `ls-remote` command.
+
+Follow the official [mise installation guide](https://mise.jdx.dev/getting-started.html) to install it locally.
+
+```bash
+mise ls-remote terragrunt
+mise ls-remote opentofu
+```
+
+:::
 
 ## Configuring Gruntwork app settings
 
@@ -25,27 +49,110 @@ Use the Gruntwork.io GitHub App to [add the repository as an Infra Root reposito
 
 If using the [machine user model](/2.0/docs/pipelines/installation/viamachineusers.md), ensure the `INFRA_ROOT_WRITE_TOKEN` (and `ORG_REPO_ADMIN_TOKEN` for enterprise customers) is added to the repository as a secret or configured as an organization secret.
 
-## Updating the Bootstrap Workflow
+## Creating `.gruntwork` HCL configurations
 
-Return to your `infrastructure-live-root` repository and follow the `README` instructions to update the bootstrap workflow for IaC Foundations. Provide details about your AWS organization, accounts, and default values for new account provisioning.
+Create [HCL configurations](/2.0/reference/pipelines/configurations-as-code/) in the `.gruntwork` directory in the root of your `infrastructure-live` repository to tell Pipelines how you plan to organize your infrastructure, and how you plan to have Pipelines authenticate with your cloud provider(s).
 
-## Running the workflow
+For example:
 
-Follow the instructions in your `infrastructure-live-root` repository to execute the Bootstrap Workflow. Gruntwork support is available to address any questions that arise. During the workflow execution, you can choose to create the `infrastructure-live-access-control` and `infrastructure-catalog` repositories. These repositories will be created in your GitHub organization using values defined in the workflow configuration.
+```hcl title=".gruntwork/repository.hcl"
+repository {
+  deploy_branch_name = "main"
+}
+```
 
-### Infrastructure live access control
+```hcl title=".gruntwork/environment.hcl"
+environment "dev" {
+  filter {
+    paths = ["dev/*"]
+  }
 
-This repository is primarily for Enterprise customers but is recommended for all users. When running the Bootstrap Workflow in your `infrastructure-live-root` repository, select the option to "Bootstrap the infrastructure-access-control repository."
+  authentication {
+    aws_oidc {
+      account_id = "123456789012"
+      plan_iam_role_arn = "arn:aws:iam::123456789012:role/pipelines-plan"
+      apply_iam_role_arn = "arn:aws:iam::123456789012:role/pipelines-apply"
+    }
+  }
+}
 
-### Infrastructure catalog
+environment "prod" {
+  filter {
+    paths = ["prod/*"]
+  }
 
-The Bootstrap Workflow also creates an empty `infrastructure-catalog` repository. This repository is used to store Terraform/OpenTofu modules authored by your organization for internal use. During the Bootstrap Workflow execution in your `infrastructure-live-root` repository, select the option to "Bootstrap the infrastructure-catalog repository."
+  authentication {
+    aws_oidc {
+      account_id = "987654321098"
+      plan_iam_role_arn = "arn:aws:iam::987654321098:role/pipelines-plan"
+      apply_iam_role_arn = "arn:aws:iam::987654321098:role/pipelines-apply"
+    }
+  }
+}
+```
 
-## Completing instructions in Bootstrap Pull Requests
+:::tip
 
-Each of your repositories will contain a Bootstrap Pull Request. Follow the instructions in these Pull Requests to finalize the setup of your IaC repositories.
+Check out the [aws block](/2.0/reference/pipelines/configurations-as-code/#aws-blocks) for more information on how to configure Pipelines to authenticate with AWS conveniently.
 
-:::info
-
-The bootstrapping pull requests include pre-configured files, such as a `mise.toml` file that specifies versions of OpenTofu and Terragrunt. Ensure you review and update these configurations to align with your organization's requirements.
 :::
+
+## Creating `.github/workflows/pipelines.yml`
+
+Create a `.github/workflows/pipelines.yml` file in the root of your `infrastructure-live` repository with the following content:
+
+```yaml title=".github/workflows/pipelines.yml"
+name: Pipelines
+run-name: "[GWP]: ${{ github.event.commits[0].message || github.event.pull_request.title || 'No commit message' }}"
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - ".github/**"
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths-ignore:
+      - ".github/**"
+
+# Permissions to assume roles and create pull requests
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  GruntworkPipelines:
+    uses: gruntwork-io/pipelines-workflows/.github/workflows/pipelines.yml@main
+```
+
+:::tip
+
+You can read the [Pipelines GitHub Actions Workflow](https://github.com/gruntwork-io/pipelines-workflows/blob/main/.github/workflows/pipelines.yml) to learn how this GitHub Actions workflow calls the Pipelines CLI to run your pipelines.
+
+:::
+
+## Commit and push your changes
+
+Commit and push your changes to your repository.
+
+:::note
+
+You should include `[skip ci]` in your commit message here to prevent triggering the Pipelines workflow.
+
+:::
+
+```bash
+git add .
+git commit -m "Add Pipelines GitHub Actions workflow [skip ci]"
+git push
+```
+
+🚀 You've successfully added Gruntwork Pipelines to your new repository!
+
+## Next steps
+
+You have successfully completed the installation of Gruntwork Pipelines in a new repository. Proceed to [Deploying your first infrastructure change](/2.0/docs/pipelines/tutorials/deploying-your-first-infrastructure-change.md) to begin deploying changes.

--- a/docs/2.0/docs/pipelines/installation/addingnewrepo.md
+++ b/docs/2.0/docs/pipelines/installation/addingnewrepo.md
@@ -1,5 +1,8 @@
 # Initial Setup
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 To configure Gruntwork Pipelines in a new GitHub repository, complete the following steps (which are explained in detail below):
 
 1. Create an `infrastructure-live` repository.
@@ -61,6 +64,9 @@ repository {
 }
 ```
 
+<Tabs>
+<TabItem value="aws" label="AWS" default>
+
 ```hcl title=".gruntwork/environment.hcl"
 environment "dev" {
   filter {
@@ -93,9 +99,96 @@ environment "prod" {
 
 :::tip
 
+Learn more about how Pipelines authenticates to AWS in the [Authenticating to AWS](/2.0/docs/pipelines/concepts/cloud-auth/aws) page.
+
+:::
+
+:::tip
+
 Check out the [aws block](/2.0/reference/pipelines/configurations-as-code/#aws-blocks) for more information on how to configure Pipelines to authenticate with AWS conveniently.
 
 :::
+
+</TabItem>
+<TabItem value="azure" label="Azure">
+
+```hcl title=".gruntwork/environment.hcl"
+environment "dev" {
+  filter {
+    paths = ["dev/*"]
+  }
+
+  authentication {
+    azure_oidc {
+      tenant_id       = "141052b1-f3e4-49c2-91a3-dc349beb66f1"
+      subscription_id = "a0afca72-e70c-4b57-acb1-e4c9019e59be"
+
+      plan_client_id  = "b5315418-c05e-471d-9b68-13695fb4863f"
+      apply_client_id = "9b4eb942-b48a-4ab8-bc47-f3a92068ae88"
+    }
+  }
+}
+
+environment "prod" {
+  filter {
+    paths = ["prod/*"]
+  }
+
+  authentication {
+    azure_oidc {
+      tenant_id       = "141052b1-f3e4-49c2-91a3-dc349beb66f1"
+      subscription_id = "b0bfdb73-f80d-5c68-bdc2-f5d9129f70cf"
+
+      plan_client_id  = "c6426529-d16f-582e-ad79-04a93fb9974e"
+      apply_client_id = "ac5fc053-c59b-5bc9-cd58-049b42179a99"
+    }
+  }
+}
+```
+
+:::tip
+
+Learn more about how Pipelines authenticates to Azure in the [Authenticating to Azure](/2.0/docs/pipelines/concepts/cloud-auth/azure) page.
+
+:::
+
+</TabItem>
+<TabItem value="custom" label="Custom">
+
+```hcl title=".gruntwork/environment.hcl"
+environment "dev" {
+  filter {
+    paths = ["dev/*"]
+  }
+
+  authentication {
+    custom {
+      auth_provider_cmd = "./scripts/custom-auth-dev.sh"
+    }
+  }
+}
+
+environment "prod" {
+  filter {
+    paths = ["prod/*"]
+  }
+
+  authentication {
+    custom {
+      auth_provider_cmd = "./scripts/custom-auth-prod.sh"
+    }
+  }
+}
+```
+
+:::tip
+
+Learn more about how Pipelines can authenticate with custom authentication in the [Custom Authentication](/2.0/docs/pipelines/concepts/cloud-auth/custom) page.
+
+:::
+
+</TabItem>
+</Tabs>
 
 ## Creating `.github/workflows/pipelines.yml`
 

--- a/docs/2.0/docs/pipelines/installation/authoverview.md
+++ b/docs/2.0/docs/pipelines/installation/authoverview.md
@@ -1,12 +1,13 @@
 # Authenticating Gruntwork Pipelines
 
 Gruntwork Pipelines requires authentication with GitHub/GitLab to perform various functions, including:
-* Downloading Gruntwork code, such as the Pipelines binary and Terraform modules, from the `gruntwork-io` GitHub organization.
-* Interacting with your repositories, such as:
-  * Creating pull requests.
-  * Commenting on pull requests.
-  * Creating new repositories via Account Factory.
-  * Updating repository settings, such as enforcing branch protection, via Account Factory.
+
+- Downloading Gruntwork code, such as the Pipelines binary and Terraform modules, from the `gruntwork-io` GitHub organization.
+- Interacting with your repositories, such as:
+  - Creating pull requests.
+  - Commenting on pull requests.
+  - Creating new repositories via Account Factory.
+  - Updating repository settings, such as enforcing branch protection, via Account Factory.
 
 Gruntwork provides two authentication methods: a [GitHub App](/2.0/docs/pipelines/installation/viagithubapp.md) and CI Users ([Machine Users](/2.0/docs/pipelines/installation/viamachineusers.md)) with personal access tokens for Pipelines.
 
@@ -15,11 +16,14 @@ Both approaches support the core functionality of Pipelines. However, the GitHub
 ## Summary of authentication mechanisms for GitHub
 
 **Advantages of the GitHub App**:
+
 - Simplified setup process.
 - Access to enhanced features and functionality.
 - Improved user experience during regular operations.
 - Reduced maintenance, as there is no need to install, maintain, or rotate powerful tokens.
 
 **Advantages of Machine Users**:
+
 - Compatibility with on-premises GitHub Enterprise installations that cannot interact with third-party servers (e.g., Gruntwork's backend).
 - Provides a fallback solution to ensure Pipelines continue functioning in the unlikely event of an outage affecting the Gruntwork-hosted backend that powers the GitHub App.
+- Allows GitLab customers to download the Pipelines binary from GitLab CI Pipelines.

--- a/docs/2.0/docs/pipelines/installation/viagithubapp.md
+++ b/docs/2.0/docs/pipelines/installation/viagithubapp.md
@@ -13,6 +13,7 @@ The [Gruntwork.io GitHub App](https://github.com/apps/gruntwork-io) is a [GitHub
 At this time Gruntwork does not provide an app for GitLab, this page is only relevant for Gruntwork Pipelines users installing in GitHub.
 
 :::
+
 ## Overview
 
 There are three major components to keep in mind when working with the Gruntwork.io GitHub App:
@@ -28,6 +29,7 @@ The Gruntwork.io GitHub App is the principal that Gruntwork products will utiliz
 #### Required Permissions
 
 As of 2024/09/10, the Gruntwork.io GitHub App requests the following permissions:
+
 - **Read access to Actions**: Allows the app to read GitHub Actions artifacts.
 - **Write access to Administration**: Allows the app to create new repositories, and add teams as collaborators to repositories.
 - **Write access to Contents**: Allows the app to read and write repository contents.
@@ -40,13 +42,15 @@ As of 2024/09/10, the Gruntwork.io GitHub App requests the following permissions
 
   Gruntwork.io requests all of these permissions because it requires them for different operations. Unfortunately, the way GitHub apps work prevents us from requesting permissions on a more granular basis. Know that the GitHub App Service will scope down its permissions whenever possible to the minimum required for the operation at hand.
 
-  The level of granularity available to customers when configuring the GitHub App installation is to either install the app on a per-repository basis or on an entire organization. Our recommendation is as follows:
+  The level of granularity available to customers when configuring the GitHub App installation is to either install the app on a per-repository basis or on an entire organization. Our recommendation is as follows for Account Factory customers:
 
-  * For non-enterprise customers, allow the app for `infrastructure-live-root` repository and (if in-use) `infrastructure-live-access-control` and `infrastructure-catalog`.
-  * For enterprise customers, allow the app to have access to the entire organization.
+  - For non-enterprise customers, allow the app for `infrastructure-live-root` repository and (if in-use) `infrastructure-live-access-control` and `infrastructure-catalog`.
 
-The reasoning for requiring entire-organization access for enterprise customers is that if you are using Account Factory to create delegated repositories then Account Factory will be creating, and then immediately modifying, new repositories in automated flows, which means it needs access to new repos as soon as they are created which is only possible with entire organization permission.
+  - For enterprise customers, allow the app to have access to the entire organization.
 
+  For non-Account Factory customers, we recommend installing the app on a per-repository basis.
+
+  The reasoning for requiring entire-organization access for enterprise customers is that if you are using Account Factory to create delegated repositories then Account Factory will be creating, and then immediately modifying, new repositories in automated flows, which means it needs access to new repos as soon as they are created which is only possible with entire organization permission.
 
   If you are unsure how to proceed here, reach out to Gruntwork Support for guidance.
 
@@ -108,7 +112,7 @@ The GitHub App Service is used by two major clients:
 
 2. **Gruntwork Pipelines**
 
-   The main client for the Gruntwork.io App, and where most of the value is derived. Pipelines uses the GitHub App Service to acquire the relevant access for interacting with GitHub resources on behalf of the user. Access control rules are enforced here to ensure that only the level of access required, and explicitly specified in the Gruntwork Developer Portal can be used by Pipelines to interact with GitHub resources on behalf of the user.
+   The main client for the Gruntwork.io App, and where most of the value is derived. Pipelines uses the GitHub App Service to acquire the relevant access for interacting with GitHub resources on behalf of the user. Access control rules are enforced here to ensure that only the level of access required (and explicitly specified in the Gruntwork Developer Portal) can be used by Pipelines to interact with GitHub resources on behalf of the user.
 
    For example, while the Gruntwork.io GitHub App does have permissions to create new repositories, Pipelines will only do so if a workflow originating from a configured `infrastructure-live-root` repository requests it.
 
@@ -118,7 +122,7 @@ The availability of the Gruntwork.io GitHub App is something Gruntwork will ende
 
 Any downtime of Gruntwork services will not impact the ability of your team to manage infrastructure using Gruntwork products.
 
-#### App Only Features
+### App Only Features
 
 The following features of the Gruntwork.io GitHub App will be unavailable during downtime:
 
@@ -126,11 +130,11 @@ The following features of the Gruntwork.io GitHub App will be unavailable during
 - **Gruntwork Pipelines Comments**: While Pipelines will allow for IaC updates in a degraded state without the availability of the GitHub App, comments are a feature that rely on the availability of the app for the best experience.
 - **Gruntwork Pipelines Drift Detection**: Drift detection requires the availability of the GitHub App to function correctly.
 
-#### Fallback
+### Fallback
 
-In order to ensure that the availability of the Gruntwork.io GitHub App is not something that can impair the ability of users to drive infrastructure updates, the legacy mechanism of authenticating with GitHub using [Machine users](/2.0/docs/pipelines/installation/viamachineusers.md) is still supported.
+In order to ensure that the availability of the Gruntwork.io GitHub App is not something that can impair the ability of users to drive infrastructure updates, users can also authenticate with GitHub using [Machine users](/2.0/docs/pipelines/installation/viamachineusers.md).
 
-Configuring the `PIPELINES_READ_TOKEN`, `INFRA_ROOT_WRITE_TOKEN` and `ORG_REPO_ADMIN_TOKEN` where necessary (following the documentation linked above) will result in Pipelines using the legacy mechanism to authenticate with GitHub, rather than the Gruntwork.io GitHub App.
+Configuring the `PIPELINES_READ_TOKEN`, `INFRA_ROOT_WRITE_TOKEN` and `ORG_REPO_ADMIN_TOKEN` where necessary (following the documentation linked above) will result in Pipelines using the machine users mechanism to authenticate with GitHub, rather than the Gruntwork.io GitHub App.
 
 Using these fallback tokens will ensure that Pipelines can continue to perform operations like:
 
@@ -160,7 +164,7 @@ To install the Gruntwork.io GitHub App in your organization follow these steps.
 
 ## Configuration
 
-<h3>Infrastructure Live Root Repositories</h3>
+### Infrastructure Live Root Repositories
 
 DevOps Foundations treats certain repositories as especially privileged in order to perform critical operations like vending new AWS accounts and creating new repositories. These repositories are called "infrastructure live root repositories" and you can configure them in the [GitHub Account section](https://app.gruntwork.io/account?scroll_to=github-app) for your organization in the Gruntwork developer portal **if you are a designated administrator**.
 
@@ -174,7 +178,7 @@ For more information, see the [relevant architecture documentation](/2.0/docs/pi
 
 ## Frequently Asked Questions
 
-#### How do I find my Gruntwork.io GitHub App installation ID?
+### How do I find my Gruntwork.io GitHub App installation ID?
 
 You can find the installation ID of the Gruntwork.io GitHub App in the URL of the installation page.
 

--- a/docs/2.0/docs/pipelines/installation/viamachineusers.md
+++ b/docs/2.0/docs/pipelines/installation/viamachineusers.md
@@ -3,12 +3,14 @@
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 ---
+
 # Setting up Pipelines via GitHub Machine Users
+
 import PersistentCheckbox from '/src/components/PersistentCheckbox';
 import Tabs from "@theme/Tabs"
 import TabItem from "@theme/TabItem"
 
-For GitHub users, of the [two methods](/2.0/docs/pipelines/installation/authoverview.md) for installing Gruntwork Pipelines, we strongly recommend using the [GitHub App](/2.0/docs/pipelines/installation/viagithubapp.md). However, if the GitHub App cannot be used or if machine users are required as a [fallback](http://localhost:3000/2.0/docs/pipelines/installation/viagithubapp#fallback), this guide outlines how to set up authentication for Pipelines using access tokens and machine users.
+For GitHub users, of the [two methods](/2.0/docs/pipelines/installation/authoverview.md) for installing Gruntwork Pipelines, we strongly recommend using the [GitHub App](/2.0/docs/pipelines/installation/viagithubapp.md). However, if the GitHub App cannot be used or if machine users are required as a [fallback](/2.0/docs/pipelines/installation/viagithubapp#fallback), this guide outlines how to set up authentication for Pipelines using access tokens and machine users.
 
 For GitHub or GitLab users, when using tokens, Gruntwork recommends setting up CI users specifically for Gruntwork Pipelines, separate from human users in your organization. This separation ensures workflows are not disrupted if an employee leaves the company and allows for more precise permission management. Additionally, using CI users allow you to apply granular permissions that may normally be too restrictive for a normal employee to do their daily work.
 
@@ -19,6 +21,7 @@ This guide will take approximately 30 minutes to complete.
 :::
 
 ## Background
+
 ### Guidance on storing secrets
 
 During this process, you will generate and securely store several access tokens. Use a temporary but secure location for these sensitive values between generating them and storing them in GitHub or GitLab. Follow your organization's security best practices and avoid insecure methods (e.g., Slack or sticky notes) during this exercise.
@@ -36,6 +39,7 @@ If screen sharing while generating tokens, **pause or hide your screen** before 
 :::
 
 ### Token types
+
 <Tabs>
 <TabItem value="github" label="GitHub" default>
 
@@ -87,16 +91,17 @@ GitLab uses access tokens for authentication. There are several types of access 
 
 For Pipelines, we recommend using Project or Group Access Tokens.
 
-Note that Project and Group access tokens are only available in certain GitLab licenses.  Specifically:
+Note that Project and Group access tokens are only available in certain GitLab licenses. Specifically:
 
 [Project Access Tokens](https://docs.gitlab.com/user/project/settings/project_access_tokens/#token-availability)
-* On GitLab SaaS: If you have the Premium or Ultimate license tier, only one project access token is available with a [trial license](https://about.gitlab.com/free-trial/).
-* On GitLab Self-Managed instances: With any license tier. If you have the Free tier, consider [restricting the creation of project access tokens](https://docs.gitlab.com/user/project/settings/project_access_tokens/#restrict-the-creation-of-project-access-tokens) to lower potential abuse.
+
+- On GitLab SaaS: If you have the Premium or Ultimate license tier, only one project access token is available with a [trial license](https://about.gitlab.com/free-trial/).
+- On GitLab Self-Managed instances: With any license tier. If you have the Free tier, consider [restricting the creation of project access tokens](https://docs.gitlab.com/user/project/settings/project_access_tokens/#restrict-the-creation-of-project-access-tokens) to lower potential abuse.
 
 [Group Access Tokens](https://docs.gitlab.com/user/group/settings/group_access_tokens/)
 
-* On GitLab.com, you can use group access tokens if you have the Premium or Ultimate license tier. Group access tokens are not available with a [trial license](https://about.gitlab.com/free-trial/).
-* On GitLab Dedicated and self-managed instances, you can use group access tokens with any license tier.
+- On GitLab.com, you can use group access tokens if you have the Premium or Ultimate license tier. Group access tokens are not available with a [trial license](https://about.gitlab.com/free-trial/).
+- On GitLab Dedicated and self-managed instances, you can use group access tokens with any license tier.
 
 </TabItem>
 </Tabs>
@@ -116,7 +121,7 @@ Both the `ci-user` and the `ci-read-only-user` must:
 
 1. Be members of your GitHub Organization.
 
-2.  Be added to your team in **Gruntwork**’s GitHub Organization (See [instructions on inviting a user to your team](https://docs.gruntwork.io/developer-portal/invite-team#inviting-team-members) and [linking the user’s GitHub ID to Gruntwork](https://docs.gruntwork.io/developer-portal/link-github-id)).
+2. Be added to your team in **Gruntwork**’s GitHub Organization (See [instructions on inviting a user to your team](https://docs.gruntwork.io/developer-portal/invite-team#inviting-team-members) and [linking the user’s GitHub ID to Gruntwork](https://docs.gruntwork.io/developer-portal/link-github-id)).
 
 :::tip
 We recommend creating two machine users for better access control, but you may adjust this setup to fit your organization’s needs. Ensure permissions are appropriate for their roles, and note that additional GitHub licenses may be required if at capacity.
@@ -141,6 +146,7 @@ Ensure the `ci-user` has write access to your:
 - `infrastructure-live-access-control` repository
 
 **Checklist:**
+
 <PersistentCheckbox id="via-machine-users-1" label="ci-user created" />
 
 **Create access tokens for the `ci-user`**
@@ -148,13 +154,13 @@ Ensure the `ci-user` has write access to your:
 Generate the required tokens for the ci-user in their GitHub account.
 
 **Checklist:**
+
 <PersistentCheckbox id="via-machine-users-2" label="INFRA_ROOT_WRITE_TOKEN created under ci-user" />
 <PersistentCheckbox id="via-machine-users-3" label="ORG_REPO_ADMIN_TOKEN created under ci-user" />
 
-
 #### INFRA_ROOT_WRITE_TOKEN
 
-This [fine-grained](#fine-grained) Personal Access Token allows GitHub Actions to clone `infrastructure-live-root`, open pull requests, and update comments.
+This [fine-grained](#fine-grained-tokens) Personal Access Token allows GitHub Actions to clone `infrastructure-live-root`, open pull requests, and update comments.
 
 This token must have the following permissions to the `INFRA_ROOT_WRITE_TOKEN` for the `infrastructure-live-root` repository:
 
@@ -175,18 +181,23 @@ Below is a detailed breakdown of the permissions needed for the `INFRA_ROOT_WRIT
 If you are not an Enterprise customer or prefer Pipelines not to execute certain behaviors, you can opt not to grant the related permissions.
 
 ##### Content read & write access
+
 Needed for cloning `infrastructure-live-root` and pushing automated changes. Without this permission, the pull request opened by the GitHub Actions workflow will not trigger automation during account vending.
 
 ##### Issues read & write access
+
 Allows Pipelines to open issues that alert teams when manual action is required.
 
 ##### Metadata read access
+
 Grants visibility into repository metadata.
 
 ##### Pull requests read & write access
+
 Allows Pipelines to create pull requests to introduce infrastructure changes.
 
 ##### Workflows read & write access
+
 Required to update workflows when provisioning new repositories.
 
 </details>
@@ -215,26 +226,30 @@ The following is a breakdown of the permissions needed for the `ORG_REPO_ADMIN_T
 If you are not an Enterprise customer or prefer Pipelines not to carry out certain actions, you can choose to withhold the related permissions.
 
 ##### Administration read & write access
+
 Allows the creation of new repositories for delegated infrastructure management.
 
 ##### Content read & write access
+
 Used for bootstrapping repositories and populating them with necessary content.
 
 ##### Metadata read access
+
 Grants repository-level insights needed for automation.
 
 ##### Pull requests read & write access
-     This is required to open pull requests. When vending delegated repositories for Enterprise customers, Pipelines will open pull requests to automate the process of introducing new Infrastructure as Code changes to drive infrastructure updates.
+
+This is required to open pull requests. When vending delegated repositories for Enterprise customers, Pipelines will open pull requests to automate the process of introducing new Infrastructure as Code changes to drive infrastructure updates.
 
 ##### Workflows read & write access
- This is required to update GitHub Action workflow files. When vending delegated repositories for Enterprise customers, Pipelines will create new repositories, including content in the `.github/workflows` directory. Without this permission, Pipelines would not be able to provision repositories with this content.
+
+This is required to update GitHub Action workflow files. When vending delegated repositories for Enterprise customers, Pipelines will create new repositories, including content in the `.github/workflows` directory. Without this permission, Pipelines would not be able to provision repositories with this content.
 
 ##### Members read & write access
 
-     Required to update GitHub organization team members. When vending delegated repositories for Enterprise customers, Pipelines will add team members to a team that has access to a delegated repository. Without this permission, Pipelines would not be able to provision repositories that are accessible to the correct team members.
+Required to update GitHub organization team members. When vending delegated repositories for Enterprise customers, Pipelines will add team members to a team that has access to a delegated repository. Without this permission, Pipelines would not be able to provision repositories that are accessible to the correct team members.
 
 </details>
-
 
 :::tip
 If you are not an Enterprise customer, you should delete it after DevOps Foundations setup.
@@ -244,13 +259,14 @@ If you are not an Enterprise customer, you should delete it after DevOps Foundat
 
 The `ci-read-only-user` is configured to download private software within GitHub Actions workflows. This user is responsible for accessing Gruntwork IaC Library modules, your infrastructure-modules repository, other private custom module repositories, and the Pipelines CLI.
 
-This user should use a single classic Personal Access Token (PAT)(https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#personal-access-tokens-classic) with read-only permissions. Since classic PATs offer coarse grained access controls, it’s recommended to assign this user to a GitHub team with READ access limited to the `infrastructure-live-root` repository and any relevant module repositories within your GitHub Organization. Adding this user to the Gruntwork Developer Portal will automatically grant access to the Gruntwork IaC Library.
+This user should use a single classic [Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#personal-access-tokens-classic) with read-only permissions. Since classic PATs offer coarse grained access controls, it’s recommended to assign this user to a GitHub team with READ access limited to the `infrastructure-live-root` repository and any relevant module repositories within your GitHub Organization. Adding this user to the Gruntwork Developer Portal will automatically grant access to the Gruntwork IaC Library.
 
 **Invite ci-read-only-user to your repository**
 
 Invite `ci-user-read-only` to your `infrastructure-live-root` repository with read access.
 
 **Checklist:**
+
 <PersistentCheckbox id="via-machine-users-4" label="ci-read-only-user invited to infrastructure-live-root" />
 
 **Create a token for ci-read-only-user**
@@ -259,8 +275,6 @@ Generate the following token for the `ci-read-only-user`:
 
 **Checklist:**
 <PersistentCheckbox id="via-machine-users-5" label="PIPELINES_READ_TOKEN created under ci-read-only-user" />
-
-
 
 #### PIPELINES_READ_TOKEN
 
@@ -275,6 +289,7 @@ This token must have `repo` scopes. Gruntwork recommends setting expiration to 9
 Make sure both machine users are added to your team in Gruntwork’s GitHub Organization. Refer to the [instructions for inviting a user to your team](https://docs.gruntwork.io/developer-portal/invite-team#inviting-team-members) and [linking the user’s GitHub ID to Gruntwork](https://docs.gruntwork.io/developer-portal/link-github-id) for guidance.
 
 **Checklist:**
+
 <PersistentCheckbox id="via-machine-users-6" label="Machine users invited to Gruntwork organization" />
 
 ## Configure secrets for GitHub Actions
@@ -287,11 +302,14 @@ Since this guide uses secrets scoped to specific repositories, the token permiss
 
 <Tabs groupId="github-actions-secrets">
 <TabItem value="Organization Secrets" label="Organization Secrets" default>
+
 **Checklist:**
+
 <PersistentCheckbox id="via-machine-users-5a" label="PIPELINES_READ_TOKEN added to organization secrets" />
 <PersistentCheckbox id="via-machine-users-5b" label="INFRA_ROOT_WRITE_TOKEN added to organization secrets" />
 <PersistentCheckbox id="via-machine-users-5c" label="ORG_REPO_ADMIN_TOKEN added to organization secrets" />
 <hr />
+
 1. Navigate to your top-level GitHub Organization and select the **Settings** tab.
 
 2. From the navigation bar on the left side, choose **Secrets and variables**, then select **Actions**.
@@ -345,13 +363,16 @@ For more details on creating and using GitHub Actions Organization secrets, refe
 
 </TabItem>
 <TabItem value="Repository Secrets" label="Repository Secrets">
+
 **Checklist:**
+
 <PersistentCheckbox id="via-machine-users-6a" label="PIPELINES_READ_TOKEN added to infrastructure-live-root" />
 <PersistentCheckbox id="via-machine-users-6b" label="INFRA_ROOT_WRITE_TOKEN added to infrastructure-live-root" />
 <PersistentCheckbox id="via-machine-users-6c" label="ORG_REPO_ADMIN_TOKEN added to infrastructure-live-root" />
 <PersistentCheckbox id="via-machine-users-6d" label="PIPELINES_READ_TOKEN added to infrastructure-live-access-control" />
 <PersistentCheckbox id="via-machine-users-6e" label="ORG_REPO_ADMIN_TOKEN added to infrastructure-live-access-control" />
 <hr />
+
 Gruntwork Pipelines retrieves these secrets from GitHub Actions secrets configured in the repository. For instructions on creating repository Actions secrets, refer to [creating secrets for a repository](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository).
 
 ### `infrastructure-live-root`
@@ -378,8 +399,8 @@ If you are **not an Enterprise customer**, you should also do the following:
 
 - Delete the `ORG_REPO_ADMIN_TOKEN` Personal Access Token from the `ci-user`’s GitHub account.
 - Remove the `ORG_REPO_ADMIN_TOKEN` Repository secret from the `infrastructure-live-root` repository.
-:::
 
+:::
 
 :::info
 For more information on creating and using GitHub Actions Repository secrets, refer to the [GitHub Documentation](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository).
@@ -391,13 +412,12 @@ For more information on creating and using GitHub Actions Repository secrets, re
 </TabItem>
 <TabItem value="gitlab" label="GitLab">
 
-
-For GitLab, Gruntwork Pipelines two CI variables. The first, the `PIPELINES_GITLAB_TOKEN` requires the `Developer`, `Maintainer` or `Owner` role and the scopes listed below. This token will be used to authenticate API calls and access repositories within your GitLab group.  The second, the `PIPELINES_GITLAB_READ_TOKEN` will be used to access your own code within GitLab. If not set, Pipelines will default to the `CI_JOB_TOKEN` when accessing internal GitLab hosted code.
-
+For GitLab, Gruntwork Pipelines two CI variables. The first, the `PIPELINES_GITLAB_TOKEN` requires the `Developer`, `Maintainer` or `Owner` role and the scopes listed below. This token will be used to authenticate API calls and access repositories within your GitLab group. The second, the `PIPELINES_GITLAB_READ_TOKEN` will be used to access your own code within GitLab. If not set, Pipelines will default to the `CI_JOB_TOKEN` when accessing internal GitLab hosted code.
 
 ### Creating the Access Token
 
 Gruntwork recommends [creating](https://docs.gitlab.com/user/project/settings/project_access_tokens/#create-a-project-access-token) two Project or Group Access Tokens as best practice:
+
 | Token Name                      | Required Scopes                              | Required Role                   | Purpose                                                                      |
 | ------------------------------- | -------------------------------------------- | ------------------------------- | ---------------------------------------------------------------------------- |
 | **PIPELINES_GITLAB_TOKEN**      | `api` (and `ai_features` if using GitLab AI) | Developer, Maintainer, or Owner | Making API calls (e.g., creating comments on merge requests)                 |
@@ -417,6 +437,7 @@ Set an expiration date according to your organization's security policies. We re
 :::
 
 **Checklist:**
+
 <PersistentCheckbox id="via-machine-users-gitlab-3" label="PIPELINES_GITLAB_TOKEN created" />
 <PersistentCheckbox id="via-machine-users-gitlab-4" label="PIPELINES_GITLAB_READ_TOKEN created" />
 
@@ -434,6 +455,7 @@ Add the `PIPELINES_GITLAB_TOKEN` and `PIPELINES_GITLAB_READ_TOKEN` as CI/CD vari
 8. Set the value as the Personal Access Token generated in the [Creating the Access Token](#creating-the-access-token) section
 
 **Checklist:**
+
 <PersistentCheckbox id="via-machine-users-gitlab-5" label="PIPELINES_GITLAB_TOKEN added to CI/CD variables" />
 <PersistentCheckbox id="via-machine-users-gitlab-6" label="PIPELINES_GITLAB_READ_TOKEN added to CI/CD variables" />
 

--- a/sidebars/docs.js
+++ b/sidebars/docs.js
@@ -225,18 +225,6 @@ const sidebar = [
         id: "2.0/docs/pipelines/installation/scm-comparison",
       },
       {
-        label: "Prerequisites",
-        type: "category",
-        collapsed: false,
-        items: [
-          {
-            label: "AWS Landing Zone",
-            type: "doc",
-            id: "2.0/docs/pipelines/installation/prerequisites/awslandingzone",
-          },
-        ],
-      },
-      {
         type: "category",
         label: "Enable Auth for Pipelines",
         collapsed: false,
@@ -479,6 +467,18 @@ const sidebar = [
         label: "Repository Topology",
         type: "doc",
         id: "2.0/docs/accountfactory/architecture/repository-topology",
+      },
+    ],
+  },
+  {
+    label: "Prerequisites",
+    type: "category",
+    collapsed: false,
+    items: [
+      {
+        label: "AWS Landing Zone",
+        type: "doc",
+        id: "2.0/docs/accountfactory/prerequisites/awslandingzone",
       },
     ],
   },

--- a/sidebars/docs.js
+++ b/sidebars/docs.js
@@ -484,8 +484,19 @@ const sidebar = [
   },
   {
     label: "Setup & Installation",
-    type: "doc",
-    id: "2.0/docs/accountfactory/installation/index",
+    type: "category",
+    collapsed: true,
+    link: {
+      type: "doc",
+      id: "2.0/docs/accountfactory/installation/index",
+    },
+    items: [
+      {
+        label: "Adding Account Factory to a new repository",
+        type: "doc",
+        id: "2.0/docs/accountfactory/installation/addingnewrepo",
+      },
+    ],
   },
   {
     label: "Guides",

--- a/src/redirects.js
+++ b/src/redirects.js
@@ -154,15 +154,15 @@ export const redirects = [
         from: "/foundations/running-apps"
     },
     {
-        to: "/2.0/docs/pipelines/installation/prerequisites/awslandingzone#prerequisites",
+        to: "/2.0/docs/accountfactory/prerequisites/awslandingzone#prerequisites",
         from: "/foundations/landing-zone/prerequisites"
     },
     {
-        to: "/2.0/docs/pipelines/installation/prerequisites/awslandingzone",
+        to: "/2.0/docs/accountfactory/prerequisites/awslandingzone",
         from: "/foundations/landing-zone/index"
     },
     {
-        to: "/2.0/docs/pipelines/installation/prerequisites/awslandingzone",
+        to: "/2.0/docs/accountfactory/prerequisites/awslandingzone",
         from: "/foundations/landing-zone"
     },
     {
@@ -170,7 +170,7 @@ export const redirects = [
         from: "/foundations/landing-zone/add-aws-account"
     },
     {
-        to: "/2.0/docs/pipelines/installation/prerequisites/awslandingzone#configure-control-tower",
+        to: "/2.0/docs/accountfactory/prerequisites/awslandingzone#configure-control-tower",
         from: "/foundations/landing-zone/enable-control-tower"
     },
     {
@@ -368,5 +368,9 @@ export const redirects = [
     {
         from: '/2.0/docs/pipelines/architecture/github-workflows',
         to: '/2.0/docs/pipelines/architecture/ci-workflows'
+    },
+    {
+        from: '/2.0/docs/pipelines/installation/prerequisites/awslandingzone',
+        to: '/2.0/docs/accountfactory/prerequisites/awslandingzone'
     }
 ]


### PR DESCRIPTION
- **docs: Moving AWS Landing Zone prereq to Account Factory**
- **docs: Adjusting redirects for moving AWS Landing Zone to Account Factory**
- **docs: Restructured initial setup to avoid assuming AWS**
- **docs: Splitting up different cloud providers**
