### PR TITLE
Update Gruntwork Releases as of 2026-06-30

### DIFF
--- a/docs/guides/stay-up-to-date/index.md
+++ b/docs/guides/stay-up-to-date/index.md
@@ -17,6 +17,7 @@ import CardGroup from "/src/components/CardGroup"
 <CardGroup cols={1} gap="1rem" stacked equalHeightRows={false} commonCardProps={{padding: "1.25rem"}}>
 
 <!-- START_DOCS_SOURCER_DYNAMIC_CONTENT id=gruntwork-releases-cards -->
+<Card title="Update to 2026-06" href="/guides/stay-up-to-date/releases/2026-06" />
 <Card title="Update to 2026-05" href="/guides/stay-up-to-date/releases/2026-05" />
 <Card title="Update to 2026-04" href="/guides/stay-up-to-date/releases/2026-04" />
 <Card title="Update to 2026-03" href="/guides/stay-up-to-date/releases/2026-03" />
@@ -31,7 +32,6 @@ import CardGroup from "/src/components/CardGroup"
 <Card title="Update to 2025-06" href="/guides/stay-up-to-date/releases/2025-06" />
 <Card title="Update to 2025-05" href="/guides/stay-up-to-date/releases/2025-05" />
 <Card title="Update to 2025-04" href="/guides/stay-up-to-date/releases/2025-04" />
-<Card title="Update to 2025-03" href="/guides/stay-up-to-date/releases/2025-03" />
 <Card title="See older releases" href="/guides/stay-up-to-date/releases" />
 <!-- END_DOCS_SOURCER_DYNAMIC_CONTENT -->
 
