### PR TITLE
Update Gruntwork Releases as of 2026-04-30

### DIFF
--- a/docs/guides/stay-up-to-date/index.md
+++ b/docs/guides/stay-up-to-date/index.md
@@ -17,6 +17,7 @@ import CardGroup from "/src/components/CardGroup"
 <CardGroup cols={1} gap="1rem" stacked equalHeightRows={false} commonCardProps={{padding: "1.25rem"}}>
 
 <!-- START_DOCS_SOURCER_DYNAMIC_CONTENT id=gruntwork-releases-cards -->
+<Card title="Update to 2026-04" href="/guides/stay-up-to-date/releases/2026-04" />
 <Card title="Update to 2026-03" href="/guides/stay-up-to-date/releases/2026-03" />
 <Card title="Update to 2026-02" href="/guides/stay-up-to-date/releases/2026-02" />
 <Card title="Update to 2026-01" href="/guides/stay-up-to-date/releases/2026-01" />
@@ -31,7 +32,6 @@ import CardGroup from "/src/components/CardGroup"
 <Card title="Update to 2025-04" href="/guides/stay-up-to-date/releases/2025-04" />
 <Card title="Update to 2025-03" href="/guides/stay-up-to-date/releases/2025-03" />
 <Card title="Update to 2025-02" href="/guides/stay-up-to-date/releases/2025-02" />
-<Card title="Update to 2025-01" href="/guides/stay-up-to-date/releases/2025-01" />
 <Card title="See older releases" href="/guides/stay-up-to-date/releases" />
 <!-- END_DOCS_SOURCER_DYNAMIC_CONTENT -->
 
