### PR TITLE
Load the GTM container from n.gruntwork.io instead of Google

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -104,6 +104,22 @@ async function createConfig() {
         : undefined,
     },
     headTags: [
+      ...(enableGoogleAnalytics
+        ? [
+            {
+              tagName: "script",
+              // `attributes` is required by Docusaurus's headTags schema
+              // (Joi `.required()`), even when empty. `innerHTML` is passed
+              // through as an unknown key and rendered by htmlTags.js.
+              attributes: {},
+              innerHTML: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://n.gruntwork.io/mtag/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${googleAnalyticsConfig.trackingID}');`,
+            },
+          ]
+        : []),
       {
         tagName: "meta",
         attributes: {
@@ -153,11 +169,12 @@ async function createConfig() {
           theme: {
             customCss: require.resolve("./src/css/custom.css"),
           },
-          googleTagManager: enableGoogleAnalytics
-            ? {
-                containerId: googleAnalyticsConfig.trackingID,
-              }
-            : undefined,
+          // Not using the preset's googleTagManager option: it hardcodes
+          // https://www.googletagmanager.com/gtm.js, which EasyPrivacy blocks
+          // by default (`||googletagmanager.com^`), taking our PostHog tag down
+          // with it. The loader is injected via headTags above instead, pointed
+          // at our own n.gruntwork.io proxy.
+          googleTagManager: undefined,
           sitemap: {
             lastmod: "date",
             changefreq: null,


### PR DESCRIPTION
## Why

`GTM-5TTJJGTL` carries our PostHog tag. EasyPrivacy — on by default in uBlock Origin — has a blanket `||googletagmanager.com^` rule, so for any visitor running a blocker the container never loads and PostHog never initializes. On a docs site for engineers that is a large share of traffic.

The other properties already handle this: the marketing sites use Webflow's Google tag gateway, and `docs.terragrunt.com` has its own Vercel rewrite (gruntwork-io/terragrunt#6699). This site is the one with no rewrite layer of its own — its CloudFront distribution comes from `terraform-aws-service-catalog//modules/services/public-static-website`, which exposes no additional-origin or cache-behavior inputs.

## What

- Stop using the preset's `googleTagManager` option. It hardcodes `https://www.googletagmanager.com/gtm.js` with no override.
- Inject the loader via the existing `headTags` array, pointed at `https://n.gruntwork.io/mtag/gtm.js`.
- Drop the preset's `<noscript>` iframe fallback, which only reaches visitors without JavaScript — who can't be measured anyway.

The `/mtag/` path matches the convention `docs.terragrunt.com` already uses.

## Dependency: satisfied

`n.gruntwork.io` is **live and serving**:

```
$ curl -s -o /dev/null -w '%{http_code} %{size_download}' \
    'https://n.gruntwork.io/mtag/gtm.js?id=GTM-5TTJJGTL'
200 399392
```

Verified the response is the real container — `GTM-5TTJJGTL`, 4 x `ph_did`, `m.gruntwork.io` present. `/mtag/ns.html` also returns 200.

- Proxy source: **gruntwork-io-team/tag-proxy** (Vercel project `gruntwork/tag-proxy`, auto-deploys from `main`)
- DNS: `CNAME -> cname.vercel-dns.com`, gruntwork-io-team/dogfood-infrastructure-live#765

## Scope

Container delivery only. GA4 measurement hits still go to `google-analytics.com` directly and stay blockable. PostHog is unaffected either way — it reports through `m.gruntwork.io`.

## Note for reviewers

This makes `docs.gruntwork.io` depend on `n.gruntwork.io` at page load. If the proxy is down, GTM (and therefore PostHog) is down on this site — the same coupling `docs.terragrunt.com` already accepts with its own rewrite, but worth knowing since this one is a shared origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Analytics**
  * Google Tag Manager now loads only when Google Analytics is configured.
  * Analytics requests use the configured tracking ID and `n.gruntwork.io` proxy.
  * Google Tag Manager remains disabled when Google Analytics is not enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->