### PR TITLE
2026 04 20 pipelines workflow location

### DIFF
--- a/docs/2.0/docs/accountfactory/installation/addingnewrepo.md
+++ b/docs/2.0/docs/accountfactory/installation/addingnewrepo.md
@@ -256,8 +256,8 @@ DefaultRegion: $$DEFAULT_REGION$$
 # CustomSCMProviderInstanceURL: https://gitlab.example.io
 
 # The location prefix of the pipelines workflows. Set this if you are using a custom/forked instance of the pipelines workflows repository.
-# For self-hosted GitLab, include the $CI_SERVER_FQDN prefix: "$CI_SERVER_FQDN/<group>/pipelines-workflows/"
-# PipelinesWorkflowLocation: $CI_SERVER_FQDN/my-group/pipelines-workflows/
+# For self-hosted GitLab, include the $CI_SERVER_FQDN prefix: "$CI_SERVER_FQDN/<group>/pipelines-workflows"
+# PipelinesWorkflowLocation: $CI_SERVER_FQDN/my-group/pipelines-workflows
 ```
 
 <h4> Generate the repository contents </h4>

--- a/docs/2.0/docs/accountfactory/installation/addingnewrepo.md
+++ b/docs/2.0/docs/accountfactory/installation/addingnewrepo.md
@@ -255,8 +255,9 @@ DefaultRegion: $$DEFAULT_REGION$$
 # The URL of the custom SCM provider instance. Set this if you are using a custom instance of GitLab.
 # CustomSCMProviderInstanceURL: https://gitlab.example.io
 
-# The relative path from the host server to the custom pipelines workflow repository. Set this if you are using a custom/forked instance of the pipelines workflow.
-# CustomWorkflowHostRelativePath: pipelines-workflows
+# The location prefix of the pipelines workflows. Set this if you are using a custom/forked instance of the pipelines workflows repository.
+# For self-hosted GitLab, include the $CI_SERVER_FQDN prefix: "$CI_SERVER_FQDN/<group>/pipelines-workflows/"
+# PipelinesWorkflowLocation: $CI_SERVER_FQDN/my-group/pipelines-workflows/
 ```
 
 <h4> Generate the repository contents </h4>

--- a/docs/2.0/reference/accountfactory/configurations-as-code.md
+++ b/docs/2.0/reference/accountfactory/configurations-as-code.md
@@ -313,7 +313,23 @@ account_factory {
 <HclListItem name="pipelines_workflow_location" requirement="optional" type="string">
   <HclListItemDescription>
 
-    (GitHub only) The location of your pipelines workflow if different from the default of `gruntwork-io/pipelines-workflows/.github/workflows/pipelines.yml@X`.
+    The location prefix of the pipelines workflows, used in delegated repositories when your organization uses a fork of `gruntwork-io/pipelines-workflows`. The workflow filename (GitHub) or component name (GitLab) plus `@<ref>` are appended per file, so this value must end with a trailing slash.
+
+    Examples:
+    - GitHub default: `gruntwork-io/pipelines-workflows/.github/workflows/`
+    - GitHub fork: `acme-org/pipelines-workflows/.github/workflows/`
+    - GitLab default: `gitlab.com/gruntwork-io/pipelines-workflows/`
+    - GitLab self-hosted: `$CI_SERVER_FQDN/acme-org/pipelines-workflows/` (GitLab resolves `$CI_SERVER_FQDN` at CI runtime)
+
+  </HclListItemDescription>
+</HclListItem>
+
+### pipelines_workflow_ref
+
+<HclListItem name="pipelines_workflow_ref" requirement="optional" type="string">
+  <HclListItemDescription>
+
+    The git ref of the pipelines workflows used in delegated repositories. Defaults to `v4` on GitHub and `v2` on GitLab. Set to a different tag, branch, or SHA if you pin to a specific version or use a fork.
 
   </HclListItemDescription>
 </HclListItem>

--- a/docs/2.0/reference/accountfactory/configurations-as-code.md
+++ b/docs/2.0/reference/accountfactory/configurations-as-code.md
@@ -313,13 +313,13 @@ account_factory {
 <HclListItem name="pipelines_workflow_location" requirement="optional" type="string">
   <HclListItemDescription>
 
-    The location prefix of the pipelines workflows, used in delegated repositories when your organization uses a fork of `gruntwork-io/pipelines-workflows`. The workflow filename (GitHub) or component name (GitLab) plus `@<ref>` are appended per file, so this value must end with a trailing slash.
+    The location prefix of the pipelines workflows, used in delegated repositories when your organization uses a fork of `gruntwork-io/pipelines-workflows`.
 
     Examples:
-    - GitHub default: `gruntwork-io/pipelines-workflows/.github/workflows/`
-    - GitHub fork: `acme-org/pipelines-workflows/.github/workflows/`
-    - GitLab default: `gitlab.com/gruntwork-io/pipelines-workflows/`
-    - GitLab self-hosted: `$CI_SERVER_FQDN/acme-org/pipelines-workflows/` (GitLab resolves `$CI_SERVER_FQDN` at CI runtime)
+    - GitHub default: `gruntwork-io/pipelines-workflows/.github/workflows`
+    - GitHub fork: `acme-org/pipelines-workflows/.github/workflows`
+    - GitLab default: `gitlab.com/gruntwork-io/pipelines-workflows`
+    - GitLab self-hosted: `$CI_SERVER_FQDN/acme-org/pipelines-workflows` (GitLab resolves `$CI_SERVER_FQDN` at CI runtime)
 
   </HclListItemDescription>
 </HclListItem>

--- a/docs/2.0/reference/accountfactory/configurations-as-code.md
+++ b/docs/2.0/reference/accountfactory/configurations-as-code.md
@@ -318,6 +318,16 @@ account_factory {
   </HclListItemDescription>
 </HclListItem>
 
+### pr_create_token_name
+
+<HclListItem name="pr_create_token_name" requirement="optional" type="string">
+  <HclListItemDescription>
+
+    (GitHub only) The name of your PR create token if different from the default of `PR_CREATE_TOKEN`.
+
+  </HclListItemDescription>
+</HclListItem>
+
 ### security_account_name
 
 <HclListItem name="security_account_name" requirement="optional" type="string">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed a GitLab setup variable and added explicit guidance and an example format for self-hosted GitLab pipeline locations.
  * Added a new optional setting to specify the pipeline workflow git ref, with documented defaults for GitHub and GitLab.
  * Clarified that pipeline workflow location is a prefix (must include a trailing slash) and explained how per-repository workflow names/refs are appended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->