### PR TITLE
DEV-1480: Fix monthly releases cutoff to include last day of month

### DIFF
--- a/scripts/create_releases_pr.sh
+++ b/scripts/create_releases_pr.sh
@@ -23,6 +23,24 @@ function set_release_date() {
   fi
 }
 
+# First day of the current month, used as the exclusive upper bound for the
+# releases plugin filter. docs-sourcer parses date-only strings as midnight
+# UTC, so passing "last day of previous month" misses releases published
+# after 00:00 UTC on that day. Passing "first day of current month" instead
+# captures everything from the previous month regardless of UTC time.
+function set_cutoff_date() {
+  unameOut="$(uname -s)"
+
+  if [ ${unameOut} = "Linux" ]; then
+    echo $(date +"%Y-%m-01")
+  elif [ ${unameOut} = "Darwin" ]; then
+    echo $(date -v1d +%Y-%m-%d)
+  else
+    echo "Unknown uname ${unameOut}, exiting"
+    exit 1
+  fi
+}
+
 function configure_git {
   local -r git_username="$1"
   local -r git_email="$2"
@@ -47,10 +65,10 @@ function assert_envvar_not_empty() {
 }
 
 function generate_release_data() {
-  local -r release_date=$1
+  local -r cutoff_date=$1
 
   # The 'releases' plugin requires this env var to be set to limit releases to before this date
-  RELEASES_PLUGIN_BEFORE_DATE="$release_date" yarn regenerate --plugins releases
+  RELEASES_PLUGIN_BEFORE_DATE="$cutoff_date" yarn regenerate --plugins releases
 }
 
 function create_branch() {
@@ -91,15 +109,15 @@ function main() {
 
   assert_envvar_not_empty "GITHUB_OAUTH_TOKEN"
 
-  # no -r for RELEASES_PLUGIN_BEFORE_DATE so we can pass it into generate_release_data and set it for the process
-  local RELEASES_PLUGIN_BEFORE_DATE=$(set_release_date)
-  local -r BRANCH_NAME=$(set_branch_name $RELEASES_PLUGIN_BEFORE_DATE)
+  local -r RELEASE_DATE=$(set_release_date)
+  local -r CUTOFF_DATE=$(set_cutoff_date)
+  local -r BRANCH_NAME=$(set_branch_name $RELEASE_DATE)
 
   create_branch $BRANCH_NAME
-  generate_release_data $RELEASES_PLUGIN_BEFORE_DATE
-  add_and_commit_changes $RELEASES_PLUGIN_BEFORE_DATE
+  generate_release_data $CUTOFF_DATE
+  add_and_commit_changes $RELEASE_DATE
   push_branch $BRANCH_NAME
-  create_pull_request $RELEASES_PLUGIN_BEFORE_DATE
+  create_pull_request $RELEASE_DATE
 }
 
 main

--- a/scripts/create_releases_pr.sh
+++ b/scripts/create_releases_pr.sh
@@ -10,13 +10,15 @@ export GH_TOKEN=${GITHUB_OAUTH_TOKEN} # required to use 'gh'
 function set_release_date() {
   unameOut="$(uname -s)"
 
-  # Handling running this on linux or mac
+  # Handling running this on linux or mac. UTC-anchored to match
+  # docs-sourcer's UTC date parsing and avoid timezone drift near month
+  # boundaries when the script is run outside UTC.
   if [ ${unameOut} = "Linux" ]; then
     # Equivalent of a return statement
-    echo $(date -d "$(date +"%Y-%m-01") - 1 day" +"%F")
+    echo $(date -u -d "$(date -u +"%Y-%m-01") - 1 day" +"%F")
   elif [ ${unameOut} = "Darwin" ]; then
     # Equivalent of a return statement
-    echo $(date -v1d -v-1d +%Y-%m-%d)
+    echo $(TZ=UTC date -v1d -v-1d +%Y-%m-%d)
   else
     echo "Unknown uname ${unameOut}, exiting"
     exit 1
@@ -32,9 +34,9 @@ function set_cutoff_date() {
   unameOut="$(uname -s)"
 
   if [ ${unameOut} = "Linux" ]; then
-    echo $(date +"%Y-%m-01")
+    echo $(date -u +"%Y-%m-01")
   elif [ ${unameOut} = "Darwin" ]; then
-    echo $(date -v1d +%Y-%m-%d)
+    echo $(TZ=UTC date -v1d +%Y-%m-%d)
   else
     echo "Unknown uname ${unameOut}, exiting"
     exit 1


### PR DESCRIPTION
## Summary

Fixes the off-by-one in the monthly releases automation that caused releases published after `00:00 UTC` on the last day of the previous month to be silently excluded.

The script passed the last day of the previous month (e.g. `2026-02-28`) as `RELEASES_PLUGIN_BEFORE_DATE`. docs-sourcer parses date-only strings as midnight UTC and filters with `<=`, so any release published after `00:00 UTC` on that day was missed. Concrete example: `terraform-aws-data-storage` v0.47.0 (published `2026-02-28T00:44:47Z`) was excluded from the February run and only appeared in the March PR.

This change adds `set_cutoff_date()` returning first-of-current-month and uses that as the filter cutoff. Display fields (branch name, commit message, PR title) still use last-of-previous-month.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable release data generation so recent releases are not missed due to timezone/cutoff handling.
* **Chores**
  * Release PRs now use a distinct cutoff date for regeneration while keeping release date for branch names and commit messages, improving consistency of regenerated content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->