### PR TITLE
PF-174: Document how customers can track the latest releases in Pipelines

### DIFF
--- a/docs/2.0/docs/pipelines/guides/updating-pipelines.md
+++ b/docs/2.0/docs/pipelines/guides/updating-pipelines.md
@@ -23,23 +23,25 @@ Due to our integration with [Dependabot](https://docs.github.com/en/code-securit
 Gruntwork recommends leaving your workflow reference at a major-tag shorthand, such as `v3` to automatically get the latest minor-tag updates.
 :::
 
-### Pipelines Release Notifications
+### Pipelines release notifications (GitHub)
 
-To stay informed about new releases of Gruntwork Pipelines, subscribe to the GitHub Atom feed for the [`gruntwork-io/pipelines-workflows`](https://github.com/gruntwork-io/pipelines-workflows) repository:
+To stay informed about new releases of Gruntwork Pipelines, you have two main options:
 
-```
-https://github.com/gruntwork-io/pipelines-workflows/releases.atom
-```
+- **GitHub notifications**: Open the [`pipelines-workflows`](https://github.com/gruntwork-io/pipelines-workflows) repository, click **Watch**, choose **Custom**, and enable **Releases**. GitHub will email you when a new release is published. This is the lowest-friction option and does not require a feed reader.
+- **RSS feed**: Subscribe to the Atom feed for the repository:
 
-There are several ways to consume this feed:
+  ```text
+  https://github.com/gruntwork-io/pipelines-workflows/releases.atom
+  ```
 
-- **GitHub's built-in watch**: Open the [`pipelines-workflows`](https://github.com/gruntwork-io/pipelines-workflows) repository, click **Watch**, choose **Custom**, and enable **Releases**. GitHub will email you when a new release is published. This is the lowest-friction option and does not require a feed reader.
-- **A standalone RSS reader**: Add the feed URL above to a reader such as Feedly, NetNewsWire, or Inoreader.
-- **Slack or Microsoft Teams**: Both platforms can post RSS items to a channel (Slack via its `/feed` slash command, Teams via an RSS connector). This lets release announcements land directly in a shared channel.
+  This feed can be consumed by:
+
+  - A standalone RSS reader such as Feedly, NetNewsWire, or Inoreader.
+  - Slack or Microsoft Teams, which can both post RSS items to a channel (Slack via its `/feed` slash command, Teams via an RSS connector). This lets release announcements land directly in a shared channel.
 
 :::note
 
-Dependabot (mentioned above) also surfaces new releases by opening pull requests against your repository. The Atom feed is a lower-latency complement: it notifies you as soon as a release is published, before a bot opens the upgrade PR.
+If you've configured Dependabot for your repository, it will also surface new releases by opening pull requests. The Atom feed is a lower-latency complement: it notifies you as soon as a release is published, before a bot opens the upgrade PR.
 :::
 
 ### Updating customized workflows
@@ -65,25 +67,27 @@ We recommend using GitLab's [Renovate integration](https://docs.gitlab.com/ee/us
 Gruntwork recommends leaving your workflow reference at a major-tag shorthand, such as `v1` to automatically get the latest minor-tag updates.
 :::
 
-### Pipelines Release Notifications
+### Pipelines release notifications (GitLab)
 
-To stay informed about new releases of Gruntwork Pipelines, subscribe to the Atom feed for the [`gruntwork-io/pipelines-workflows`](https://gitlab.com/gruntwork-io/pipelines-workflows) project on GitLab:
+To stay informed about new releases of Gruntwork Pipelines, you have two main options:
 
-```
-https://gitlab.com/gruntwork-io/pipelines-workflows/-/releases.atom
-```
+- **GitLab notifications**: On the [`pipelines-workflows`](https://gitlab.com/gruntwork-io/pipelines-workflows) project page, set your notification level to **Custom** and enable **New release**. GitLab will email you when a new release is published. This option does not require a feed reader.
+- **RSS feed**: Subscribe to the Atom feed for the project:
 
-There are several ways to consume this feed:
+  ```text
+  https://gitlab.com/gruntwork-io/pipelines-workflows/-/releases.atom
+  ```
 
-- **A standalone RSS reader**: Add the feed URL above to a reader such as Feedly, NetNewsWire, or Inoreader.
-- **GitLab notification settings**: On the [`pipelines-workflows`](https://gitlab.com/gruntwork-io/pipelines-workflows) project page, set your notification level to **Custom** and enable **New release**. GitLab will email you when a new release is published. This option does not require a feed reader.
-- **Slack or Microsoft Teams**: Both platforms can post RSS items to a channel (Slack via its `/feed` slash command, Teams via an RSS connector). This lets release announcements land directly in a shared channel.
+  This feed can be consumed by:
+
+  - A standalone RSS reader such as Feedly, NetNewsWire, or Inoreader.
+  - Slack or Microsoft Teams, which can both post RSS items to a channel (Slack via its `/feed` slash command, Teams via an RSS connector). This lets release announcements land directly in a shared channel.
 
 For GitLab users, applying a release maps to bumping the CI component version in your `.gitlab-ci.yml` (rather than updating a workflow file reference). The underlying concept is the same: a version bump on a Gruntwork dependency.
 
 :::note
 
-Renovate (mentioned above) also surfaces new releases by opening merge requests against your project. The Atom feed is a lower-latency complement: it notifies you as soon as a release is published, before a bot opens the upgrade MR.
+If you've configured Renovate for your project, it will also surface new releases by opening merge requests. The Atom feed is a lower-latency complement: it notifies you as soon as a release is published, before a bot opens the upgrade MR.
 :::
 
 </TabItem>

--- a/docs/2.0/docs/pipelines/guides/updating-pipelines.md
+++ b/docs/2.0/docs/pipelines/guides/updating-pipelines.md
@@ -23,6 +23,25 @@ Due to our integration with [Dependabot](https://docs.github.com/en/code-securit
 Gruntwork recommends leaving your workflow reference at a major-tag shorthand, such as `v3` to automatically get the latest minor-tag updates.
 :::
 
+### Pipelines Release Notifications
+
+To stay informed about new releases of Gruntwork Pipelines, subscribe to the GitHub Atom feed for the [`gruntwork-io/pipelines-workflows`](https://github.com/gruntwork-io/pipelines-workflows) repository:
+
+```
+https://github.com/gruntwork-io/pipelines-workflows/releases.atom
+```
+
+There are several ways to consume this feed:
+
+- **GitHub's built-in watch**: Open the [`pipelines-workflows`](https://github.com/gruntwork-io/pipelines-workflows) repository, click **Watch**, choose **Custom**, and enable **Releases**. GitHub will email you when a new release is published. This is the lowest-friction option and does not require a feed reader.
+- **A standalone RSS reader**: Add the feed URL above to a reader such as Feedly, NetNewsWire, or Inoreader.
+- **Slack or Microsoft Teams**: Both platforms can post RSS items to a channel (Slack via its `/feed` slash command, Teams via an RSS connector). This lets release announcements land directly in a shared channel.
+
+:::note
+
+Dependabot (mentioned above) also surfaces new releases by opening pull requests against your repository. The Atom feed is a lower-latency complement: it notifies you as soon as a release is published, before a bot opens the upgrade PR.
+:::
+
 ### Updating customized workflows
 
 If you have customized workflows as outlined in [Extending Pipelines](/2.0/docs/pipelines/guides/extending-pipelines.md), maintaining updates to these workflows may require additional effort. For those who have forked the [pipelines-workflows](https://github.com/gruntwork-io/pipelines-workflows) repository to implement customizations, manual updates will be necessary to incorporate the latest changes from the upstream repository.
@@ -44,6 +63,27 @@ We recommend using GitLab's [Renovate integration](https://docs.gitlab.com/ee/us
 :::note
 
 Gruntwork recommends leaving your workflow reference at a major-tag shorthand, such as `v1` to automatically get the latest minor-tag updates.
+:::
+
+### Pipelines Release Notifications
+
+To stay informed about new releases of Gruntwork Pipelines, subscribe to the Atom feed for the [`gruntwork-io/pipelines-workflows`](https://gitlab.com/gruntwork-io/pipelines-workflows) project on GitLab:
+
+```
+https://gitlab.com/gruntwork-io/pipelines-workflows/-/releases.atom
+```
+
+There are several ways to consume this feed:
+
+- **A standalone RSS reader**: Add the feed URL above to a reader such as Feedly, NetNewsWire, or Inoreader.
+- **GitLab notification settings**: On the [`pipelines-workflows`](https://gitlab.com/gruntwork-io/pipelines-workflows) project page, set your notification level to **Custom** and enable **New release**. GitLab will email you when a new release is published. This option does not require a feed reader.
+- **Slack or Microsoft Teams**: Both platforms can post RSS items to a channel (Slack via its `/feed` slash command, Teams via an RSS connector). This lets release announcements land directly in a shared channel.
+
+For GitLab users, applying a release maps to bumping the CI component version in your `.gitlab-ci.yml` (rather than updating a workflow file reference). The underlying concept is the same: a version bump on a Gruntwork dependency.
+
+:::note
+
+Renovate (mentioned above) also surfaces new releases by opening merge requests against your project. The Atom feed is a lower-latency complement: it notifies you as soon as a release is published, before a bot opens the upgrade MR.
 :::
 
 </TabItem>

--- a/docs/2.0/docs/pipelines/guides/updating-pipelines.md
+++ b/docs/2.0/docs/pipelines/guides/updating-pipelines.md
@@ -23,7 +23,7 @@ Due to our integration with [Dependabot](https://docs.github.com/en/code-securit
 Gruntwork recommends leaving your workflow reference at a major-tag shorthand, such as `v3` to automatically get the latest minor-tag updates.
 :::
 
-### Pipelines release notifications (GitHub)
+### Pipelines release notifications
 
 To stay informed about new releases of Gruntwork Pipelines, you have two main options:
 
@@ -41,7 +41,7 @@ To stay informed about new releases of Gruntwork Pipelines, you have two main op
 
 :::note
 
-If you've configured Dependabot for your repository, it will also surface new releases by opening pull requests. The Atom feed is a lower-latency complement: it notifies you as soon as a release is published, before a bot opens the upgrade PR.
+If you've configured Dependabot for your repository, it will also surface new releases by opening pull requests.
 :::
 
 ### Updating customized workflows
@@ -67,11 +67,11 @@ We recommend using GitLab's [Renovate integration](https://docs.gitlab.com/ee/us
 Gruntwork recommends leaving your workflow reference at a major-tag shorthand, such as `v1` to automatically get the latest minor-tag updates.
 :::
 
-### Pipelines release notifications (GitLab)
+### Pipelines release notifications
 
 To stay informed about new releases of Gruntwork Pipelines, you have two main options:
 
-- **GitLab notifications**: On the [`pipelines-workflows`](https://gitlab.com/gruntwork-io/pipelines-workflows) project page, set your notification level to **Custom** and enable **New release**. GitLab will email you when a new release is published. This option does not require a feed reader.
+- **GitLab notifications**: On the [`pipelines-workflows`](https://gitlab.com/gruntwork-io/pipelines-workflows) project page, set your notification level to **Custom** and enable **Release is created**. GitLab will email you when a new release is published. This option does not require a feed reader.
 - **RSS feed**: Subscribe to the Atom feed for the project:
 
   ```text
@@ -83,11 +83,11 @@ To stay informed about new releases of Gruntwork Pipelines, you have two main op
   - A standalone RSS reader such as Feedly, NetNewsWire, or Inoreader.
   - Slack or Microsoft Teams, which can both post RSS items to a channel (Slack via its `/feed` slash command, Teams via an RSS connector). This lets release announcements land directly in a shared channel.
 
-For GitLab users, applying a release maps to bumping the CI component version in your `.gitlab-ci.yml` (rather than updating a workflow file reference). The underlying concept is the same: a version bump on a Gruntwork dependency.
+For GitLab users, applying a release maps to bumping the CI component version in your `.gitlab-ci.yml`.
 
 :::note
 
-If you've configured Renovate for your project, it will also surface new releases by opening merge requests. The Atom feed is a lower-latency complement: it notifies you as soon as a release is published, before a bot opens the upgrade MR.
+If you've configured Renovate for your project, it will also surface new releases by opening merge requests.
 :::
 
 </TabItem>


### PR DESCRIPTION
Implements plan for Linear issue [PF-174](https://linear.app/issue/6e44c5f2-873d-4836-83cf-a1f117363c29).

Plan source: https://github.com/gruntwork-io-team/linear-claude-plans/blob/main/plans/PF-174.md

---

<details>
<summary>Claude's implementation summary</summary>

```
The new section is in both tabs with consistent structure. No changes needed in the pipelines repo itself (docs-only feature, as the plan acknowledged) and ARCHITECTURE.md is accurate as-is.

## Summary of changes

### `gruntwork-io/docs`

**File modified**: `docs/2.0/docs/pipelines/guides/updating-pipelines.md`

Added a new `### Pipelines Release Notifications` subsection inside both the GitHub and GitLab tabs of the existing `<Tabs groupId="platform">` block, positioned between the major-tag note and (in the GitHub tab) the `### Updating customized workflows` subsection.

**GitHub tab** documents:
- The releases Atom feed: `https://github.com/gruntwork-io/pipelines-workflows/releases.atom`
- Three consumption options: GitHub's built-in **Watch → Custom → Releases** (lowest friction), a standalone RSS reader (Feedly, NetNewsWire, Inoreader), and Slack/Teams via their RSS apps (described at a high level without fabricating specific support-article URLs)
- A `:::note` framing the Atom feed as a lower-latency complement to Dependabot

**GitLab tab** documents:
- The releases Atom feed: `https://gitlab.com/gruntwork-io/pipelines-workflows/-/releases.atom`
- Three consumption options: a standalone RSS reader, GitLab's built-in per-project notification setting (**Custom → New release**), and Slack/Teams via their RSS apps
- A brief paragraph noting that for GitLab users, "applying a release" means bumping the CI component version in `.gitlab-ci.yml` rather than a workflow file ref, but it's the same concept (version bump on a Gruntwork dependency)
- A `:::note` framing the Atom feed as a lower-latency complement to Renovate

No `cspell.json` changes (per the plan, do not pre-emptively add words; let CI flag any failures).

No sidebar changes needed — only adding a section to an existing page that's already in the sidebar.

### `gruntwork-io/pipelines`

No changes. This feature is docs-only; `pipelines` was listed in `target_repos` per the workflow rule but does not require Go, HCL, or test changes. `ARCHITECTURE.md` already correctly lists `pipelines-workflows` under "Related repos" and is not stale relative to this task.
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for subscribing to Pipelines release notifications on GitHub and GitLab, including watching Releases or subscribing to project Atom feeds for lower-latency alerts.
  * Documented consumption options (RSS readers, Slack/Teams via RSS) and clarified that “applying a release” means updating CI component versions.
  * Noted that Dependabot and Renovate may surface new releases via PR/MR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->