### PR TITLE
Use TG_ environment variables instead of the removed TERRAGRUNT_ names

### DIFF
--- a/docs/2.0/docs/pipelines/guides/terragrunt-env-vars.md
+++ b/docs/2.0/docs/pipelines/guides/terragrunt-env-vars.md
@@ -2,13 +2,13 @@
 
 ## Introduction
 
-When Pipelines detects changes to Infrastructure as Code (IaC) in your repositories, it invokes `terragrunt` with a predefined set of command-line arguments for the detected changes. For instance, if a single unit is modified in a pull request, Pipelines will `chdir` into the unit's directory and execute `terragrunt plan --terragrunt-non-interactive`.
+When Pipelines detects changes to Infrastructure as Code (IaC) in your repositories, it invokes `terragrunt` with a predefined set of command-line arguments for the detected changes. For instance, if a single unit is modified in a pull request, Pipelines will `chdir` into the unit's directory and execute `terragrunt plan --non-interactive`.
 
 You can view the specific commands used in different scenarios by examining the logs of a Pipelines workflow run.
 
 In some situations, you may need to provide additional options to `terragrunt` to accommodate specific requirements. Many Terragrunt CLI options can be controlled through environment variables, allowing for flexible customization of its behavior.
 
-Refer to the complete list of available options in the [Terragrunt CLI documentation](https://terragrunt.gruntwork.io/docs/reference/cli-options/#cli-options).
+Refer to the complete list of available options in the [Terragrunt CLI documentation](https://docs.terragrunt.com/reference/cli/).
 
 ## Adding environment variables
 
@@ -20,13 +20,13 @@ You can configure Pipelines to pass additional environment variables to Terragru
 
 Each entry in the `env` sequence represents an environment variable name and its value.
 
-For example, to enable the `--terragrunt-strict-include` flag in your Terragrunt runs, set the environment variable `TERRAGRUNT_STRICT_INCLUDE` to `true` in the Pipelines configuration file.
+For example, to set the `--parallelism` flag in your Terragrunt runs, set the environment variable `TG_PARALLELISM` to `10` in the Pipelines configuration file.
 
 ```yml title=".gruntwork/config.yml"
 pipelines:
     env:
-    - name: TERRAGRUNT_STRICT_INCLUDE
-      value: true
+    - name: TG_PARALLELISM
+      value: 10
 ```
 
 On the next workflow run, review the workflow logs and locate the `env:` block for the action that executes Terragrunt. If the configuration is correct, your additional environment variable will appear in the `env:` block, confirming it has been successfully passed to the action.

--- a/docs/2.0/reference/pipelines/configurations.md
+++ b/docs/2.0/reference/pipelines/configurations.md
@@ -93,14 +93,14 @@ pipelines:
 
 <HclListItem name="env" requirement="optional" type="sequence(mapping)">
 <HclListItemDescription>
-(Optional) additional env vars to set for pipelines executions, e.g. TF_VAR or TERRAGRUNT_ values to customize the Terragrunt/Terraform/Opentofu run.
+(Optional) additional env vars to set for pipelines executions, e.g. TF_VAR or TG_ values to customize the Terragrunt/Terraform/Opentofu run.
 </HclListItemDescription>
 <HclListItemExample>
 
 ```yaml
 pipelines:
   env:
-    - name: TERRAGRUNT_PARALLELISM
+    - name: TG_PARALLELISM
       value: 10
     - name: CUSTOM_ENVVAR
       value: SOME_DATA
@@ -199,7 +199,7 @@ pipelines:
 <HclListItemDescription>
 Enables the <span class="external-link"><a href="https://terragrunt.gruntwork.io/docs/features/provider-cache/">Terragrunt Provider Cache</a></span> for plans and applies.
 
-This option is deprecated in favor of setting `TERRAGRUNT_PROVIDER_CACHE` as an [`env`](#env) option.
+This option is deprecated in favor of setting `TG_PROVIDER_CACHE` as an [`env`](#env) option.
 </HclListItemDescription>
 <HclListItemDefaultValue defaultValue="false"/>
 <HclListItemExample>


### PR DESCRIPTION
## Why

The Terragrunt CLI redesign renamed every environment variable from the `TERRAGRUNT_` prefix to `TG_`, and 1.0 dropped the old names. The env vars these pages tell users to set are therefore inert — a Pipelines user following them today gets no error, just no effect.

## Not a blanket prefix swap

Terragrunt's own migration guide is explicit that the rename was per-flag — "usually the same exact environment variable with `TERRAGRUNT_` replaced with `TG_`, **but not always**" (e.g. `TERRAGRUNT_DEBUG` → `TG_INPUTS_DEBUG`). Each name here was checked against the current CLI source rather than pattern-substituted:

| Old | New | Verified against |
| --- | --- | --- |
| `TERRAGRUNT_PARALLELISM` | `TG_PARALLELISM` | `internal/cli/flags/shared/parallelism.go:26-27` |
| `TERRAGRUNT_PROVIDER_CACHE` | `TG_PROVIDER_CACHE` | `internal/cli/commands/run/flags.go:51` |
| `TERRAGRUNT_` (prose) | `TG_` | — |

### One case needed replacing, not renaming

The guide's example was `--terragrunt-strict-include` / `TERRAGRUNT_STRICT_INCLUDE`. That flag became `--queue-strict-include`, which is *itself* deprecated — the behavior it enabled is now Terragrunt's default, and it trips a strict control. So there's no current env var worth recommending, and a mechanical rename would have documented a deprecated no-op. Swapped the example to `--parallelism` / `TG_PARALLELISM`, which is a live option Pipelines users actually tune.

## Also fixed, same file, same root cause

Both stale from the same CLI redesign, in a file already being edited:

- `terragrunt plan --terragrunt-non-interactive` → `--non-interactive` in the intro
- The CLI docs link's `#cli-options` anchor no longer exists. The URL still 301s to `docs.terragrunt.com/reference/cli/`, so it's pointed there directly.

## Deliberately left alone

Three sets of `TERRAGRUNT_` matches are **not** stale docs and should not be renamed:

- **`docs/discussions/knowledge-base/355.mdx`** — an auto-generated verbatim mirror of GitHub discussion #355, `custom_edit_url: null`, canonical link to GitHub, one of 521 such files. Editing it would falsify the archive and be overwritten on regeneration.
- **`PIPELINES_FEATURE_TERRAGRUNT_INCLUDE_UNITS_READING` / `..._STACK_GENERATE`** in `reference/pipelines/feature-flags.md` — Pipelines' own feature-flag names that happen to contain the string. Renaming these would break real config.
- **`guides/stay-up-to-date/releases/2025-10/index.md`** — release notes quoting PR titles about this very migration ("using modern env vars instead of legacy `TERRAGRUNT_`").

## Checks

`npx cspell` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Terragrunt command examples to use non-interactive execution.
  * Replaced outdated CLI documentation links.
  * Updated environment-variable examples and guidance to use the `TG_` prefix.
  * Added an example for configuring parallelism with `TG_PARALLELISM=10`.
  * Clarified provider-cache deprecation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->