### PR TITLE
fix: Fixing URL for terragrunt-scale-catalog

### DIFF
--- a/docs/2.0/docs/pipelines/tutorials/deploying-your-first-infrastructure-change.mdx
+++ b/docs/2.0/docs/pipelines/tutorials/deploying-your-first-infrastructure-change.mdx
@@ -121,7 +121,7 @@ This section covers creating a cloud storage resource using Pipelines and GitOps
     }
 
     terraform {
-      source = "github.com/gruntwork-io/terragrunt-scale/catalog//modules/azure/storage-account?ref=v1.0.0"
+      source = "github.com/gruntwork-io/terragrunt-scale-catalog//modules/azure/storage-account?ref=v1.0.0"
     }
 
     dependency "resource_group" {


### PR DESCRIPTION
Accidentally set the URL to `terragrunt-scale`.