### PR TITLE
PF-138: Pipelines - Document ways to achieve Plan Only Mode (Disable Apply on Merge)

### DIFF
--- a/docs/2.0/docs/pipelines/guides/running-plan-apply.md
+++ b/docs/2.0/docs/pipelines/guides/running-plan-apply.md
@@ -127,7 +127,7 @@ All three fields are required for this to behave as plan-only:
 
 - **`if = true`** -- the exclude condition is unconditionally true. You can substitute a dynamic expression here if you want the exclusion to depend on the environment, branch, or any other Terragrunt-visible input.
 - **`actions = ["apply"]`** -- restricts the exclusion to the `apply` action only, so `plan` still runs normally on this unit.
-- **`no_run = true`** -- causes Terragrunt to skip execution of the matched action.
+- **`no_run = true`** -- Required to ensure that this exclude is effective for both consolidated (`--all`) and non-consolidated runs.
 
 #### Dependency considerations
 

--- a/docs/2.0/docs/pipelines/guides/running-plan-apply.md
+++ b/docs/2.0/docs/pipelines/guides/running-plan-apply.md
@@ -75,9 +75,6 @@ on:
       - reopened
 ```
 
-:::note
-When you are ready to let Pipelines run Apply, restore the `push:` block (using the same `branches` and `paths-ignore` values you had before).
-:::
 
 </TabItem>
 <TabItem value="gitlab" label="GitLab">
@@ -103,10 +100,6 @@ workflow:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: always
 ```
-
-:::note
-When you are ready to let Pipelines run Apply, restore the `$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH` rule.
-:::
 
 </TabItem>
 </Tabs>

--- a/docs/2.0/docs/pipelines/guides/running-plan-apply.md
+++ b/docs/2.0/docs/pipelines/guides/running-plan-apply.md
@@ -56,24 +56,11 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - ".github/**"
   pull_request:
     types:
       - opened
       - synchronize
       - reopened
-    paths-ignore:
-      - ".github/**"
-
-permissions:
-  id-token: write
-  contents: write
-  pull-requests: write
-
-jobs:
-  GruntworkPipelines:
-    uses: gruntwork-io/pipelines-workflows/.github/workflows/pipelines.yml@<ref>
 ```
 
 After (the `push:` block is removed):
@@ -86,17 +73,6 @@ on:
       - opened
       - synchronize
       - reopened
-    paths-ignore:
-      - ".github/**"
-
-permissions:
-  id-token: write
-  contents: write
-  pull-requests: write
-
-jobs:
-  GruntworkPipelines:
-    uses: gruntwork-io/pipelines-workflows/.github/workflows/pipelines.yml@<ref>
 ```
 
 :::note

--- a/docs/2.0/docs/pipelines/guides/running-plan-apply.md
+++ b/docs/2.0/docs/pipelines/guides/running-plan-apply.md
@@ -153,10 +153,6 @@ All three fields are required for this to behave as plan-only:
 - **`actions = ["apply"]`** -- restricts the exclusion to the `apply` action only, so `plan` still runs normally on this unit.
 - **`no_run = true`** -- causes Terragrunt to skip execution of the matched action.
 
-:::warning
-`no_run = true` is the field that actually prevents Apply from executing. Without it, the `exclude` block records the match but Terragrunt still runs the action, so the unit will still be applied. If plan-only behavior is the goal, do not omit `no_run`.
-:::
-
 #### Dependency considerations
 
 When excluding Apply for a unit, be aware of how Terragrunt handles its dependency graph:

--- a/docs/2.0/docs/pipelines/guides/running-plan-apply.md
+++ b/docs/2.0/docs/pipelines/guides/running-plan-apply.md
@@ -30,6 +30,147 @@ To initiate an **Apply**, merge your changes into the Deploy Branch. Any commits
 
 Pipelines will add a comment to the merged merge request/pull request containing the apply output.
 
