### PR TITLE
docs: document EXPERIMENT_AUTO_UNLOCK_STATE_LOCK

### DIFF
--- a/docs/2.0/reference/pipelines/feature-flags.md
+++ b/docs/2.0/reference/pipelines/feature-flags.md
@@ -124,6 +124,21 @@ Enables Terragrunt features to reduce the potential changes during a run-all. Te
 </li>
 </ul>
 
+#### `PIPELINES_FEATURE_EXPERIMENT_AUTO_UNLOCK_STATE_LOCK`
+<ul>
+<li>
+Enables Pipelines to automatically force-unlock a stale Terraform/OpenTofu state lock when an AWS session timeout causes the lock-release step to fail mid-apply. When detected (both `Error releasing the state lock` and `ExpiredTokenException` appear in the apply output), Pipelines runs `terragrunt plan -- -lock-timeout=0s` with fresh credentials to identify the stale lock ID, then calls `terragrunt force-unlock` to release it. The original apply error is still returned — the unlock only clears the lock so the next run can proceed.
+
+Only applies to single-unit commands. Use of this feature with `run --all` is not yet supported.
+</li>
+<li>
+**Default Value**: Disabled
+</li>
+<li>
+**How to Enable**: Set to `"true"`
+</li>
+</ul>
+
 #### `PIPELINES_FEATURE_EXPERIMENT_USE_MISE_EXEC_TG_WRAPPER`
 <ul>
 <li>

--- a/docs/2.0/reference/pipelines/feature-flags.md
+++ b/docs/2.0/reference/pipelines/feature-flags.md
@@ -127,7 +127,9 @@ Enables Terragrunt features to reduce the potential changes during a run-all. Te
 #### `PIPELINES_FEATURE_EXPERIMENT_AUTO_UNLOCK_STATE_LOCK`
 <ul>
 <li>
-Enables Pipelines to automatically force-unlock a stale Terraform/OpenTofu state lock when an AWS session timeout causes the lock-release step to fail mid-apply. When detected (both `Error releasing the state lock` and `ExpiredTokenException` appear in the apply output), Pipelines runs `terragrunt plan -- -lock-timeout=0s` with fresh credentials to identify the stale lock ID, then calls `terragrunt force-unlock` to release it. The original apply error is still returned — the unlock only clears the lock so the next run can proceed.
+Enables Pipelines to automatically force-unlock a stale Terraform/OpenTofu state lock when an AWS session timeout causes the lock-release step to fail mid-apply. When detected (both `Error releasing the state lock` and `ExpiredTokenException` appear in the apply output), Pipelines runs `terragrunt plan -- -lock-timeout=0s` with fresh credentials to identify the stale lock ID, then calls `terragrunt force-unlock` to release it. The original apply error is still returned -- the unlock only clears the lock so the next run can proceed.
+
+Requires Terragrunt 1.0 or later. Earlier versions do not produce the structured run report that this feature depends on.
 
 Only applies to single-unit commands. Use of this feature with `run --all` is not yet supported.
 </li>


### PR DESCRIPTION
## Summary
- Adds documentation for the new Pipelines experiment flag `PIPELINES_FEATURE_EXPERIMENT_AUTO_UNLOCK_STATE_LOCK`.
- The flag enables automatic force-unlock of stale Terraform/OpenTofu state locks when an AWS session timeout causes the lock-release step to fail mid-apply.
- Single-unit only (run --all not supported yet). Default OFF.

## Related
- Implementation PR: gruntwork-io/pipelines#555
- Scale catalog PR (opts new installs in): gruntwork-io/terragrunt-scale-catalog#41



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new feature flag that enables automatic recovery of stale Terraform/OpenTofu state locks when pipeline apply operations fail due to expired AWS session credentials. The system detects the specific error pattern, retries with fresh credentials to identify and clear stale locks, and still surfaces the original apply error. Disabled by default, must be explicitly enabled, and only applies to single-unit commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->