### PR TITLE
Document remote script sources for hooks

### DIFF
--- a/docs/2.0/docs/pipelines/guides/hooks/configuring.md
+++ b/docs/2.0/docs/pipelines/guides/hooks/configuring.md
@@ -60,7 +60,7 @@ Any changes a hook makes to files are not persisted. The copy is discarded once 
 
 ### Remote script sources
 
-By default, `execute` runs programs committed to the repository itself. To run a script defined in a different location, declare a `source`: a [go-getter](https://github.com/hashicorp/go-getter#url-format) URL that Pipelines fetches before the hook runs.
+To execute a script from a remote source, declare a `source`: a [go-getter](https://github.com/hashicorp/go-getter#url-format) URL, and set `execute` to a path within the remote source.
 
 ```hcl
 repository {
@@ -73,9 +73,13 @@ repository {
 }
 ```
 
-The source is fetched into a directory whose path is exported to the hook in the `PIPELINES_HOOK_CTX_SOURCE_DIR` environment variable, and references to that variable in `execute` are expanded before the hook starts. The variable is set in the hook's environment like any other [context variable](/2.0/reference/pipelines/hooks-api), so the program `execute` runs can also read it directly (for example, a script committed to the repository can use it to invoke tools from the fetched source). The working directory does not change: the hook still runs from its isolated copy of the repository, with the fetched files available alongside it.
+The source is fetched into a directory whose path is provided to the hook as the `PIPELINES_HOOK_CTX_SOURCE_DIR` environment variable. This variable is expanded within the `execute` arguments, allowing execute to reference files within the source.
 
-The URL accepts the same syntax as [Terragrunt module sources](https://terragrunt.gruntwork.io/docs/reference/hcl/blocks/#terraform), handled by go-getter. Pin a `ref` so hook runs are reproducible. A source must resolve to a directory, from which you specify the script to run via the `execute` arguments.
+Within a hook, `PIPELINES_HOOK_CTX_SOURCE_DIR` can be used to reference (i.e. import) other files from the fetched source.
+
+Using `source` does not affect the working directory `execute` runs in.
+
+The URL accepts the same syntax as [Terragrunt module sources](https://terragrunt.gruntwork.io/docs/reference/hcl/blocks/#terraform), handled by go-getter. Pin a `ref` so hook runs are reproducible. A source must resolve to a directory, paths to individual files are not supported.
 
 :::tip
 

--- a/docs/2.0/docs/pipelines/guides/hooks/configuring.md
+++ b/docs/2.0/docs/pipelines/guides/hooks/configuring.md
@@ -75,7 +75,7 @@ repository {
 
 The repository is fetched into a directory whose path is exported to the hook in the `PIPELINES_HOOK_CTX_SOURCE_DIR` environment variable, and references to that variable in `execute` are expanded before the hook starts. The variable is set in the hook's environment like any other [context variable](/2.0/reference/pipelines/hooks-api), so the program `execute` runs can also read it directly (for example, a script committed to the repository can use it to invoke tools from the fetched source). The working directory does not change: the hook still runs from its isolated copy of the repository, with the fetched files available alongside it.
 
-The URL accepts the same syntax as [Terragrunt module sources](https://terragrunt.gruntwork.io/docs/reference/hcl/blocks/#terraform), handled by [go-getter](https://github.com/hashicorp/go-getter). Pin a `ref` so hook runs are reproducible. Private sources are fetched with the same git credentials the Pipelines job already uses to read your repositories.
+The URL accepts the same syntax as [Terragrunt module sources](https://terragrunt.gruntwork.io/docs/reference/hcl/blocks/#terraform), handled by [go-getter](https://github.com/hashicorp/go-getter). Pin a `ref` so hook runs are reproducible. A source resolves to a directory, from which you specify the script to run via the `execute` arguments. Private sources are fetched with the same git credentials the Pipelines job already uses to read your repositories.
 
 Fetching counts against the hook's `timeout_seconds` and is retried on transient failures. A fetch failure fails the hook like any other hook error. Preflight also fetches every declared source, so a broken URL or ref fails the pull/merge request before any plan or apply runs.
 

--- a/docs/2.0/docs/pipelines/guides/hooks/configuring.md
+++ b/docs/2.0/docs/pipelines/guides/hooks/configuring.md
@@ -60,7 +60,7 @@ Any changes a hook makes to files are not persisted. The copy is discarded once 
 
 ### Remote script sources
 
-By default, `execute` runs programs committed to the repository itself. To run a script defined in a different location, declare a `source`: a [go-getter](https://github.com/hashicorp/go-getter) URL that Pipelines fetches before the hook runs.
+By default, `execute` runs programs committed to the repository itself. To run a script defined in a different location, declare a `source`: a [go-getter](https://github.com/hashicorp/go-getter#url-format) URL that Pipelines fetches before the hook runs.
 
 ```hcl
 repository {

--- a/docs/2.0/docs/pipelines/guides/hooks/configuring.md
+++ b/docs/2.0/docs/pipelines/guides/hooks/configuring.md
@@ -60,7 +60,7 @@ Any changes a hook makes to files are not persisted. The copy is discarded once 
 
 ### Remote script sources
 
-By default, `execute` runs programs committed to the repository itself. To run a script defined in a different location, declare a `source`: a go-getter URL that Pipelines fetches before the hook runs.
+By default, `execute` runs programs committed to the repository itself. To run a script defined in a different location, declare a `source`: a [go-getter](https://github.com/hashicorp/go-getter) URL that Pipelines fetches before the hook runs.
 
 ```hcl
 repository {
@@ -75,7 +75,7 @@ repository {
 
 The source is fetched into a directory whose path is exported to the hook in the `PIPELINES_HOOK_CTX_SOURCE_DIR` environment variable, and references to that variable in `execute` are expanded before the hook starts. The variable is set in the hook's environment like any other [context variable](/2.0/reference/pipelines/hooks-api), so the program `execute` runs can also read it directly (for example, a script committed to the repository can use it to invoke tools from the fetched source). The working directory does not change: the hook still runs from its isolated copy of the repository, with the fetched files available alongside it.
 
-The URL accepts the same syntax as [Terragrunt module sources](https://terragrunt.gruntwork.io/docs/reference/hcl/blocks/#terraform), handled by [go-getter](https://github.com/hashicorp/go-getter). Pin a `ref` so hook runs are reproducible. A source must resolve to a directory, from which you specify the script to run via the `execute` arguments.
+The URL accepts the same syntax as [Terragrunt module sources](https://terragrunt.gruntwork.io/docs/reference/hcl/blocks/#terraform), handled by go-getter. Pin a `ref` so hook runs are reproducible. A source must resolve to a directory, from which you specify the script to run via the `execute` arguments.
 
 :::tip
 

--- a/docs/2.0/docs/pipelines/guides/hooks/configuring.md
+++ b/docs/2.0/docs/pipelines/guides/hooks/configuring.md
@@ -25,7 +25,7 @@ The block label (`hello_world` in the example above) is also required and must b
 ### Optional fields
 
 - **`name`**: a human-readable display name for the hook.
-- **`source`**: a git URL of a repository to fetch before the hook runs, so `execute` can run scripts that live outside the repository. See [Remote script sources](#remote-script-sources).
+- **`source`**: a URL to fetch before the hook runs, so `execute` can run scripts that live outside the repository. See [Remote script sources](#remote-script-sources).
 - **`env`**: environment variables to set for the `execute` command.
 - **`run_on_error`**: whether the hook runs when a preceding command or hook failed. Defaults to `false`.
 - **`timeout_seconds`**: how long the hook may run before it is terminated. Defaults to `300`.
@@ -60,7 +60,7 @@ Any changes a hook makes to files are not persisted. The copy is discarded once 
 
 ### Remote script sources
 
-By default, `execute` runs programs committed to the repository itself. To run a script defined in a different location, declare a `source`: a git URL that Pipelines fetches before the hook runs.
+By default, `execute` runs programs committed to the repository itself. To run a script defined in a different location, declare a `source`: a go-getter URL that Pipelines fetches before the hook runs.
 
 ```hcl
 repository {
@@ -73,9 +73,15 @@ repository {
 }
 ```
 
-The repository is fetched into a directory whose path is exported to the hook in the `PIPELINES_HOOK_CTX_SOURCE_DIR` environment variable, and references to that variable in `execute` are expanded before the hook starts. The variable is set in the hook's environment like any other [context variable](/2.0/reference/pipelines/hooks-api), so the program `execute` runs can also read it directly (for example, a script committed to the repository can use it to invoke tools from the fetched source). The working directory does not change: the hook still runs from its isolated copy of the repository, with the fetched files available alongside it.
+The source is fetched into a directory whose path is exported to the hook in the `PIPELINES_HOOK_CTX_SOURCE_DIR` environment variable, and references to that variable in `execute` are expanded before the hook starts. The variable is set in the hook's environment like any other [context variable](/2.0/reference/pipelines/hooks-api), so the program `execute` runs can also read it directly (for example, a script committed to the repository can use it to invoke tools from the fetched source). The working directory does not change: the hook still runs from its isolated copy of the repository, with the fetched files available alongside it.
 
-The URL accepts the same syntax as [Terragrunt module sources](https://terragrunt.gruntwork.io/docs/reference/hcl/blocks/#terraform), handled by [go-getter](https://github.com/hashicorp/go-getter). Pin a `ref` so hook runs are reproducible. A source resolves to a directory, from which you specify the script to run via the `execute` arguments. Private sources are fetched with the same git credentials the Pipelines job already uses to read your repositories.
+The URL accepts the same syntax as [Terragrunt module sources](https://terragrunt.gruntwork.io/docs/reference/hcl/blocks/#terraform), handled by [go-getter](https://github.com/hashicorp/go-getter). Pin a `ref` so hook runs are reproducible. A source must resolve to a directory, from which you specify the script to run via the `execute` arguments.
+
+:::tip
+
+We recommend using a git repository for your source to get the advantage of fetching private repositories with the same git credentials Pipelines already uses to access your repositories.
+
+:::
 
 Fetching counts against the hook's `timeout_seconds` and is retried on transient failures. A fetch failure fails the hook like any other hook error. Preflight also fetches every declared source, so a broken URL or ref fails the pull/merge request before any plan or apply runs.
 

--- a/docs/2.0/docs/pipelines/guides/hooks/configuring.md
+++ b/docs/2.0/docs/pipelines/guides/hooks/configuring.md
@@ -25,6 +25,7 @@ The block label (`hello_world` in the example above) is also required and must b
 ### Optional fields
 
 - **`name`**: a human-readable display name for the hook.
+- **`source`**: a git URL of a repository to fetch before the hook runs, so `execute` can run scripts that live outside the repository. See [Remote script sources](#remote-script-sources).
 - **`env`**: environment variables to set for the `execute` command.
 - **`run_on_error`**: whether the hook runs when a preceding command or hook failed. Defaults to `false`.
 - **`timeout_seconds`**: how long the hook may run before it is terminated. Defaults to `300`.
@@ -57,6 +58,27 @@ Each hook runs in its own temporary copy of the repository, with that copy as it
 
 Any changes a hook makes to files are not persisted. The copy is discarded once the hook finishes, so edits are never committed, pushed, or seen by the rest of the run. Because each hook gets its own fresh copy, hooks also do not see file changes made by other hooks.
 
+### Remote script sources
+
+By default, `execute` runs programs committed to the repository itself. To run a script defined in a different location, declare a `source`: a git URL that Pipelines fetches before the hook runs.
+
+```hcl
+repository {
+  after_hook "policy_scan" {
+    name     = "Policy Scan"
+    commands = ["plan"]
+    source   = "git::https://github.com/acme/pipelines-hooks.git?ref=v1.2.0"
+    execute  = ["bash", "$PIPELINES_HOOK_CTX_SOURCE_DIR/scripts/scan.sh"]
+  }
+}
+```
+
+The repository is fetched into a directory whose path is exported to the hook in the `PIPELINES_HOOK_CTX_SOURCE_DIR` environment variable, and references to that variable in `execute` are expanded before the hook starts. The variable is set in the hook's environment like any other [context variable](/2.0/reference/pipelines/hooks-api), so the program `execute` runs can also read it directly (for example, a script committed to the repository can use it to invoke tools from the fetched source). The working directory does not change: the hook still runs from its isolated copy of the repository, with the fetched files available alongside it.
+
+The URL accepts the same syntax as [Terragrunt module sources](https://terragrunt.gruntwork.io/docs/reference/hcl/blocks/#terraform), handled by [go-getter](https://github.com/hashicorp/go-getter). Pin a `ref` so hook runs are reproducible. Private sources are fetched with the same git credentials the Pipelines job already uses to read your repositories.
+
+Fetching counts against the hook's `timeout_seconds` and is retried on transient failures. A fetch failure fails the hook like any other hook error. Preflight also fetches every declared source, so a broken URL or ref fails the pull/merge request before any plan or apply runs.
+
 ### Exit codes
 
 A hook's exit code is how it tells Pipelines whether it succeeded:
@@ -79,7 +101,7 @@ Set `run_on_error = true` to run the hook regardless of an earlier failure. This
 
 ### Timeout and cancellation
 
-Each hook has a `timeout_seconds` limit (default `300`). The limit covers the whole hook, including acquiring any credentials from its [`authentication`](/2.0/docs/pipelines/guides/hooks/authentication) block. A hook that runs longer than its limit is cancelled.
+Each hook has a `timeout_seconds` limit (default `300`). The limit covers the whole hook, including fetching its [`source`](#remote-script-sources) and acquiring any credentials from its [`authentication`](/2.0/docs/pipelines/guides/hooks/authentication) block. A hook that runs longer than its limit is cancelled.
 
 When a hook is cancelled, Pipelines signals the hook's process group to terminate, gives it a brief grace period to exit cleanly, and then forcibly kills it. Because the whole process group is signalled, any child processes the hook started are terminated too.
 

--- a/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
+++ b/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
@@ -426,7 +426,7 @@ execute = [".gruntwork/hooks/affected-units.sh"]
 <HclListItem name="source" requirement="optional" type="string">
 <HclListItemDescription>
 
-A go-getter URL Pipelines fetches before running the hook. The fetched directory's path is exported to the hook in the `PIPELINES_HOOK_CTX_SOURCE_DIR` environment variable, which `execute` can reference to run a script defined outside the repository:
+A [go-getter](https://github.com/hashicorp/go-getter) URL Pipelines fetches before running the hook. The fetched directory's path is exported to the hook in the `PIPELINES_HOOK_CTX_SOURCE_DIR` environment variable, which `execute` can reference to run a script defined outside the repository:
 
 ```hcl
 source  = "git::https://github.com/acme/pipelines-hooks.git?ref=v1.2.0"

--- a/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
+++ b/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
@@ -423,6 +423,21 @@ execute = [".gruntwork/hooks/affected-units.sh"]
 </HclListItemDescription>
 </HclListItem>
 
+<HclListItem name="source" requirement="optional" type="string">
+<HclListItemDescription>
+
+A git URL of a repository Pipelines fetches before running the hook. The fetched directory's path is exported to the hook in the `PIPELINES_HOOK_CTX_SOURCE_DIR` environment variable, which `execute` can reference to run a script defined outside the repository:
+
+```hcl
+source  = "git::https://github.com/acme/pipelines-hooks.git?ref=v1.2.0"
+execute = ["bash", "$PIPELINES_HOOK_CTX_SOURCE_DIR/scripts/scan.sh"]
+```
+
+See [Remote script sources](/2.0/docs/pipelines/guides/hooks/configuring#remote-script-sources).
+
+</HclListItemDescription>
+</HclListItem>
+
 <HclListItem name="env" requirement="optional" type="block">
 <HclListItemDescription>
 An [env](#env-block) block of key/value environment variables made available to the `execute` command. Values may be strings, numbers, or booleans and are converted to strings.

--- a/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
+++ b/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
@@ -426,7 +426,7 @@ execute = [".gruntwork/hooks/affected-units.sh"]
 <HclListItem name="source" requirement="optional" type="string">
 <HclListItemDescription>
 
-A [go-getter](https://github.com/hashicorp/go-getter) URL Pipelines fetches before running the hook. The fetched directory's path is exported to the hook in the `PIPELINES_HOOK_CTX_SOURCE_DIR` environment variable, which `execute` can reference to run a script defined outside the repository:
+A [go-getter](https://github.com/hashicorp/go-getter#url-format) URL Pipelines fetches before running the hook. The fetched directory's path is exported to the hook in the `PIPELINES_HOOK_CTX_SOURCE_DIR` environment variable, which `execute` can reference to run a script defined outside the repository:
 
 ```hcl
 source  = "git::https://github.com/acme/pipelines-hooks.git?ref=v1.2.0"

--- a/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
+++ b/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
@@ -426,7 +426,7 @@ execute = [".gruntwork/hooks/affected-units.sh"]
 <HclListItem name="source" requirement="optional" type="string">
 <HclListItemDescription>
 
-A git URL of a repository Pipelines fetches before running the hook. The fetched directory's path is exported to the hook in the `PIPELINES_HOOK_CTX_SOURCE_DIR` environment variable, which `execute` can reference to run a script defined outside the repository:
+A go-getter URL Pipelines fetches before running the hook. The fetched directory's path is exported to the hook in the `PIPELINES_HOOK_CTX_SOURCE_DIR` environment variable, which `execute` can reference to run a script defined outside the repository:
 
 ```hcl
 source  = "git::https://github.com/acme/pipelines-hooks.git?ref=v1.2.0"

--- a/docs/2.0/reference/pipelines/hooks-api.md
+++ b/docs/2.0/reference/pipelines/hooks-api.md
@@ -34,6 +34,7 @@ A context variable that does not apply to the run is left unset, rather than set
 | `PIPELINES_HOOK_CTX_CHANGE_REQUEST_NUMBER` | The pull/merge request number. |
 | `PIPELINES_HOOK_CTX_CHANGE_REQUEST_URL` | The pull/merge request URL. |
 | `PIPELINES_HOOK_CTX_CHANGE_REQUEST_BRANCH` | The source branch of the pull/merge request. |
+| `PIPELINES_HOOK_CTX_SOURCE_DIR` | The directory the hook's [`source`](/2.0/docs/pipelines/guides/hooks/configuring#remote-script-sources) was fetched into. Set only for hooks that declare a `source`. |
 
 The three `CHANGE_REQUEST` variables are set or absent together: they are set when the run is associated with a pull/merge request, and absent for a push to a deploy branch.
 


### PR DESCRIPTION
Documents the new `source` attribute for hooks: a "Remote script sources" section in the hooks configuring guide, the attribute in the `after_hook` block reference, and `PIPELINES_HOOK_CTX_SOURCE_DIR` in the hooks API reference.

Hold merging until the Pipelines release carrying `source` ships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an optional `source` field in `after_hook` configuration to fetch hook scripts from a remote directory before execution.
  * Introduced `PIPELINES_HOOK_CTX_SOURCE_DIR` to point hooks to the fetched source location (only when `source` is used).
* **Documentation**
  * Added a “Remote script sources” guide covering fetching behavior, `execute` reference expansion, and interaction with reproducibility, retries, and preflight fetching.
  * Clarified that hook `timeout_seconds` covers the full hook lifetime, including fetching and credential acquisition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->