### PR TITLE
Add hook filter docs

### DIFF
--- a/docs/2.0/docs/pipelines/guides/hooks/configuring.md
+++ b/docs/2.0/docs/pipelines/guides/hooks/configuring.md
@@ -30,6 +30,7 @@ The block label (`hello_world` in the example above) is also required and must b
 - **`run_on_error`**: whether the hook runs when a preceding command or hook failed. Defaults to `false`.
 - **`timeout_seconds`**: how long the hook may run before it is terminated. Defaults to `300`.
 - **`authentication`**: cloud credentials and secrets for the hook. See [Authentication & Secrets](/2.0/docs/pipelines/guides/hooks/authentication).
+- **`filter`**: scopes the hook to a subset of the run's affected units by path, environment, and/or label. See [Scoping a hook to specific units](#scoping-a-hook-to-specific-units).
 
 See the [`after_hook` block attributes](/2.0/reference/pipelines/configurations-as-code/api#after_hook-block-attributes) reference for full details.
 
@@ -51,6 +52,36 @@ In both cases there is nothing for a hook to act on, so no hooks run.
 A run executes a single command, either `plan` or `apply`, and only hooks whose `commands` include that command run. A hook scoped to `apply` does not run on a pull/merge request plan, and a hook scoped to `plan` does not run on an apply.
 
 A destroy is treated as an `apply` for this purpose, so a hook configured with `commands = ["apply"]` also runs after a destroy.
+
+### Scoping a hook to specific units
+
+By default a hook applies to every affected unit in the run. Add a `filter` block to scope it to a subset of those units, matching by path, environment, and/or label:
+
+```hcl
+repository {
+  after_hook "notify_prod" {
+    commands = ["apply"]
+    execute  = [".gruntwork/hooks/notify.sh"]
+
+    filter {
+      environments = ["prod"]
+      labels = {
+        team = ["platform"]
+      }
+    }
+  }
+}
+```
+
+The filter is evaluated against the run's affected units:
+
+- **`paths`**: a list of path globs. A unit matches if its path matches one of the globs.
+- **`environments`**: a list of environment names. A unit matches if its environment is one of them. Each name must correspond to a configured `environment` block.
+- **`labels`**: a map of label keys to lists of values. A unit matches only if it carries every listed key with every listed value. Labels are assigned to units by [`annotation`](/2.0/reference/pipelines/configurations-as-code/api#annotation-block) blocks.
+
+At least one of these must be set. When more than one is set, a unit must satisfy all of them.
+
+If at least one affected unit matches, the hook runs and receives only the matched units. If no affected unit matches, the hook is skipped, exactly as if no unit were affected.
 
 ### Isolated working directory
 

--- a/docs/2.0/docs/pipelines/guides/hooks/configuring.md
+++ b/docs/2.0/docs/pipelines/guides/hooks/configuring.md
@@ -77,7 +77,7 @@ The filter is evaluated against the run's units:
 
 - **`paths`**: a list of path globs. A unit matches if its path matches any of the globs.
 - **`environments`**: a list of [`environment`](/2.0/reference/pipelines/configurations-as-code/api#environment-block) names. Units in any of the listed environments match.
-- **`labels`**: a map of label keys to values. Units must have all label values to match. Labels are assigned to units by [`annotation`](/2.0/reference/pipelines/configurations-as-code/api#annotation-block) blocks.
+- **`labels`**: a map of label keys to lists of values. A unit matches only if it has every listed key/value. Labels are assigned by [`annotation`](/2.0/reference/pipelines/configurations-as-code/api#annotation-block) blocks.
 
 If at least one affected unit matches, the hook runs and receives only the matched units. If no affected unit matches, the hook is skipped.
 

--- a/docs/2.0/docs/pipelines/guides/hooks/configuring.md
+++ b/docs/2.0/docs/pipelines/guides/hooks/configuring.md
@@ -55,7 +55,7 @@ A destroy is treated as an `apply` for this purpose, so a hook configured with `
 
 ### Scoping a hook to specific units
 
-By default a hook applies to every affected unit in the run. Add a `filter` block to scope it to a subset of those units, matching by path, environment, and/or label:
+By default a hook applies to every unit in the run. Add a `filter` block to scope it to a subset of those units, matching by path, environment, and/or label:
 
 ```hcl
 repository {
@@ -73,15 +73,13 @@ repository {
 }
 ```
 
-The filter is evaluated against the run's affected units:
+The filter is evaluated against the run's units:
 
-- **`paths`**: a list of path globs. A unit matches if its path matches one of the globs.
-- **`environments`**: a list of environment names. A unit matches if its environment is one of them. Each name must correspond to a configured `environment` block.
-- **`labels`**: a map of label keys to lists of values. A unit matches only if it carries every listed key with every listed value. Labels are assigned to units by [`annotation`](/2.0/reference/pipelines/configurations-as-code/api#annotation-block) blocks.
+- **`paths`**: a list of path globs. A unit matches if its path matches any of the globs.
+- **`environments`**: a list of [`environment`](/2.0/reference/pipelines/configurations-as-code/api#environment-block) names. Units in any of the listed environments match.
+- **`labels`**: a map of label keys to values. Units must have all label values to match. Labels are assigned to units by [`annotation`](/2.0/reference/pipelines/configurations-as-code/api#annotation-block) blocks.
 
-At least one of these must be set. When more than one is set, a unit must satisfy all of them.
-
-If at least one affected unit matches, the hook runs and receives only the matched units. If no affected unit matches, the hook is skipped, exactly as if no unit were affected.
+If at least one affected unit matches, the hook runs and receives only the matched units. If no affected unit matches, the hook is skipped.
 
 ### Isolated working directory
 

--- a/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
+++ b/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
@@ -49,11 +49,9 @@ aws {
 
 <HclListItem name="annotation" requirement="optional" type="labeled-block">
 <HclListItemDescription>
-Annotation blocks assign labels to units. Every unit whose path matches the block's [filter](#filter-block) receives the block's labels. Labels can then be used to target units, for example from an [after_hook `filter`](#after_hook-filter-block).
+Annotation blocks assign labels to units. Every unit whose path matches the block's [filter](#filter-block) receives the block's labels.
 <br />
-The label applied to an annotation block is a user-defined name for the annotation and must be unique across annotation blocks.
-<br />
-A unit may match more than one annotation block, in which case it accumulates the labels from every block it matches. As a result a single label key can carry multiple values on a unit.
+A unit may match more than one annotation block, in which case it accumulates the labels from every block it matches.
 <br />
 See more [below](#annotation-block-attributes).
 </HclListItemDescription>
@@ -194,28 +192,24 @@ repository {
 </HclListItemExample>
 </HclListItem>
 
-### `filter` block
+### `filter` block (environments and annotations)
 
 <HclListItem name="filter" requirement="optional" type="block">
 <HclListItemDescription>
 
-A filter block nested inside an [environment](#environment-block) block that determines which units the environment applies to. It matches only on `paths`. Paths are relative to the directory containing the .gruntwork directory.
-
-For the richer filter used inside [after_hook](#after_hook-block) blocks, which also matches on `environments` and `labels`, see the [after_hook `filter` block](#after_hook-filter-block).
+A filter block nested inside an [environment](#environment-block) or [annotation](#annotation-block) block that determines which units the block applies to.
+See more [below](#filter-block-environments-and-annotations-attributes).
 
 </HclListItemDescription>
 </HclListItem>
 
-### after_hook `filter` block
+### `filter` block (hooks)
 
 <HclListItem name="filter" requirement="optional" type="block">
 <HclListItemDescription>
 
-A filter block nested inside an [after_hook](#after_hook-block) block that scopes the hook to a subset of the run's affected units. It matches units on `paths`, `environments`, and/or `labels`. At least one of these attributes must be set, and a unit must satisfy every attribute the filter specifies (the dimensions are combined with AND).
-
-This is distinct from the [`filter` block](#filter-block) used inside `environment` blocks, which matches only on `paths`.
-
-See more [below](#after_hook-filter-block-attributes).
+A filter block nested inside an [after_hook](#after_hook-block) block that scopes the hook to a subset of the run's units.
+See more [below](#filter-block-hooks-attributes).
 
 </HclListItemDescription>
 </HclListItem>
@@ -312,7 +306,7 @@ An authentication block that determines how Pipelines will authenticate with clo
 <HclListItem name="filter" requirement="required" type="block">
 <HclListItemDescription>
 
-A [filter](#filter-block) block that determines which units the annotation's labels are applied to. It matches only on `paths`. See more [below](#filter-block-attributes).
+A [filter](#filter-block) block that determines which units the annotation's labels are applied to. See more [below](#filter-block-attributes).
 </HclListItemDescription>
 </HclListItem>
 
@@ -551,7 +545,7 @@ repository {
 </HclListItemExample>
 </HclListItem>
 
-### `filter` block attributes
+### `filter` block (environments and annotations) attributes
 
 <HclListItem name="paths" requirement="required" type="array[string]">
 <HclListItemDescription>
@@ -560,28 +554,28 @@ A list of path globs that the filter should match against. Paths are relative to
 </HclListItemDescription>
 </HclListItem>
 
-### after_hook `filter` block attributes
+### `filter` block (hooks) attributes
 
 At least one of `paths`, `environments`, or `labels` must be set. A unit matches only if it satisfies every attribute the filter specifies.
 
 <HclListItem name="paths" requirement="optional" type="array[string]">
 <HclListItemDescription>
 
-A list of path globs. A unit matches if its path matches any one of the globs. Paths are relative to the directory containing the .gruntwork directory.
+A list of path globs that the filter should match against. Paths are relative to the directory containing the .gruntwork directory.
 </HclListItemDescription>
 </HclListItem>
 
 <HclListItem name="environments" requirement="optional" type="array[string]">
 <HclListItemDescription>
 
-A list of [environment](#environment-block) names. A unit matches if its environment is any one of the listed names. Each name must correspond to a configured `environment` block.
+A list of environment names. A unit matches if its environment is any one of the listed names. Each name must correspond to a configured [`environment`](#environment-block) block.
 </HclListItemDescription>
 </HclListItem>
 
 <HclListItem name="labels" requirement="optional" type="map[string, array[string]]">
 <HclListItemDescription>
 
-A map of label keys to lists of values. A unit matches only if it carries every listed key with every listed value. Labels are assigned to units by [annotation](#annotation-block) blocks.
+A map of label keys to lists of values. A unit matches only if it carries every listed key with every listed value. Labels are assigned to units by [`annotation`](#annotation-block) blocks.
 </HclListItemDescription>
 </HclListItem>
 

--- a/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
+++ b/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
@@ -49,7 +49,7 @@ aws {
 
 <HclListItem name="annotation" requirement="optional" type="labeled-block">
 <HclListItemDescription>
-Annotation blocks assign labels to units. Every unit whose path matches the block's [filter](#filter-block-environments-and-annotations) receives the block's labels.
+Annotation blocks assign labels to units. Every unit whose path matches the block's [filter](#filter-block) receives the block's labels.
 <br />
 A unit may match more than one annotation block, in which case it accumulates the labels from every block it matches.
 <br />
@@ -192,24 +192,13 @@ repository {
 </HclListItemExample>
 </HclListItem>
 
-### `filter` block (environments and annotations)
+### `filter` block
 
 <HclListItem name="filter" requirement="optional" type="block">
 <HclListItemDescription>
 
-A filter block nested inside an [environment](#environment-block) or [annotation](#annotation-block) block that determines which units the block applies to.
-See more [below](#filter-block-environments-and-annotations-attributes).
-
-</HclListItemDescription>
-</HclListItem>
-
-### `filter` block (hooks)
-
-<HclListItem name="filter" requirement="optional" type="block">
-<HclListItemDescription>
-
-A filter block nested inside an [after_hook](#after_hook-block) block that scopes the hook to a subset of the run's units.
-See more [below](#filter-block-hooks-attributes).
+A filter block nested inside an [environment](#environment-block), [annotation](#annotation-block), or [after_hook](#after_hook-block) block that determines which units the block applies to.
+See more [below](#filter-block-attributes).
 
 </HclListItemDescription>
 </HclListItem>
@@ -287,7 +276,7 @@ A custom authentication block that determines how Pipelines will authenticate wi
 <HclListItem name="filter" requirement="required" type="block">
 <HclListItemDescription>
 
-A filter block that determines which units the environment is applicable to.  See more [below](#filter-block-environments-and-annotations-attributes).
+A filter block that determines which units the environment is applicable to.  See more [below](#filter-block-attributes).
 
 :::caution
 Every unit must be uniquely matched by the filters of a single environment block. If a unit is matched by multiple environment blocks, Pipelines will throw an error.
@@ -306,7 +295,7 @@ An authentication block that determines how Pipelines will authenticate with clo
 <HclListItem name="filter" requirement="required" type="block">
 <HclListItemDescription>
 
-A [filter](#filter-block-environments-and-annotations) block that determines which units the annotation's labels are applied to. See more [below](#filter-block-environments-and-annotations-attributes).
+A [filter](#filter-block) block that determines which units the annotation's labels are applied to. See more [below](#filter-block-attributes).
 </HclListItemDescription>
 </HclListItem>
 
@@ -522,7 +511,7 @@ An [authentication](#authentication-block) block defining the credentials for th
 <HclListItem name="filter" requirement="optional" type="block">
 <HclListItemDescription>
 
-An [after_hook `filter`](#filter-block-hooks) block that scopes the hook to a subset of the run's affected units by `paths`, `environments`, and/or `labels`. When present, the hook runs only if at least one affected unit matches the filter, and it receives only the matched units. When no affected unit matches, the hook is skipped. When omitted, the hook applies to all affected units. See more [below](#filter-block-hooks-attributes).
+An [after_hook `filter`](#filter-block) block that scopes the hook to a subset of the run's affected units by `paths`, `environments`, and/or `labels`. When present, the hook runs only if at least one affected unit matches the filter, and it receives only the matched units. When no affected unit matches, the hook is skipped. When omitted, the hook applies to all affected units. See more [below](#filter-block-attributes).
 
 </HclListItemDescription>
 <HclListItemExample>
@@ -545,37 +534,33 @@ repository {
 </HclListItemExample>
 </HclListItem>
 
-### `filter` block (environments and annotations) attributes
+### `filter` block attributes
 
-<HclListItem name="paths" requirement="required" type="array[string]">
-<HclListItemDescription>
+The valid attributes depend on which block the `filter` is nested in:
 
-A list of path globs that the filter should match against. Paths are relative to the directory containing the .gruntwork directory.
-</HclListItemDescription>
-</HclListItem>
+- Inside an [`environment`](#environment-block) or [`annotation`](#annotation-block) block, only `paths` is valid, and it is required.
+- Inside an [`after_hook`](#after_hook-block) block, `paths`, `environments`, and `labels` are all valid, and at least one of them must be set.
 
-### `filter` block (hooks) attributes
-
-At least one of `paths`, `environments`, or `labels` must be set. A unit matches only if it satisfies every attribute the filter specifies.
+A unit matches only if it satisfies every attribute the filter specifies.
 
 <HclListItem name="paths" requirement="optional" type="array[string]">
 <HclListItemDescription>
 
-A list of path globs that the filter should match against. Paths are relative to the directory containing the .gruntwork directory.
+A list of path globs that the filter should match against. Paths are relative to the directory containing the .gruntwork directory. Required when nested inside an [`environment`](#environment-block) or [`annotation`](#annotation-block) block.
 </HclListItemDescription>
 </HclListItem>
 
 <HclListItem name="environments" requirement="optional" type="array[string]">
 <HclListItemDescription>
 
-A list of environment names. A unit matches if its environment is any one of the listed names. Each name must correspond to a configured [`environment`](#environment-block) block.
+A list of environment names. Only valid inside an [`after_hook`](#after_hook-block) block. A unit matches if its environment is any one of the listed names. Each name must correspond to a configured [`environment`](#environment-block) block.
 </HclListItemDescription>
 </HclListItem>
 
 <HclListItem name="labels" requirement="optional" type="map[string, array[string]]">
 <HclListItemDescription>
 
-A map of label keys to lists of values. A unit matches only if it carries every listed key with every listed value. Labels are assigned to units by [`annotation`](#annotation-block) blocks.
+A map of label keys to lists of values. Only valid inside an [`after_hook`](#after_hook-block) block. A unit matches only if it carries every listed key with every listed value. Labels are assigned to units by [`annotation`](#annotation-block) blocks.
 </HclListItemDescription>
 </HclListItem>
 

--- a/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
+++ b/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
@@ -49,7 +49,7 @@ aws {
 
 <HclListItem name="annotation" requirement="optional" type="labeled-block">
 <HclListItemDescription>
-Annotation blocks assign labels to units. Every unit whose path matches the block's [filter](#filter-block) receives the block's labels.
+Annotation blocks assign labels to units. Every unit whose path matches the block's [filter](#filter-block-environments-and-annotations) receives the block's labels.
 <br />
 A unit may match more than one annotation block, in which case it accumulates the labels from every block it matches.
 <br />
@@ -287,7 +287,7 @@ A custom authentication block that determines how Pipelines will authenticate wi
 <HclListItem name="filter" requirement="required" type="block">
 <HclListItemDescription>
 
-A filter block that determines which units the environment is applicable to.  See more [below](#filter-block-attributes).
+A filter block that determines which units the environment is applicable to.  See more [below](#filter-block-environments-and-annotations-attributes).
 
 :::caution
 Every unit must be uniquely matched by the filters of a single environment block. If a unit is matched by multiple environment blocks, Pipelines will throw an error.
@@ -306,7 +306,7 @@ An authentication block that determines how Pipelines will authenticate with clo
 <HclListItem name="filter" requirement="required" type="block">
 <HclListItemDescription>
 
-A [filter](#filter-block) block that determines which units the annotation's labels are applied to. See more [below](#filter-block-attributes).
+A [filter](#filter-block-environments-and-annotations) block that determines which units the annotation's labels are applied to. See more [below](#filter-block-environments-and-annotations-attributes).
 </HclListItemDescription>
 </HclListItem>
 
@@ -522,7 +522,7 @@ An [authentication](#authentication-block) block defining the credentials for th
 <HclListItem name="filter" requirement="optional" type="block">
 <HclListItemDescription>
 
-An [after_hook `filter`](#after_hook-filter-block) block that scopes the hook to a subset of the run's affected units by `paths`, `environments`, and/or `labels`. When present, the hook runs only if at least one affected unit matches the filter, and it receives only the matched units. When no affected unit matches, the hook is skipped. When omitted, the hook applies to all affected units. See more [below](#after_hook-filter-block-attributes).
+An [after_hook `filter`](#filter-block-hooks) block that scopes the hook to a subset of the run's affected units by `paths`, `environments`, and/or `labels`. When present, the hook runs only if at least one affected unit matches the filter, and it receives only the matched units. When no affected unit matches, the hook is skipped. When omitted, the hook applies to all affected units. See more [below](#filter-block-hooks-attributes).
 
 </HclListItemDescription>
 <HclListItemExample>

--- a/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
+++ b/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
@@ -45,6 +45,35 @@ aws {
 </HclListItemExample>
 </HclListItem>
 
+### `annotation` block
+
+<HclListItem name="annotation" requirement="optional" type="labeled-block">
+<HclListItemDescription>
+Annotation blocks assign labels to units. Every unit whose path matches the block's [filter](#filter-block) receives the block's labels. Labels can then be used to target units, for example from an [after_hook `filter`](#after_hook-filter-block).
+<br />
+The label applied to an annotation block is a user-defined name for the annotation and must be unique across annotation blocks.
+<br />
+A unit may match more than one annotation block, in which case it accumulates the labels from every block it matches. As a result a single label key can carry multiple values on a unit.
+<br />
+See more [below](#annotation-block-attributes).
+</HclListItemDescription>
+<HclListItemExample>
+
+```hcl
+# .gruntwork/annotations.hcl
+annotation "core" {
+  filter {
+    paths = ["management/*"]
+  }
+
+  labels = {
+    team = "platform"
+  }
+}
+```
+</HclListItemExample>
+</HclListItem>
+
 ### `unit` block
 <HclListItem name="unit" requirement="optional" type="block">
 <HclListItemDescription>
@@ -170,7 +199,23 @@ repository {
 <HclListItem name="filter" requirement="optional" type="block">
 <HclListItemDescription>
 
-A list of path globs that the filter should match against. Paths are relative to the directory containing the .gruntwork directory.
+A filter block nested inside an [environment](#environment-block) block that determines which units the environment applies to. It matches only on `paths`. Paths are relative to the directory containing the .gruntwork directory.
+
+For the richer filter used inside [after_hook](#after_hook-block) blocks, which also matches on `environments` and `labels`, see the [after_hook `filter` block](#after_hook-filter-block).
+
+</HclListItemDescription>
+</HclListItem>
+
+### after_hook `filter` block
+
+<HclListItem name="filter" requirement="optional" type="block">
+<HclListItemDescription>
+
+A filter block nested inside an [after_hook](#after_hook-block) block that scopes the hook to a subset of the run's affected units. It matches units on `paths`, `environments`, and/or `labels`. At least one of these attributes must be set, and a unit must satisfy every attribute the filter specifies (the dimensions are combined with AND).
+
+This is distinct from the [`filter` block](#filter-block) used inside `environment` blocks, which matches only on `paths`.
+
+See more [below](#after_hook-filter-block-attributes).
 
 </HclListItemDescription>
 </HclListItem>
@@ -259,6 +304,22 @@ Every unit must be uniquely matched by the filters of a single environment block
 <HclListItem name="authentication" requirement="required" type="block">
 <HclListItemDescription>
 An authentication block that determines how Pipelines will authenticate with cloud platforms when running Terragrunt commands. See more [below](#authentication-block-attributes).
+</HclListItemDescription>
+</HclListItem>
+
+### `annotation` block attributes
+
+<HclListItem name="filter" requirement="required" type="block">
+<HclListItemDescription>
+
+A [filter](#filter-block) block that determines which units the annotation's labels are applied to. It matches only on `paths`. See more [below](#filter-block-attributes).
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="labels" requirement="required" type="map[string, string]">
+<HclListItemDescription>
+
+A map of label keys to values applied to every unit the `filter` matches. A unit that matches multiple annotation blocks accumulates the labels from all of them, so a key can end up with multiple values on a unit.
 </HclListItemDescription>
 </HclListItem>
 
@@ -464,12 +525,63 @@ An [authentication](#authentication-block) block defining the credentials for th
 </HclListItemDescription>
 </HclListItem>
 
+<HclListItem name="filter" requirement="optional" type="block">
+<HclListItemDescription>
+
+An [after_hook `filter`](#after_hook-filter-block) block that scopes the hook to a subset of the run's affected units by `paths`, `environments`, and/or `labels`. When present, the hook runs only if at least one affected unit matches the filter, and it receives only the matched units. When no affected unit matches, the hook is skipped. When omitted, the hook applies to all affected units. See more [below](#after_hook-filter-block-attributes).
+
+</HclListItemDescription>
+<HclListItemExample>
+
+```hcl
+repository {
+  after_hook "notify_prod" {
+    commands = ["apply"]
+    execute  = [".gruntwork/hooks/notify.sh"]
+
+    filter {
+      environments = ["prod"]
+      labels = {
+        team = ["platform"]
+      }
+    }
+  }
+}
+```
+</HclListItemExample>
+</HclListItem>
+
 ### `filter` block attributes
 
 <HclListItem name="paths" requirement="required" type="array[string]">
 <HclListItemDescription>
 
 A list of path globs that the filter should match against. Paths are relative to the directory containing the .gruntwork directory.
+</HclListItemDescription>
+</HclListItem>
+
+### after_hook `filter` block attributes
+
+At least one of `paths`, `environments`, or `labels` must be set. A unit matches only if it satisfies every attribute the filter specifies.
+
+<HclListItem name="paths" requirement="optional" type="array[string]">
+<HclListItemDescription>
+
+A list of path globs. A unit matches if its path matches any one of the globs. Paths are relative to the directory containing the .gruntwork directory.
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="environments" requirement="optional" type="array[string]">
+<HclListItemDescription>
+
+A list of [environment](#environment-block) names. A unit matches if its environment is any one of the listed names. Each name must correspond to a configured `environment` block.
+</HclListItemDescription>
+</HclListItem>
+
+<HclListItem name="labels" requirement="optional" type="map[string, array[string]]">
+<HclListItemDescription>
+
+A map of label keys to lists of values. A unit matches only if it carries every listed key with every listed value. Labels are assigned to units by [annotation](#annotation-block) blocks.
 </HclListItemDescription>
 </HclListItem>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for an optional `filter` field on after-hooks, including how scoping works via path, environment, and label matching.
  * Clarified hook execution behavior when filters match only some units (run only matched units; skip when nothing matches).
  * Updated the Pipelines Configurations as Code API reference with a new top-level `annotation` block (label assignment based on nested `filter`), and revised/expanded `filter` documentation and examples/requirements across related blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->