### PR TITLE
Remove unused Source Sans Pro and update stylesheet

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -78,9 +78,7 @@ async function createConfig() {
     organizationName: "gruntwork-io", // Usually your GitHub org/user name.
     projectName: "docs", // Usually your repo name.,
 
-    stylesheets: [
-      "https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600;1,700&display=swap",
-    ],
+    stylesheets: [],
     customFields: {
       libraryIndexName: algoliaConfig
         ? algoliaConfig.libraryIndexName

--- a/src/components/SearchArea.module.css
+++ b/src/components/SearchArea.module.css
@@ -76,7 +76,7 @@
   margin-left: 1px;
   margin-top: 0px;
   font-size: 15px;
-  font-family: "Source Sans Pro";
+  font-family: "Inter", sans-serif;
 }
 
 .SearchInput:focus-visible {


### PR DESCRIPTION
Optimization - remove Sans pro in favor of Inter (already in use)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated site typography by replacing the Source Sans Pro font with Inter font throughout the application.
  * Removed external Google Fonts stylesheet dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->