### PR TITLE
Document trivy v0.3.1

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -128,7 +128,8 @@
     "CMEK",
     "aiplatform",
     "Feedly",
-    "Inoreader"
+    "Inoreader",
+    "unscanned"
   ],
   "ignoreWords": [],
   "ignorePaths": [

--- a/docs/2.0/docs/pipelines/guides/hooks/gruntwork-provided/trivy/_hook.json
+++ b/docs/2.0/docs/pipelines/guides/hooks/gruntwork-provided/trivy/_hook.json
@@ -1,0 +1,66 @@
+{
+  "commands": [
+    "plan"
+  ],
+  "description": "Scan each unit's plan for misconfigurations with Trivy",
+  "env": [],
+  "flags": [
+    {
+      "bool": false,
+      "default": "0.74.0",
+      "env": [
+        "PIPELINES_HOOK_TRIVY_CLI_VERSION"
+      ],
+      "help": "Trivy CLI version to install and run.",
+      "name": "cli-version",
+      "required": false
+    },
+    {
+      "bool": false,
+      "default": "CRITICAL",
+      "env": [
+        "PIPELINES_HOOK_TRIVY_DENY_SEVERITY"
+      ],
+      "help": "Deny at this severity or above. Empty denies nothing.",
+      "name": "deny-severity",
+      "required": false
+    },
+    {
+      "bool": false,
+      "default": "HIGH",
+      "env": [
+        "PIPELINES_HOOK_TRIVY_WARN_SEVERITY"
+      ],
+      "help": "Warn at this severity or above. UNKNOWN and unscanned always warn.",
+      "name": "warn-severity",
+      "required": false
+    },
+    {
+      "bool": false,
+      "default": "info",
+      "enum": [
+        "trace",
+        "debug",
+        "info",
+        "warning",
+        "error",
+        "fatal",
+        "panic"
+      ],
+      "env": [
+        "PIPELINES_HOOK_TRIVY_LOG_LEVEL"
+      ],
+      "group": "Logging",
+      "help": "Log verbosity. A more verbose PIPELINES_LOG_LEVEL overrides it. One of: trace,debug,info,warning,error,fatal,panic.",
+      "name": "log-level",
+      "required": false
+    }
+  ],
+  "internal": false,
+  "line": "v0.3",
+  "name": "trivy",
+  "phase": "after_hook",
+  "release": "https://github.com/gruntwork-io/pipelines-hooks-cli/releases/tag/trivy-v0.3.1",
+  "title": "Trivy",
+  "version": "0.3.1"
+}

--- a/docs/2.0/docs/pipelines/guides/hooks/gruntwork-provided/trivy/index.md
+++ b/docs/2.0/docs/pipelines/guides/hooks/gruntwork-provided/trivy/index.md
@@ -1,0 +1,24 @@
+import hook from './_hook.json'
+import HookVersion from '@site/src/components/HookVersion'
+import HookUsage from '@site/src/components/HookUsage'
+import HookInputs from '@site/src/components/HookInputs'
+
+# Trivy
+
+<HookVersion {...hook} />
+
+Scan each unit's plan for misconfigurations with Trivy
+
+## Usage
+
+<HookUsage {...hook} />
+
+## Inputs
+
+<HookInputs {...hook} />
+
+## Related documentation
+
+- [Gruntwork Provided Hooks](/2.0/docs/pipelines/guides/hooks/gruntwork-provided) - version pinning and configuration common to every provided hook.
+- [Configuring Hooks](/2.0/docs/pipelines/guides/hooks/configuring) - the full set of hook fields.
+- [Authentication & Secrets](/2.0/docs/pipelines/guides/hooks/authentication) - giving a hook cloud credentials.


### PR DESCRIPTION
Generated by grreleaser from `cmd/trivy/api/v0.3.json`. This is trivy's first page: write its prose before approving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Trivy after-hook for `plan` commands, with configurable severity, logging, CLI version, and environment-variable options.
  - Added documentation covering Trivy hook usage, inputs, misconfiguration scanning, configuration, and authentication.

- **Chores**
  - Updated the spell-check dictionary to recognize an additional term.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->