### PR TITLE
Update Gruntwork Releases as of 2026-07-31

### DIFF
--- a/docs/guides/stay-up-to-date/index.md
+++ b/docs/guides/stay-up-to-date/index.md
@@ -17,6 +17,7 @@ import CardGroup from "/src/components/CardGroup"
 <CardGroup cols={1} gap="1rem" stacked equalHeightRows={false} commonCardProps={{padding: "1.25rem"}}>
 
 <!-- START_DOCS_SOURCER_DYNAMIC_CONTENT id=gruntwork-releases-cards -->
+<Card title="Update to 2026-07" href="/guides/stay-up-to-date/releases/2026-07" />
 <Card title="Update to 2026-06" href="/guides/stay-up-to-date/releases/2026-06" />
 <Card title="Update to 2026-05" href="/guides/stay-up-to-date/releases/2026-05" />
 <Card title="Update to 2026-04" href="/guides/stay-up-to-date/releases/2026-04" />
@@ -31,7 +32,6 @@ import CardGroup from "/src/components/CardGroup"
 <Card title="Update to 2025-07" href="/guides/stay-up-to-date/releases/2025-07" />
 <Card title="Update to 2025-06" href="/guides/stay-up-to-date/releases/2025-06" />
 <Card title="Update to 2025-05" href="/guides/stay-up-to-date/releases/2025-05" />
-<Card title="Update to 2025-04" href="/guides/stay-up-to-date/releases/2025-04" />
 <Card title="See older releases" href="/guides/stay-up-to-date/releases" />
 <!-- END_DOCS_SOURCER_DYNAMIC_CONTENT -->
 
@@ -115,6 +115,6 @@ href="/guides/stay-up-to-date/cis/cis-1.5.0"
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "7063bcbf9e42848193ecf88eb01a7516"
+  "hash": "dab05e407c799411cb16c2c91c3bd4c1"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2026-06/index.md
+++ b/docs/guides/stay-up-to-date/releases/2026-06/index.md
@@ -368,10 +368,10 @@ Special thanks to the following users for their contribution!
 ## terraform-aws-service-catalog
 
 
-### [v2.12.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v2.11.1)
+### [v2.12.0](https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v2.12.0)
 
 <p style={{marginTop: "-20px", marginBottom: "10px"}}>
-  <small>Published: 6/30/2026 | Modules affected: data-stores, mgmt, services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v2.11.1">Release notes</a></small>
+  <small>Published: 6/30/2026 | Modules affected: data-stores, mgmt, services | <a href="https://github.com/gruntwork-io/terraform-aws-service-catalog/releases/tag/v2.12.0">Release notes</a></small>
 </p>
 
 <div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
@@ -444,6 +444,6 @@ Special thanks to @a-hat for this contribution!
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "2fe6efe134b0f1baf5314fc4a2e76a75"
+  "hash": "f797bf78b30778abae764735cb894938"
 }
 ##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/2026-07/index.md
