### PR TITLE
PF-173: Add logs as artifact for a job

### DIFF
--- a/docs/2.0/reference/pipelines/feature-flags.md
+++ b/docs/2.0/reference/pipelines/feature-flags.md
@@ -108,6 +108,23 @@ When running plans and applies, units with no environment are excluded from the 
 </li>
 </ul>
 
+#### `PIPELINES_FEATURE_EXPERIMENT_LOGS_AS_ARTIFACT`
+<ul>
+<li>
+Uploads each unit's raw Terragrunt output as a downloadable CI artifact, and renders a "Download Logs" link in the per-unit row of the PR/MR comment. Useful when units produce more output than the GitLab job-log UI cap (4 MB) or the GitHub job-log UI cap, since the artifact is unaffected by those limits.
+
+Artifact upload is conditioned on a step output emitted by the `pipelines` CLI (`pipelines_logs_artifact_path`), which the CLI sets to the path of the combined output file when the feature is enabled. The feature flag itself is resolved from both the HCL `env { }` block and OS environment variables — either source works and no separate CI-level variable is needed in addition to an HCL setting.
+
+Requires Pipelines GitHub workflows and actions versions that support the upload step (companion changes in `pipelines-workflows` and `pipelines-actions`).
+</li>
+<li>
+**Default Value**: Disabled
+</li>
+<li>
+**How to Enable**: Set to `"true"` in your CI environment (e.g. GitHub Actions repository variable, or GitLab CI/CD variable) — or, equivalently, in the `env { }` block of your `gruntwork.hcl`.
+</li>
+</ul>
+
 #### `PIPELINES_FEATURE_EXPERIMENT_MINIMIZE_BLAST_RADIUS`
 <ul>
 <li>


