### PR TITLE
docs: Bumping recommended version of Terragrunt to `v1.0`

### DIFF
--- a/docs/2.0/reference/pipelines/terragrunt-version-compatibility.md
+++ b/docs/2.0/reference/pipelines/terragrunt-version-compatibility.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 | Type | Terragrunt Ver | Pipelines Ver | Comments |
 | ---- | -------------- | ------------- | -------- |
-| Recommended | 0.93.1 | v4.y.z | Pipeline/Terragrunt is considerably faster on 0.93.1+ for environment auth |
+| Recommended | 1.0.0 | v4.y.z | Terragrunt v1 releases are guaranteed to be backwards compatible until v2 |
 | Minimum | 0.86.3 | v4.y.z | This is the absolute minimum version of Terragrunt for Pipelines v4 |
 | Maximum | 0.84.z | v3.y.z | Pipelines v3.y.z is not compatible with Terragrunt 0.85.0 and above.|
 | Recommended | 0.77.11 | v3.y.z | Pipelines is actively tested with this version of Terragrunt |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Terragrunt version compatibility recommendations with the latest supported version and backwards-compatibility details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->