+++ b/docs/guides/stay-up-to-date/releases/2026-07/index.md
@@ -1,0 +1,552 @@
+
+# Gruntwork release 2026-07
+
+<p style={{marginTop: "-25px"}}><small><a href="/guides">Guides</a> / <a href="/guides/stay-up-to-date">Update Guides</a> / <a href="/guides/stay-up-to-date/releases">Releases</a> / 2026-07</small></p>
+
+This page lists all the updates to the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) that were released in 2026-07.
+For instructions on how to use these updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
+
+Here are the repos that were updated:
+
+- [pipelines-actions](#pipelines-actions)
+- [pipelines-cli](#pipelines-cli)
+- [pipelines-workflows](#pipelines-workflows)
+- [terraform-aws-architecture-catalog](#terraform-aws-architecture-catalog)
+- [terraform-aws-asg](#terraform-aws-asg)
+- [terraform-aws-data-storage](#terraform-aws-data-storage)
+- [terraform-aws-eks](#terraform-aws-eks)
+- [terraform-aws-security](#terraform-aws-security)
+- [terraform-aws-vpc](#terraform-aws-vpc)
+
+
+## pipelines-actions
+
+
+### [v4.11.2](https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.11.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/20/2026 | <a href="https://github.com/gruntwork-io/pipelines-actions/releases/tag/v4.11.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * fix(pipelines-code-auth): keep path separator in generic fallback insteadOf rewrites by @Tensho in https://github.com/gruntwork-io/pipelines-actions/pull/168
+
+* @Tensho made their first contribution in https://github.com/gruntwork-io/pipelines-actions/pull/168
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-actions/compare/v4.11.1...v4.11.2
+
+</div>
+
+
+
+## pipelines-cli
+
+
+### [v0.58.0](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.58.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/23/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.58.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  Details on user-facing changes will be documented in the release notes for:
+- https://github.com/gruntwork-io/pipelines-workflows
+- https://gitlab.com/gruntwork-io/pipelines-workflows
+
+</div>
+
+
+### [v0.57.0](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.57.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/20/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.57.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  Details on user-facing changes will be documented in the release notes for:
+- https://github.com/gruntwork-io/pipelines-workflows
+- https://gitlab.com/gruntwork-io/pipelines-workflows
+
+</div>
+
+
+### [v0.56.0](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.56.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/14/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.56.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  Details on user-facing changes will be documented in the release notes for:
+- https://github.com/gruntwork-io/pipelines-workflows
+- https://gitlab.com/gruntwork-io/pipelines-workflows
+
+</div>
+
+
+### [v0.55.5](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.55.5)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/8/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.55.5">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  Details on user-facing changes will be documented in the release notes for:
+- https://github.com/gruntwork-io/pipelines-workflows
+- https://gitlab.com/gruntwork-io/pipelines-workflows
+
+</div>
+
+
+### [v0.55.4](https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.55.4)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/3/2026 | <a href="https://github.com/gruntwork-io/pipelines-cli/releases/tag/v0.55.4">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  Details on user-facing changes will be documented in the release notes for:
+- https://github.com/gruntwork-io/pipelines-workflows
+- https://gitlab.com/gruntwork-io/pipelines-workflows
+
+</div>
+
+
+
+## pipelines-workflows
+
+
+### [v4.23.0](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.23.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/23/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.23.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+Added an [`auto_expand`](https://docs.gruntwork.io/2.0/reference/pipelines/configurations-as-code/api/#auto_expand) option to hooks, when enabled hook outputs will be expanded by default in the PR comment.
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4.22.1...v4.23.0
+
+</div>
+
+
+### [v4.22.1](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.22.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/20/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.22.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+A bug in the logic for authenticating private GitHub repositories in Pipelines resulted in CAS downloads failing when using a version of Terragrunt &gt;= 1.1. Due to the way that CAS error handling works, a fallback automatically kicked in for users experiencing this, allowing the download to succeed anyways without CAS de-duplication. This prevented users from getting the performance improvements they expect from usage of CAS.
+
+This has been fixed. Special thanks to @Tensho for contributing this fix!
+
+* chore: Bumping `pipelines-actions` to `v4.11.2` by @yhakbar in https://github.com/gruntwork-io/pipelines-workflows/pull/238
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4...v4.22.1
+
+</div>
+
+
+### [v4.22.0](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.22.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/20/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.22.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Update to pipelines CLI v0.57.0 by @ZachGoldberg in https://github.com/gruntwork-io/pipelines-workflows/pull/237
+
+Included in this CLI change is bugfixes and a code-refactor for pipelines hooks.  There should be no visible customer-visible behavior change with this release.  
+
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4...v4.22.0
+
+</div>
+
+
+### [v4.21.0](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.21.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/14/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.21.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+GitHub is [rolling out a new format](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/) for the OIDC `sub` used by Pipelines to authenticate to the cloud. Repositories created after July 15, 2026 will use this new format. In order to use the correct format when Account Factory creates new delegated repositories, upgrade to this Pipelines release along with [terraform-aws-architecture-catalog v6.1.2](https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v6.1.2) and [terraform-aws-security v1.5.1](https://github.com/gruntwork-io/terraform-aws-security/releases#release-v1.5.1) or newer.
+
+
+Hooks can now specify a `filter` attribute to scope hooks to specific units. Hooks can be filtered by environment, label, and path. Hooks with a `filter` will only run when their targeted units are planned/applied. Read more [here](https://docs.gruntwork.io/2.0/docs/pipelines/guides/hooks/configuring/#scoping-a-hook-to-specific-units).
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4.20.0...v4.21.0
+
+</div>
+
+
+### [v4.20.0](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.20.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/9/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.20.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+:sparkles: Remote script sources for hooks
+
+The default Pipelines CLI version is now v0.55.5, which lets an [`after_hook`](https://docs.gruntwork.io/2.0/docs/pipelines/guides/hooks/overview) declare a `source`: a URL that Pipelines fetches before the hook runs, so `execute` can run scripts that live outside the repository.
+
+[See the documentation](https://docs.gruntwork.io/2.0/docs/pipelines/guides/hooks/configuring#remote-script-sources) for setup instructions and additional details.
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4.19.1...v4.20.0
+
+
+</div>
+
+
+### [v4.19.1](https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.19.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/3/2026 | <a href="https://github.com/gruntwork-io/pipelines-workflows/releases/tag/v4.19.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+:bug: Restored authless environment support
+
+The default Pipelines CLI version is now v0.55.4, which restores support for authless environments: an environment declaring an empty `authentication &#x7B;&#x7D;` block once again resolves to empty credentials instead of failing with an unrecognized-provider error.
+
+:gear: Maintenance
+
+The CLI update also improves troubleshooting when preflight checks fail: the output of the failing command now appears in the workflow logs at the default log level, without needing to enable debug logging. And code authentication is now configured before preflight checks run, as groundwork for upcoming support for remote [hook](https://docs.gruntwork.io/2.0/docs/pipelines/guides/hooks/overview) sources.
+
+**Full Changelog**: https://github.com/gruntwork-io/pipelines-workflows/compare/v4.19.0...v4.19.1
+
+
+</div>
+
+
+
+## terraform-aws-architecture-catalog
+
+
+### [v6.1.2](https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v6.1.2)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/14/2026 | <a href="https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v6.1.2">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Fix invalid tags.yml by @Resonance1584 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1215
+
+
+**Full Changelog**: https://github.com/gruntwork-io/terraform-aws-architecture-catalog/compare/v6.1.1...v6.1.2
+
+</div>
+
+
+### [v6.1.1](https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v6.1.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/14/2026 | <a href="https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v6.1.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Fix access control PR should append accounts by @Resonance1584 in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1214
+
+
+**Full Changelog**: https://github.com/gruntwork-io/terraform-aws-architecture-catalog/compare/v6.1.0...v6.1.1
+
+</div>
+
+
+### [v6.1.0](https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v6.1.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/13/2026 | <a href="https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v6.1.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * Reduce retry count on security hub subscriptions by @odgrim in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1211
+* DEV-1581 changes needed for GitHub Immutable ID subject-claim by @x-nightwing in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1212
+
+* @x-nightwing made their first contribution in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1212
+
+**Full Changelog**: https://github.com/gruntwork-io/terraform-aws-architecture-catalog/compare/v6.0.2...v6.1.0
+
+</div>
+
+
+### [v6.0.1](https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v6.0.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/1/2026 | <a href="https://github.com/gruntwork-io/terraform-aws-architecture-catalog/releases/tag/v6.0.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * fix access control account name in .gruntwork account config by @odgrim in https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/1209
+
+
+**Full Changelog**: https://github.com/gruntwork-io/terraform-aws-architecture-catalog/compare/v6.0.0...v6.0.1
+
+</div>
+
+
+
+## terraform-aws-asg
+
+
+### [v.1.2.0](https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v1.2.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/8/2026 | Modules affected: asg-rolling-deploy, server-group | <a href="https://github.com/gruntwork-io/terraform-aws-asg/releases/tag/v1.2.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- feat: add gw: namespaced tagging and scheduled cloud-nuke cleanup
+- chore: bump cloud-nuke to v0.49.0
+- chore: run cloud-nuke cleanup across all regions
+- fix: harden cloud-nuke cleanup CI and bump to v0.50.0
+- boto3: add logic to verify boto3 packages were in-sync
+- Scope cloud-nuke cleanup to repo resource types (v0.51.0)
+- Bump cloud-nuke cleanup to v0.52.0 (parallel scan)
+- Fix rolling-deploy failure on Python 3.13+ (bump bundled boto3 to 1.35.99, urllib3&lt;2)
+
+
+
+
+
+</div>
+
+
+
+## terraform-aws-data-storage
+
+
+### [v1.3.1](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v1.3.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/30/2026 | Modules affected: - aurora | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v1.3.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+- `aurora`
+
+
+- **fix(aurora): stop perpetual plan drift on Serverless v2 `seconds_until_auto_pause`** (#601). For Aurora Serverless v2, `seconds_until_auto_pause` only applies when `scaling_configuration_min_capacity_V2` is `0` (scale-to-zero). With a min capacity above `0` the AWS provider never sends the value, AWS reports it back as `0`, and because the attribute is computed every plan showed a `0 -&gt; 300` diff. The module now omits the argument unless min capacity is `0`, so the value computed from AWS stands and the drift stops. No input or output changes, and no action needed on upgrade. On earlier versions the workaround is `scaling_configuration_seconds_until_auto_pause_V2 = null`.
+- **fix(examples): parameterize the `aurora-serverless-v2` engine version** (#602). The example hardcoded `engine_version = &quot;16.6&quot;`, which AWS retired, so the example and upgrade tests failed at `CreateDBCluster` with `InvalidParameterCombination`. It now defaults to the major family `16` so it resolves to an available minor. Examples and tests only; no module changes.
+- **fix(test): make upgrade-test resilient to retired MySQL engine versions** (#600). Tests only; no module changes.
+
+
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/600
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/601
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/602
+
+</div>
+
+
+### [v1.3.0](https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v1.3.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/10/2026 | Modules affected: - dms | <a href="https://github.com/gruntwork-io/terraform-aws-data-storage/releases/tag/v1.3.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+- `dms`
+
+
+- **feat: add PostgreSQL and DMS Serverless support** (#590). Adds DMS Serverless (`task_compute_config`) plus new optional inputs on the `dms` module (`create_replication_instance`, `create_iam_roles`, and others), all backward compatible with defaults.
+- **fix(examples): move off retired MySQL 8.0.40 to 8.0.43** (#599). AWS retired MySQL 8.0.40; the RDS/MySQL, DMS, and rds-proxy examples pinned it, so `CreateDBInstance` failed. Examples only; no module changes.
+- **chore(ci): scope cloud-nuke cleanup to repo resource types; bump to v0.51.0** (#596).
+- **chore(ci): bump cloud-nuke cleanup to v0.52.0 (parallel scan/nuke)** (#597).
+
+
+Special thanks to @FriedCircuits for the contribution!
+
+
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/590
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/596
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/597
+- https://github.com/gruntwork-io/terraform-aws-data-storage/pull/599
+
+
+</div>
+
+
+
+## terraform-aws-eks
+
+
+### [v5.0.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v5.0.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/10/2026 | Modules affected: eks-alb-ingress-controller-iam-policy, eks-alb-ingress-controller, eks-aws-auth-merger, eks-cloudwatch-agent | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v5.0.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Scope cloud-nuke cleanup to repo resource types (v0.51.0)
+- require AWS provider v6 across all modules (LIB-5235)
+
+
+
+</div>
+
+
+### [v.5.1.0](https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v5.1.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/22/2026 | Modules affected: eks-cluster-control-plane, eks-k8s-karpenter | <a href="https://github.com/gruntwork-io/terraform-aws-eks/releases/tag/v5.1.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- aded support zonal_shift_config and Karpenter enableZonalShift (#819)
+
+
+
+</div>
+
+
+
+## terraform-aws-security
+
+
+### [v1.6.0](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v1.6.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/16/2026 | Modules affected: github-actions-iam-role, gitlab-pipelines-iam-role | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v1.6.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+
+
+Updated github-actions-iam-role validation to allow wildcards (*)
+Added validation to github-actions-iam-role and gitlab-actions-iam-role to verify role is using StringLike when wildcards are present.
+
+
+</div>
+
+
+### [v1.5.1](https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v1.5.1)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/8/2026 | <a href="https://github.com/gruntwork-io/terraform-aws-security/releases/tag/v1.5.1">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  * chore: bump cloud-nuke to v0.49.0 by @james00012 in https://github.com/gruntwork-io/terraform-aws-security/pull/914
+* chore: run cloud-nuke cleanup across all regions by @james00012 in https://github.com/gruntwork-io/terraform-aws-security/pull/915
+* fix: harden cloud-nuke cleanup CI and bump to v0.50.0 by @james00012 in https://github.com/gruntwork-io/terraform-aws-security/pull/916
+* fix: drop --exclude-region me-central-1 from cloud-nuke cleanup by @james00012 in https://github.com/gruntwork-io/terraform-aws-security/pull/917
+* Scope cloud-nuke cleanup to repo resource types (v0.51.0) by @james00012 in https://github.com/gruntwork-io/terraform-aws-security/pull/918
+* Bump cloud-nuke cleanup to v0.52.0 (parallel scan) by @james00012 in https://github.com/gruntwork-io/terraform-aws-security/pull/919
+* GitHub Immutable IDs by @x-nightwing in https://github.com/gruntwork-io/terraform-aws-security/pull/921
+
+* @x-nightwing made their first contribution in https://github.com/gruntwork-io/terraform-aws-security/pull/921
+
+**Full Changelog**: https://github.com/gruntwork-io/terraform-aws-security/compare/v1.5.0...v1.5.1
+
+</div>
+
+
+
+## terraform-aws-vpc
+
+
+### [v0.29.0](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.29.0)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/15/2026 | Modules affected: vpc-interface-endpoint | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.29.0">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- feat(vpc-interface-endpoint): add Cognito User Pools and Identity Pools VPC endpoints
+
+
+
+</div>
+
+
+### [v0.28.16](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.28.16)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/2/2026 | Modules affected: transit-gateway | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.28.16">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- feat(transit-gateway): add encryption_support argument
+
+
+
+</div>
+
+
+### [v0.28.15](https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.28.15)
+
+<p style={{marginTop: "-20px", marginBottom: "10px"}}>
+  <small>Published: 7/2/2026 | Modules affected: vpc-flow-logs | <a href="https://github.com/gruntwork-io/terraform-aws-vpc/releases/tag/v0.28.15">Release notes</a></small>
+</p>
+
+<div style={{"overflow":"hidden","textOverflow":"ellipsis","display":"-webkit-box","WebkitLineClamp":10,"lineClamp":10,"WebkitBoxOrient":"vertical"}}>
+
+  
+
+- Scope cloud-nuke cleanup to repo resource types (v0.51.0)
+- Bump cloud-nuke cleanup to v0.52.0 (parallel scan)
+- Bump private-s3-bucket to v1.5.0 in vpc-flow-logs
+
+
+
+
+</div>
+
+<!-- ##DOCS-SOURCER-START
+{
+  "sourcePlugin": "releases",
+  "hash": "523a51da13ea85ff91300c91fe0db169"
+}
+##DOCS-SOURCER-END -->

--- a/docs/guides/stay-up-to-date/releases/index.md
+++ b/docs/guides/stay-up-to-date/releases/index.md
@@ -11,7 +11,8 @@ Library](https://gruntwork.io/infrastructure-as-code-library/), grouped by month
 updates in your code, check out the [updating documentation](/library/stay-up-to-date/updating).
 
 <CardGroup cols={1} gap="1rem" stacked equalHeightRows={false} commonCardProps={{padding: "1.25rem"}}>
-  <Card title="Gruntwork Release 2026-06" href="/guides/stay-up-to-date/releases/2026-06" />
+  <Card title="Gruntwork Release 2026-07" href="/guides/stay-up-to-date/releases/2026-07" />
+<Card title="Gruntwork Release 2026-06" href="/guides/stay-up-to-date/releases/2026-06" />
 <Card title="Gruntwork Release 2026-05" href="/guides/stay-up-to-date/releases/2026-05" />
 <Card title="Gruntwork Release 2026-04" href="/guides/stay-up-to-date/releases/2026-04" />
 <Card title="Gruntwork Release 2026-03" href="/guides/stay-up-to-date/releases/2026-03" />
@@ -137,6 +138,6 @@ updates in your code, check out the [updating documentation](/library/stay-up-to
 <!-- ##DOCS-SOURCER-START
 {
   "sourcePlugin": "releases",
-  "hash": "f709d5297bbbddcfa609e49ebd7b602c"
+  "hash": "f3cd70c2b7f0057be3724456faa39be6"
 }
 ##DOCS-SOURCER-END -->


### PR DESCRIPTION
Update Gruntwork releases as of 2026-07-31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the July 2026 release index with updates spanning pipelines, CLI, workflows, architecture, storage, EKS, security, and networking.
  * Added July 2026 release links to the stay-up-to-date documentation.

* **Documentation**
  * Corrected the June 2026 service-catalog release entry to reference version 2.12.0.
  * Removed the outdated April 2025 release card.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->