@@ -115,6 +115,6 @@ href="/guides/stay-up-to-date/cis/cis-1.5.0"
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "26815cfb1ebb5b0b70c6d05e12e7cd91"
+  "hash": "33e6822cb1670c28ac85e52b71021568"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-06/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2016-06</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2016-06. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2016-06.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -562,6 +560,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "d5ffc4ecfe26ace369cf269a90b06d43"
+  "hash": "606bd358c713dd4e4e739a67d19cb48b"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-07/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2016-07</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2016-07. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2016-07.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -550,6 +548,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "eb934ab1e8489d856a35536890d98c6a"
+  "hash": "8b5487c51192b15e49f01c512b7ea1ab"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-08/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2016-08</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2016-08. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2016-08.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -208,6 +206,6 @@ ENHANCEMENT: `vpc-app` and `vpc-mgmt` now allow for specifying the exact CIDR bl
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "39fcf4fcae7d86b79e55ee1d4ad807ee"
+  "hash": "6b9035b823417abbcc21b8e44dddd41e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-09/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2016-09</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2016-09. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2016-09.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -646,6 +644,6 @@ In `modules/ecs-cluster`:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "b219c37209ebcff718373e5e600667ce"
+  "hash": "740785ec6e45c972f4a54c90e86d6522"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-10/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2016-10</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2016-10. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2016-10.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -104,6 +102,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "58d348eff14daa26fd8491c2cd8428dd"
+  "hash": "c8aafda54869f8b3a5e40c5cff598027"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-11/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2016-11</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2016-11. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2016-11.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -73,6 +71,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "2777dbfa6d9dc932d5d1a6840ef95cd3"
+  "hash": "02db40147cfa949a86b68e9bf5bda97e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2016-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2016-12/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2016-12</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2016-12. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2016-12.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -287,6 +285,6 @@ This change is fully backwards-compatible in terms of the vars and outputs, but 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "d133da4c931b3bed662bad408022f613"
+  "hash": "ebef7fa7483aaabafdf4df5616ce3245"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-01/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2017-01</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-01. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-01.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -361,6 +359,6 @@ Note that we are seeing intermittent test failures with the ALB that indicate a 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "9e39d57dcb4ef119a886183ca0b6e71e"
+  "hash": "5958ffab8e89b35944fc0712639209fa"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-02/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2017-02</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-02. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-02.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -178,6 +176,6 @@ We&apos;ve updated the `ecs-service-with-alb` module and example code accordingl
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "2285235c4150b59a76a9be9a8d2ab44d"
+  "hash": "cab747e04c17206206a97a37cbd28962"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-03/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2017-03</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-03. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-03.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -435,6 +433,6 @@ To use this, you need to configure the new `iam_groups_for_cross_account_access`
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "215f988d6eb9b603cede19f0d3234d74"
+  "hash": "6aec4e930661000d80be55b909b25f03"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-04/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2017-04</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-04. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-04.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -310,6 +308,6 @@ terraform state mv module.database.aws_db_instance.replicas module.database.aws_
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "7a405c0b917fd420e437d110098181dc"
+  "hash": "1d006a9f0ed5be0c7888c3ac315e99a6"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-05/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2017-05</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-05. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-05.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -225,6 +223,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "2ad5b23ca84ab2d60b5418ec8500e30c"
+  "hash": "729325973f53e89f47d0ccf055a2ace4"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-06/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2017-06</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-06. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-06.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -308,6 +306,6 @@ Please note that this is a backwards incompatible release:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "e905572151bad00209ad74a6db6f9f42"
+  "hash": "c68d3ab4fab2f65bb7635405afdd5a8d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-07/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2017-07</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-07. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-07.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -459,6 +457,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "5e4091a05621f0dede762db7212f68b2"
+  "hash": "8bb36e094ac79b93af8c23b8d4542185"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-08/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2017-08</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-08. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-08.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -403,6 +401,6 @@ https://github.com/gruntwork-io/module-vpc/pull/26: Fix a bug where the `num_ava
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "598bdd162188a79cc9417659ba968dbc"
+  "hash": "e87d448600d9843b6c18176a7fbb57c6"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-09/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2017-09</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-09. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-09.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -204,6 +202,6 @@ https://github.com/gruntwork-io/package-static-assets/pull/3: The `s3-cloudfront
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "5ea3562b990b7339841eee52cf2ded96"
+  "hash": "8b6243c80a85e776acca156548c5e6c5"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-10/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2017-10</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-10. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-10.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -264,6 +262,6 @@ This change is backwards compatible from a code perspective, but it changes the 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "80d28b43c5e0b55e99acbcd064b90697"
+  "hash": "3c047715bef291bc9802eb98400a51e9"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-11/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2017-11</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-11. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-11.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -424,6 +422,6 @@ https_listener_ports_and_acm_ssl_certs = [
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "ae561a15658c47563f2a99d6b4f7dc2d"
+  "hash": "fdf219bf6fdfad33ea159178fedfc7e2"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2017-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2017-12/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2017-12</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-12. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2017-12.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -247,6 +245,6 @@ We also suggest explicitly providing values for the `--request-url` parameter to
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "dfc7cbfb80f106f8b3e789b5defde871"
+  "hash": "559ee1d53fcb1a535234ac18f46c6c7b"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-01/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2018-01</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-01. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-01.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -331,6 +329,6 @@ add new tests for num_nat_gateways=0
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "799b8117ca65eace0bddf8aee56e747f"
+  "hash": "b4ce10b72c2f875ef44d70d2a7e43965"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-02/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2018-02</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-02. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-02.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -204,6 +202,6 @@ Note, this release contains BACKWARDS INCOMPATIBLE CHANGES to the `single-server
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "b68121e7654c5b9599f0ce7f467783bd"
+  "hash": "7fe66f840a7532e57337a0de50a4e0f8"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-03/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2018-03</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-03. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-03.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -427,6 +425,6 @@ The primary use case is so we can format paths properly on Windows vs Linux.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "470ebfc490c789dfad8631a6939bb7c0"
+  "hash": "51477fd50d030b96dc69c843bdb43cf0"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-04/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2018-04</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-04. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-04.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -224,6 +222,6 @@ The main motivation for locking down EC2 metadata is as follows:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "9047b53c50ab470755b96d9e9b6edcc5"
+  "hash": "26e8aca208138ae8f5a09b0488a5161d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-05/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2018-05</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-05. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-05.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -350,6 +348,6 @@ BACKWARDS INCOMPATIBLE CHANGES
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "0cac4ef8efefab7906ebda4b9f348d1f"
+  "hash": "cdec6d32f9c1aaeed4561283f7c6edae"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-06/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2018-06</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-06. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-06.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -274,6 +272,6 @@ The `saml-iam-roles` module now sets a default max expiration of 12 hours for IA
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "feb9bdd208c2b3106f9fce124cd33aff"
+  "hash": "410d8aa1393e739f2706bb7feb57b5de"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-07/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2018-07</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-07. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-07.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -115,6 +113,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "acd50c78a0008241ba5c4de2e59f85e6"
+  "hash": "97a2ae98bada3809bba7439b6e24f6ab"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-08/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2018-08</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-08. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-08.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -290,6 +288,6 @@ Fix a bug in the `aws-auth` script so that you can now assume an IAM role _and_ 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "77a6179d7409622b770039d146c5aa73"
+  "hash": "5db84c9da2b1844f3f78961620c33520"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-09/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2018-09</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-09. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-09.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -214,6 +212,6 @@ This release is **BACKWARD INCOMPATIBLE** with previous releases only if you wer
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "a9a6d4224a6609eee5ffe81c02725c27"
+  "hash": "e43f0b3ac76beba174261c098c128d5e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-10/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2018-10</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-10. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-10.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -324,6 +322,6 @@ A special thanks to @jeckhart for contributing all of these PRs!
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "b13a95f60ee405786aac05bf19c132c7"
+  "hash": "faa5d7e7d7d0cf9c4509fd41f9c0fdf8"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-11/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2018-11</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-11. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-11.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -357,6 +355,6 @@ You can now specify custom tags for all S3 buckets created by these modules usin
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "8772ab6efd04bf25012d538b0a67dcd0"
+  "hash": "e8ec90473d8797393f518d88c19cb83a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2018-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2018-12/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2018-12</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-12. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2018-12.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -676,6 +674,6 @@ To upgrade to this version, simply bump the value of the `ref` parameter on your
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "da8978a29701e5149e6c018cdcc8d400"
+  "hash": "720483c251cdd13b0bf6ca4179aed7d2"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-01/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2019-01</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-01. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-01.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -755,6 +753,6 @@ This is a backwards incompatible change. Specifically, the modules no longer nee
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "9698f887de5554fb708197e27b4c1827"
+  "hash": "303d5b8f0533ab5470afe4205323b6d7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-02/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2019-02</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-02. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-02.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -410,6 +408,6 @@ Other changes:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "0dc60fd6512b08d377a8de0246917122"
+  "hash": "bd301122ee764e7ccb4eb1ca84814ac4"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-03/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2019-03</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-03. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-03.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -229,6 +227,6 @@ The `kinesis` module now supports server-side encryption.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "dd5c723ceb9c4b37d4732ae267e6daa4"
+  "hash": "7def48f5532a1b19c335091641d8164f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-04/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2019-04</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-04. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-04.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -660,6 +658,6 @@ This release introduces two new modules that can be used to setup Route 53 Resol
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "6497c3f775b8577722edacb03efe76bf"
+  "hash": "86e9d6b4dba5f51c70efb9972e42b11e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-05/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2019-05</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-05. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-05.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -442,6 +440,6 @@ The other modules have backwards compatible minor changes in the way dependencie
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "609239358eb36eb1a6d727fec29ed0dc"
+  "hash": "754c8459e8578c3966a09da4573a783f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-06/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2019-06</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-06. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-06.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -849,6 +847,6 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "1ba766a7b475b61671d571e57201838a"
+  "hash": "c1a99392c1d10ac6a819306195323169"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-07/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2019-07</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-07. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-07.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -504,6 +502,6 @@ Note that as part of this, we switched to using `null` to indicate unset values 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "7af3b48b01a1434647d260dab548eca9"
+  "hash": "32640f102cefcad4c56b8d9dd161f710"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-08/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2019-08</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-08. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-08.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -284,6 +282,6 @@ The module has support for the following features:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "be31556b6d645709e9dde3acb85742fd"
+  "hash": "b50acffa406f4c9328c60f523102bd60"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-09/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2019-09</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-09. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-09.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -566,6 +564,6 @@ The `run-pex-as-resource` module now exposes the `null_resource` triggers and th
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "6aa8e201037ec812f20bfe8a8b603087"
+  "hash": "a186719fb3df6892a38ee2ec03884b06"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-10/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2019-10</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-10. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-10.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -681,6 +679,6 @@ Listening on localhost is now optional. To disable localhost listening, set the 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "826798562dc2306da21c248b4c3705d7"
+  "hash": "56ee4e549edb7c84cd86968d8f900533"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-11/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2019-11</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-11. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-11.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -297,6 +295,6 @@ terraform state mv &quot;$MODULE_ADDRESS.aws_alb.alb_without_logs[0]&quot; &quot
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "25ff034c5c740707508537111e380ad5"
+  "hash": "9d31b29b545de02c1978b874af390b6d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2019-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2019-12/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2019-12</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-12. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2019-12.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -700,6 +698,6 @@ This release introduces the ability to tag just the VPC, but not any of the othe
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "435f1ee7adb617da0545056e48aa5676"
+  "hash": "fc1ae9535d830499f82020ae10003cea"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-01/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2020-01</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-01. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-01.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -925,6 +923,6 @@ Now `vpc-app` and `vpc-mgmt` will create a single VPC endpoint for all tiers. Pr
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "e456100bd8838e622ba7d4d247c68cbb"
+  "hash": "7c31c7e04cf6b173dbb1e9825be2287f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-02/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2020-02</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-02. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-02.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -713,6 +711,6 @@ Now it&apos;s possible to fully deactivate the `vpc-flow-logs` module passing th
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "998593ae654be49c14bcea91347ae9b2"
+  "hash": "49e0cfdba2031255e256c7636dfd1be5"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-03/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2020-03</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-03. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-03.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -889,6 +887,6 @@ Thanks to @mmiranda for his contribution, and to @marinalimeira for her suggesti
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "ab4929597fd101f5d27c597f097f1326"
+  "hash": "753feceebe3c818c07f692c431415ee5"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-04/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2020-04</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-04. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-04.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -631,6 +629,6 @@ This new module allows to create a VPC Interface Endpoint to connect services wi
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "ed0237e7cd99b2c688611fa033c661f2"
+  "hash": "5bf143740977b7d548be7507b01db128"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-05/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2020-05</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-05. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-05.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -773,6 +771,6 @@ Special thanks to @jdhornsby for the fix!
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "fddce19327eb058806bc50b77116ae64"
+  "hash": "0278eb392ec7e3f47da9422a9ffc2901"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-06/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2020-06</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-06. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-06.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -735,6 +733,6 @@ This release adds the ability to create `tags` with the modules mentioned above.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "0dcede3d3d168330263e16a82ef55a8d"
+  "hash": "ac94caba4aa9dea7a8e3bd3c90f61633"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-07/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2020-07</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-07. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-07.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -965,6 +963,6 @@ add glue support to vpc-interface-endpoint
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "c11060e9734e1414ce3d641f3107bb93"
+  "hash": "191654c5461b1f67f268bdf29dfa588d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-08/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2020-08</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-08. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-08.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -928,6 +926,6 @@ This release introduces two changes:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "6f6ec1e4dd4b935dacc84e3cb0180eb2"
+  "hash": "8eac3608eb09c997b260d0a8de8977ca"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-09/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2020-09</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-09. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-09.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1458,6 +1456,6 @@ This is a minor update that fixes a perpetual diff in the `vpc-flow-logs` module
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "87d485445beef099b1e35c40ea2ceadf"
+  "hash": "301382e350d64f7d765c3391b022806f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-10/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2020-10</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-10. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-10.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -846,6 +844,6 @@ This release updates the following modules to the latest releases of their respe
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "fa989da779cb98e94ebe45fb83c2452c"
+  "hash": "9440147151cbe1bb1ab45bd21b491f51"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-11/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2020-11</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-11. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-11.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -853,6 +851,6 @@ This release updates the default names set for the VPC DNS resolvers. The names 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "14ae50ac8dd4721e06b2a18569c4e014"
+  "hash": "e32cce356b516c5ac288ee1752d3b949"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2020-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2020-12/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2020-12</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-12. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2020-12.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -943,6 +941,6 @@ The `vpc-flow-logs` module has been refactored to use the `private-s3-bucket` mo
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "cd59b27ac77961e216d55d63cebbdb0a"
+  "hash": "c27f00e331bb16c1be52e5b3e0ce39ad"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-01/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2021-01</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-01. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-01.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -852,6 +850,6 @@ In this release, we have updated the behavior to not explicitly apply the defaul
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "419b9ae35e6a20d32c5ffdaa2dbfb5f7"
+  "hash": "4b1e8b54096de10c7a72d41b8aad21be"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-02/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2021-02</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-02. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-02.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -895,6 +893,6 @@ Fixes a bug in the `ecs-cluster` module to allow SSH from CIDR blocks to work co
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "8c553ecbc6cd1f025967ba1f4b322c73"
+  "hash": "811bfa09d9908a1fa2dc911cc88d4232"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-03/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2021-03</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-03. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-03.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1461,6 +1459,6 @@ Support for optional resource creation via the `create_resources` parameter was 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "edcdb2bf999840b8102e0fedf3200150"
+  "hash": "b02cdb96238314f28da925ee0f8a54a8"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-04/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2021-04</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-04. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-04.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1677,6 +1675,6 @@ adds a number of conditional variables to the App Account Baseline in order to o
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "a0218784b7820fe21d80cc35e51b07ca"
+  "hash": "82d8db53b5f0b0ed28aca45a840d5464"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-05/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2021-05</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-05. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-05.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1155,6 +1153,6 @@ Add support for exposing client access directly in the nacls for the private app
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "951db9908c818da1a733953bf83a2488"
+  "hash": "071a457ea955e16272e6916d84d18b8a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-06/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2021-06</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-06. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-06.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1169,6 +1167,6 @@ Adds support for tags to the redis module.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "a866c4d243f0eeacc6cce1867c7bfab7"
+  "hash": "3f23082b944ec51d3441a5116f5eca14"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-07/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2021-07</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-07. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-07.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1782,6 +1780,6 @@ Fixed bug with configuring default NACLs, where default NACLs were applied and c
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "c8d77a20b07c089e4d99783b3ae2422e"
+  "hash": "d5177b39604d695d55e2f50abca17892"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-08/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2021-08</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-08. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-08.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1483,6 +1481,6 @@ Updated the `s3-cloudfront` module to create the S3 bucket for access logs using
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "925f016a02210616194dbf32717a33dc"
+  "hash": "9d5667142d96e01771f02f5eb6722627"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-09/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2021-09</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-09. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-09.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -864,6 +862,6 @@ This release also adds a script to enable MFA Delete for the `private-s3-bucket`
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "4a410c3879c584ba968accf76d38e061"
+  "hash": "fe4e55b7a80e9b1356cf4340702f774e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-10/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2021-10</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-10. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-10.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -879,6 +877,6 @@ With this release, we are improving the documentation around how to best use thi
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "45b64eebeaf7bc49ff38ab31db6ba500"
+  "hash": "1f6de64242a891e899f50684c33b2d4c"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-11/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2021-11</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-11. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-11.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -565,6 +563,6 @@ This release also updates versions of underlying dependencies:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "66be96e8168a42812f9fec3a68da0715"
+  "hash": "bd1b7d0c098f6a4b59385a85aa7e53cb"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2021-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2021-12/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2021-12</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-12. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2021-12.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -649,6 +647,6 @@ For terragrunt, add `ap-southeast-3` to the `all_aws_regions` local variable.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "6850031e4061bf8595b069fae31eb60c"
+  "hash": "5ed12d8965b7a42667b9067dd01968cb"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-01/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2022-01</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-01. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-01.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -992,6 +990,6 @@ route_table_deletion_timeout
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "97cc9f34c98fb60f812c6e7427763d82"
+  "hash": "352c78eab7197f39a07a96d4afa26f05"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-02/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2022-02</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-02. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-02.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1945,6 +1943,6 @@ Exposed `icmp_type` and `icmp_code` in `var.private_app_allow_inbound_ports_from
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "813b41e9d6a3ac18ccf97173ddd115c1"
+  "hash": "17dafb97a30e6fe82eec327da0951b80"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-03/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2022-03</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-03. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-03.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1183,6 +1181,6 @@ You can bump the provider by running `terraform init` with the `-upgrade` flag, 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "93cc9a8809e6228236083491eab4656c"
+  "hash": "63693fba6d48f321b4225aad6db6190d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-04/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2022-04</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-04. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-04.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -891,6 +889,6 @@ Modules calling `s3-static-website` and `s3-cloudfront` have to bump the provide
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "180fffd39171e9e527df19493c07ffea"
+  "hash": "b5c8a03a6836c3d7be122d2db8ba153b"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-05/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2022-05</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-05. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-05.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -728,6 +726,6 @@ Support for python2 has been dropped. All modules that depend on python now requ
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "7ce8162d02e774c4d2521de76644e354"
+  "hash": "8faf4110932ba7e9e9eea79af69757b3"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-06/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2022-06</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-06. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-06.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1292,6 +1290,6 @@ Updated dependency `terraform-aws-security` to `v0.65.2`.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "a788fd224eed2288c149422a32e241cd"
+  "hash": "4afa125a1c3bbe59c17d9132b71a5a24"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-07/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2022-07</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-07. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-07.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -866,6 +864,6 @@ https://github.com/gruntwork-io/terraform-aws-ci-steampipe/pull/28
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "51992003b22e42963e7a70d0935954e8"
+  "hash": "03ee0cb80045345f701ebf836dc1ff13"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-08/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2022-08</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-08. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-08.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -892,6 +890,6 @@ Special thanks to @lorelei-rupp-imprivata for catching this issue!
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "fc6c96c24f3b3ce483fb9d11801fae95"
+  "hash": "e4f51311e705d518cb5ba082db071684"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-09/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2022-09</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-09. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-09.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -153,6 +151,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "9fe2ec43bcfcd25a7cb9423088ca0b4c"
+  "hash": "94a89d378e229e1aebd103019f95eed6"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-10/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2022-10</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-10. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-10.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -433,6 +431,6 @@ Due to the Cluster Autoscaler version bump, additional IAM Permissions have been
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "0d229c908973917f4f1455e8f60fb534"
+  "hash": "b9f6cdf4f22a3fc50578cc3acc683a7a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-11/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2022-11</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-11. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-11.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -440,6 +438,6 @@ Note: Previously, importing aws_iam_user_login_profiles would trigger a password
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "e4881a9c09186d88c722af36b231c17b"
+  "hash": "df32256e360ac1a345aae973b9cd0cf3"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2022-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2022-12/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2022-12</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-12. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2022-12.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -330,6 +328,6 @@ Special thanks to the following user for their contribution!
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "bdb34f6b52b71c49121027e42bb086f8"
+  "hash": "b3f0289c1add7d9347841d7e934301f6"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2023-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2023-01/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2023-01</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-01. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-01.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -387,6 +385,6 @@ If you wish to maintain backward compatibility with your existing setup of the E
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "8148e8976b3b455218c44d18665c93ad"
+  "hash": "9fef1f8eda948a63f4bcf8282a2c0d2c"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2023-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2023-02/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2023-02</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-02. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-02.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -519,6 +517,6 @@ Migrated the example in examples/asg-alarms to use a launch template instead of 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "bd82a2241d0ca7e23899e37b7e8d606b"
+  "hash": "f1519e53512236cab1940ef1f3e39c91"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2023-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2023-03/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2023-03</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-03. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-03.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -775,6 +773,6 @@ ingress from 443 is created.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "b4a4c78dcae302364b15a8234e3bcbe5"
+  "hash": "030fd21d0e87c93aaefd0e150aa67cd5"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2023-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2023-04/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2023-04</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-04. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-04.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1327,6 +1325,6 @@ The new signature for Docker Compose is `docker compose &lt;command&gt;` (Not th
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "267911595652a8f897b9b66a3ea666b9"
+  "hash": "186d8acde8cdc11914714029fc5ae315"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2023-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2023-05/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2023-05</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-05. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-05.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -838,6 +836,6 @@ Fixed the user certificate request with pattern name similar to the already adde
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "0a810d2ec73ffd46299b685e758c9a63"
+  "hash": "15ad764b53a0332d87c1d8f53db6e604"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2023-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2023-06/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2023-06</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-06. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-06.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -901,6 +899,6 @@ Note: EKS 1.26 requires kubergrunt v0.11.3 and above
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "669336d8a6b5af3ac2b74b2c96a221e0"
+  "hash": "a04cd930f397fa097607d415654a4bd6"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2023-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2023-07/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2023-07</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-07. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-07.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -653,6 +651,6 @@ Remove deprecated eks version 1.22
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "fd02b80b4ee869c6c3b52c5d9384ae53"
+  "hash": "bee2100516266816cf34cec3123eaa26"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2023-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2023-08/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2023-08</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-08. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-08.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1077,6 +1075,6 @@ This release includes the following improvements:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "e87f89da902a1e90c9d5382f4e084476"
+  "hash": "e1832598f0b3f71258ac6742168559df"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2023-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2023-09/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2023-09</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-09. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-09.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -491,6 +489,6 @@ Updated for aws provider v5 compatibility. See Migration Guide for breaking chan
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "b693d44cef54af0c431d23a9ce758b91"
+  "hash": "892ec29d488ad8807679c01f8b637975"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2023-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2023-10/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2023-10</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-10. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-10.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1393,6 +1391,6 @@ Initial release of devops-foundations templates
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "1bdff6e4633a347f216b6aa59c9ec587"
+  "hash": "66f9386ebbc86d3aefdccf5315df1dd6"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2023-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2023-11/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2023-11</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-11. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-11.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -764,6 +762,6 @@ NOTE: We have since discovered that this release should have been classified as 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "50602de91ce3a0731d3c5e99a53b7286"
+  "hash": "fb3c142d2a4d9fc8021469d1815ed552"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2023-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2023-12/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2023-12</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-12. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2023-12.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -808,6 +806,6 @@ Update to latest `terraform-aws-service-catalog` and `terraform-aws-vpc` modules
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "37acba9680e8d9952fdd2c9ed6d31d17"
+  "hash": "03884458999b7f2bd06a0441ba310068"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2024-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2024-01/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2024-01</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-01. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-01.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -748,6 +746,6 @@ Special thanks to the following users for their contribution!
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "10d89a5f7d4ab7073884e928906023f1"
+  "hash": "fb3aa6678cc9f6b384e5698368565de1"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2024-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2024-02/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2024-02</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-02. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-02.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -880,6 +878,6 @@ Update the outputs of the Transit Gateway module.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "389f44fced33bf9aa2c58abea6496d6d"
+  "hash": "6f8d118422067c042fd17fb7efd4e35c"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2024-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2024-03/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2024-03</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-03. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-03.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1530,6 +1528,6 @@ Special thanks to the following users for their contribution!
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "2e9167191b0da18ae09c59bb5a23d881"
+  "hash": "a095ca77d05d9a406e39409175cf5b2d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2024-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2024-04/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2024-04</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-04. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-04.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1630,6 +1628,6 @@ Default EKS version is 1.29 with this release! Please see the links below for fu
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "d089e2fec7b5c23e83918eec936e3908"
+  "hash": "7580a298047ec3374c80af5dd66c9292"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2024-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2024-05/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2024-05</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-05. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-05.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1347,6 +1345,6 @@ This release includes updates to breaking changes in multiple actions. Given tha
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "2e17b2889ca092d4f1edadb7e20a3cf8"
+  "hash": "7eb7252fd5d766b38b57e11687991ff7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2024-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2024-06/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2024-06</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-06. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-06.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -876,6 +874,6 @@ This release updates our multi-region code generators to use [Boilerplate](https
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "92ff1a0fbde6481d157c31627735e941"
+  "hash": "270a5a79ca9c92624381b257cda277df"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2024-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2024-07/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2024-07</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-07. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-07.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1463,6 +1461,6 @@ For Pipelines users that allowlist specific actions, version 2.0 includes the fo
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "e7281362b433e52bca326943c3c79a2c"
+  "hash": "c3d45b2538061cd5d4982399ee62fcbd"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2024-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2024-08/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2024-08</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-08. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-08.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -861,6 +859,6 @@ This is a no-op release to include a patcher config change, no module code was c
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "0c142b2af470630849fbc7b5d01c215b"
+  "hash": "4db89a020d475ba77c1b778f825b58e7"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2024-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2024-09/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2024-09</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-09. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-09.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -777,6 +775,6 @@ Default version of EKS is `1.30` with this release! Please see the links below f
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "3beb9ec84e60041fa01bf0bb383d9596"
+  "hash": "595be6215bcd529a2d2e6e6e7d28095a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2024-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2024-10/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2024-10</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-10. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-10.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1194,6 +1192,6 @@ This PR does NOT introduce any changes that are not backwards compatible or requ
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "f6d9c4326abd1de6f840b0a0d7489c50"
+  "hash": "92d773ebf7e83a3fedd9e2bab71fa1d9"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2024-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2024-11/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2024-11</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-11. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-11.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -496,6 +494,6 @@ Here are the repos that were updated:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "20813cbf7621adade8fd435ad5a27b7c"
+  "hash": "5b0cbba38ca718c0365f1bc38ab3c258"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2024-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2024-12/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2024-12</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-12. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2024-12.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -733,6 +731,6 @@ New Terraform module implements a CloudFront Distribution that supports custom o
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "04352463150f35ee8dfa81e7262cac00"
+  "hash": "8469b71375492c025a78f740e186bea8"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2025-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2025-01/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2025-01</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-01. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-01.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -867,6 +865,6 @@ Added option to use service-linked role. (`account-baseline-app` module)
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "39efff7ae4ca9bbe09d878bcf901c244"
+  "hash": "e554a109fa1a114fee4c012dadbf2a8d"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2025-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2025-02/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2025-02</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-02. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-02.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1173,6 +1171,6 @@ Fixes a bug was introduced in pipelines [v0.32.0](https://github.com/gruntwork-i
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "18b6630414155ef6bf84e60c5e2870dc"
+  "hash": "3c35abb05dfd94beb02bc32a563212b1"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2025-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2025-03/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2025-03</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-03. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-03.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -891,6 +889,6 @@ If `pipelines-execute` exits with non-zero return code we now forward stderr to 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "cb6188b60e4153c8ebc88bce6f85065a"
+  "hash": "b4b986fa6757a882fde66b8670abfd8a"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2025-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2025-04/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2025-04</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-04. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-04.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -722,6 +720,6 @@ Default EKS version is 1.31 with this release! Please see the links below for fu
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "2a284b541be88f711f2d441d6a82c38f"
+  "hash": "05d58373d2b1df0a02817d1d8d88dab9"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2025-05/index.md
+++ b/docs/guides/stay-up-to-date/releases/2025-05/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2025-05</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-05. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-05.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -904,6 +902,6 @@ Each release will include detailed notes indicating whether changes are breaking
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "e9bc244866c1a8f71d30e04e38daedc1"
+  "hash": "d9ea358ceafcd84e33b4d4b258efc009"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2025-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2025-06/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2025-06</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-06. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-06.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -409,6 +407,6 @@ Each release will include detailed notes indicating whether changes are breaking
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "522aa0bdae5b6ea312d5b32d0b4c25a7"
+  "hash": "c1d5ffaad653839427e440bb20f54ef8"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2025-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2025-07/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2025-07</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-07. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-07.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -748,6 +746,6 @@ Updated the following modules to use terraform-aws-security v1.0.1 and terraform
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "89c4fc6f7c105b5a73c290ca120fdfb0"
+  "hash": "e8d7879bc658d029ce0b7f024dfa7342"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2025-08/index.md
+++ b/docs/guides/stay-up-to-date/releases/2025-08/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2025-08</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-08. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-08.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -730,6 +728,6 @@ Each release will include detailed notes indicating whether changes are breaking
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "3b60ef3bbe7a800cb2983917e6debab9"
+  "hash": "2fc2b68f9d4e95ae46f256578a800e2f"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2025-09/index.md
+++ b/docs/guides/stay-up-to-date/releases/2025-09/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2025-09</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-09. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-09.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -444,6 +442,6 @@ This release sets the default version of Karpenter to `1.6.2` and also updates t
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "c95b86c9684c9c564a46b7967b9c3d98"
+  "hash": "8f8769901a4050c40f5755a8d77cc678"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2025-10/index.md
+++ b/docs/guides/stay-up-to-date/releases/2025-10/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2025-10</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-10. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-10.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -886,6 +884,6 @@ The following attributes and variables have were added:
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "611953e375c563ab852e36cea11fcd3e"
+  "hash": "6772c28e6861e0c86e11348785679002"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2025-11/index.md
+++ b/docs/guides/stay-up-to-date/releases/2025-11/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2025-11</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-11. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-11.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -485,6 +483,6 @@ This is an interim fix, with more nuanced flag ordering planned for the future.
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "dcca12190eaf0e4e9fa134da2ae660a7"
+  "hash": "61acf884dc4bf2a98998fb68ae452eab"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2025-12/index.md
+++ b/docs/guides/stay-up-to-date/releases/2025-12/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2025-12</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-12. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2025-12.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -617,6 +615,6 @@ This release updates the module&apos;s AWS provider version constraint to suppor
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "83f87c9ce826703a48232f1a343c5e14"
+  "hash": "45fa36d4b2d428f95bce0e68a0cde06e"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2026-01/index.md
+++ b/docs/guides/stay-up-to-date/releases/2026-01/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2026-01</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2026-01. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2026-01.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -893,6 +891,6 @@ Default EKS version is 1.33 with this release! Please see the links below for fu
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "8ec19defc385537f8256763068694db2"
+  "hash": "e3e7ce4bd3ffc9873aa906c50e3aaed6"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2026-02/index.md
+++ b/docs/guides/stay-up-to-date/releases/2026-02/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2026-02</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2026-02. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2026-02.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -1168,6 +1166,6 @@ Each release will include detailed notes indicating whether changes are breaking
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "923e96bc32d5c27e7eddef9dff386f65"
+  "hash": "b3f114683d3feab2f2399196c0db4309"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2026-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2026-03/index.md
@@ -19,6 +19,7 @@ Here are the repos that were updated:
 - [terraform-aws-load-balancer](#terraform-aws-load-balancer)
 - [terraform-aws-security](#terraform-aws-security)
 - [terraform-aws-service-catalog](#terraform-aws-service-catalog)
+- [terraform-aws-vpc](#terraform-aws-vpc)
 
 
 ## boilerplate
@@ -187,6 +188,23 @@ The validation package is now exported directly, so consumers of Boilerplate as 
 ## pipelines-credentials
 
 
+### [v1.3.1](https://github.com/gruntwork-io/pipelines-credentials/releases/tag/v1.3.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 3/31/2026 | <a href="https://github.com/gruntwork-io/pipelines-credentials/releases/tag/v1.3.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Update error text when pipelines are paused due to usage limit by @oredavids in https://github.com/gruntwork-io/pipelines-credentials/pull/24
+
+* @oredavids made their first contribution in https://github.com/gruntwork-io/pipelines-credentials/pull/24
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-credentials/compare/v1.3.0...v1.3.1
+
+</div>
+
+
 ### [v1.3.0](https://github.com/gruntwork-io/pipelines-credentials/releases/tag/v1.3.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
@@ -222,6 +240,22 @@ The validation package is now exported directly, so consumers of Boilerplate as 
 
 
 ## pipelines-workflows
+
+
+### [v4.10.2](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.10.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 3/31/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.10.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Bump pipelines credentials actions ref to v1.3.1 by @oredavids in https://github.com/gruntwork-io/pipelines-workflows/pull/199
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4...v4.10.2
+
+</div>
 
 
 ### [v4.10.1](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.10.1)
@@ -372,6 +406,26 @@ The validation package is now exported directly, so consumers of Boilerplate as 
 ## terraform-aws-security
 
 
+### [v1.4.1](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v1.4.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 3/31/2026 | Modules affected: custom-iam-entity | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v1.4.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- `custom-iam-entity`: add tags to IAM role
+- test fixes: improved tagging and cleanup (no functional change from this)
+
+
+
+
+
+</div>
+
+
 ### [v1.4.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v1.4.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
@@ -499,9 +553,30 @@ The validation package is now exported directly, so consumers of Boilerplate as 
 
 </div>
 
+
+
+## terraform-aws-vpc
+
+
+### [v0.28.12](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.28.12)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 3/31/2026 | Modules affected: vpc-peering-cross-accounts-accepter, vpc-peering-cross-accounts-requester, vpc-peering-external, vpc-peering | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.28.12">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Added VPC Peering Support for multiple CIDR blocks
+
+
+
+</div>
+
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "161fe8d4812d1c2fc86f31bdbfa6ccf8"
+  "hash": "f559903fc664ca6d1f86da6116385875"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2026-03/index.md
+++ b/docs/guides/stay-up-to-date/releases/2026-03/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2026-03</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2026-03. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2026-03.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -577,6 +575,6 @@ The validation package is now exported directly, so consumers of Boilerplate as 
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "f559903fc664ca6d1f86da6116385875"
+  "hash": "0d79396086ec71461ae2a3b3e2b038eb"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2026-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2026-04/index.md
@@ -1,0 +1,1160 @@
+
+# Gruntwork release 2026-04
+
+<p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2026-04</small></p>
+
+This page is lists all the updates to the [Gruntwork Infrastructure as Code
+Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2026-04. For instructions
+on how to use these updates in your code, check out the [updating
+documentation](/library/stay-up-to-date/updating).
+
+Here are the repos that were updated:
+
+- [pipelines-actions](#pipelines-actions)
+- [pipelines-cli](#pipelines-cli)
+- [pipelines-credentials](#pipelines-credentials)
+- [pipelines-workflows](#pipelines-workflows)
+- [terraform-aws-architecture-catalog](#terraform-aws-architecture-catalog)
+- [terraform-aws-cis-service-catalog](#terraform-aws-cis-service-catalog)
+- [terraform-aws-control-tower](#terraform-aws-control-tower)
+- [terraform-aws-data-storage](#terraform-aws-data-storage)
+- [terraform-aws-eks](#terraform-aws-eks)
+- [terraform-aws-lambda](#terraform-aws-lambda)
+- [terraform-aws-openvpn](#terraform-aws-openvpn)
+- [terraform-aws-security](#terraform-aws-security)
+- [terraform-aws-service-catalog](#terraform-aws-service-catalog)
+- [terraform-aws-vpc](#terraform-aws-vpc)
+
+
+## pipelines-actions
+
+
+### [v4.8.0](https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.8.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/28/2026 | <a href="https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.8.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Mise 2026.4.11 by @Resonance1584 in https://github.com/gruntwork-io/pipelines-actions/pull/156
+* DEV-1441 Add orchestrate error comments by @Resonance1584 in https://github.com/gruntwork-io/pipelines-actions/pull/158
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-actions/compare/v4.7.0...v4.8.0
+
+</div>
+
+
+### [v4.7.0](https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.7.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/16/2026 | <a href="https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.7.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * add new post access control action by @odgrim in https://github.com/gruntwork-io/pipelines-actions/pull/157
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-actions/compare/v4.6.0...v4.7.0
+
+</div>
+
+
+### [v4.6.0](https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.6.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/13/2026 | <a href="https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.6.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Add job and account_names inputs by @Resonance1584 in https://github.com/gruntwork-io/pipelines-actions/pull/155
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-actions/compare/v4.5.1...v4.6.0
+
+</div>
+
+
+### [v4.5.2](https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.5.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/13/2026 | <a href="https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.5.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  Upgrade mise to 2026.4.11
+
+</div>
+
+
+### [v4.5.1](https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.5.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/7/2026 | <a href="https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.5.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Speed up preflight by @Resonance1584 in https://github.com/gruntwork-io/pipelines-actions/pull/154
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-actions/compare/v4.5.0...v4.5.1
+
+</div>
+
+
+### [v4.5.0](https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.5.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/2/2026 | <a href="https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.5.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * 2026 04 01 fix node warnings by @Resonance1584 in https://github.com/gruntwork-io/pipelines-actions/pull/153
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-actions/compare/v4.4.0...v4.5.0
+
+</div>
+
+
+
+## pipelines-cli
+
+
+### [v0.53.1](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.53.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/29/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.53.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * [DEV-1429] Reflect output-only changes in plan summary by @odgrim in https://github.com/gruntwork-io/pipelines/pull/562
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines/compare/v0.53.0...v0.53.1
+
+
+</div>
+
+
+### [v0.53.0](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.53.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/28/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.53.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Dont update deploy branch unless on a PR by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/568
+* Pin architecture catalog version in tests by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/570
+* Fix architecture details by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/569
+* DEV-1441 Add PIPELINES_FEATURE_VALIDATE_DAG_ON_DELETE by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/567
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines/compare/v0.52.1...v0.53.0
+
+
+</div>
+
+
+### [v0.52.1](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.52.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/23/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.52.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * chore: Use `stack generate` with `--filters-file` when possible by @yhakbar in https://github.com/gruntwork-io/pipelines/pull/566
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines/compare/v0.52.0...v0.52.1
+
+
+</div>
+
+
+### [v0.52.0](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.52.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/23/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.52.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * DEV-1460 Accurate apply vs destroy feedback in PR comments by @oredavids in https://github.com/gruntwork-io/pipelines/pull/561
+* Arch doc by @ZachGoldberg in https://github.com/gruntwork-io/pipelines/pull/565
+* Support custom CI config file name and location (DEV-1425) by @oredavids in https://github.com/gruntwork-io/pipelines/pull/563
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines/compare/v0.51.0...v0.52.0
+
+
+</div>
+
+
+### [v0.51.0](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.51.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/20/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.51.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Gruntwork Claude marketplace config by @ZachGoldberg in https://github.com/gruntwork-io/pipelines/pull/557
+* Fix RepoBaseURL parameter by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/558
+* Add account_factory.pr_create_token_name hcl config by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/559
+* Fix pipelines_workflow_location by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/560
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines/compare/v0.50.0...v0.51.0
+
+
+</div>
+
+
+### [v0.50.0](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.50.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/13/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.50.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Add pipelines config get
+* Add pipelines account-factory execute-via-control-tower
+* Add pipelines account-factory get-account-request-field
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines/compare/v0.49.1...v0.50.0
+
+
+</div>
+
+
+### [v0.49.1](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.49.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/10/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.49.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Regenerate test-fixtures by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/550
+* fix govcloud regions, add missing regions by @odgrim in https://github.com/gruntwork-io/pipelines/pull/551
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines/compare/v0.49.0...v0.49.1
+
+
+</div>
+
+
+### [v0.49.0](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.49.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/9/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.49.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * DEV-1433 - Comment consolidation by @ZachGoldberg in https://github.com/gruntwork-io/pipelines/pull/547
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines/compare/v0.48.5...v0.49.0
+
+
+</div>
+
+
+### [v0.48.5](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.48.5)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/8/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.48.5">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Decrease binary size by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/546
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines/compare/v0.48.4...v0.48.5
+
+
+</div>
+
+
+### [v0.48.4](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.48.4)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/8/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.48.4">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Remove PIPELINES_READ_TOKEN preflight checks by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/544
+* Preflight children checks run in parallel by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/545
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines/compare/v0.48.3...v0.48.4
+
+
+</div>
+
+
+### [v0.48.3](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.48.3)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/2/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.48.3">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Run preflight checks in parallel by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/543
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines/compare/v0.48.2...v0.48.3
+
+
+</div>
+
+
+### [v0.48.2](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.48.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/1/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.48.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Wrap git operations in retry by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/541
+* Fix whitespace in unit paths causing separate args to terragrunt by @Resonance1584 in https://github.com/gruntwork-io/pipelines/pull/542
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines/compare/v0.48.1...v0.48.2
+
+
+</div>
+
+
+
+## pipelines-credentials
+
+
+### [v2.0.0](https://github.com/gruntwork-io/pipelines-credentials/releases/tag/v2.0.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/7/2026 | <a href="https://github.com/gruntwork-io/pipelines-credentials/releases/tag/v2.0.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Refactor to fetch tokens in parallel by @Resonance1584 in https://github.com/gruntwork-io/pipelines-credentials/pull/25
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-credentials/compare/v1.3.1...v2.0.0
+
+</div>
+
+
+
+## pipelines-workflows
+
+
+### [v4.16.1](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.16.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/30/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.16.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+Previously, Terragrunt plans that only changed Terraform outputs (no resource adds, changes, or destroys) rendered as `Plan Summary: 0 to add, 0 to change, 0 to destroy`, which was misleading.
+
+Plan summaries now include per-action output counts and (in the GitHub formatter) a `Changed Outputs` list of changed output names. For example:
+
+`Plan Summary: 0 to add, 0 to change, 0 to destroy, 0 outputs to add, 1 outputs to change, 0 outputs to destroy`
+
+* Pipelines CLI v0.53.1 by @oredavids in https://github.com/gruntwork-io/pipelines-workflows/pull/215
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4.16.0...v4.16.1
+
+</div>
+
+
+### [v4.16.0](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.16.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/28/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.16.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+
+Pipelines can now fail a pull request when it deletes a Terragrunt unit (or a file read by a unit) that is still referenced elsewhere in the [DAG](https://docs.terragrunt.com/getting-started/terminology#directed-acyclic-graph-dag).
+
+When enabled, orchestrate runs `terragrunt find` against the target ref and cross-references each deleted path against every Pipelines unit&apos;s `dependencies` and `mark_as_read` entries.
+
+If any Pipelines unit still references a deleted path, the run fails on pull request events with a comment listing the offending references; on other events the violation is logged as a warning and the run continues.
+
+This is an opt-in feature, disabled by default. Enable it by setting `PIPELINES_FEATURE_VALIDATE_DAG_ON_DELETE=true` in your repository&apos;s environment configuration.
+
+To enable a feature flag, add it to the `env` block of `repository` in `.gruntwork/repository.hcl`:
+
+```hcl
+repository &#x7B;
+  env &#x7B;
+    PIPELINES_FEATURE_VALIDATE_DAG_ON_DELETE = &quot;true&quot;
+  &#x7D;
+&#x7D;
+```
+
+Validation of `mark_as_read` entries requires Terragrunt newer than v0.91.3; older versions only validate `dependencies`.
+
+See [the feature flag reference](https://docs.gruntwork.io/2.0/reference/pipelines/feature-flags#pipelines_feature_validate_dag_on_delete) for full details.
+
+
+
+Fixed a race where a Push event to the deploy branch could compute a changeset against a newer deploy-branch tip than the one that triggered the run if another pull request merged in between; the comparison only ever moved forward in history, never backward.
+
+Pipelines no longer touches the local deploy branch on Push events; the runner&apos;s checkout already provides the correct state for the trigger commit. Pull request events are unchanged.
+
+We recommend enabling &quot;Require branches to be up to date before merging&quot; in your repository&apos;s branch protection rules. That requirement prevents the wider class of races where two pull requests land against the same deploy-branch tip without either one seeing the other&apos;s changes.
+
+
+mise version used in the preflight action lagged the version used in workflows (2025.10.0 -&gt; 2026.4.11)
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4.15.1...v4.16.0
+
+</div>
+
+
+### [v4.15.1](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.15.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/24/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.15.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+Pipelines now calls a single `terragrunt stack generate` invocation with usage of the `--filters-file` flag when using a Terragrunt modern enough to support the `--filters-file` flag (&gt;= `v0.97.0`) instead of calling `terragrunt stack generate` per stack being generated.
+
+This allows Terragrunt to synchronize stack generations more carefully with full awareness of the stacks being generated, reducing the likelihood of contention between different stack generations.
+
+* chore: Bumping Pipelines to `v0.52.1` by @yhakbar in https://github.com/gruntwork-io/pipelines-workflows/pull/213
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4.15.0...v4.15.1
+
+</div>
+
+
+### [v4.15.0](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.15.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/23/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.15.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Bump pipelines CLI to v0.52.0 by @oredavids in https://github.com/gruntwork-io/pipelines-workflows/pull/212 (Accurate apply vs destroy feedback in PR comments)
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4...v4.15.0
+
+</div>
+
+
+### [v4.14.0](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.14.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/20/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.14.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+
+The following improvements affect Account Factory customers using [custom actions](https://docs.gruntwork.io/2.0/docs/pipelines/guides/extending-pipelines/) to extend Pipelines.
+
+
+Added new optional inputs to pipelines-root, `pipelines_actions_customizations_repo` and `pipelines_actions_customizations_ref`. When set, custom-actions will be cloned from this repository instead of pipelines-actions.
+
+
+A new custom action runs after provisioning access-control but before opening the pull request, allowing customization of the pull request contents.
+
+
+Updated signatures of all custom actions with additional context. The `job` is the output from pipelines orchestrate, and `account_names` is a comma separate list of new accounts being created during account provisioning.
+
+
+The pipelines-execute action inputs `infra_live_repo_branch`, `infra_live_repo`, and `infra_live_directory` are now deprecated. Use `ref` in place of `infra_live_repo_branch`.
+
+
+Added the following commands to the pipelines CLI. These should be used in place for the deprecated pipelines-bootstrap context from v3 (no longer available in v4).
+
+- `pipelines config get --wd . &lt;path_to.hcl_config_value&gt;`
+- `pipelines account-factory get-account-request-field --wd . --acount-name &lt;account_name&gt; &lt;path_to.account_request_yaml&gt;`
+- `pipelines account-factory execute-via-control-tower --wd . --job $&#x7B;&#x7B; inputs.job &#x7D;&#x7D; --terragrunt-command &lt;command&gt;  --path &lt;path_to_unit&gt;`
+
+
+These fixes work in tandem with template changes in terraform-aws-architecture-catalog [v4.5.0](https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v4.5.0)
+
+
+Value would incorrectly include https://, leading to invalid module sources like `git://https://`
+
+
+Value was ignored, now correctly passed to delegated repository template
+
+
+Similar to `pipelines_read_token_name` this value can be used to customize the secret name for `PR_CREATE_TOKEN` when templating a new repository
+
+
+`pipelines_workflow_location` was previously being ignored. Fixed this and added `pipelines_workflow_ref`. 
+
+Previously `pipelines_workflow_location` was documented as being the full path to a forked pipelines workflow e.g. `acme-org/pipelines-workflows/.github/workflows/pipelines.yml@X`. If migrating from pipelines YAML config, this value needs to be changed to the path up to but not including the workflow file name e.g. `acme-org/pipelines-workflows/.github/workflows`. This value is then used in the pipelines, unlock, and drift-detection workflows.
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4.13.0...v4.14.0
+
+</div>
+
+
+### [v4.13.0](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.13.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/13/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.13.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Bump mise from 2025.10.0 to 2026.4.11 by @chrisbarrett in https://github.com/gruntwork-io/pipelines-workflows/pull/209
+* Mise 2026.4.11 by @Resonance1584 in https://github.com/gruntwork-io/pipelines-workflows/pull/210
+
+* @chrisbarrett made their first contribution in https://github.com/gruntwork-io/pipelines-workflows/pull/209
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4...v4.13.0
+
+</div>
+
+
+### [v4.12.1](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.12.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/10/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.12.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * :bug: Fix a bug preventing us-gov regions from being recognized by the unlock all workflow
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4...v4.12.1
+
+</div>
+
+
+### [v4.12.0](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.12.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/9/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.12.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+:sparkles: Added a new `status_update` configuration block for the `repository` block. This allows you to control how Pipelines posts status comments on pull/merge requests.
+
+By default, Pipelines creates a new comment for every push to a PR branch. You can now set `new_comment_per_push = false` to have Pipelines update a single comment in-place instead. On GitHub, previous plan outputs are preserved in the comment&apos;s edit history. On GitLab, previous outputs are overwritten since GitLab does not support comment edit history.
+
+```hcl
+repository &#x7B;
+  status_update &#x7B;
+    new_comment_per_push = false
+  &#x7D;
+&#x7D;
+```
+
+Read more in [the docs](https://docs.gruntwork.io/2.0/reference/pipelines/configurations-as-code/api#new_comment_per_push)
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4...v4.12.0
+
+</div>
+
+
+### [v4.11.0](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.11.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/9/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.11.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+- :sparkles: Added support for `PIPELINES_GRUNTWORK_READ_TOKEN` and `PIPELINES_CUSTOMER_ORG_READ_TOKEN` as fallback secrets. These optional fallback secrets take precedence over `PIPELINES_READ_TOKEN` and can be used in situations where a single PAT cannot access both the gruntwork-io organization and the customer organization. Read the full docs [here](https://docs.gruntwork.io/2.0/docs/pipelines/installation/viamachineusers/#pipelines_gruntwork_read_token)
+- :zap: pipelines-credentials now fetches tokens from the Gruntwork Dev portal in parallel, saving a few seconds of overhead per job.
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4...v4.11.0
+
+</div>
+
+
+### [v4.10.3](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.10.3)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/8/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.10.3">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+* :bug: Fix issues with whitespace in unit paths causing separate args to be passed to  `terragrunt run --all`
+* :bug: Remove invalid PIPELINES_READ_TOKEN preflight checks
+* :gear: Updated actions to remove deprecated node version warnings
+* :zap: Some small speed improvements to job overheads by parallelizing some tasks, in our tests this can save anywhere from 1 to 20 seconds per job
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4...v4.10.3
+
+</div>
+
+
+
+## terraform-aws-architecture-catalog
+
+
+### [v5.0.0](https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v5.0.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/28/2026 | <a href="https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v5.0.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Updated the architecture catalog from CIS AWS Foundations Benchmark v1.5.0 to v3.0.0 and restructures CloudTrail implementation to use a single organization trail instead of per-account trails
+
+
+- New required boilerplate variables: Users re-running boilerplate generation will now be prompted for SecurityContactName, SecurityContactEmail, SecurityContactPhone, and SecurityContactTitle
+  - These have no defaults and must be provided. 
+  - Users running `--non-interactive` must add `--var SecurityContactName=...` `--var SecurityContactEmail=...` etc. to their commands.
+- CloudTrail migration to organization trail: Existing deployments that have per-account CloudTrail trails will be migrated to a single organization trail:
+  - The management account trail becomes an org trail; This requires the management account to have `organizations:ListAccounts` and `organizations:DescribeOrganization` permissions
+  - Sub-account baselines disable their individual CloudTrail trails (`enable_cloudtrail = false`); Users must apply the management account changes first (to enable the org trail) before applying sub-account changes (which disable their individual trails), or there will be a window with no CloudTrail coverage
+- AWS provider constraint tightened: The minimum AWS provider version moves from ~&gt; 6.0 to ~&gt; 6.25
+- KMS key policy change in shared account: The addition of `allow_manage_key_permissions_with_iam = true` to both KMS keys changes how key access is managed; Existing key policies will be updated on the next apply
+-  New Terragrunt units: The following new units must be applied:                                                                                                                                 
+    - `account-security-contact` (all accounts)
+    - `default-vpc-hardening` (all accounts; gracefully skips if no default VPC exists)
+    - `ebs-encryption` (management account only)
+    - `s3-account-public-access-block` (all accounts)
+    - `s3-tls-enforcement-scp` (management account only)
+    - `iam-groups` (management account only)
+
+
+**Full Changelog**: https://github.com/gruntwork-io/terraform-aws-architecture-catalog/compare/v4.5.0...v5.0.0
+
+</div>
+
+
+### [v4.5.0](https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v4.5.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/20/2026 | <a href="https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v4.5.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * chore: bump cloud-nuke to v0.49.0 by @james00012 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1193
+* chore: run cloud-nuke cleanup across all regions by @james00012 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1194
+* Fix access control PR by @Resonance1584 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1195
+* Fix root.hcl invalid merge by @Resonance1584 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1196
+* Fix delegated update workflow by @Resonance1584 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1197
+* Fix catalog tags yamldecode by @Resonance1584 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1198
+* Fix pipelines_read_token_name, add pr_create_token_name by @Resonance1584 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1200
+* Update terragrunt to 1.01 and opentofu to 1.11.6 in delegated repositories by @Resonance1584 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1199
+* Add PipelinesWorkflowLocation to templates by @Resonance1584 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1201
+
+
+**Full Changelog**: https://github.com/gruntwork-io/terraform-aws-architecture-catalog/compare/v4.4.0...v4.5.0
+
+</div>
+
+
+### [v4.4.0](https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v4.4.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/10/2026 | <a href="https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v4.4.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * chore: Removing usage of `pull_request_target` by @yhakbar in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1186
+* feat: add gw: namespaced tagging and scheduled cloud-nuke cleanup by @james00012 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1188
+* DEV-1433 Catalog updates for new status update config value by @ZachGoldberg in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1190
+
+
+**Full Changelog**: https://github.com/gruntwork-io/terraform-aws-architecture-catalog/compare/v4.3.2...v4.4.0
+
+</div>
+
+
+
+## terraform-aws-cis-service-catalog
+
+
+### [v1.2.1](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v1.2.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/20/2026 | Modules affected: observability | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v1.2.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Updated `observability/cloudtrail` with a new data-events-only mode to disable logging management events if Control Tower is already capturing them
+
+
+
+
+
+</div>
+
+
+### [v1.2.0](https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v1.2.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/3/2026 | Modules affected: data-stores, landingzone, networking, observability | <a href="https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v1.2.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Add IPv6 CIDR block support for dual-stack networking
+- CIS AWS Foundations Benchmark v3.0.0 support
+- Test fixes/improvements
+
+
+
+
+
+</div>
+
+
+
+## terraform-aws-control-tower
+
+
+### [v2.0.2](https://github.com/gruntwork-io/terraform-aws-control-tower/releases/tag/v2.0.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/22/2026 | Modules affected: landingzone | <a href="https://github.com/gruntwork-io/terraform-aws-control-tower/releases/tag/v2.0.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- feat: CT Role Description variable
+
+
+
+</div>
+
+
+### [v2.0.1](https://github.com/gruntwork-io/terraform-aws-control-tower/releases/tag/v2.0.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/21/2026 | Modules affected: landingzone | <a href="https://github.com/gruntwork-io/terraform-aws-control-tower/releases/tag/v2.0.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+chore: bump cloud-nuke to v0.49.0
+chore: run cloud-nuke cleanup across all regions
+plumb through enable_default_standards in security hub
+
+
+
+</div>
+
+
+### [v2.0.0](https://github.com/gruntwork-io/terraform-aws-control-tower/releases/tag/v2.0.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/9/2026 | Modules affected: landingzone | <a href="https://github.com/gruntwork-io/terraform-aws-control-tower/releases/tag/v2.0.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- CIS AWS Foundations Benchmark v3.0.0 support
+
+
+
+
+
+</div>
+
+
+
+## terraform-aws-data-storage
+
+
+### [v1.0.0](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v1.0.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/10/2026 | Modules affected: aurora, rds, rds-replicas, rds-proxy | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v1.0.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+- `aurora`
+- `rds`
+- `rds-replicas`
+- `rds-proxy`
+- `redshift`
+- `opensearch`
+- `backup-plan`
+- `backup-vault`
+- `dms`
+- `efs`
+- `org-backup-policy`
+- `lambda-create-snapshot` **(REMOVED)**
+- `lambda-share-snapshot` **(REMOVED)**
+- `lambda-copy-shared-snapshot` **(REMOVED)**
+- `lambda-cleanup-snapshots` **(REMOVED)**
+
+
+
+**Lambda snapshot modules removed.** The following modules have been deleted in favor of AWS Backup&apos;s native capabilities (#580):
+
+- `lambda-create-snapshot` → Use `backup-plan` with a cron schedule
+- `lambda-share-snapshot` → Use `copy_action` in backup plan rule
+- `lambda-copy-shared-snapshot` → Use `copy_action` with automatic KMS re-encryption
+- `lambda-cleanup-snapshots` → Use `lifecycle &#x7B; delete_after &#x7D;` on source and destination
+
+See the [backup-rds-cross-account example](/examples/backup-rds-cross-account) for a full end-to-end replacement.
+
+
+- **RDS**: Add `multi_az` support for read replicas (#575)
+- **Aurora/RDS**: Replace `local-exec` sleep provisioners with `time_sleep` resources, replace `element(concat(...))` with `one()`, add output descriptions (#578)
+- **All modules**: Standardize Terraform (`&gt;= 1.3.0`) and AWS provider (`&gt;= 5.0.0, &lt; 7.0.0`) version constraints (#577)
+- **CI**: Add `gw:` namespaced tagging for test resources, scheduled cloud-nuke cleanup (#582, #583)
+
+
+- **Aurora**: Fix cross-region replica example — add explicit KMS key, fix parameter group attachment bug (#573)
+- **Tests**: Restrict all tests to known-good AWS regions to avoid quota issues (#576)
+
+
+- Resolve 8 Dependabot alerts: upgrade pgx/v4→v5, grpc (critical auth bypass), go-getter, logrus, x/oauth2, x/crypto, ulikunitz/xz (#584)
+
+
+- Update module READMEs with new feature entries, typo fixes, maturity notes (#579)
+- Align all examples to `required_version &gt;= 1.3.0`, remove OpenSearch rough-edges warning, clean up skipped tests (#584)
+
+
+Special thanks to the following users for their contribution!
+
+- @mkiss-apr
+
+
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/580
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/578
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/577
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/575
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/573
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/582
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/583
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/579
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/576
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/584
+
+</div>
+
+
+
+## terraform-aws-eks
+
+
+### [v4.5.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v4.5.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/7/2026 | Modules affected: eks-aws-auth-merger, eks-cluster-control-plane, eks-ebs-csi-driver, eks-k8s-cluster-autoscaler | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v4.5.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- `eks-aws-auth-merger`
+- `eks-cluster-control-plane`
+- `eks-ebs-csi-driver`
+- `eks-k8s-cluster-autoscaler`
+
+
+Default EKS version is 1.34 with this release! Please see the links below for full details of the EKS 1.34 release including new features and any API changes.
+
+**Kubernetes 1.34 (&quot;Of Wind &amp; Will&quot;) highlights:**
+- Dynamic Resource Allocation (DRA) core functionality graduated to GA
+- VolumeAttributesClass (VAC) graduated to GA (storage.k8s.io/v1)
+- 23 enhancements graduating to stable, including Direct Service Return (DSR) for Windows kube-proxy
+- No deprecated APIs or removed features — safe upgrade path
+
+[Official AWS EKS 1.34 Announcement](https://aws.amazon.com/about-aws/whats-new/2025/10/amazon-eks-distro-kubernetes-version-1-34/)
+[Amazon EKS Distro Docs](https://distro.eks.amazonaws.com/)
+[Kubernetes 1.34 Announcement](https://kubernetes.io/blog/2025/08/27/kubernetes-v1-34-release/)
+[Kubernetes 1.34 Release Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md)
+
+
+No breaking changes. The default EKS version has been updated to `1.34`. Users pinning a specific version via the `kubernetes_version` variable are unaffected.
+
+
+- https://github.com/gruntwork-io/terraform-aws-eks/pull/809
+
+
+</div>
+
+
+### [v4.4.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v4.4.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/3/2026 | Modules affected: eks-alb-ingress-controller | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v4.4.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Add `gw:` namespaced tagging and scheduled cloud-nuke cleanup
+- Expose all remaining `aws-load-balancer-controller` helm chart values (v1.4.6) as Terraform variables for the `eks-alb-ingress-controller` module. This includes resource requests/limits, node scheduling (nodeSelector, topologySpreadConstraints, podDisruptionBudget), AWS feature toggles (WAF, Shield, WAFv2, EndpointSlices), webhook configuration, observability settings, and more. All new variables default to the chart&apos;s defaults to ensure no breaking changes.
+
+
+</div>
+
+
+
+## terraform-aws-lambda
+
+
+### [v1.3.1](https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v1.3.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/29/2026 | Modules affected: - lambda-alias, - lambda-function-url, - api-gateway-account-settings, - api-gateway-proxy | <a href="https://github.com/gruntwork-io/terraform-aws-lambda/releases/tag/v1.3.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- feat: Add `gw:`-namespaced default tagging and scheduled cloud-nuke cleanup workflow (#282)
+- fix: Make CORS configuration optional in `lambda-function-url` (#284)
+- docs: Update module documentation (#285)
+- chore: Bump cloud-nuke to v0.49.0 (#286)
+- chore: Run cloud-nuke cleanup across all regions (#287)
+- feat: Propagate `custom_tags` to the `api-gateway-proxy` stage (#288)
+- fix: Harden cloud-nuke cleanup CI and bump cloud-nuke to v0.50.0 (#289)
+
+
+
+</div>
+
+
+
+## terraform-aws-openvpn
+
+
+### [v1.0.0](https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v1.0.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/24/2026 | Modules affected: init-openvpn, install-openvpn, openvpn-server | <a href="https://github.com/gruntwork-io/terraform-aws-openvpn/releases/tag/v1.0.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+-  feat: add gw: namespaced tagging and scheduled cloud-nuke cleanup
+- chore: bump cloud-nuke to v0.49.0
+- chore: run cloud-nuke cleanup across all regions
+- Base Image upgrades
+
+
+
+</div>
+
+
+
+## terraform-aws-security
+
+
+### [v1.5.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v1.5.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/3/2026 | Modules affected: private-s3-bucket | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v1.5.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Transition data source aws_region from name (deprecated) to region in output
+
+
+
+
+
+</div>
+
+
+
+## terraform-aws-service-catalog
+
+
+### [v2.5.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v2.5.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/20/2026 | Modules affected: networking/vpc, services/eks-argocd, services/eks-cluster, services/eks-core-services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v2.5.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Bump cloud-nuke to v0.49.0
+- Run cloud-nuke cleanup across all regions
+- Add Default Support for EKS 1.34
+- Bump `cluster-autoscaler` to `v1.34.0` (chart `9.56.0`)
+- Bump `terraform-aws-eks` library module from `v4.4.0` → `v4.5.0`
+
+Default EKS version is 1.34 with this release! Please see the links below for full details of the EKS 1.34 release including new features and any API changes.
+
+[Official AWS EKS 1.34 Announcement](https://aws.amazon.com/about-aws/whats-new/2025/10/amazon-eks-kubernetes-version-1-34/)
+[Amazon EKS Distro Docs](https://distro.eks.amazonaws.com/)
+[Kubernetes 1.34 Announcement](https://kubernetes.io/blog/2025/08/27/kubernetes-v1-34-release/)
+[Kubernetes 1.34 Release Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md)
+
+
+
+</div>
+
+
+### [v2.4.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v2.4.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/4/2026 | Modules affected: networking/vpc, services/eks-argocd, services/eks-cluster, services/eks-core-services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v2.4.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+- `networking/vpc`
+- `services/eks-argocd`
+- `services/eks-cluster`
+- `services/eks-core-services`
+- `services/eks-karpenter`
+- `services/eks-workers`
+- `services/helm-service`
+- `services/k8s-service`
+
+
+- Bump `terraform-aws-eks` to `v4.4.0`
+- Replace `alb_ingress_controller_extra_args` with `alb_ingress_controller_feature_gates` (`map(bool)`) in `eks-core-services`
+- Expose all remaining `aws-load-balancer-controller` helm chart values (v1.4.6) as Terraform variables in `eks-core-services`, including resource requests/limits, node scheduling, security contexts, WAF/Shield/WAFv2 toggles, webhook configuration, observability settings, and more
+
+&gt; [!WARNING]
+&gt; #### Breaking Changes
+&gt; - `alb_ingress_controller_extra_args` has been removed and replaced with `alb_ingress_controller_feature_gates`. If you were using `extra_args` to pass feature gates, update your configuration:
+&gt; 
+&gt; **Before:**
+&gt; ```hcl
+&gt; alb_ingress_controller_extra_args = &#x7B;
+&gt;   &quot;feature-gates&quot; = &quot;NLBGatewayAPI=true,ALBGatewayAPI=true&quot;
+&gt; &#x7D;
+&gt; ```
+&gt; 
+&gt; **After:**
+&gt; ```hcl
+&gt; alb_ingress_controller_feature_gates = &#x7B;
+&gt;   NLBGatewayAPI = true
+&gt;   ALBGatewayAPI = true
+&gt; &#x7D;
+&gt; ```
+
+
+- https://github.com/gruntwork-io/terraform-aws-service-catalog/pull/2368
+- https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v4.4.0
+
+
+</div>
+
+
+### [v2.3.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v2.3.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/3/2026 | Modules affected: base, data-stores, landingzone, mgmt | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v2.3.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Updated all usage of terraform-aws-security to v1.4.1 and of terraform-aws-data-storage to v0.47.0
+- Replace Lambda Snapshot usage in data-stores modules with AWS Backup (requires migration, see below)
+
+
+
+
+
+</div>
+
+
+
+## terraform-aws-vpc
+
+
+### [v0.28.13](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.28.13)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 4/23/2026 | Modules affected: vpc-app, transit-gateway-peering-attachment-accepter, vpc-app-lookup, vpc-flow-logs | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.28.13">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- chore: bump cloud-nuke to v0.49.0
+- chore: run cloud-nuke cleanup across all regions
+- LIB-4871 Don&apos;t create EIP if using private NAT gateway
+- Fix TGW accepter: skip data lookup when attachment ID is provided
+- Remove deprecated attribute &quot;name&quot; for aws_region resource
+
+
+
+</div>
+
+<!-- ##DOCS-SOURCER-START
+{
+  "sourcePlugin": "releases",
+  "hash": "29cca8027aa77017de59b0da0c22bb95"
+}
+##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2026-04/index.md
+++ b/docs/guides/stay-up-to-date/releases/2026-04/index.md
@@ -3,10 +3,8 @@
 
 <p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2026-04</small></p>
 
-This page is lists all the updates to the [Gruntwork Infrastructure as Code
-Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2026-04. For instructions
-on how to use these updates in your code, check out the [updating
-documentation](/library/stay-up-to-date/updating).
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2026-04.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 Here are the repos that were updated:
 
@@ -853,7 +851,7 @@ plumb through enable_default_standards in security hub
 - `lambda-copy-shared-snapshot` → Use `copy_action` with automatic KMS re-encryption
 - `lambda-cleanup-snapshots` → Use `lifecycle &#x7B; delete_after &#x7D;` on source and destination
 
-See the [backup-rds-cross-account example](/examples/backup-rds-cross-account) for a full end-to-end replacement.
+See the [backup-rds-cross-account example](https://github.com/gruntwork-io/terraform-aws-data-storage/tree/v1.0.0/examples/backup-rds-cross-account) for a full end-to-end replacement.
 
 
 - **RDS**: Add `multi_az` support for read replicas (#575)
@@ -1155,6 +1153,6 @@ Default EKS version is 1.34 with this release! Please see the links below for fu
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "29cca8027aa77017de59b0da0c22bb95"
+  "hash": "3833637559095eb7fd1d21cbd8c29498"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/index.md
+++ b/docs/guides/stay-up-to-date/releases/index.md
@@ -11,7 +11,8 @@ Library](https://gruntwork.io/infrastructure-as-code-library/), grouped by month
 updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 <CardGroup cols={1} gap="1rem" stacked equalHeightRows={false} commonCardProps={{padding: "1.25rem"}}>
-  <Card title="Gruntwork Release 2026-03" href="/guides/stay-up-to-date/releases/2026-03" />
+  <Card title="Gruntwork Release 2026-04" href="/guides/stay-up-to-date/releases/2026-04" />
+<Card title="Gruntwork Release 2026-03" href="/guides/stay-up-to-date/releases/2026-03" />
 <Card title="Gruntwork Release 2026-02" href="/guides/stay-up-to-date/releases/2026-02" />
 <Card title="Gruntwork Release 2026-01" href="/guides/stay-up-to-date/releases/2026-01" />
 <Card title="Gruntwork Release 2025-12" href="/guides/stay-up-to-date/releases/2025-12" />
@@ -134,6 +135,6 @@ updates in your code, check out the [updating documentation](/library/stay-up-to
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "8ae6e2e36db703383cee9846ab08493b"
+  "hash": "05d646a7121363a30dbd4cb78668a0b2"
 }
 ##DOCS-SOURCER-END -->

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "yargs": "^17.4.0"
   },
   "optionalDependencies": {
-    "docs-sourcer": "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.36",
+    "docs-sourcer": "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.36.2",
     "ts-commons": "gruntwork-io/ts-commons#v5.3.1"
   },
   "browserslist": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8034,9 +8034,9 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
-"docs-sourcer@git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.36":
+"docs-sourcer@git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#v0.36.2":
   version "0.0.1"
-  resolved "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#ab2f7e13f2d2ce770d6a76ea99fa36b2a04edd4e"
+  resolved "git+ssh://git@github.com/gruntwork-io/docs-sourcer.git#5c43cc0161f20d5ed3c949005d51b001d86a2260"
   dependencies:
     "@octokit/auth-app" "^3.6.1"
     "@octokit/plugin-retry" "^3.0.9"


### PR DESCRIPTION
Update Gruntwork releases as of 2026-04-30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added full 2026-04 release notes and detailed per-repo changelogs
  * Updated 2026-03 notes (pipelines, security, and VPC updates) and refreshed the releases index to surface latest releases
  * Applied editorial fixes and refreshed source metadata hashes across many release pages
* **Chores**
  * Bumped docs-sourcer tooling version in metadata
<!-- end of auto-generated comment: release notes by coderabbit.ai -->