@@ -115,6 +115,6 @@ href="/guides/stay-up-to-date/cis/cis-1.5.0"
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "1857265ec47259b993a4dd31bc8e13c1"
+  "hash": "7063bcbf9e42848193ecf88eb01a7516"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2026-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2026-06/index.md
@@ -1,0 +1,449 @@
+
+# Gruntwork release 2026-06
+
+<p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2026-06</small></p>
+
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2026-06.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
+
+Here are the repos that were updated:
+
+- [pipelines-actions](#pipelines-actions)
+- [pipelines-cli](#pipelines-cli)
+- [pipelines-workflows](#pipelines-workflows)
+- [terraform-aws-architecture-catalog](#terraform-aws-architecture-catalog)
+- [terraform-aws-control-tower](#terraform-aws-control-tower)
+- [terraform-aws-data-storage](#terraform-aws-data-storage)
+- [terraform-aws-load-balancer](#terraform-aws-load-balancer)
+- [terraform-aws-service-catalog](#terraform-aws-service-catalog)
+
+
+## pipelines-actions
+
+
+### [v4.11.1](https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.11.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/18/2026 | <a href="https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.11.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Remove preflight checks comment causing duplicates by @Resonance1584 in https://github.com/gruntwork-io/pipelines-actions/pull/166
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-actions/compare/v4.11.0...v4.11.1
+
+</div>
+
+
+### [v4.11.0](https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.11.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/15/2026 | <a href="https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.11.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Add pipelines-hooks-after action by @Resonance1584 in https://github.com/gruntwork-io/pipelines-actions/pull/159
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-actions/compare/v4.10.1...v4.11.0
+
+</div>
+
+
+### [v4.10.1](https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.10.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/11/2026 | <a href="https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.10.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Set mise working_directory correctly by @Resonance1584 in https://github.com/gruntwork-io/pipelines-actions/pull/164
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-actions/compare/v4.10.0...v4.10.1
+
+</div>
+
+
+
+## pipelines-cli
+
+
+### [v0.55.3](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.55.3)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/25/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.55.3">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  Details on user-facing changes will be documented in the release notes for:
+- https://github.com/gruntwork-io/pipelines-workflows
+- https://gitlab.com/gruntwork-io/pipelines-workflows
+
+</div>
+
+
+### [v0.55.2](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.55.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/22/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.55.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  Details on user-facing changes will be documented in the release notes for:
+- https://github.com/gruntwork-io/pipelines-workflows
+- https://gitlab.com/gruntwork-io/pipelines-workflows
+
+</div>
+
+
+### [v0.55.2-glab-remote](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.55.2-glab-remote)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/24/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.55.2-glab-remote">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  Details on user-facing changes will be documented in the release notes for:
+- https://github.com/gruntwork-io/pipelines-workflows
+- https://gitlab.com/gruntwork-io/pipelines-workflows
+
+</div>
+
+
+### [v0.55.1](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.55.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/18/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.55.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  Details on user-facing changes will be documented in the release notes for:
+- https://github.com/gruntwork-io/pipelines-workflows
+- https://gitlab.com/gruntwork-io/pipelines-workflows
+
+</div>
+
+
+### [v0.55.0](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.55.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/17/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.55.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  Details on user-facing changes will be documented in the release notes for:
+- https://github.com/gruntwork-io/pipelines-workflows
+- https://gitlab.com/gruntwork-io/pipelines-workflows
+
+</div>
+
+
+
+## pipelines-workflows
+
+
+### [v4.19.0](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.19.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/25/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.19.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+:sparkles: Added support for `after_hook` 
+
+This release introduces Pipeline Hooks, a new Enterprise feature that lets you extend pipeline runs with custom logic in response to Terragrunt plans and applies.
+
+As a first step, we’re introducing the `after_hook` repository block, which allows you to run a custom script after Terragrunt execution completes. Support for `before_hook` and `error_hook` is planned for a future release.
+
+Hooks receive rich context about the pipeline run, including execution results and access to plan files for each unit. They can also generate custom output that is displayed in the pull request comment, making it easy to tailor the developer experience to your team’s needs.
+
+[See the documentation](https://docs.gruntwork.io/2.0/docs/pipelines/guides/hooks/overview) for setup instructions and additional details.
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4.18.2...v4.19.0
+
+</div>
+
+
+### [v4.18.4](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.18.4)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/23/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.18.4">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+This release removes some unused features from 4.18.3 to maximize stability of the 4.18 release series.  The as-yet-unreleased features will be introduced in 4.19.
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4.18.3...v4.18.4
+
+</div>
+
+
+### [v4.18.3](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.18.3)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/22/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.18.3">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  This is a preparation release for our upcoming new feature: after-hooks.  Included is, currently unused, foundational APIs that will be exposed in an upcoming release. 
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4.18.2...v4.18.3
+
+</div>
+
+
+### [v4.18.2](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.18.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/11/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.18.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+Previously the first mise install call was incorrectly running outside of the infra live directory. This caused the initial cache value to be incorrectly populated with only the mise binary (no Terragrunt or OpenTofu/Terraform binaries). Fixing this improves subsequent mise install times in execute steps.
+
+* Pipelines actions v4.10.1 by @Resonance1584 in https://github.com/gruntwork-io/pipelines-workflows/pull/224
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4...v4.18.2
+
+</div>
+
+
+### [v4.18.1](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.18.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/1/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.18.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+When force pushing updates to the drift detection branch, the Drift Detection workflow could force push updates to the deploy branch if branch protection settings were not enabled, and a stale drift detection branch was allowed to go stale with self-hosted runners.
+
+The force push for updating the drift detection branch is now restricted to the relevant Refspec, preventing accidental rewinds of the deploy branch, even when branch protection is removed.
+
+
+* chore: Bumping Pipelines to `v0.54.1` by @yhakbar in https://github.com/gruntwork-io/pipelines-workflows/pull/222
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4...v4.18.1
+
+</div>
+
+
+
+## terraform-aws-architecture-catalog
+
+
+### [v6.0.0](https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v6.0.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/30/2026 | <a href="https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v6.0.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * PF-119: Account Factory should be able to vend in a subdirectory by @gruntwork-ci in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1203
+* PF-119: write vended env HCL to repo-root .gruntwork by @james00012 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1204
+* Bump cloud-nuke cleanup to v0.52.0 (parallel scan) by @james00012 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1208
+* Feat: Landingzone v4 by @odgrim in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1207
+
+
+**Full Changelog**: https://github.com/gruntwork-io/terraform-aws-architecture-catalog/compare/v5.0.0...v6.0.0
+
+</div>
+
+
+
+## terraform-aws-control-tower
+
+
+### [v2.1.0](https://github.com/gruntwork-io/terraform-aws-control-tower/releases/tag/v2.1.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/19/2026 | Modules affected: landingzone | <a href="https://github.com/gruntwork-io/terraform-aws-control-tower/releases/tag/v2.1.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- fix: harden cloud-nuke cleanup CI and bump to v0.50.0
+- Bump cloud-nuke cleanup to v0.52.0 (parallel scan)
+- Feat: Add landingzone 4.0 support
+
+
+
+</div>
+
+
+
+## terraform-aws-data-storage
+
+
+### [v1.2.0](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v1.2.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/5/2026 | Modules affected: - rds, - rds-proxy, - rds-replicas, - backup-plan | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v1.2.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+- `rds`
+- `rds-proxy`
+- `rds-replicas`
+- `backup-plan`
+- `opensearch`
+
+
+- **feat(opensearch): add `identity_center_options` support** (#594). New nullable variable for AWS IAM Identity Center integration, defaulting to `null` (disabled). **Breaking:** raises the module&apos;s AWS provider floor from `&gt;= 5.0.0` to `&gt;= 6.20.0`.
+- **fix(rds): use `vpc_security_group_*_rule` to avoid create race** (#591). Swaps `aws_security_group_rule` for `aws_vpc_security_group_ingress_rule` / `aws_vpc_security_group_egress_rule` in `rds`, `rds-proxy`, `rds-replicas`. Inputs, outputs, and AWS end state unchanged; only state representation changes. Included Patcher patch handles migration. See `UPGRADING.md`.
+- **fix(backup-plan): wire `completion_window`, `start_window`, `recovery_point_tags`** (#595, LIB-5144). These local vars now pass through to the `aws_backup_plan` resource.
+- **chore: cloud-nuke CI maintenance** (#587, #588, #589). Bumps cloud-nuke to v0.50.0 and hardens cleanup. CI only; no module changes.
+
+
+Special thanks to the following users for their contribution!
+
+- @james00012
+- @x-nightwing
+
+
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/587
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/588
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/589
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/591
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/595
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/594
+
+
+</div>
+
+
+
+## terraform-aws-load-balancer
+
+
+### [v1.3.2](https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v1.3.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/2/2026 | Modules affected: alb | <a href="https://github.com/gruntwork-io/terraform-aws-load-balancer/releases/tag/v1.3.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Added `security_group_tags` variable to modules/alb providing a simple way to customize specific security group tags independently of `custom_tags`
+
+
+
+
+</div>
+
+
+
+## terraform-aws-service-catalog
+
+
+### [v2.12.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v2.11.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/30/2026 | Modules affected: data-stores, mgmt, services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v2.11.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Bump cloud-nuke cleanup to v0.52.0 (parallel scan)
+- Bump data-stores rds, rds-replica, aurora to data-storage v1.2.0
+- feat(data-stores): expose backup-plan start_window, completion_window, recovery_point_tags
+- Test fix: resolve failing mgmt test
+- Upgraded OVPN resources 
+
+
+</div>
+
+
+### [v2.11.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v2.11.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/18/2026 | Modules affected: services/eks-workers | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v2.11.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Drop unused `cloud-nuke --config` from `cloud_nuke_cleanup`
+- fix(eks-workers): AL2023 nodes fail to rejoin the cluster after a reboot:
+    -  AL2023 EKS worker nodes (managed node groups or self-managed ASGs using an `AL2023_*` `ami_type`) previously failed to rejoin the cluster after a reboot, kubelet never restarted and the node was stuck `NotReady` until terminated and replaced. 
+    - The module bootstrapped AL2023 nodes with a one-time cloud-init script that wrote `/etc/eks/nodeconfig.yaml` and ran `nodeadm init`; on reboot the AMI&apos;s `nodeadm-config.service` reads the NodeConfig only from the instance user-data (caching to `/run`, which is tmpfs and wiped on reboot), found none, and the bootstrap failed. 
+    - The fix delivers the core NodeConfig as an `application/node.eks.aws` user-data MIME part so `nodeadm` finds it on **every** boot, and reduces the cloud-init script to writing the EC2-tag node labels to a persistent `/etc/eks/nodeadm.d/` drop-in that `nodeadm-run.service` re-merges on each boot. `max_pods_allowed` and `eks_kubelet_extra_args` continue to be honored on AL2023. The AL2 path is unchanged.
+
+
+
+</div>
+
+
+### [v2.10.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v2.10.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 6/8/2026 | Modules affected: - data-stores | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v2.10.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+- `data-stores`
+
+
+- **rds**: Added configuration variables for read replica instance settings (`read_replica_instance_type`, `read_replica_multi_az`) and read replica CloudWatch alarms (`replication_error_*`, `high_replica_lag_*`). Bumps the underlying `terraform-aws-data-storage//modules/rds` module from v0.47.0 to v1.1.0.
+
+
+This release bumps the rds module&apos;s reference to `terraform-aws-data-storage` from v0.47.0 to v1.1.0. That upstream version replaces the legacy `aws_security_group_rule` resources with one `aws_vpc_security_group_ingress_rule` / `aws_vpc_security_group_egress_rule` per CIDR. The AWS end state is identical (same security group, same rules); only the Terraform state representation changed, so a state migration is required.
+
+- Recommended path is `patcher upgrade`. The upstream repo ships migrations that `terraform import` the existing rules under their new addresses, producing no destroy/create plan diff.
+- Without Patcher, `terraform plan` will show a destroy and recreate for each security group rule. Apply in a maintenance window, since each rule is briefly removed before recreation.
+- Treat `allow_connections_from_*_cidr_blocks` and `allow_outbound_*` lists as ordered. Reordering entries on a future change will recreate the corresponding rule resources.
+
+See the upstream guide for full details: https://github.com/gruntwork-io/terraform-aws-data-storage/blob/v1.1.0/UPGRADING.md
+
+
+Special thanks to @a-hat for this contribution!
+
+
+- https://github.com/gruntwork-io/terraform-aws-service-catalog/pull/2379
+
+
+</div>
+
+<!-- ##DOCS-SOURCER-START
+{
+  "sourcePlugin": "releases",
+  "hash": "2fe6efe134b0f1baf5314fc4a2e76a75"
+}
+##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/index.md
+++ b/docs/guides/stay-up-to-date/releases/index.md
@@ -11,7 +11,8 @@ Library](https://gruntwork.io/infrastructure-as-code-library/), grouped by month
 updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 <CardGroup cols={1} gap="1rem" stacked equalHeightRows={false} commonCardProps={{padding: "1.25rem"}}>
-  <Card title="Gruntwork Release 2026-05" href="/guides/stay-up-to-date/releases/2026-05" />
+  <Card title="Gruntwork Release 2026-06" href="/guides/stay-up-to-date/releases/2026-06" />
+<Card title="Gruntwork Release 2026-05" href="/guides/stay-up-to-date/releases/2026-05" />
 <Card title="Gruntwork Release 2026-04" href="/guides/stay-up-to-date/releases/2026-04" />
 <Card title="Gruntwork Release 2026-03" href="/guides/stay-up-to-date/releases/2026-03" />
 <Card title="Gruntwork Release 2026-02" href="/guides/stay-up-to-date/releases/2026-02" />
@@ -136,6 +137,6 @@ updates in your code, check out the [updating documentation](/library/stay-up-to
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "37c47324bfdcc73e4afa215b48c29008"
+  "hash": "f709d5297bbbddcfa609e49ebd7b602c"
 }
 ##DOCS-SOURCER-END -->


### PR DESCRIPTION
Update Gruntwork releases as of 2026-06-30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new monthly release page for **2026-06** with updated notes across multiple repositories.
  * Updated the releases index and stay-up-to-date guide to include the new **2026-06** release entry.
  * Removed an older release card from the guide to keep the release list current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->