### PR TITLE
Add account_factory.pr_create_token_name hcl config

### DIFF
--- a/docs/2.0/reference/accountfactory/configurations-as-code.md
+++ b/docs/2.0/reference/accountfactory/configurations-as-code.md
@@ -318,6 +318,16 @@ account_factory {
   </HclListItemDescription>
 </HclListItem>
 
+### pr_create_token_name
+
+<HclListItem name="pr_create_token_name" requirement="optional" type="string">
+  <HclListItemDescription>
+
+    (GitHub only) The name of your PR create token if different from the default of `PR_CREATE_TOKEN`.
+
+  </HclListItemDescription>
+</HclListItem>
+
 ### security_account_name
 
 <HclListItem name="security_account_name" requirement="optional" type="string">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new optional GitHub configuration option `pr_create_token_name` that enables customization of the token name default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->