### PR TITLE
No op commit to trigger redeploy on merge

### DIFF
--- a/docs/2.0/reference/pipelines/configurations-as-code/index.md
+++ b/docs/2.0/reference/pipelines/configurations-as-code/index.md
@@ -276,7 +276,7 @@ authentication {
 }
 ```
 
-In this example, Pipelines authenticates with AWS using OIDC and assumes the `role-to-assume-for-plans` role within the AWS account identified by `an-aws-account-id` when executing Terragrunt plan commands.
+In this example, Pipelines authenticates with AWS using OIDC and assumes the `role-to-assume-for-plans` role within the AWS account identified by `an-aws-account-id` when executing Terragrunt plan commands. 
 
 ### Environment variables block
 


### PR DESCRIPTION
Merge of https://github.com/gruntwork-io/docs/pull/3207 did not trigger a [Circle CI deployment to production](https://app.circleci.com/pipelines/github/gruntwork-io/docs?branch=main). Cause not determined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated an example under the authentication section for clearer formatting.
* **Style**
  * Minor whitespace and line layout adjustments only; no content or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->