### PR TITLE
Document hook auto_expand

### DIFF
--- a/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
+++ b/docs/2.0/reference/pipelines/configurations-as-code/api.mdx
@@ -495,6 +495,13 @@ Whether the hook runs even when the preceding Pipelines `plan` or `apply` comman
 <HclListItemDefaultValue defaultValue="false"/>
 </HclListItem>
 
+<HclListItem name="auto_expand" requirement="optional" type="boolean">
+<HclListItemDescription>
+Whether the hook's section in the pull/merge request comment is expanded by default rather than collapsed.
+</HclListItemDescription>
+<HclListItemDefaultValue defaultValue="false"/>
+</HclListItem>
+
 <HclListItem name="timeout_seconds" requirement="optional" type="number">
 <HclListItemDescription>
 The maximum number of seconds the hook is allowed to run before Pipelines terminates it. Must be greater than `0`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented the optional `auto_expand` setting for after-hooks.
  - Clarified that it controls whether the hook section is expanded by default in pull or merge request comments.
  - Specified the default value as `false`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->