### PR TITLE
DEV-1494 Serialize prod deploys to prevent races on rapid main merges

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,6 +184,10 @@ workflows:
             branches:
               only: main
       - deploy-to-prod:
+          # Serialize prod deploys so multiple PRs merged in quick succession can't race on the S3 sync (with --delete)
+          # or the Algolia reindex. Jobs sharing this serial-group run one at a time in trigger order instead of in parallel.
+          # https://circleci.com/docs/guides/orchestrate/controlling-serial-execution-across-your-organization/#how-serial-groups-work
+          serial-group: << pipeline.project.slug >>/deploy-to-prod
           context:
             - SLACK__WEBHOOK__team-platform
             - AWS__DOGFOOD_SECURITY__gruntwork-website-ci


### PR DESCRIPTION
## Summary
- Adds `serial-group: << pipeline.project.slug >>/deploy-to-prod` to the `deploy-to-prod` job invocation in `.circleci/config.yml`. [Docs](https://circleci.com/docs/guides/orchestrate/controlling-serial-execution-across-your-organization/#how-serial-groups-work)
- Since #3160 switched prod deployment from `v*` tags to every merge on `main`, two PRs merged in quick succession kick off two parallel `prod_deployment` workflows that race on (a) `aws s3 sync ... --delete` (an older finishing build can overwrite the newer one and delete its files) and (b) the Algolia reindex (concurrent crawls of the live site interleave records). Serial groups queue jobs sharing the same group so they run one at a time in trigger order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved production deployment infrastructure to serialize concurrent deployment triggers. This configuration change ensures that production releases process sequentially rather than simultaneously, significantly enhancing the overall stability and reliability of the deployment pipeline while reducing the potential for conflicts or interference between concurrent release operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->