### PR DESCRIPTION
Implements plan for Linear issue [PF-173](https://linear.app/issue/69e4048d-9264-463e-a0f2-8ef0324bb797).

Plan source: https://github.com/gruntwork-io-team/linear-claude-plans/blob/main/plans/PF-173.md

---

<details>
<summary>Claude's implementation summary</summary>

```
No fixture impact. Implementation complete. Let me provide the summary of changes per repo.

---

## Summary of changes

### `gruntwork-io/pipelines` (this repo)

Added `EXPERIMENT_LOGS_AS_ARTIFACT` opt-in experiment and the CLI plumbing to surface a per-unit Terragrunt log artifact path and "Download Logs" link.

- `internal/features/features.go` — added `LogsAsArtifact` constant + default-OFF entry.
- `internal/features/features_test.go` — added focused test asserting default is false (the existing AST-driven `TestAllFeaturesHaveCase` also picks it up).
- `internal/actions/terragrunt/terragruntexecutor.go` — added `LogsArtifactPath string \`output:"logs_artifact_path,omitempty"\`` to `TerragruntOutput`; populated only when the experiment is enabled and `--combined-output-path` was provided. Added a `combinedOutputAbsPath()` helper shared with `writeCombinedOutput`.
- `internal/step/step.go` — added `LogsArtifactURL string \`json:"logs_artifact_url,omitempty"\`` to `StepSummary`.
- `internal/comment/comment.go` — added `LogsArtifactURL` to `CommentInfraChange` and copied it from `step.Result` in `formatCommentData`.
- `internal/comment/templates/comment.gohtml` — render a `· <a href=...>Download Logs</a>` anchor next to "View Job Logs" when `LogsArtifactURL` is non-empty.
- `internal/comment/comment_test.go` — added two tests covering present-link and absent-link cases.
- `internal/actions/statusupdate/statusupdate.go` — added `logsArtifactURL` field to `Update`, new param on `NewUpdate`, populated `StepSummary.LogsArtifactURL`.
- `main.go` — added `--logs-artifact-url` CLI flag on `status-update update`, threaded into `NewUpdate`.
- `internal/actions/gitlabyml/templates/execute.goyml` — extended the generated child-pipeline execute job's `artifacts:` stanza to include `access: developer`, `expire_in: 30 days`, and the `pipelines-artifacts/` directory.
- `internal/actions/gitlabyml/gitlabdynamicchildren_test.go` — updated the `TestExecutePlan` snapshot to match the new artifacts block.
- `test/plumbing/statusupdate/update/update_test.go` and `test/porcelain/add-units-consolidated/add-unit-consolidated_test.go` — added the new `logsArtifactURL` constructor arg (empty string) to existing `NewUpdate(...)` call sites.

### `gruntwork-io/pipelines-workflows`

Added a conditional artifact upload step in the matrix execute jobs and passed the resulting URL through to the comment-job-update step.

- `.github/workflows/pipelines.yml` — added `Sanitize artifact name fragment` shell step (replaces `/` with `-` in the working directory) and `Upload unit logs as artifact` using `actions/upload-artifact@v6.0.0`, both gated on `steps.terragrunt.outputs.pipelines_logs_artifact_path != ''`. Added `logs_artifact_url: ${{ steps.upload_logs.outputs.artifact-url }}` to the `Update comment` step.
- `.github/workflows/pipelines-root.yml` — same change, with the AccountsRequested/AccountsAdded skip condition propagated to the new steps.

### `gruntwork-io/pipelines-actions`

Declared the new step output on the execute action and accepted/forwarded the new URL on the comment-job-update action.

- `.github/actions/pipelines-execute/action.yml` — declared `pipelines_logs_artifact_path` in the top-level `outputs:` block so the CLI's `OutputWriter`-emitted value bubbles to the calling workflow.
- `.github/actions/pipelines-comment-job-update/action.yml` — added `logs_artifact_url` input (default empty) and plumbed it into the composite's `env:` as `LOGS_ARTIFACT_URL`.
- `.github/actions/pipelines-comment-job-update/scripts/update.sh` — defaulted `LOGS_ARTIFACT_URL` to empty and appended `--logs-artifact-url "$LOGS_ARTIFACT_URL"` to the `pipelines status-update update` invocation.

### `gruntwork-io/docs`

- `docs/2.0/reference/pipelines/feature-flags.md` — documented `PIPELINES_FEATURE_EXPERIMENT_LOGS_AS_ARTIFACT` between `IGNORE_UNITS_WITHOUT_ENVIRONMENT` and `MINIMIZE_BLAST_RADIUS`, including a note about workflow/action version requirements and the dual env-var / HCL `env { }` enablement options.

### Missing / out-of-scope repos

The plan calls for changes in two GitLab-side repositories that are **not** present in this checked-out workspace:

- `gitlab.com/gruntwork-io/pipelines-workflows` (referred to as `gitlab-pipelines-workflows`) — the plan said no template changes were required here; only the `pipelines` CLI change (already applied to `internal/actions/gitlabyml/templates/execute.goyml`) was needed. **Effectively done from this repo.**
- `gitlab.com/gruntwork-io/pipelines-actions` (referred to as `pipelines-gitlab-actions`) — the plan required edits to `scripts/pipelines-execute.sh` to: extract `LogsArtifactPath` from the CLI JSON via `jq`, conditionally stage the log to `./pipelines-artifacts/`, derive the GitLab raw-artifact URL from `CI_SERVER_URL`/`CI_PROJECT_PATH`/`CI_JOB_ID`, and forward it as `--logs-artifact-url` to `status-update update`. **This repo is not checked out — these changes are skipped here and must be applied in a follow-up PR against `pipelines-gitlab-actions`.**

Tests run: `go build ./...`, `go vet ./...`, and `go test ./internal/features/ ./internal/comment/ ./internal/actions/gitlabyml/ ./internal/platform/outputs/ ./internal/step/` all pass. Two preexisting test failures (`TestTerragruntPlanOutDirNestsByUnitPath` and `TestExecuteTerragrunt`) are environmental — they require the `terragrunt` binary on `$PATH` and are unrelated to these changes.
```

</details>

---

### Related PRs in this change set

- pipelines: https://github.com/gruntwork-io/pipelines/pull/637
- pipelines-workflows: https://github.com/gruntwork-io/pipelines-workflows/pull/229
- pipelines-actions: https://github.com/gruntwork-io/pipelines-actions/pull/167
