### PR TITLE
DEV-1441 Document PIPELINES_FEATURE_VALIDATE_DAG_ON_DELETE

### DIFF
--- a/docs/2.0/reference/pipelines/feature-flags.md
+++ b/docs/2.0/reference/pipelines/feature-flags.md
@@ -143,6 +143,23 @@ opentofu = "1.6.2"
 </li>
 </ul>
 
+#### `PIPELINES_FEATURE_EXPERIMENT_VALIDATE_DAG_ON_DELETE`
+<ul>
+<li>
+Validates the Terragrunt DAG when files are deleted in a pull/merge request. Pipelines inspects the DAG that would result from merging the change and cross-references the deleted files against every active unit's `dependencies` and `reading` ([`mark_as_read`](https://docs.terragrunt.com/reference/hcl/functions/#mark_as_read)) entries. If a remaining unit still depends on a deleted file or unit directory, Pipelines prevents the plan from running, surfacing the broken reference instead of letting it appear as a confusing error during `terragrunt plan/apply`.
+
+This check only runs on pull/merge requests.
+
+Requires Terragrunt newer than `v0.91.3` to validate `mark_as_read` entries. On older versions only `dependencies` are checked.
+</li>
+<li>
+**Default Value**: Disabled
+</li>
+<li>
+**How to Enable**: Set to `"true"`
+</li>
+</ul>
+
 ## Deprecated Flags
 
 The following flags are valid in Pipelines GitHub v3/GitLab v1 but are deprecated in Pipelines GitHub v4+/GitLab v2+.

--- a/docs/2.0/reference/pipelines/feature-flags.md
+++ b/docs/2.0/reference/pipelines/feature-flags.md
@@ -143,12 +143,12 @@ opentofu = "1.6.2"
 </li>
 </ul>
 
-#### `PIPELINES_FEATURE_EXPERIMENT_VALIDATE_DAG_ON_DELETE`
+#### `PIPELINES_FEATURE_VALIDATE_DAG_ON_DELETE`
 <ul>
 <li>
-Validates the Terragrunt DAG when files are deleted in a pull/merge request. Pipelines inspects the DAG that would result from merging the change and cross-references the deleted files against every active unit's `dependencies` and `reading` ([`mark_as_read`](https://docs.terragrunt.com/reference/hcl/functions/#mark_as_read)) entries. If a remaining unit still depends on a deleted file or unit directory, Pipelines prevents the plan from running, surfacing the broken reference instead of letting it appear as a confusing error during `terragrunt plan/apply`.
+Validates the [Terragrunt DAG](https://docs.terragrunt.com/getting-started/terminology#directed-acyclic-graph-dag) when files are deleted in a pull/merge request. Pipelines inspects the DAG that would result from merging the change and cross-references the deleted files against every active unit's `dependencies` and `reading` (files marked with [`mark_as_read`](https://docs.terragrunt.com/reference/hcl/functions/#mark_as_read)) entries. If a remaining unit still depends on a deleted file or unit directory, Pipelines prevents the plan from running, surfacing the broken reference instead of letting it appear as a confusing error during `terragrunt plan/apply`.
 
-This check only runs on pull/merge requests.
+This check only blocks the run on pull/merge requests. On other events violations are logged as warnings.
 
 Requires Terragrunt newer than `v0.91.3` to validate `mark_as_read` entries. On older versions only `dependencies` are checked.
 </li>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added docs for the experimental Pipelines flag PIPELINES_FEATURE_VALIDATE_DAG_ON_DELETE. When enabled ("true"), pull/merge requests validate the resulting DAG, detect broken references from deleted files and block plan runs on violations. On non-PR events violations are logged as warnings. Full validation of mark_as_read requires Terragrunt v0.91.3 or newer; otherwise only dependencies are checked. The feature is disabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->