### PR TITLE
Add llms.txt and llms-full.txt to docs.gruntwork.io

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -51,6 +51,25 @@ const segmentPlugin = [
 // @ts-ignore - types don't understand the plugin config
 plugins.push(segmentPlugin)
 
+// Generates /llms-full.txt (full doc content concatenated) on `yarn build`.
+// generateLLMsTxt is false on purpose: the /llms.txt index is hand-curated at
+// static/llms.txt, so we let the plugin produce only the full-content file and
+// leave our curated index untouched.
+const llmsPlugin = [
+  "docusaurus-plugin-llms",
+  {
+    docsDir: "docs",
+    generateLLMsTxt: false,
+    generateLLMsFullTxt: true,
+    title: "Gruntwork Docs",
+    description:
+      "Full documentation for the Gruntwork Platform: an end-to-end DevOps platform for Infrastructure as Code, covering Gruntwork Pipelines, AWS Account Factory, the IaC Library, Patcher, and the Gruntwork Way.",
+  },
+]
+
+// @ts-ignore - types don't understand the plugin config
+plugins.push(llmsPlugin)
+
 /** @type {import('@docusaurus/types').FasterConfig} */
 const fasterConfig = {
   rspackBundler: true,

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@docusaurus/tsconfig": "3.7.0",
     "@docusaurus/types": "^3.7.0",
     "cspell": "^8.19.4",
+    "docusaurus-plugin-llms": "0.4.0",
     "husky": "^9.1.7",
     "jest": "^27.4.7",
     "onchange": "^7.1.0",

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,37 @@
+# Gruntwork Docs
+
+> Documentation for the Gruntwork Platform: an end-to-end DevOps platform for Infrastructure as Code. Covers onboarding, deploying infrastructure with Gruntwork Pipelines, provisioning AWS accounts with Account Factory, consuming the IaC Library of reusable modules, keeping code current with Patcher, and the architectural principles behind the platform ("the Gruntwork Way").
+
+Current docs use the `/2.0/` path. Older content lives under `/guides/`.
+
+## Getting Started
+
+- [Setting up the Gruntwork Platform](https://docs.gruntwork.io/2.0/docs/overview/getting-started/): Activate your account, set up a Landing Zone, configure Pipelines and Account Factory
+
+## Gruntwork Pipelines
+
+- [Pipelines overview](https://docs.gruntwork.io/2.0/docs/pipelines/overview): Secure, PR-driven deployments for infrastructure and application code
+- [Pipelines reference](https://docs.gruntwork.io/2.0/reference/pipelines/): Configuration reference
+
+## AWS Account Factory
+
+- [Account Factory architecture](https://docs.gruntwork.io/2.0/docs/accountfactory/architecture/): Provision AWS accounts with best-practice baselines and compliance
+- [Account Factory reference](https://docs.gruntwork.io/2.0/reference/accountfactory/): Configuration reference
+
+## AWS IaC Library
+
+- [IaC Library overview](https://docs.gruntwork.io/2.0/docs/library/concepts/overview): Reusable Infrastructure as Code modules for AWS
+
+## Gruntwork Patcher
+
+- [Patcher overview](https://docs.gruntwork.io/2.0/docs/patcher/): Automatically update infrastructure code and handle breaking changes
+
+## The Gruntwork Way
+
+- [Platform principles](https://docs.gruntwork.io/2.0/way/platform/overview): Architecture patterns and best practices behind the platform
+
+## Optional
+
+- [Reference documentation](https://docs.gruntwork.io/2.0/reference/): API, configuration, and module references
+- [Achieve compliance guide](https://docs.gruntwork.io/guides/build-it-yourself/achieve-compliance/): Build-it-yourself compliance guidance
+- [Legacy guides](https://docs.gruntwork.io/guides/stay-up-to-date/): Older release notes and migration guides

--- a/yarn.lock
+++ b/yarn.lock
@@ -5894,6 +5894,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.1.tgz#c68b1c4111c76aae3a6fba55d496cee10c39dad8"
+  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
   resolved "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz"
@@ -7767,6 +7774,15 @@ dns-packet@^5.2.2:
     url-loader "^4.1.1"
     winston "^3.3.3"
     yargs "^17.3.1"
+
+docusaurus-plugin-llms@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-llms/-/docusaurus-plugin-llms-0.4.0.tgz#020f00d83459c7feb71c7b6e61774d864336d8ae"
+  integrity sha512-jYlj2HJ5+gu7oJZuJ83Hk8KlB65YlZZ/7UpHXiL7Qr+qpNBkVocmt2Molc6F3HNr5RqcfhWD/98CvgyNztg/ow==
+  dependencies:
+    gray-matter "^4.0.3"
+    minimatch "^9.0.3"
+    yaml "^2.8.1"
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -12136,6 +12152,13 @@ minimatch@3.1.2, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^9.0.3:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
+  dependencies:
+    brace-expansion "^2.0.2"
 
 minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
@@ -16685,6 +16708,11 @@ yaml@^2.7.1:
   version "2.7.1"
   resolved "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz"
   integrity sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==
+
+yaml@^2.8.1:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
+  integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
 
 yargs-parser@20.x, yargs-parser@^20.2.2:
   version "20.2.9"


### PR DESCRIPTION
**What & why**
Adds [llms.txt](https://llmstxt.org/) support to the docs site so LLMs and AI tools can discover and consume our documentation in a structured, machine-friendly way. This mirrors what we already ship on docs.terragrunt.com.

Two files are now served at the site root:
- /llms.txt — a hand-curated index of the docs (top-level sections + key landing pages), following the llmstxt.org spec.
- /llms-full.txt — the full documentation content concatenated into a single file, auto-generated on every build.
We intentionally do not ship an abridged llms-small.txt. Docusaurus has no native equivalent to Starlight's abridged generator, and the curated /llms.txt already fills the "short context" role.

**Changes**
static/llms.txt (new) — hand-curated index. Lives in static/, so Docusaurus serves it at /llms.txt (same mechanism as robots.txt). All links were validated against the live sitemap and the local docs source.
docusaurus.config.js — registered [docusaurus-plugin-llms](https://github.com/rachfop/docusaurus-plugin-llms) with generateLLMsTxt: false / generateLLMsFullTxt: true. Disabling the plugin's own index generation is deliberate: it keeps our curated static/llms.txt as the source of truth for /llms.txt and avoids a route conflict. The plugin runs in the postBuild hook, so llms-full.txt regenerates automatically on every yarn build.
package.json / yarn.lock — added docusaurus-plugin-llms@0.4.0 as a dev dependency (peer-compatible with our Docusaurus 3.7).

**Testing**
Ran yarn docusaurus build — completes successfully (exit 0).
build/llms-full.txt is generated (~14.6 MB) with the correct # Gruntwork Docs title/description header.
build/llms.txt is byte-identical to static/llms.txt, confirming the plugin leaves the curated index untouched.
The generated build/ output is gitignored, so no build artifacts are committed.

**Notes**
Pre-existing "broken anchor" warnings from the module-reference pages still appear in the build log; they're unrelated to this change and don't fail the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LLM-friendly documentation file containing consolidated platform documentation sections: Getting Started, Gruntwork Pipelines, AWS Account Factory, AWS IaC Library, Gruntwork Patcher, and "The Gruntwork Way."
  * Included reference documentation and guide links in the generated documentation.
  * Enabled automatic documentation file generation during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->