+If you would rather have Pipelines run only plans on pull/merge requests and have Apply handled elsewhere, see [Running in plan-only mode](#running-in-plan-only-mode).
+
+## Running in plan-only mode
+
+Some teams want Pipelines to comment plans on pull/merge requests but **not** run Apply when those PRs/MRs merge. Common reasons:
+
+- You are migrating onto Pipelines from an existing Apply workflow and want to adopt plan first, switching Apply over later.
+- You want to review infrastructure changes through the Pipelines comment UX before you are ready to provision real cloud resources.
+
+Plan-only mode can be configured at two granularities: across the entire repository, or on individual Terragrunt units. The two approaches can be combined.
+
+### Disabling apply for the entire repository
+
+<Tabs groupId="platform">
+<TabItem value="github" label="GitHub" default>
+
+To disable Apply repository-wide, remove the `push:` trigger block from `.github/workflows/pipelines.yml`. Plans continue to run on pull requests because the `pull_request:` trigger is unaffected; merges to the Deploy Branch no longer start a workflow, so no Apply runs.
+
+Before:
+
+```yaml title=".github/workflows/pipelines.yml"
+name: Pipelines
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - ".github/**"
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths-ignore:
+      - ".github/**"
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  GruntworkPipelines:
+    uses: gruntwork-io/pipelines-workflows/.github/workflows/pipelines.yml@<ref>
+```
+
+After (the `push:` block is removed):
+
+```yaml title=".github/workflows/pipelines.yml"
+name: Pipelines
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths-ignore:
+      - ".github/**"
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  GruntworkPipelines:
+    uses: gruntwork-io/pipelines-workflows/.github/workflows/pipelines.yml@<ref>
+```
+
+:::note
+When you are ready to let Pipelines run Apply, restore the `push:` block (using the same `branches` and `paths-ignore` values you had before).
+:::
+
+</TabItem>
+<TabItem value="gitlab" label="GitLab">
+
+To disable Apply repository-wide, remove the `$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH` rule from the `workflow.rules` block in `.gitlab-ci.yml`. Plans continue to run on merge requests because the `$CI_PIPELINE_SOURCE == "merge_request_event"` rule is unaffected; commits on the default branch no longer match any rule, so no pipeline (and no Apply) runs.
+
+Before:
+
+```yaml title=".gitlab-ci.yml"
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: always
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+      when: always
+```
+
+After (the default-branch rule is removed):
+
+```yaml title=".gitlab-ci.yml"
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: always
+```
+
+:::note
+When you are ready to let Pipelines run Apply, restore the `$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH` rule.
+:::
+
+</TabItem>
+</Tabs>
+
+### Disabling apply for individual units
+
+To run Plan for a unit but skip Apply for that same unit, add a Terragrunt [`exclude` block](https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#exclude) to the unit's `terragrunt.hcl`:
+
+```hcl title="terragrunt.hcl"
+exclude {
+  if      = true
+  no_run  = true
+  actions = ["apply"]
+}
+```
+
+All three fields are required for this to behave as plan-only:
+
+- **`if = true`** -- the exclude condition is unconditionally true. You can substitute a dynamic expression here if you want the exclusion to depend on the environment, branch, or any other Terragrunt-visible input.
+- **`actions = ["apply"]`** -- restricts the exclusion to the `apply` action only, so `plan` still runs normally on this unit.
+- **`no_run = true`** -- causes Terragrunt to skip execution of the matched action.
+
+:::warning
+`no_run = true` is the field that actually prevents Apply from executing. Without it, the `exclude` block records the match but Terragrunt still runs the action, so the unit will still be applied. If plan-only behavior is the goal, do not omit `no_run`.
+:::
+
+#### Dependency considerations
+
+When excluding Apply for a unit, be aware of how Terragrunt handles its dependency graph:
+
+1. If unit B depends on unit A and Apply is excluded for unit A, an Apply of unit B will use unit A's last-known outputs rather than re-applying it. Make sure those outputs reflect the state you expect.
+2. Use `terragrunt dag graph` to visualize your dependency tree before excluding units.
+
+### Re-enabling apply
+
+To turn Apply back on:
+
+- **Repository-wide:** restore the `push:` block in `.github/workflows/pipelines.yml` (GitHub) or the `$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH` rule in `.gitlab-ci.yml` (GitLab).
+- **Per unit:** delete the `exclude` block from the unit's `terragrunt.hcl`.
+
 ## Skipping Pipelines plan/apply
 
 <Tabs groupId="platform">

--- a/docs/2.0/docs/pipelines/guides/running-plan-apply.md
+++ b/docs/2.0/docs/pipelines/guides/running-plan-apply.md
@@ -39,7 +39,7 @@ Some teams want Pipelines to comment plans on pull/merge requests but **not** ru
 - You are migrating onto Pipelines from an existing Apply workflow and want to adopt plan first, switching Apply over later.
 - You want to review infrastructure changes through the Pipelines comment UX before you are ready to provision real cloud resources.
 
-Plan-only mode can be configured at two granularities: across the entire repository, or on individual Terragrunt units. The two approaches can be combined.
+Plan-only mode can be configured at two granularities: across the entire repository, or on individual Terragrunt units.
 
 ### Disabling apply for the entire repository
 

--- a/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
+++ b/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
@@ -253,6 +253,8 @@ An AWS OIDC authentication block that determines how Pipelines will authenticate
 
 The branch that Pipelines will deploy infrastructure changes from.
 
+To run plans without applies, see [Running in plan-only mode](/2.0/docs/pipelines/guides/running-plan-apply#running-in-plan-only-mode). There is no dedicated config field for this; it is controlled via the workflow trigger or a per-unit Terragrunt `exclude` block.
+
 </HclListItemDescription>
 <HclListItemDefaultValue defaultValue="main"/>
 </HclListItem>

--- a/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
+++ b/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
@@ -253,7 +253,6 @@ An AWS OIDC authentication block that determines how Pipelines will authenticate
 
 The branch that Pipelines will deploy infrastructure changes from.
 
-To run plans without applies, see [Running in plan-only mode](/2.0/docs/pipelines/guides/running-plan-apply#running-in-plan-only-mode). There is no dedicated config field for this; it is controlled via the workflow trigger or a per-unit Terragrunt `exclude` block.
 
 </HclListItemDescription>
 <HclListItemDefaultValue defaultValue="main"/>


### PR DESCRIPTION
Implements plan for Linear issue [PF-138](https://linear.app/issue/dac4cc76-5789-46b4-862e-27b679db30c0).

Plan source: https://github.com/gruntwork-io-team/linear-claude-plans/blob/main/plans/PF-138.md

---

<details>
<summary>Claude's implementation summary</summary>

```
The changes look good. Both files are updated cleanly with no em dashes in the new content, proper Docusaurus admonitions, anchored cross-references, and follow the existing tab/code-block conventions on the page.

## Summary

### `gruntwork-io/docs`

**`docs/2.0/docs/pipelines/guides/running-plan-apply.md`** — Added a new top-level section "Running in plan-only mode" between "Running apply" and "Skipping Pipelines plan/apply", with:

- Introduction motivating the feature (gradual migration; reviewing changes without provisioning).
- `### Disabling apply for the entire repository` using `<Tabs groupId="platform">`:
  - **GitHub tab**: explanation + before/after snippets of `.github/workflows/pipelines.yml` showing removal of the `push:` trigger block; `:::note` callout reminding readers how to revert.
  - **GitLab tab**: explanation + before/after snippets of `.gitlab-ci.yml` showing removal of the `$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH` rule from `workflow.rules`; `:::note` callout reminding readers how to revert.
- `### Disabling apply for individual units`: the Terragrunt `exclude` block with explanations of all three required fields (`if = true`, `actions = ["apply"]`, `no_run = true`) and a `:::warning` admonition emphasizing that `no_run = true` is mandatory (per Zach's PF-138 comment).
- `#### Dependency considerations` subsection mirroring the dependency caveats from `handling-broken-iac.md`.
- `### Re-enabling apply` short reversal instructions.
- Added a one-line cross-reference at the end of the "Running apply" section pointing to the new anchor.

**`docs/2.0/reference/pipelines/configurations-as-code/api.mdx`** — Appended a one-line pointer inside the `deploy_branch_name` `HclListItem` description noting that plan-only mode is documented in the guides and is not controlled by a dedicated config field. No new `HclListItem` was added (per the plan: no `plan_only` config field is being introduced).

### `gruntwork-io/pipelines`

No file changes. Listed in `target_repos` for bookkeeping only — the customer-validated solutions require no CLI or workflow code changes. `ARCHITECTURE.md` was read and remains accurate (no architecture change to record).

### Open items the reviewer should consider

- **Terragrunt version compatibility**: did not add a minimum-version callout next to the `exclude` snippet. If needed, add a pointer to `docs/2.0/reference/pipelines/terragrunt-version-compatibility.md`.
- **Promote to standalone guide?** Kept as a subsection inside `running-plan-apply.md` (no `sidebars/docs.js` change). Reviewer call.
- **Comment footer CTA**: not modified. Since no config field exists, Pipelines has no signal that the repo is in plan-only mode. Recommend a follow-up ticket if richer signaling is desired.
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for plan-only mode configuration, enabling pipelines to comment Terragrunt Plans on pull/merge requests while preventing Apply on merge.
  * Provided configuration instructions at both repository-wide and per-unit levels.
  * Updated attribute documentation to clarify plan-only execution behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/docs/pull/3136)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->